### PR TITLE
[Fix] return carrage

### DIFF
--- a/lmdeploy/pytorch/utils.py
+++ b/lmdeploy/pytorch/utils.py
@@ -92,7 +92,7 @@ class InternLMStreamer(DecodeOutputStreamer):
         tok = self.tokenizer.decode(value)
         if res := self.hex_regex.match(tok):
             tok = chr(int(res.group(1), 16))
-        if tok == '</s>' or tok == '<eoa>':
+        if tok == '</s>' or tok == '<eoa>' or tok == '\r':
             tok = '\n'
 
         return tok


### PR DESCRIPTION
For python print, a single \r will return the cursor to head of line and overwrite existing text. 
Force replacing to \n instead. 