### PR TITLE
Add `launch.py` to `<workspace>` when it created.

### DIFF
--- a/lmdeploy/serve/turbomind/_launch.py
+++ b/lmdeploy/serve/turbomind/_launch.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+from lmdeploy.serve.openai.api_server import main as serve
+from pathlib import Path
+
+# # Register your custom model.
+#
+# from lmdeploy.model import MODELS, BaseModel
+# @MODELS.register_module(name='custom_model')
+# class CustomModel(BaseModel):
+#     pass
+
+
+if __name__ == '__main__':
+    serve(
+        model_path=str(Path(__file__).resolve().parent),
+        server_name="0.0.0.0",
+        server_port=23333,
+        instance_num=32,
+        tp=1
+    )

--- a/lmdeploy/serve/turbomind/deploy.py
+++ b/lmdeploy/serve/turbomind/deploy.py
@@ -77,6 +77,7 @@ def copy_triton_model_templates(_path: str):
         print(f'copy triton model templates from "{triton_models_path}" to '
               f'"{dst_path}" successfully')
         shutil.copy(osp.join(dir_path, 'service_docker_up.sh'), _path)
+        shutil.copy(osp.join(dir_path, '_launch.py'), osp.join(_path, "launch.py"))
         return dst_path
     except Exception as e:
         print(f'copy triton model templates from "{triton_models_path}"'


### PR DESCRIPTION
## Motivation

Make it easy to start a model service, just run `./<workspace>/launch.py`. and easy to set `address`, `port`, `tp` and others arguments in the `./<workspace>/launch.py` file.

## Modification

Add `_launch.py` template to `lmdeploy/serve/turbomind/` and copy it to `<workspace>` when workspace created.


## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
