### PR TITLE
Fix disk space limit for building docker image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -26,7 +26,13 @@ jobs:
         uses: actions/checkout@v3
       - name: Check disk space
         run: |
+          df -h
+          ls /opt/hostedtoolcache
           rm -rf ${GITHUB_WORKSPACE}/.git
+          rm -rf  /opt/hostedtoolcache/go
+          rm -rf  /opt/hostedtoolcache/node
+          rm -rf  /opt/hostedtoolcache/Ruby
+          rm -rf  /opt/hostedtoolcache/CodeQL
           cat /proc/cpuinfo  | grep -ic proc
           free
           df -h


### PR DESCRIPTION

Fix disk space limit for building docker image
tested workflow https://github.com/RunningLeon/lmdeploy/actions/runs/6154601980/job/16700202668

## Motivation

Remove unused files in `/opt/hostedtoolcache` to save disk space.
### disk info before
```
Filesystem      Size  Used Avail Use% Mounted on
/dev/root        84G   63G   21G  76% /
tmpfs           3.4G  [17](https://github.com/RunningLeon/lmdeploy/actions/runs/6154601980/job/16700202668#step:3:18)2K  3.4G   1% /dev/shm
tmpfs           1.4G  1.1M  1.4G   1% /run
tmpfs           5.0M     0  5.0M   0% /run/lock
/dev/sda15      105M  6.1M   99M   6% /boot/efi
/dev/sdb1        14G  4.1G  9.0G  31% /mnt
tmpfs           694M   12K  694M   1% /run/user/1001
```
### disk info after
```
Filesystem      Size  Used Avail Use% Mounted on
/dev/root        84G   53G   31G  64% /
tmpfs           3.4G  172K  3.4G   1% /dev/shm
tmpfs           1.4G  1.1M  1.4G   1% /run
tmpfs           5.0M     0  5.0M   0% /run/lock
/dev/sda15      105M  6.1M   99M   6% /boot/efi
/dev/sdb1        14G  4.1G  9.0G  [31](https://github.com/RunningLeon/lmdeploy/actions/runs/6154601980/job/16700202668#step:3:32)% /mnt
tmpfs           694M   12K  694M   1% /run/user/1001
```
## Modification

Please briefly describe what modification is made in this PR.

## BC-breaking (Optional)

None

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
