### PR TITLE
lmdeploy.serve.turbomind.deploy the value of input param model_format is confused

### DIFF
--- a/lmdeploy/serve/turbomind/deploy.py
+++ b/lmdeploy/serve/turbomind/deploy.py
@@ -488,8 +488,8 @@ def main(model_name: str,
         model_name (str): the name of the to-be-deployed model, such as
             llama-7b, llama-13b, vicuna-7b and etc
         model_path (str): the directory path of the model
-        model_format (str): the format of the model, llama or hf. 
-            'llama' stands for META's llama format, and 
+        model_format (str): the format of the model, llama or hf.
+            'llama' stands for META's llama format, and
             'hf' means huggingface format.
         tokenizer_path (str): the path of tokenizer model
         dst_path (str): the destination path that saves outputs

--- a/lmdeploy/serve/turbomind/deploy.py
+++ b/lmdeploy/serve/turbomind/deploy.py
@@ -488,8 +488,9 @@ def main(model_name: str,
         model_name (str): the name of the to-be-deployed model, such as
             llama-7b, llama-13b, vicuna-7b and etc
         model_path (str): the directory path of the model
-        model_format (str): the format of the model, fb or hf. 'fb' stands for
-            META's llama format, and 'hf' means huggingface format
+        model_format (str): the format of the model, llama or hf. 
+            'llama' stands for META's llama format, and 
+            'hf' means huggingface format.
         tokenizer_path (str): the path of tokenizer model
         dst_path (str): the destination path that saves outputs
         tp (int): the number of GPUs used for tensor parallelism


### PR DESCRIPTION
出于修改最少以及讨论的心态，先修改docstring

docstring里注释的model_format值是'fb'和'hf'，感觉更合理

'llama' 更倾向于和 'internlm' 意义相近的model_name？