### PR TITLE
Fix readthedocs building

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -2,8 +2,12 @@ version: 2
 
 formats: all
 
+build:
+  os: "ubuntu-22.04"
+  tools:
+    python: "3.8"
+
 python:
-  version: 3.8
   install:
     - requirements: requirements/docs.txt
     - requirements: requirements/readthedocs.txt


### PR DESCRIPTION
## Motivation

Fix https://readthedocs.org/projects/lmdeploy/builds/21738675/

`The configuration key "build.os" is required to build your documentation.` Read more at https://docs.readthedocs.io/en/stable/config-file/v2.html#build-os

## Modification

Please briefly describe what modification is made in this PR.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
