### PR TITLE
[Feature] Add script to split HuggingFace model to the smallest sharded checkpoints

### DIFF
--- a/lmdeploy/lite/apis/get_small_sharded_hf.py
+++ b/lmdeploy/lite/apis/get_small_sharded_hf.py
@@ -39,8 +39,8 @@ def main():
 
     checkpoints = set(index['weight_map'].values())
     for ckpt in checkpoints:
-        state_dict = torch.load(
-            os.path.join(args.src_dir, ckpt), map_location='cuda')
+        state_dict = torch.load(os.path.join(args.src_dir, ckpt),
+                                map_location='cuda')
         keys = sorted(list(state_dict.keys()))
         for k in keys:
             new_state_dict_name = 'pytorch_model-{:05d}-of-{:05d}.bin'.format(

--- a/lmdeploy/lite/apis/get_small_sharded_hf.py
+++ b/lmdeploy/lite/apis/get_small_sharded_hf.py
@@ -1,0 +1,63 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+import argparse
+import copy
+import json
+import os
+import shutil
+
+import torch
+from mmengine.utils import mkdir_or_exist
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description='Convert a hugging face model to the smallest sharded one')
+    parser.add_argument('src_dir', help='the directory of the model')
+    parser.add_argument('dst_dir', help='the directory to save the new model')
+    args = parser.parse_args()
+    return args
+
+
+def main():
+    args = parse_args()
+    mkdir_or_exist(args.dst_dir)
+
+    all_files = os.listdir(args.src_dir)
+    for name in all_files:
+        if not name.startswith(('pytorch_model', '.')):
+            src_path = os.path.join(args.src_dir, name)
+            dst_path = os.path.join(args.dst_dir, name)
+            shutil.copy(src_path, dst_path)
+
+    with open(os.path.join(args.src_dir, 'pytorch_model.bin.index.json')) as f:
+        index = json.load(f)
+
+    n_shard = len(index['weight_map'])
+    new_index = copy.deepcopy(index)
+    new_index['weight_map'] = {}
+    cnt = 1
+
+    checkpoints = set(index['weight_map'].values())
+    for ckpt in checkpoints:
+        state_dict = torch.load(
+            os.path.join(args.src_dir, ckpt), map_location='cuda')
+        keys = sorted(list(state_dict.keys()))
+        for k in keys:
+            new_state_dict_name = 'pytorch_model-{:05d}-of-{:05d}.bin'.format(
+                cnt, n_shard)
+            new_index['weight_map'][k] = new_state_dict_name
+            new_state_dict = {k: state_dict[k]}
+            torch.save(new_state_dict,
+                       os.path.join(args.dst_dir, new_state_dict_name))
+            cnt += 1
+        del state_dict
+        torch.cuda.empty_cache()
+    with open(os.path.join(args.dst_dir, 'pytorch_model.bin.index.json'),
+              'w') as f:
+        json.dump(new_index, f)
+    assert new_index['weight_map'].keys() == index['weight_map'].keys(
+    ), 'Mismatch on `weight_map`!'
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily receiving feedbacks. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Split HuggingFace model to the smallest sharded checkpoints, to support low RAM machine load large model.

## Modification

Add `lmdeploy/lite/apis/get_small_sharded_hf.py`

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
