### PR TITLE
Visualize layer activations and weights to simplify the quantization process.

### DIFF
--- a/lmdeploy/cli/cli.py
+++ b/lmdeploy/cli/cli.py
@@ -3,6 +3,7 @@ import fire
 
 from .chat import SubCliChat
 from .lite import SubCliLite
+from .quant_visualization import SubCliDraw
 from .serve import SubCliServe
 
 
@@ -57,5 +58,6 @@ def run():
     cli.lite = SubCliLite()
     cli.chat = SubCliChat()
     cli.serve = SubCliServe()
+    cli.quant_visualization = SubCliDraw()
 
     fire.Fire(cli, name='lmdeploy')

--- a/lmdeploy/cli/quant_visualization.py
+++ b/lmdeploy/cli/quant_visualization.py
@@ -1,0 +1,44 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+
+
+class SubCliDraw(object):
+    """CLI for compressing LLMs."""
+
+    def draw(self,
+             modes=None,
+             linear_name=None,
+             pretrained_model_name_or_path=None,
+             work_dir='work_dir',
+             use_input=True,
+             key='absmax',
+             layers=None,
+             force_calibrate=False):
+        """This function is used to visualize data from a pre-trained
+        transformer model. Depending on the mode, it will leverage different
+        visualization functions (draw1, draw2, draw3, draw4).
+
+        Args:
+            mode (list of int, optional): Modes determine which visualization
+                function(s) will be used. If not provided, all four
+                visualization functions are executed.
+                Available modes: [1, 2, 3, 4].
+            linear_name (str, optional): Name of the linear layer for which
+                the visualization will be created. If not provided, it will
+                process all available layers.
+            pretrained_model_name_or_path (str, optional): Path or name of the
+                pretrained model. Required if `force_calibrate` is True or
+                no calibration data exists in `work_dir`. Defaults to None.
+            work_dir (str, optional): Working directory where intermediate
+                files are saved. Defaults to 'work_dir'.
+            use_input (bool, optional): Use the input or output of a linear
+                layer. Defaults to use the input of a linear layer.
+            key (str, optional): The specific feature to plot. Can be 'absmax',
+                'absmean', 'max', 'mean' or 'min'. Defaults to 'absmax'.
+            layers (list, optional): List of layers to draw. If None,
+                all layers will be drawn. Defaults to None.
+            force_calibrate (bool, optional): Whether to force recalibration
+                even if calibration data exists. Defaults to False.
+        """
+        from lmdeploy.lite.apis.quant_visualization import draw
+        draw(modes, linear_name, pretrained_model_name_or_path, work_dir,
+             use_input, key, layers, force_calibrate)

--- a/lmdeploy/lite/apis/quant_visualization.py
+++ b/lmdeploy/lite/apis/quant_visualization.py
@@ -1,0 +1,328 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+
+import os
+from pathlib import Path
+
+import fire
+import matplotlib.pyplot as plt
+import torch
+from accelerate import infer_auto_device_map, init_empty_weights
+from calibrate import calibrate
+from matplotlib import rc
+from transformers import AutoModelForCausalLM
+
+from lmdeploy.lite.utils import collect_target_modules
+from lmdeploy.pytorch.model import LoadWoInit
+
+rc('mathtext', default='regular')
+
+LAYER_TYPE_MAP = {
+    'InternLMForCausalLM': 'InternLMDecoderLayer',
+    'QWenLMHeadModel': 'QWenBlock',
+    'BaiChuanForCausalLM': 'DecoderLayer',
+    'LlamaForCausalLM': 'LlamaDecoderLayer',
+}
+NORM_TYPE_MAP = {
+    'InternLMForCausalLM': 'InternLMRMSNorm',
+    'QWenLMHeadModel': 'RMSNorm',
+    'BaiChuanForCausalLM': 'RMSNorm',
+    'LlamaForCausalLM': 'LlamaRMSNorm',
+}
+
+
+def get_layer_idx(name):
+    """Extract layer index from layer name."""
+    return int(name.split('.')[2])
+
+
+def draw1(linear_name,
+          use_input=True,
+          key='absmax',
+          work_dir='work_dir',
+          layers=None):
+    """Draw the first type of plot which shows the absmax/absmean/max/mean/min
+    value of a linear layer at different layers.
+
+    Args:
+        linear_name (str): Name of the linear layer.
+        use_input (bool, optional): Use the input or output of a linear layer.
+            Defaults to use the input of a linear layer.
+        key (str, optional): The specific feature to plot. Can be 'absmax',
+            'absmean', 'max', 'mean' or 'min'. Defaults to 'absmax'.
+        work_dir (str, optional): Working directory where intermediate files
+            are saved. Defaults to 'work_dir'.
+        layers (list, optional): List of layers to draw. If None,
+            all layers will be drawn. Defaults to None.
+    """
+
+    def draw_one(tensor, idx):
+        tensor = tensor.to('cpu')
+        dim = tensor.shape[0]
+        x = list(range(dim))
+        y = list(tensor.numpy())
+        var = tensor.var().item()
+        plt.plot(x, y)
+        plt.xlabel('dim')
+        plt.ylabel(key)
+        plt.title(f'layer{idx}  variance = {round(var, 4)}')
+        plt.savefig(f'{work_dir}/case_1/layer_{idx}.png')
+        plt.clf()
+
+    work_dir = Path(work_dir)
+    tmp_dir = work_dir / 'case_1'
+    tmp_dir.mkdir(parents=True, exist_ok=True)
+
+    if use_input:
+        stats = torch.load(f'{work_dir}/inputs_stats.pth')
+    else:
+        stats = torch.load(f'{work_dir}/outputs_stats.pth')
+    assert key in stats
+    stats = stats[key]
+    tensor_list = {
+        get_layer_idx(k): v
+        for k, v in stats.items() if linear_name in k
+    }
+    if layers is None:
+        for i, tensor in enumerate(tensor_list):
+            draw_one(tensor, i)
+    else:
+        for layer_idx in layers:
+            draw_one(tensor_list[layer_idx], layer_idx)
+
+
+def draw2(linear_name,
+          model_path,
+          key='absmax',
+          work_dir='work_dir',
+          layers=None):
+    """Draw the second type of plot which shows the relationship between
+    activations and weights.
+
+    Args:
+        linear_name (str): Name of the linear layer.
+        model_path (str): The name or path of the model to be loaded.
+        key (str, optional): The specific feature to plot. Can be 'absmax',
+            'absmean', 'max', 'mean' or 'min'. Defaults to 'absmax'.
+        work_dir (str, optional): Working directory where intermediate
+            files are saved. Defaults to 'work_dir'.
+        layers (list, optional): List of layers to draw. If None,
+            all layers will be drawn. Defaults to None.
+    """
+
+    def draw_one(act, weight, idx, topk=100):
+        act = act.to('cpu').float()
+        weight = weight.to('cpu').float()
+        assert act.shape[0] == weight.shape[
+            0] and act.ndim == 1 and weight.ndim == 1
+
+        y1, x1 = act.topk(topk)
+        y2, x2 = weight.topk(topk)
+        x1, y1 = list(x1.numpy()), list(y1.numpy())
+        x2, y2 = list(x2.numpy()), list(y2.numpy())
+        tuple1 = [(x, y) for x, y in zip(x1, y1)]
+        tuple1.sort(key=lambda x: x[0])
+        x1, y1 = [x[0] for x in tuple1], [x[1] for x in tuple1]
+        tuple2 = [(x, y) for x, y in zip(x2, y2)]
+        tuple2.sort(key=lambda x: x[0])
+        x2, y2 = [x[0] for x in tuple2], [x[1] for x in tuple2]
+
+        fig = plt.figure()
+        ax = fig.add_subplot(111)
+        line1 = ax.plot(x1, y1, '-', label='act')
+        ax2 = ax.twinx()
+        line2 = ax2.plot(x2, y2, '-r', label='weight')
+        lines = line1 + line2
+        labels = [line.get_label() for line in lines]
+        ax.legend(lines, labels, loc=0)
+        ax.grid()
+        ax.set_xlabel('dim')
+        ax.set_ylabel(f'Activation_{key}')
+        ax2.set_ylabel(f'Weight_{key}')
+        plt.title(f'layer{idx}  topk = {topk}')
+        plt.savefig(f'{work_dir}/case_2/layer_{idx}.png')
+        plt.clf()
+
+    work_dir = Path(work_dir)
+    tmp_dir = work_dir / 'case_2'
+    tmp_dir.mkdir(parents=True, exist_ok=True)
+
+    stats = torch.load(f'{work_dir}/inputs_stats.pth')
+    assert key in stats
+    stats = stats[key]
+    act_list = {
+        get_layer_idx(k): v
+        for k, v in stats.items() if linear_name in k
+    }
+
+    with init_empty_weights():
+        # Load model
+        model = AutoModelForCausalLM.from_pretrained(model_path,
+                                                     torch_dtype=torch.float16,
+                                                     trust_remote_code=True)
+        model.config.use_cache = False
+    layer_type = LAYER_TYPE_MAP[type(model).__name__]
+    decoder_layers = collect_target_modules(model, layer_type)
+    device_map = infer_auto_device_map(model,
+                                       no_split_module_classes=[layer_type])
+    for name in device_map.keys():
+        if name in decoder_layers or 'lm_head' in name:
+            device_map[name] = 'cpu'
+        else:
+            device_map[name] = 0
+    with LoadWoInit():
+        model = AutoModelForCausalLM.from_pretrained(model_path,
+                                                     torch_dtype=torch.float16,
+                                                     trust_remote_code=True)
+        model.config.use_cache = False
+
+    weight_list = {}
+    for k, v in model.state_dict().items():
+        if linear_name in k:
+            if key == 'absmax':
+                v = v.abs().max(dim=0)[0]
+            elif key == 'absmean':
+                v = v.abs().mean(dim=0)[0]
+            weight_list[get_layer_idx(k)] = v
+
+    if layers is None:
+        for i, (act, weight) in enumerate(zip(act_list, weight_list)):
+            draw_one(act, weight, i)
+    else:
+        for layer_idx in layers:
+            draw_one(act_list[layer_idx], weight_list[layer_idx], layer_idx)
+
+
+def draw3(linear_name, use_input=True, key='absmax', work_dir='work_dir'):
+    """Draw the third type of plot which is a boxplot showing the
+    absmax/absmean/max/mean/min value of the input or output of a linear layer
+    at different layers.
+
+    Args:
+        linear_name (str): Name of the linear layer.
+        use_input (bool, optional): Use the input or output of a linear layer.
+            Defaults to use the input of a linear layer.
+        key (str, optional): The specific feature to plot. Can be 'absmax',
+            'absmean', 'max', 'mean' or 'min'. Defaults to 'absmax'.
+        work_dir (str, optional): Working directory where intermediate files
+            are saved. Defaults to 'work_dir'.
+    """
+
+    def draw_one(tensor_list):
+        all_data = []
+        for val in tensor_list.values():
+            all_data.append(val.to('cpu').numpy())
+        plt.boxplot(all_data, None, None, None, 20)  # codespell-ignore
+        plt.xlabel('layer')
+        plt.ylabel(key)
+        plt.title(f'linear_name {linear_name}')
+        plt.savefig(f'{work_dir}/case_3.png')
+
+    if use_input:
+        stats = torch.load(f'{work_dir}/inputs_stats.pth')
+    else:
+        stats = torch.load(f'{work_dir}/outputs_stats.pth')
+    assert key in stats
+    stats = stats[key]
+    tensor_list = {
+        get_layer_idx(k): v
+        for k, v in stats.items() if linear_name in k
+    }
+    draw_one(tensor_list)
+
+
+def draw4(linear_name, use_input=True, work_dir='work_dir', layers=None):
+    """Draw the fourth type of plot which shows the relationship between
+    maximum and minimum values of activations.
+
+    Args:
+        linear_name (str): Name of the linear layer.
+        use_input (bool, optional): Use the input or output of a linear layer.
+            Defaults to use the input of a linear layer.
+        work_dir (str, optional): Working directory where intermediate files
+            are saved. Defaults to 'work_dir'.
+        layers (list, optional): List of layers to draw. If None,
+            all layers will be drawn. Defaults to None.
+    """
+
+    def draw_one(tensor_max, tensor_min, idx):
+        tensor_max = tensor_max.to('cpu').numpy()
+        tensor_min = tensor_min.to('cpu').numpy()
+        plt.scatter(tensor_max, tensor_min)
+        plt.xlabel('max')
+        plt.ylabel('min')
+        plt.title(f'layer{idx}')
+        plt.savefig(f'{work_dir}/case_4/layer_{idx}.png')
+        plt.clf()
+
+    work_dir = Path(work_dir)
+    tmp_dir = work_dir / 'case_4'
+    tmp_dir.mkdir(parents=True, exist_ok=True)
+    if use_input:
+        stats = torch.load(f'{work_dir}/inputs_stats.pth')
+    else:
+        stats = torch.load(f'{work_dir}/outputs_stats.pth')
+    stats_max = stats['max']
+    stats_min = stats['min']
+    max_list = {
+        get_layer_idx(k): v
+        for k, v in stats_max.items() if linear_name in k
+    }
+    min_list = {
+        get_layer_idx(k): v
+        for k, v in stats_min.items() if linear_name in k
+    }
+    if layers is None:
+        for i, (mmax, mmin) in enumerate(zip(max_list, min_list)):
+            draw_one(mmax, mmin, i)
+    else:
+        for layer_idx in layers:
+            draw_one(max_list[layer_idx], min_list[layer_idx], layer_idx)
+
+
+def draw(mode,
+         pretrained_model_name_or_path=None,
+         work_dir='work_dir',
+         use_input=True,
+         key='absmax',
+         linear_name=None,
+         layers=None,
+         force_calibrate=False):
+    """Draw specific type of plots based on the given mode.
+
+    Args:
+        mode (int): Plot mode. Can be 1, 2, 3 or 4.
+        pretrained_model_name_or_path (str, optional): Path or name of the
+            pretrained model. Required if `force_calibrate` is True or
+            no calibration data exists in `work_dir`. Defaults to None.
+        work_dir (str, optional): Working directory where intermediate files
+            are saved. Defaults to 'work_dir'.
+        use_input (bool, optional): Use the input or output of a linear layer.
+            Defaults to use the input of a linear layer.
+        key (str, optional): The specific feature to plot. Can be 'absmax',
+            'absmean', 'max', 'mean' or 'min'. Defaults to 'absmax'.
+        linear_name (str, optional): Name of the linear layer. Defaults to None
+        layers (list, optional): List of layers to draw. If None, all layers
+            will be drawn. Defaults to None.
+        force_calibrate (bool, optional): Whether to force recalibration
+            even if calibration data exists. Defaults to False.
+    """
+    if not os.path.exists(work_dir) or force_calibrate:
+        assert pretrained_model_name_or_path is not None
+        calibrate(pretrained_model_name_or_path, work_dir=work_dir)
+    if mode == 1:
+        draw1(linear_name, use_input, key, work_dir, layers=layers)
+    elif mode == 2:
+        assert pretrained_model_name_or_path
+        draw2(linear_name,
+              pretrained_model_name_or_path,
+              key,
+              work_dir,
+              layers=layers)
+    elif mode == 3:
+        draw3(linear_name, use_input, key, work_dir)
+    elif mode == 4:
+        draw4(linear_name, use_input, work_dir, layers=layers)
+
+
+if __name__ == '__main__':
+    fire.Fire(draw)

--- a/lmdeploy/lite/apis/quant_visualization.py
+++ b/lmdeploy/lite/apis/quant_visualization.py
@@ -3,13 +3,12 @@
 import os
 from pathlib import Path
 
-import fire
 import matplotlib.pyplot as plt
 import torch
 import torch.nn as nn
-from calibrate import calibrate
 from matplotlib import rc
 
+from lmdeploy.lite.apis.calibrate import calibrate
 from lmdeploy.lite.utils import collect_target_modules, load_hf_from_pretrained
 
 rc('mathtext', default='regular')
@@ -406,4 +405,5 @@ def draw(modes=None,
 
 
 if __name__ == '__main__':
+    import fire
     fire.Fire(draw)

--- a/lmdeploy/lite/apis/quant_visualization.py
+++ b/lmdeploy/lite/apis/quant_visualization.py
@@ -80,7 +80,8 @@ def draw1(linear_name,
         for k, v in stats.items() if linear_name in k
     }
     if layers is None:
-        for i, tensor in enumerate(tensor_list):
+        for i, tensor in tensor_list.items():
+            # for i, tensor in enumerate(tensor_list):
             draw_one(tensor, i)
     else:
         for layer_idx in layers:
@@ -163,11 +164,10 @@ def draw2(linear_name,
             elif key == 'absmean':
                 v = v.abs().mean(dim=0)[0]
             weight_list[get_layer_idx(k)] = v
-    # import pdb;pdb.set_trace()
 
     if layers is None:
-        for i, (act, weight) in enumerate(zip(act_list, weight_list)):
-            draw_one(act, weight, i)
+        for i in range(len(act_list)):
+            draw_one(act_list[i], weight_list[i], i)
     else:
         for layer_idx in layers:
             draw_one(act_list[layer_idx], weight_list[layer_idx], layer_idx)
@@ -253,8 +253,8 @@ def draw4(linear_name, use_input=True, work_dir='work_dir', layers=None):
         for k, v in stats_min.items() if linear_name in k
     }
     if layers is None:
-        for i, (mmax, mmin) in enumerate(zip(max_list, min_list)):
-            draw_one(mmax, mmin, i)
+        for i in range(len(max_list)):
+            draw_one(max_list[i], min_list[i], i)
     else:
         for layer_idx in layers:
             draw_one(max_list[layer_idx], min_list[layer_idx], layer_idx)

--- a/lmdeploy/lite/apis/quant_visualization.py
+++ b/lmdeploy/lite/apis/quant_visualization.py
@@ -62,11 +62,11 @@ def draw1(linear_name,
         plt.xlabel('dim')
         plt.ylabel(key)
         plt.title(f'layer{idx}  variance = {round(var, 4)}')
-        plt.savefig(f'{work_dir}/case_1/layer_{idx}.png')
+        plt.savefig(f'{work_dir}/case_1/{linear_name}/layer_{idx}.png')
         plt.clf()
 
     work_dir = Path(work_dir)
-    tmp_dir = work_dir / 'case_1'
+    tmp_dir = work_dir / 'case_1' / linear_name
     tmp_dir.mkdir(parents=True, exist_ok=True)
 
     if use_input:
@@ -137,11 +137,11 @@ def draw2(linear_name,
         ax.set_ylabel(f'Activation_{key}')
         ax2.set_ylabel(f'Weight_{key}')
         plt.title(f'layer{idx}  topk = {topk}')
-        plt.savefig(f'{work_dir}/case_2/layer_{idx}.png')
+        plt.savefig(f'{work_dir}/case_2/{linear_name}/layer_{idx}.png')
         plt.clf()
 
     work_dir = Path(work_dir)
-    tmp_dir = work_dir / 'case_2'
+    tmp_dir = work_dir / 'case_2' / linear_name
     tmp_dir.mkdir(parents=True, exist_ok=True)
 
     stats = torch.load(f'{work_dir}/inputs_stats.pth')
@@ -196,7 +196,11 @@ def draw3(linear_name, use_input=True, key='absmax', work_dir='work_dir'):
         plt.xlabel('layer')
         plt.ylabel(key)
         plt.title(f'linear_name {linear_name}')
-        plt.savefig(f'{work_dir}/case_3.png')
+        plt.savefig(f'{work_dir}/case_3/{linear_name}.png')
+
+    work_dir = Path(work_dir)
+    tmp_dir = work_dir / 'case_3'
+    tmp_dir.mkdir(parents=True, exist_ok=True)
 
     if use_input:
         stats = torch.load(f'{work_dir}/inputs_stats.pth')
@@ -232,11 +236,11 @@ def draw4(linear_name, use_input=True, work_dir='work_dir', layers=None):
         plt.xlabel('max')
         plt.ylabel('min')
         plt.title(f'layer{idx}')
-        plt.savefig(f'{work_dir}/case_4/layer_{idx}.png')
+        plt.savefig(f'{work_dir}/case_4/{linear_name}/layer_{idx}.png')
         plt.clf()
 
     work_dir = Path(work_dir)
-    tmp_dir = work_dir / 'case_4'
+    tmp_dir = work_dir / 'case_4' / linear_name
     tmp_dir.mkdir(parents=True, exist_ok=True)
     if use_input:
         stats = torch.load(f'{work_dir}/inputs_stats.pth')
@@ -261,17 +265,18 @@ def draw4(linear_name, use_input=True, work_dir='work_dir', layers=None):
 
 
 def draw(mode,
+         linear_name,
          pretrained_model_name_or_path=None,
          work_dir='work_dir',
          use_input=True,
          key='absmax',
-         linear_name=None,
          layers=None,
          force_calibrate=False):
     """Draw specific type of plots based on the given mode.
 
     Args:
         mode (int): Plot mode. Can be 1, 2, 3 or 4.
+        linear_name (str, optional): Name of the linear layer.
         pretrained_model_name_or_path (str, optional): Path or name of the
             pretrained model. Required if `force_calibrate` is True or
             no calibration data exists in `work_dir`. Defaults to None.
@@ -281,7 +286,6 @@ def draw(mode,
             Defaults to use the input of a linear layer.
         key (str, optional): The specific feature to plot. Can be 'absmax',
             'absmean', 'max', 'mean' or 'min'. Defaults to 'absmax'.
-        linear_name (str, optional): Name of the linear layer. Defaults to None
         layers (list, optional): List of layers to draw. If None, all layers
             will be drawn. Defaults to None.
         force_calibrate (bool, optional): Whether to force recalibration

--- a/lmdeploy/lite/apis/quant_visualization.py
+++ b/lmdeploy/lite/apis/quant_visualization.py
@@ -6,10 +6,11 @@ from pathlib import Path
 import fire
 import matplotlib.pyplot as plt
 import torch
+import torch.nn as nn
 from calibrate import calibrate
 from matplotlib import rc
 
-from lmdeploy.lite.utils import load_hf_from_pretrained
+from lmdeploy.lite.utils import collect_target_modules, load_hf_from_pretrained
 
 rc('mathtext', default='regular')
 
@@ -32,7 +33,87 @@ def get_layer_idx(name):
     return int(name.split('.')[2])
 
 
-def draw1(linear_name,
+def get_linear_input_or_output(linear_name, stats):
+    """Retrieves the input or output data for a specific linear layer from a
+    statistics dictionary (stats).
+
+    Args:
+        linear_name (str, optional): Name of the linear layer for which
+            the visualization will be created. If not provided, it will
+            process all available layers.
+
+        stats (dict): A dictionary containing the statistics for each layer.
+            Each key is the layer's name and its value is a dictionary that
+            maps the layer's index to its corresponding statistics.
+    """
+
+    if linear_name is None:
+        acts = {}
+        for k, v in stats.items():
+            linear_name = k.split('.')[-1]
+            if linear_name in acts:
+                acts[linear_name].update({get_layer_idx(k): v})
+            else:
+                acts[linear_name] = {get_layer_idx(k): v}
+    else:
+        acts = {
+            linear_name: {
+                get_layer_idx(k): v
+                for k, v in stats.items() if linear_name in k
+            }
+        }
+
+    return acts
+
+
+def get_linear_weights(linear_name, model, key):
+    """Fetches specific statistics (based on the provided key) for the weights
+    of a specified linear layer in a given model. If `linear_name` is None, the
+    function retrieves these statistics for all linear layers.
+
+    The function supports the following keys: 'absmax', 'absmean', 'max',
+    'mean', 'min'.
+
+    Args:
+        linear_name (str, optional): Name of the linear layer for which
+            the visualization will be created. If not provided, it will
+            process all available layers.
+        model (torch.nn.Module): CasualLM model from which the weights
+            will be retrieved.
+        key (str): The specific feature to plot. Can be 'absmax',
+            'absmean', 'max', 'mean' or 'min'. Defaults to 'absmax'.
+    """
+    layer_type = LAYER_TYPE_MAP[type(model).__name__]
+    name2layer = collect_target_modules(model, layer_type)
+    name2fc = {}
+    for l_name, layer in name2layer.items():
+        name2fc.update(collect_target_modules(layer, nn.Linear, prefix=l_name))
+    weights = {}
+    for name, module in name2fc.items():
+        if linear_name is None or linear_name in name:
+            l_name = linear_name or name.split('.')[-1]
+            if key == 'absmax':
+                v = module.weight.detach().abs().max(dim=0)[0]
+            elif key == 'absmean':
+                v = module.weight.detach().abs().mean(dim=0)[0]
+            elif key == 'max':
+                v = module.weight.detach().max(dim=0)[0]
+            elif key == 'mean':
+                v = module.weight.detach().mean(dim=0)[0]
+            elif key == 'min':
+                v = module.weight.detach().min(dim=0)[0]
+            else:
+                raise NotImplementedError(
+                    "Support key in ['absmax', 'absmean', 'max', 'mean', "
+                    f"'min'], but got key = {key}")
+            if l_name in weights:
+                weights[l_name].update({get_layer_idx(name): v})
+            else:
+                weights[l_name] = {get_layer_idx(name): v}
+    return weights
+
+
+def draw1(linear_name=None,
           use_input=True,
           key='absmax',
           work_dir='work_dir',
@@ -41,7 +122,9 @@ def draw1(linear_name,
     value of a linear layer at different layers.
 
     Args:
-        linear_name (str): Name of the linear layer.
+        linear_name (str, optional): Name of the linear layer for which
+            the visualization will be created. If not provided, it will
+            process all available layers.
         use_input (bool, optional): Use the input or output of a linear layer.
             Defaults to use the input of a linear layer.
         key (str, optional): The specific feature to plot. Can be 'absmax',
@@ -52,7 +135,7 @@ def draw1(linear_name,
             all layers will be drawn. Defaults to None.
     """
 
-    def draw_one(tensor, idx):
+    def draw_one(tensor, idx, linear_name):
         tensor = tensor.to('cpu')
         dim = tensor.shape[0]
         x = list(range(dim))
@@ -62,11 +145,13 @@ def draw1(linear_name,
         plt.xlabel('dim')
         plt.ylabel(key)
         plt.title(f'layer{idx}  variance = {round(var, 4)}')
-        plt.savefig(f'{work_dir}/case_1/{linear_name}/layer_{idx}.png')
+        (tmp_dir / linear_name).mkdir(parents=True, exist_ok=True)
+        plt.savefig(tmp_dir / linear_name / f'layer_{idx}.png')
         plt.clf()
 
     work_dir = Path(work_dir)
-    tmp_dir = work_dir / 'case_1' / linear_name
+    name = 'linear_input' if use_input else 'linear_output'
+    tmp_dir = work_dir / 'visualization' / f'case_1_{name}_{key}'
     tmp_dir.mkdir(parents=True, exist_ok=True)
 
     if use_input:
@@ -75,17 +160,15 @@ def draw1(linear_name,
         stats = torch.load(f'{work_dir}/outputs_stats.pth')
     assert key in stats
     stats = stats[key]
-    tensor_list = {
-        get_layer_idx(k): v
-        for k, v in stats.items() if linear_name in k
-    }
-    if layers is None:
-        for i, tensor in tensor_list.items():
-            # for i, tensor in enumerate(tensor_list):
-            draw_one(tensor, i)
-    else:
-        for layer_idx in layers:
-            draw_one(tensor_list[layer_idx], layer_idx)
+
+    acts = get_linear_input_or_output(linear_name, stats)
+    for linear_name, act_dict in acts.items():
+        if layers is None:
+            for i, act in act_dict.items():
+                draw_one(act, i, linear_name)
+        else:
+            for i in layers:
+                draw_one(act_dict[i], i, linear_name)
 
 
 def draw2(linear_name,
@@ -97,7 +180,9 @@ def draw2(linear_name,
     activations and weights.
 
     Args:
-        linear_name (str): Name of the linear layer.
+        linear_name (str, optional): Name of the linear layer for which
+            the visualization will be created. If not provided, it will
+            process all available layers.
         model_path (str): The name or path of the model to be loaded.
         key (str, optional): The specific feature to plot. Can be 'absmax',
             'absmean', 'max', 'mean' or 'min'. Defaults to 'absmax'.
@@ -107,7 +192,7 @@ def draw2(linear_name,
             all layers will be drawn. Defaults to None.
     """
 
-    def draw_one(act, weight, idx, topk=100):
+    def draw_one(act, weight, idx, linear_name, topk=100):
         act = act.to('cpu').float()
         weight = weight.to('cpu').float()
         assert act.shape[0] == weight.shape[
@@ -137,40 +222,34 @@ def draw2(linear_name,
         ax.set_ylabel(f'Activation_{key}')
         ax2.set_ylabel(f'Weight_{key}')
         plt.title(f'layer{idx}  topk = {topk}')
-        plt.savefig(f'{work_dir}/case_2/{linear_name}/layer_{idx}.png')
+        (tmp_dir / linear_name).mkdir(parents=True, exist_ok=True)
+        plt.savefig(tmp_dir / linear_name / f'layer_{idx}.png')
         plt.clf()
 
     work_dir = Path(work_dir)
-    tmp_dir = work_dir / 'case_2' / linear_name
+    tmp_dir = work_dir / 'visualization' / f'case_2_linear_input_{key}'
     tmp_dir.mkdir(parents=True, exist_ok=True)
 
     stats = torch.load(f'{work_dir}/inputs_stats.pth')
     assert key in stats
     stats = stats[key]
-    act_list = {
-        get_layer_idx(k): v
-        for k, v in stats.items() if linear_name in k
-    }
+
+    acts = get_linear_input_or_output(linear_name, stats)
 
     model = load_hf_from_pretrained(model_path,
                                     torch_dtype=torch.float16,
                                     trust_remote_code=True)
 
-    weight_list = {}
-    for k, v in model.state_dict().items():
-        if linear_name in k and 'weight' in k:
-            if key == 'absmax':
-                v = v.abs().max(dim=0)[0]
-            elif key == 'absmean':
-                v = v.abs().mean(dim=0)[0]
-            weight_list[get_layer_idx(k)] = v
+    weights = get_linear_weights(linear_name, model, key)
 
-    if layers is None:
-        for i in range(len(act_list)):
-            draw_one(act_list[i], weight_list[i], i)
-    else:
-        for layer_idx in layers:
-            draw_one(act_list[layer_idx], weight_list[layer_idx], layer_idx)
+    for linear_name in acts.keys():
+        act_dict, weights_dict = acts[linear_name], weights[linear_name]
+        if layers is None:
+            for i in range(len(act_dict)):
+                draw_one(act_dict[i], weights_dict[i], i, linear_name)
+        else:
+            for i in layers:
+                draw_one(act_dict[i], weights_dict[i], i, linear_name)
 
 
 def draw3(linear_name, use_input=True, key='absmax', work_dir='work_dir'):
@@ -179,7 +258,9 @@ def draw3(linear_name, use_input=True, key='absmax', work_dir='work_dir'):
     at different layers.
 
     Args:
-        linear_name (str): Name of the linear layer.
+        linear_name (str, optional): Name of the linear layer for which
+            the visualization will be created. If not provided, it will
+            process all available layers.
         use_input (bool, optional): Use the input or output of a linear layer.
             Defaults to use the input of a linear layer.
         key (str, optional): The specific feature to plot. Can be 'absmax',
@@ -192,14 +273,15 @@ def draw3(linear_name, use_input=True, key='absmax', work_dir='work_dir'):
         all_data = []
         for val in tensor_list.values():
             all_data.append(val.to('cpu').numpy())
-        plt.boxplot(all_data, None, None, None, 20)  # codespell-ignore
+        plt.boxplot(all_data, None, None, None, 20)
         plt.xlabel('layer')
         plt.ylabel(key)
         plt.title(f'linear_name {linear_name}')
-        plt.savefig(f'{work_dir}/case_3/{linear_name}.png')
+        plt.savefig(tmp_dir / f'{linear_name}.png')
 
     work_dir = Path(work_dir)
-    tmp_dir = work_dir / 'case_3'
+    name = 'linear_input' if use_input else 'linear_output'
+    tmp_dir = work_dir / 'visualization' / f'case_3_{name}_{key}'
     tmp_dir.mkdir(parents=True, exist_ok=True)
 
     if use_input:
@@ -208,11 +290,10 @@ def draw3(linear_name, use_input=True, key='absmax', work_dir='work_dir'):
         stats = torch.load(f'{work_dir}/outputs_stats.pth')
     assert key in stats
     stats = stats[key]
-    tensor_list = {
-        get_layer_idx(k): v
-        for k, v in stats.items() if linear_name in k
-    }
-    draw_one(tensor_list)
+
+    acts = get_linear_input_or_output(linear_name, stats)
+    for linear_name, act_dict in acts.items():
+        draw_one(act_dict)
 
 
 def draw4(linear_name, use_input=True, work_dir='work_dir', layers=None):
@@ -220,7 +301,9 @@ def draw4(linear_name, use_input=True, work_dir='work_dir', layers=None):
     maximum and minimum values of activations.
 
     Args:
-        linear_name (str): Name of the linear layer.
+        linear_name (str, optional): Name of the linear layer for which
+            the visualization will be created. If not provided, it will
+            process all available layers.
         use_input (bool, optional): Use the input or output of a linear layer.
             Defaults to use the input of a linear layer.
         work_dir (str, optional): Working directory where intermediate files
@@ -229,54 +312,62 @@ def draw4(linear_name, use_input=True, work_dir='work_dir', layers=None):
             all layers will be drawn. Defaults to None.
     """
 
-    def draw_one(tensor_max, tensor_min, idx):
+    def draw_one(tensor_max, tensor_min, idx, linear_name):
         tensor_max = tensor_max.to('cpu').numpy()
         tensor_min = tensor_min.to('cpu').numpy()
         plt.scatter(tensor_max, tensor_min)
         plt.xlabel('max')
         plt.ylabel('min')
         plt.title(f'layer{idx}')
-        plt.savefig(f'{work_dir}/case_4/{linear_name}/layer_{idx}.png')
+        (tmp_dir / linear_name).mkdir(parents=True, exist_ok=True)
+        plt.savefig(tmp_dir / linear_name / f'layer_{idx}.png')
         plt.clf()
 
     work_dir = Path(work_dir)
-    tmp_dir = work_dir / 'case_4' / linear_name
+    name = 'linear_input' if use_input else 'linear_output'
+    tmp_dir = work_dir / 'visualization' / f'case_4_{name}'
     tmp_dir.mkdir(parents=True, exist_ok=True)
+
     if use_input:
         stats = torch.load(f'{work_dir}/inputs_stats.pth')
     else:
         stats = torch.load(f'{work_dir}/outputs_stats.pth')
     stats_max = stats['max']
     stats_min = stats['min']
-    max_list = {
-        get_layer_idx(k): v
-        for k, v in stats_max.items() if linear_name in k
-    }
-    min_list = {
-        get_layer_idx(k): v
-        for k, v in stats_min.items() if linear_name in k
-    }
-    if layers is None:
-        for i in range(len(max_list)):
-            draw_one(max_list[i], min_list[i], i)
-    else:
-        for layer_idx in layers:
-            draw_one(max_list[layer_idx], min_list[layer_idx], layer_idx)
+    acts_max = get_linear_input_or_output(linear_name, stats_max)
+    acts_min = get_linear_input_or_output(linear_name, stats_min)
+    for linear_name in acts_max.keys():
+        acts_max_cur_linear = acts_max[linear_name]
+        acts_min_cur_linear = acts_min[linear_name]
+        if layers is None:
+            for i in range(len(acts_max_cur_linear)):
+                draw_one(acts_max_cur_linear[i], acts_min_cur_linear[i], i,
+                         linear_name)
+        else:
+            for i in layers:
+                draw_one(acts_max_cur_linear[i], acts_min_cur_linear[i], i,
+                         linear_name)
 
 
-def draw(mode,
-         linear_name,
+def draw(modes=None,
+         linear_name=None,
          pretrained_model_name_or_path=None,
          work_dir='work_dir',
          use_input=True,
          key='absmax',
          layers=None,
          force_calibrate=False):
-    """Draw specific type of plots based on the given mode.
+    """This function is used to visualize data from a pre-trained transformer
+    model. Depending on the mode, it will leverage different visualization
+    functions (draw1, draw2, draw3, draw4).
 
     Args:
-        mode (int): Plot mode. Can be 1, 2, 3 or 4.
-        linear_name (str, optional): Name of the linear layer.
+        mode (list of int, optional): Modes determine which visualization
+            function(s) will be used. If not provided, all four visualization
+            functions are executed. Available modes: [1, 2, 3, 4].
+        linear_name (str, optional): Name of the linear layer for which
+            the visualization will be created. If not provided, it will
+            process all available layers.
         pretrained_model_name_or_path (str, optional): Path or name of the
             pretrained model. Required if `force_calibrate` is True or
             no calibration data exists in `work_dir`. Defaults to None.
@@ -294,19 +385,24 @@ def draw(mode,
     if not os.path.exists(work_dir) or force_calibrate:
         assert pretrained_model_name_or_path is not None
         calibrate(pretrained_model_name_or_path, work_dir=work_dir)
-    if mode == 1:
-        draw1(linear_name, use_input, key, work_dir, layers=layers)
-    elif mode == 2:
-        assert pretrained_model_name_or_path
-        draw2(linear_name,
-              pretrained_model_name_or_path,
-              key,
-              work_dir,
-              layers=layers)
-    elif mode == 3:
-        draw3(linear_name, use_input, key, work_dir)
-    elif mode == 4:
-        draw4(linear_name, use_input, work_dir, layers=layers)
+    if modes is None:
+        modes = [1, 2, 3, 4]
+    elif isinstance(modes, int):
+        modes = [modes]
+    for mode in modes:
+        if mode == 1:
+            draw1(linear_name, use_input, key, work_dir, layers=layers)
+        elif mode == 2:
+            assert pretrained_model_name_or_path
+            draw2(linear_name,
+                  pretrained_model_name_or_path,
+                  key,
+                  work_dir,
+                  layers=layers)
+        elif mode == 3:
+            draw3(linear_name, use_input, key, work_dir)
+        elif mode == 4:
+            draw4(linear_name, use_input, work_dir, layers=layers)
 
 
 if __name__ == '__main__':

--- a/lmdeploy/lite/utils/__init__.py
+++ b/lmdeploy/lite/utils/__init__.py
@@ -11,6 +11,7 @@ from .calib_dataloader import get_calib_loaders
 from .collect import (bimap_name_mod, collect_target_modules,
                       collect_target_weights)
 from .global_avail import GlobalAvailMixin
+from .load import load_hf_from_pretrained
 
 __all__ = [
     'cal_qparams_per_channel_absmax', 'cal_qparams_per_channel_minmax',
@@ -18,5 +19,5 @@ __all__ = [
     'cal_qparams_per_tensor_absmax', 'cal_qparams_per_tensor_minmax',
     'QParams', 'get_calib_loaders', 'collect_target_modules',
     'collect_target_weights', 'GlobalAvailMixin', 'split_decoder_layer_inputs',
-    'bimap_name_mod', 'concat_decoder_layer_outputs'
+    'bimap_name_mod', 'concat_decoder_layer_outputs', 'load_hf_from_pretrained'
 ]

--- a/lmdeploy/lite/utils/load.py
+++ b/lmdeploy/lite/utils/load.py
@@ -1,0 +1,40 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+
+from accelerate import infer_auto_device_map, init_empty_weights
+from transformers import AutoModelForCausalLM
+
+from lmdeploy.lite.utils import collect_target_modules
+from lmdeploy.pytorch.model import LoadWoInit
+
+LAYER_TYPE_MAP = {
+    'InternLMForCausalLM': 'InternLMDecoderLayer',
+    'QWenLMHeadModel': 'QWenBlock',
+    'BaiChuanForCausalLM': 'DecoderLayer',
+    'LlamaForCausalLM': 'LlamaDecoderLayer',
+}
+
+
+def load_hf_from_pretrained(pretrained_model_name_or_path, **kwargs):
+    with init_empty_weights():
+        # Load model
+        model = AutoModelForCausalLM.from_pretrained(
+            pretrained_model_name_or_path, **kwargs)
+        model.config.use_cache = False
+    layer_type = LAYER_TYPE_MAP[type(model).__name__]
+    decoder_layers = collect_target_modules(model, layer_type)
+    # Infer device map
+    device_map = infer_auto_device_map(model,
+                                       no_split_module_classes=[layer_type])
+    for name in device_map.keys():
+        if name in decoder_layers or 'lm_head' in name:
+            device_map[name] = 'cpu'
+        else:
+            device_map[name] = 0
+    if 'device_map' in kwargs:
+        kwargs.pop('device_map')
+    with LoadWoInit():
+        model = AutoModelForCausalLM.from_pretrained(
+            pretrained_model_name_or_path, device_map=device_map, **kwargs)
+        model.config.use_cache = False
+
+    return model


### PR DESCRIPTION
## Usage
1. Draw the first type of plot which shows the absmax/absmean/max/mean/min value of a linear layer at different layers.

For instance, the code below presents the visualized results of computing the absolute maximum value across multiple tokens specifically for the input of all 'q_proj' linear layers within DecoderLayers 0 and 1
```
lmdeploy quant_visualization draw \
    --modes 1  \
    --pretrained_model_name_or_path internlm/internlm-chat-7b \
    --work_dir work_dir \
    --use_input \
    --key absmax \
    --linear_name q_proj \
    --layers 0,1
```
Output:
![image](https://github.com/InternLM/lmdeploy/assets/41630003/6baeb823-ca05-425f-9eab-3f8a1438e5e0)

2. Draw the second type of plot which shows the relationship between activations and weights.

For instance, the code below presents the visualized results of the relationship between the input of all 'q_proj' linear layers within DecoderLayers 0 and 1, and their corresponding weights.

```
lmdeploy quant_visualization draw \
    --modes 2  \
    --pretrained_model_name_or_path internlm/internlm-chat-7b \
    --work_dir work_dir \
    --key absmax \
    --linear_name q_proj \
    --layers 0,1
```
![image](https://github.com/InternLM/lmdeploy/assets/41630003/8a80c43c-34da-4df1-90ca-4495553e952d)

3. Draw the third type of plot which is a boxplot showing the absmax/absmean/max/mean/min value of the input or output of a linear layer at different layers.

For instance, the code below displays a boxplot showcasing the absolute maximum values computed across multiple tokens, specifically for the input of all 'q_proj' linear layers.

```
lmdeploy quant_visualization draw \
    --modes 3  \
    --pretrained_model_name_or_path internlm/internlm-chat-7b \
    --work_dir work_dir \
    --key absmax \
    --linear_name q_proj \
    --use_input
```
![image](https://github.com/InternLM/lmdeploy/assets/41630003/50ea4c5a-a523-4ad1-b1c0-9f071a98793f)

4. Draw the fourth type of plot which shows the relationship between maximum and minimum values of activations.

For instance, the code below illustrates the computed maximum and minimum values across multiple tokens, specifically for the input of all 'q_proj' linear layers within DecoderLayers 0 and 1.

```
lmdeploy quant_visualization draw \
    --modes 4  \
    --pretrained_model_name_or_path internlm/internlm-chat-7b \
    --work_dir work_dir \
    --linear_name q_proj \
    --use_input
    --layers 0,1
```
![image](https://github.com/InternLM/lmdeploy/assets/41630003/3c938de2-0f28-4fdd-85bc-139224c459d7)
