### PR TITLE
fix: build from source with MPI & NCCL in other directories

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 cmake_minimum_required(VERSION 3.11 FATAL_ERROR) # for PyTorch extensions, version should be greater than 3.13
+cmake_policy(SET CMP0074 NEW)
 project(TurboMind LANGUAGES CXX CUDA)
 
 find_package(CUDA 10.2 REQUIRED)
@@ -265,8 +266,8 @@ print(torch._C._GLIBCXX_USE_CXX11_ABI,end='');"
 endif()
 
 if (BUILD_MULTI_GPU)
-  list(APPEND COMMON_HEADER_DIRS ${MPI_INCLUDE_PATH})
-  list(APPEND COMMON_LIB_DIRS /usr/local/mpi/lib)
+  list(APPEND COMMON_HEADER_DIRS ${MPI_CXX_INCLUDE_DIRS})
+  list(APPEND COMMON_HEADER_DIRS ${NCCL_INCLUDE_DIRS})
 endif()
 
 if(USE_TRITONSERVER_DATATYPE)
@@ -347,7 +348,7 @@ add_library(transformer-shared SHARED
 
 if (BUILD_MULTI_GPU)
 target_link_libraries(transformer-shared PUBLIC
-  -lmpi
+  ${MPI_CXX_LIBRARIES}
   ${NCCL_LIBRARIES}
 )
 endif()

--- a/src/turbomind/utils/CMakeLists.txt
+++ b/src/turbomind/utils/CMakeLists.txt
@@ -63,7 +63,7 @@ add_library(mpi_utils STATIC mpi_utils.cc)
 set_property(TARGET mpi_utils PROPERTY POSITION_INDEPENDENT_CODE  ON)
 set_property(TARGET mpi_utils PROPERTY CUDA_RESOLVE_DEVICE_SYMBOLS  ON)
 if (BUILD_MULTI_GPU)
-    target_link_libraries(mpi_utils PUBLIC mpi logger)
+    target_link_libraries(mpi_utils PUBLIC ${MPI_CXX_LIBRARIES} logger)
 endif()
 
 add_library(nccl_utils STATIC nccl_utils.cc)


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily receiving feedbacks. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Tried building `lmdeploy` from source with NCCL & MPI installed in other directory, here is my commands

```bash
mkdir build && cd build
NCCL_ROOT=/my/path/to/nccl bash ../generate.sh
```

This gets me wrong because

1. [CMAKE_POLICY 0074](https://cmake.org/cmake/help/latest/policy/CMP0074.html) not enabled, so `NCCL_ROOT` doesn't work
2. MPI library path is hardcoded so mine was not found

## Modification

1. Enable CMP0074
2. fix NCCL & MPI related paths

## BC-breaking (Optional)

No

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
3. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
4. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
5. The documentation has been modified accordingly, like docstring or example tutorials.
