### PR TITLE
Change to github-hosted runner for building docker image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   publish_docker_image:
-    runs-on: [self-hosted, linux-3090]
+    runs-on: ubuntu-latest
     environment: 'prod'
     env:
       TAG_PREFIX: "openmmlab/lmdeploy"
@@ -28,6 +28,20 @@ jobs:
           export commit_id=$(git log --format="%H" -n 1)
           echo "commit id = $commit_id"
           echo "COMMIT_ID=$commit_id" >> $GITHUB_ENV
+      - name: Check disk space
+        run: |
+          cat /proc/cpuinfo  | grep -ic proc
+          free
+          df -h
+          df . -h
+      - name: Get docker info
+        run: |
+          docker info
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and push the latest Docker image
         run: |
           export TAG=$TAG_PREFIX:latest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,6 +3,7 @@ name: publish-docker
 on:
   push:
     paths-ignore:
+      - "!.github/workflows/docker.yml"
       - ".github/**"
       - "docs/**"
       - "resources/**"
@@ -23,13 +24,9 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-      - name: Get lmdeploy commit id
-        run: |
-          export commit_id=$(git log --format="%H" -n 1)
-          echo "commit id = $commit_id"
-          echo "COMMIT_ID=$commit_id" >> $GITHUB_ENV
       - name: Check disk space
         run: |
+          rm -rf ${GITHUB_WORKSPACE}/.git
           cat /proc/cpuinfo  | grep -ic proc
           free
           df -h
@@ -46,7 +43,7 @@ jobs:
         run: |
           export TAG=$TAG_PREFIX:latest
           echo $TAG
-          docker build docker/ -t ${TAG} --build-arg COMMIT_ID=${COMMIT_ID}
+          docker build docker/ -t ${TAG} --no-cache
           docker push $TAG
           echo "TAG=${TAG}" >> $GITHUB_ENV
       - name: Push docker image with released tag

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,11 +9,10 @@ RUN python3 -m pip install --no-cache-dir cmake
 
 ENV NCCL_LAUNCH_MODE=GROUP
 
-ARG COMMIT_ID=main
+ARG VERSION=main
 
-RUN git clone --depth=1 https://github.com/InternLM/lmdeploy.git &&\
+RUN git clone --depth=1 --branch=${VERSION} https://github.com/InternLM/lmdeploy.git &&\
     cd lmdeploy &&\
-    git checkout ${COMMIT_ID} &&\
     python3 -m pip install --no-cache-dir -r requirements.txt &&\
     mkdir -p build && cd build &&\
     cmake .. \


### PR DESCRIPTION


## Motivation

Use github-hosted runner instead of self-hosted runner

Tested OK on my forked repo: https://github.com/RunningLeon/lmdeploy/actions/runs/5946428500

## Modification

Please briefly describe what modification is made in this PR.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
