### PR TITLE
[bug] fix mismatched shape for decoder output tensor

### DIFF
--- a/src/turbomind/models/llama/LlamaV2.cc
+++ b/src/turbomind/models/llama/LlamaV2.cc
@@ -256,7 +256,7 @@ void LlamaV2<T>::contextDecode(T*         deocder_output,
     };
 
     std::unordered_map<std::string, Tensor> decoder_output_tensors{
-        {"decoder_output", {MEMORY_GPU, dtype, {bsz, max_input_len, hidden_units_}, context_decoder_output_buf}},
+        {"decoder_output", {MEMORY_GPU, dtype, {token_num, hidden_units_}, context_decoder_output_buf}},
         {"key_cache", {MEMORY_GPU, TYPE_UINT64, {bsz}, k_cache_ptr}},
         {"value_cache", {MEMORY_GPU, TYPE_UINT64, {bsz}, v_cache_ptr}},
         {"last_token_hidden_units", {MEMORY_GPU, dtype, {bsz, hidden_units_}, deocder_output}}};


### PR DESCRIPTION
This data is [allocated](https://github.com/InternLM/lmdeploy/blob/main/src/turbomind/models/llama/LlamaBatch.cc#L169) and  used ([1](https://github.com/InternLM/lmdeploy/blob/main/src/turbomind/models/llama/LlamaContextDecoder.cc#L189), [2](https://github.com/InternLM/lmdeploy/blob/main/src/turbomind/models/llama/LlamaContextDecoder.cc#L264), [3](https://github.com/InternLM/lmdeploy/blob/main/src/turbomind/models/llama/LlamaContextDecoder.cc#L266)) with the other shape