### PR TITLE
reduce logic block

### DIFF
--- a/lmdeploy/pytorch_poc/paging/scheduler.py
+++ b/lmdeploy/pytorch_poc/paging/scheduler.py
@@ -139,7 +139,7 @@ class Scheduler:
                 if self.block_manager.can_append_slot(session):
                     msg_length = len(msg.token_ids)
                     block_size = self.cache_config.block_size
-                    session.append_tokens(msg_length + 1, block_size)
+                    session.append_tokens(msg_length, block_size)
                     self.block_manager.append_slot(session)
                     enable_running = True
             else:
@@ -147,7 +147,7 @@ class Scheduler:
                     # update logical blocks of session
                     msg_length = len(msg.token_ids)
                     block_size = self.cache_config.block_size
-                    session.append_tokens(msg_length + 1, block_size)
+                    session.append_tokens(msg_length, block_size)
 
                     # allocate session memory
                     self.block_manager.allocate(session)


### PR DESCRIPTION
It seems that logic blocks are assigned with 1 more block, which make history length calculation wrong. As shown in below debug. 

After fixing this, falcon output the same as the original hf version. 

![06ccf213-183e-4e0c-b2de-d107de552262](https://github.com/InternLM/lmdeploy/assets/12756472/327be6b7-940d-4dcf-bff4-5c07981b0fb7)
