### PR TITLE
Support Tensor parallel on Falcon models

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,7 +16,7 @@ jobs:
           python -m pip install pre-commit
           pre-commit install
       - name: Linting
-        run: pre-commit run --all-files || git diff
+        run: pre-commit run --all-files
       - name: Format c/cuda codes with clang-format
         uses: DoozyX/clang-format-lint-action@v0.13
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,7 +16,7 @@ jobs:
           python -m pip install pre-commit
           pre-commit install
       - name: Linting
-        run: pre-commit run --all-files
+        run: pre-commit run --all-files || git diff
       - name: Format c/cuda codes with clang-format
         uses: DoozyX/clang-format-lint-action@v0.13
         with:

--- a/lmdeploy/pytorch_poc/config.py
+++ b/lmdeploy/pytorch_poc/config.py
@@ -31,6 +31,7 @@ class ModelConfig:
     bos_token_id: int
     eos_token_id: int
     dtype: str
+    multi_query_attention: bool = False
 
     def get_head_size(self):
         return self.hidden_size // self.num_heads

--- a/lmdeploy/pytorch_poc/engine/cache_engine.py
+++ b/lmdeploy/pytorch_poc/engine/cache_engine.py
@@ -66,8 +66,9 @@ class CacheEngine:
     def get_key_block_shape(self, local: bool = False) -> Tuple[int, int, int]:
         """get shape of key block."""
         num_heads = self.num_heads
-        if local:
-            assert self.num_heads % self.world_size == 0
+        if local and not self.model_config.multi_query_attention:
+            assert self.num_heads % self.world_size == 0, \
+                f'num_heads: {self.num_heads}, world_size: {self.world_size}'
             num_heads = self.num_heads // self.world_size
         return (
             self.block_size,
@@ -79,8 +80,9 @@ class CacheEngine:
                               local: bool = False) -> Tuple[int, int, int]:
         """get shape of value block."""
         num_heads = self.num_heads
-        if local:
-            assert self.num_heads % self.world_size == 0
+        if local and not self.model_config.multi_query_attention:
+            assert self.num_heads % self.world_size == 0, \
+                f'num_heads: {self.num_heads}, world_size: {self.world_size}'
             num_heads = self.num_heads // self.world_size
         return (
             self.block_size,

--- a/lmdeploy/pytorch_poc/engine/engine.py
+++ b/lmdeploy/pytorch_poc/engine/engine.py
@@ -480,10 +480,17 @@ class Engine:
                                        num_cpu_blocks=0,
                                        num_gpu_blocks=0)
         if 'falcon' in model_path:
+            if hf_config.new_decoder_architecture:
+                # 40b-instruct, GQA
+                kv_dim = hf_config.hidden_size // hf_config.num_attention_heads
+                kv_dim *= hf_config.num_kv_heads
+                kv_head = hf_config.num_kv_heads
             if hf_config.multi_query:
+                # 7b-instruct, MQA
                 kv_dim = hf_config.hidden_size // hf_config.num_attention_heads
                 kv_head = 1
             else:
+                # rw-1b, MHA
                 kv_dim = hf_config.hidden_size
                 kv_head = hf_config.num_attention_heads
             model_config = ModelConfig(

--- a/lmdeploy/pytorch_poc/engine/engine.py
+++ b/lmdeploy/pytorch_poc/engine/engine.py
@@ -493,7 +493,7 @@ class Engine:
                 bos_token_id=hf_config.bos_token_id,
                 eos_token_id=hf_config.eos_token_id,
                 dtype=torch_dtype,
-            )
+                multi_query_attention=hf_config.multi_query)
         elif 'chatglm' in model_path:
             model_config = ModelConfig(
                 hf_config.hidden_size // hf_config.num_attention_heads *

--- a/lmdeploy/pytorch_poc/models/falcon.py
+++ b/lmdeploy/pytorch_poc/models/falcon.py
@@ -1,5 +1,5 @@
 # Copyright (c) OpenMMLab. All rights reserved.
-# Adapter from:
+# Adapted from:
 # https://huggingface.co/tiiuae/falcon-7b-instruct
 # https://github.com/huggingface/transformers/blob/v4.33-release/src/transformers/models/falcon/modeling_falcon.py  # noqa
 

--- a/lmdeploy/pytorch_poc/models/falcon.py
+++ b/lmdeploy/pytorch_poc/models/falcon.py
@@ -189,7 +189,7 @@ class PatchedFalconAttention(nn.Module):
         else:
             # e.g. 7b-instruct model
             batch_size, seq_length, three_times_hidden_size = fused_qkv.shape
-            if not dist.is_initialized:
+            if not dist.is_initialized():
                 num_head = self.num_heads
             else:
                 # this trick will, for example, split 11 into [4, 4, 3]

--- a/lmdeploy/pytorch_poc/models/falcon.py
+++ b/lmdeploy/pytorch_poc/models/falcon.py
@@ -145,8 +145,6 @@ class PatchedFalconAttention(nn.Module):
                 if mod.bias:
                     mod.weight.data = mod.weight.data.reshape(self.hidden_size)
 
-            print(dist.get_rank(), mod.weight.shape)
-
         elif mod_name in ['dense']:
             if self.multi_query:
                 mod.weight.data = mod.weight.reshape(self.hidden_size, -1,

--- a/lmdeploy/pytorch_poc/models/patch.py
+++ b/lmdeploy/pytorch_poc/models/patch.py
@@ -34,16 +34,18 @@ MODULE_MAP.update({
     'lmdeploy.pytorch_poc.models.falcon.PatchedFalconModel',
     'transformers.models.falcon.modeling_falcon.FalconRotaryEmbedding':
     'lmdeploy.pytorch_poc.models.falcon.PatchedFalconRotaryEmbedding',
+    'transformers.models.falcon.modeling_falcon.FalconMLP':
+    'lmdeploy.pytorch_poc.models.falcon.PatchedFalconMLP',
     'modelling_RW.Attention':
     'lmdeploy.pytorch_poc.models.falcon.PatchedFalconAttention',
+    'modelling_RW.MLP':
+    'lmdeploy.pytorch_poc.models.falcon.PatchedFalconMLP',
     'modelling_RW.RWModel':
     'lmdeploy.pytorch_poc.models.falcon.PatchedFalconModel',
     'modelling_RW.RotaryEmbedding':
     'lmdeploy.pytorch_poc.models.falcon.PatchedFalconRotaryEmbedding',
     'transformers.models.falcon.modeling_falcon.FalconForCausalLM':
     'lmdeploy.pytorch_poc.models.falcon.PatchedFalconForCausalLM',
-    # 'transformers.models.falcon.modeling_falcon.FalconDecoderLayer':
-    # 'lmdeploy.pytorch_poc.models.falcon.PatchedFalconDecoderLayer',
 })
 
 # baichuan

--- a/lmdeploy/pytorch_poc/models/patch.py
+++ b/lmdeploy/pytorch_poc/models/patch.py
@@ -28,14 +28,17 @@ MODULE_MAP = {
 
 # Falcon Models in transformer / on hub
 MODULE_MAP.update({
-    'transformers.models.falcon.modeling_falcon.FalconAttention':
+    'modeling_falcon.FalconAttention':
     'lmdeploy.pytorch_poc.models.falcon.PatchedFalconAttention',
-    'transformers.models.falcon.modeling_falcon.FalconModel':
+    'modeling_falcon.FalconModel':
     'lmdeploy.pytorch_poc.models.falcon.PatchedFalconModel',
-    'transformers.models.falcon.modeling_falcon.FalconRotaryEmbedding':
+    'modeling_falcon.FalconRotaryEmbedding':
     'lmdeploy.pytorch_poc.models.falcon.PatchedFalconRotaryEmbedding',
-    'transformers.models.falcon.modeling_falcon.FalconMLP':
+    'modeling_falcon.FalconMLP':
     'lmdeploy.pytorch_poc.models.falcon.PatchedFalconMLP',
+    'modeling_falcon.FalconForCausalLM':
+    'lmdeploy.pytorch_poc.models.falcon.PatchedFalconForCausalLM',
+    # for old implementations on hub
     'modelling_RW.Attention':
     'lmdeploy.pytorch_poc.models.falcon.PatchedFalconAttention',
     'modelling_RW.MLP':
@@ -44,8 +47,6 @@ MODULE_MAP.update({
     'lmdeploy.pytorch_poc.models.falcon.PatchedFalconModel',
     'modelling_RW.RotaryEmbedding':
     'lmdeploy.pytorch_poc.models.falcon.PatchedFalconRotaryEmbedding',
-    'transformers.models.falcon.modeling_falcon.FalconForCausalLM':
-    'lmdeploy.pytorch_poc.models.falcon.PatchedFalconForCausalLM',
 })
 
 # baichuan


### PR DESCRIPTION
Tested with falcon-rw-1b, falcon-7b-instruct and (new) 40b-instruct

Modifies outside falcon to make things work:
1. add multi_query_attention in ModelConfig and let CacheEngine not to split the single k/v head. 
2. some error message on asserts, in the cache engine