### PR TITLE
fix warnings.warn of `lmdeploy/pytorch/chat.py` 

### DIFF
--- a/lmdeploy/pytorch/chat.py
+++ b/lmdeploy/pytorch/chat.py
@@ -73,7 +73,7 @@ def init_model(
     model = model.cuda(local_rank)
 
     if not _is_deepspeed_available:
-        warnings.warn('deepspeed is not installed, ',
+        warnings.warn('deepspeed is not installed, '
                       'use plain huggingface model.')
     else:
         model = deepspeed.init_inference(


### PR DESCRIPTION
这个错误是由于 warnings.warn 函数被错误地调用。这个函数的第二个参数（category参数）应该是一个 Warning 的子类，但在代码中，这个参数被设定为了一个字符串，这导致了 TypeError。