### PR TITLE
[Docs] Simplify `build.md`

### DIFF
--- a/docs/en/build.md
+++ b/docs/en/build.md
@@ -1,25 +1,20 @@
 ## Build from source
 
-- make sure local gcc version no less than 9, which can be conformed by `gcc --version`.
 - install packages for compiling and running:
+
   ```shell
+  conda create -n lmdeploy python=3.10
+  conda activate lmdeploy
+
+  git clone https://github.com/InternLM/lmdeploy.git
+  cd lmdeploy
+
   pip install -r requirements.txt
+  conda install openmpi-mpicxx nccl rapidjson -c conda-forge
   ```
-- install [nccl](https://docs.nvidia.com/deeplearning/nccl/install-guide/index.html), set environment variables:
-  ```shell
-  export NCCL_ROOT_DIR=/path/to/nccl/build
-  export NCCL_LIBRARIES=/path/to/nccl/build/lib
-  ```
-- install rapidjson
-- install openmpi, installing from source is recommended.
-  ```shell
-  wget https://download.open-mpi.org/release/open-mpi/v4.1/openmpi-4.1.5.tar.gz
-  tar -xzf openmpi-*.tar.gz && cd openmpi-*
-  ./configure --with-cuda
-  make -j$(nproc)
-  make install
-  ```
+
 - build and install lmdeploy:
+
   ```shell
   mkdir build && cd build
   sh ../generate.sh

--- a/docs/zh_cn/build.md
+++ b/docs/zh_cn/build.md
@@ -3,7 +3,12 @@
 - 安装编译和运行依赖包：
 
   ```shell
-  conda create -n lmdeploy python=3.9
+  conda create -n lmdeploy python=3.10
+  conda activate lmdeploy
+
+  git clone https://github.com/InternLM/lmdeploy.git
+  cd lmdeploy
+
   pip install -r requirements.txt
   conda install openmpi-mpicxx nccl rapidjson -c conda-forge
   ```

--- a/docs/zh_cn/build.md
+++ b/docs/zh_cn/build.md
@@ -1,25 +1,15 @@
 ### 源码安装
 
-- 确保物理机环境的 gcc 版本不低于 9，可以通过`gcc --version`确认。
 - 安装编译和运行依赖包：
+
   ```shell
+  conda create -n lmdeploy python=3.9
   pip install -r requirements.txt
+  conda install openmpi-mpicxx nccl rapidjson -c conda-forge
   ```
-- 安装 [nccl](https://docs.nvidia.com/deeplearning/nccl/install-guide/index.html),设置环境变量
-  ```shell
-  export NCCL_ROOT_DIR=/path/to/nccl/build
-  export NCCL_LIBRARIES=/path/to/nccl/build/lib
-  ```
-- rapidjson 安装
-- openmpi 安装, 推荐从源码安装:
-  ```shell
-  wget https://download.open-mpi.org/release/open-mpi/v4.1/openmpi-4.1.5.tar.gz
-  tar -xzf openmpi-*.tar.gz && cd openmpi-*
-  ./configure --with-cuda
-  make -j$(nproc)
-  make install
-  ```
+
 - lmdeploy 编译安装:
+
   ```shell
   mkdir build && cd build
   sh ../generate.sh


### PR DESCRIPTION

## Motivation

Use conda to install openmpi, nccl and rapidjson

Conda will automatically install the required version of GCC.
