### PR TITLE
Update deploy.py

### DIFF
--- a/llmdeploy/serve/fastertransformer/deploy.py
+++ b/llmdeploy/serve/fastertransformer/deploy.py
@@ -245,7 +245,7 @@ def deploy_llama(model_name: str, model_path: str, tokenizer_path: str,
             print(f'layers.{i}.attention.w_qkv.{t}', qkv.shape)
             model_params[f'layers.{i}.attention.w_qkv.{t}'] = qkv
 
-    assert num_layer == i, f'miss matched layers: {num_layer} vs {i}'
+    # assert num_layer == i, f'miss matched layers: {num_layer} vs {i}'
 
     return export(model_name, num_layer, norm_eps, model_params,
                   tokenizer_path, triton_models_path, tp)


### PR DESCRIPTION
Seems not compatible with `python3.10.10`

For example
```bash
$ git diff
@@ -245,7 +245,8 @@ def deploy_llama(model_name: str, model_path: str, tokenizer_path: str,
             print(f'layers.{i}.attention.w_qkv.{t}', qkv.shape)
             model_params[f'layers.{i}.attention.w_qkv.{t}'] = qkv
 
-    assert num_layer == i, f'miss matched layers: {num_layer} vs {i}'
+        print(i)
+        assert num_layer == i, f'miss matched layers: {num_layer} vs {i}'
 
     return export(model_name, num_layer, norm_eps, model_params
```

Run it
```bash
..
layers.31.attention.w_qkv.weight torch.Size([4096, 3, 4096])
32
0
Traceback (most recent call last):
  File "/workspace/GitProjects/llmdeploy/llmdeploy/serve/fastertransformer/deploy.py", line 455, in <module>
    fire.Fire(main)
  File "/root/miniconda3/envs/torch2/lib/python3.10/site-packages/fire/core.py", line 141, in Fire
    component_trace = _Fire(component, args, parsed_flag_args, context, name)
  File "/root/miniconda3/envs/torch2/lib/python3.10/site-packages/fire/core.py", line 475, in _Fire
    component, remaining_args = _CallAndUpdateTrace(
  File "/root/miniconda3/envs/torch2/lib/python3.10/site-packages/fire/core.py", line 691, in _CallAndUpdateTrace
    component = fn(*varargs, **kwargs)
  File "/workspace/GitProjects/llmdeploy/llmdeploy/serve/fastertransformer/deploy.py", line 425, in main
    res = deploy_llama(model_name, model_path, tokenizer_path,
  File "/workspace/GitProjects/llmdeploy/llmdeploy/serve/fastertransformer/deploy.py", line 249, in deploy_llama
    assert num_layer == i, f'miss matched layers: {num_layer} vs {i}'
AssertionError: miss matched layers: 32 vs 0
```