### PR TITLE
fix: gradio gr.Button.update deprecated after 4.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ accelerate
 datasets
 fastapi
 fire
-gradio
+gradio<4.0.0
 mmengine
 numpy
 pybind11


### PR DESCRIPTION

## Motivation

gradio >= 4.0.0 doesn't support `gr.Button.update`

## Modification

make gradio version < 4.0.0

