### PR TITLE
[Fix] Set the default value of `step` being 0

### DIFF
--- a/lmdeploy/turbomind/turbomind.py
+++ b/lmdeploy/turbomind/turbomind.py
@@ -229,7 +229,7 @@ class TurboMindInstance:
                      request_output_len: int = 512,
                      sequence_start: bool = True,
                      sequence_end: bool = False,
-                     step=1,
+                     step=0,
                      stop=False,
                      top_p=0.8,
                      top_k=40,


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily receiving feedbacks. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

I found the first generated token was swallowed when integrating turbomind python API to opencompass.
That's because it uses the default value of `step` as 1 in `stream_infer` API.
Changing to 0 can resolve it.

## Modification

Please briefly describe what modification is made in this PR.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
