### PR TITLE
Move `q_seq_info` into `context`

### DIFF
--- a/lmdeploy/pytorch_poc/engine/engine.py
+++ b/lmdeploy/pytorch_poc/engine/engine.py
@@ -35,9 +35,6 @@ from .cache_engine import CacheEngine
 
 logger = get_logger('lmdeploy')
 
-# import logging
-# logger = logging.getLogger(__name__)
-
 
 class RequestType(enum.Enum):
     ADD_SESSION = enum.auto()
@@ -138,8 +135,6 @@ class ModelContext:
             free_offset = first_free_block_offsets[bid]
             token_offset = first_token_offsets[bid]
 
-            # 支持新模型的时候如果shape有些不对的可以通过assert识别
-            # 因为slice遇到shape不对也不会报错，只是返回一个空的数组
             assert 0 <= loc <= k_states.size(0)
             assert 0 <= loc + seq_len <= k_states.size(0)
 
@@ -604,7 +599,6 @@ class Engine:
         logits = self._model_forward(inputs, swap_in_map, swap_out_map)
 
         logits = logits[0]  # [bs, seq, prob] -> [seq, prob]
-        # logger.debug('logits.shape = %s', logits.shape)
 
         # gather output
         sampling_params: List[SamplingParam] = [
@@ -619,8 +613,6 @@ class Engine:
         next_token_ids = []
         for msg, logit, param in zip(running, split_logits, sampling_params):
             input_ids = torch.tensor(msg.token_ids)
-            # logger.debug(f'msg = {msg}')
-            # logger.debug(f'input_ids = {input_ids}')
             logits_processor = LogitsProcessorList([
                 TopKLogitsWarper(param.top_k),
                 TopPLogitsWarper(param.top_p),

--- a/lmdeploy/pytorch_poc/engine/engine.py
+++ b/lmdeploy/pytorch_poc/engine/engine.py
@@ -494,17 +494,6 @@ class Engine:
         if input_ids.ndim == 1:
             input_ids = input_ids.unsqueeze(0)
 
-
-        # logger.debug('In Make inputs')
-        # logger.debug(f'q_start_loc {q_start_loc}')
-        # logger.debug(f'q_seq_length {q_seq_length}')
-        # logger.debug("kv_seq_length {q_seq_length}")
-
-        # past_key_values = self.cache_engine.gpu_cache
-        # for i, pkv in enumerate(past_key_values):
-        #     past_key_values[i] = pkv[:2] + (q_start_loc, q_seq_length)
-
-
         return dict(input_ids=input_ids,
                     seq_length=seq_length,
                     attention_mask=attention_mask,

--- a/lmdeploy/pytorch_poc/patch/llama.py
+++ b/lmdeploy/pytorch_poc/patch/llama.py
@@ -211,29 +211,10 @@ class LlamaAttention(nn.Module):
         query_states, key_states = apply_rotary_pos_emb(
             query_states, key_states, cos, sin, position_ids)
 
-        # kv_seq_length = position_ids[..., -1] + 1
-        # q_seq_length = kv_seq_length - kv_seq_length.new_tensor(
-        #     history_lengths)
-        # q_start_loc = q_seq_length.cumsum(0)
-        # q_start_loc = torch.cat([q_start_loc.new_zeros(1), q_start_loc[:-1]])
-
-
-        # # print('===Context Fill===')
-        # # print('key_states.shape', key_states.shape)
-        # # print('value_states.shape', value_states.shape)
-        # print('q_start_loc', q_start_loc)
-        # print('q_seq_length', q_seq_length)
-        # print('kv_seq_length', kv_seq_length)
-        # # print('cache_k', past_key_value[0].shape)
-
         q_start_loc, q_seq_length = self.context.q_seq_info
 
         history_lengths = q_seq_length.new_tensor(history_lengths)
         kv_seq_length = q_seq_length + history_lengths
-
-        # print('q_start_loc', q_start_loc)
-        # print('q_seq_length', q_seq_length)
-        # print('kv_seq_length', kv_seq_length)
 
         context.fill_cache(
             key_states,
@@ -243,7 +224,6 @@ class LlamaAttention(nn.Module):
             past_key_value[0],
             past_key_value[1],
         )
-        # print('cache_k', past_key_value[0].shape)
 
         # TODO: fix GQA
         # # repeat k/v heads if n_kv_heads < n_heads
@@ -255,13 +235,6 @@ class LlamaAttention(nn.Module):
 
         block_offsets = context.block_offsets
         block_size = past_key_value[0].size(1)
-
-        # print('===Attention===')
-        # print('kv_seq_length = ', kv_seq_length)
-        # print('query_states.shape', query_states.shape)
-        # print('max_seq_len', max_seq_len)
-        # print('block_size', block_size)
-        # print('block_offsets', block_offsets)
 
         paged_attention_fwd(query_states,
                             past_key_value[0],


### PR DESCRIPTION
As `q_seq_info` is always required in paged attention and it is ready when making inputs, I moved it into context, in order to simply supporting new models in future. 
The result is the same as computing these values based on position ids. 

+ some other improvements