### PR TITLE
bug-fix: when using stream is False, continuous batching doesn't work

### DIFF
--- a/lmdeploy/serve/async_engine.py
+++ b/lmdeploy/serve/async_engine.py
@@ -136,6 +136,8 @@ class AsyncEngine:
                         repetition_penalty=repetition_penalty,
                         ignore_eos=ignore_eos,
                         random_seed=seed if sequence_start else None):
+                    if outputs is None:
+                        continue
                     res, tokens = outputs[0]
                     # decode res
                     response = self.tokenizer.decode(res)[response_size:]

--- a/lmdeploy/turbomind/turbomind.py
+++ b/lmdeploy/turbomind/turbomind.py
@@ -329,6 +329,9 @@ class TurboMindInstance:
             while self.que.qsize() > 1:
                 self.que.get()
 
+            if self.que.qsize() == 0:
+                yield
+                continue
             finish, tm_outputs = self.que.get()
 
             outputs = _tm_dict_to_torch_dict(tm_outputs)


### PR DESCRIPTION
## Motivation

bug fix : when using stream=False, the continuous batching is not working.
See details in this issue: https://github.com/InternLM/lmdeploy/issues/308

## Modification

In non-streaming mode, the main thread which is responsible for receiving request is stuck in the following code since self.que.get() will wait until the queue is not empty. 

But when using non-stream mode, the queue is always empty unless a request is finished.

So the newly coming request won't be processed before the last request is done. So the batching doesn't work.

```python
 while True:
            while self.que.qsize() > 1:
                self.que.get()

            finish, tm_outputs = self.que.get()

            outputs = _tm_dict_to_torch_dict(tm_outputs)
```

I modify here to avoid the long wait. just see the commits.

I'm not sure if there is a better way to fix this. If any, please comment.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
