### PR TITLE
add cli to list the supported model names

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ LMDeploy is a toolkit for compressing, deploying, and serving LLM, developed by 
 
 ## Supported Models
 
-`LMDeploy` has two inference backends, `Pytorch` and `TurboMind`.
+`LMDeploy` has two inference backends, `Pytorch` and `TurboMind`. You can run `lmdeploy list` to check the supported model names.
 
 ### TurboMind
 

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -53,7 +53,7 @@ LMDeploy 由 [MMDeploy](https://github.com/open-mmlab/mmdeploy) 和 [MMRazor](ht
 
 ## 支持的模型
 
-`LMDeploy` 支持 `TurboMind` 和 `Pytorch` 两种推理后端
+`LMDeploy` 支持 `TurboMind` 和 `Pytorch` 两种推理后端。运行`lmdeploy list`可查看支持模型列表
 
 ### TurboMind
 

--- a/lmdeploy/cli/cli.py
+++ b/lmdeploy/cli/cli.py
@@ -49,6 +49,29 @@ class CLI(object):
                 quant_path=quant_path,
                 group_size=group_size)
 
+    def list(self, is_torch: bool = False):
+        """List supported model names.
+
+        Examples 1:
+            lmdeploy list
+
+        Examples 2:
+            lmdeploy list --is_torch True
+
+        Args:
+            is_torch (bool): A flag to list model names for
+                turbomind or pytorch.
+        """
+        if is_torch:
+            model_names = ['llama', 'llama2', 'internlm-7b']
+        else:
+            from lmdeploy.model import MODELS
+            model_names = list(MODELS.module_dict.keys())
+            model_names = [n for n in model_names if n.lower() not in ['base']]
+        model_names.sort()
+        print('Supported model names:')
+        print('\n'.join(model_names))
+
 
 def run():
     """The entry point of running LMDeploy CLI."""


### PR DESCRIPTION


## Motivation

add cli to list the supported model names

## Modification

Add sub cli `lmdeploy list`


## BC-breaking (Optional)

None

## Use cases (Optional)

#### show help info: `lmdeploy list --help`
```
NAME
    lmdeploy list - List supported model names.

SYNOPSIS
    lmdeploy list <flags>

DESCRIPTION
    Examples 1:
        lmdeploy list

    Examples 2:
        lmdeploy list --is_torch True

FLAGS
    -i, --is_torch=IS_TORCH
        Type: bool
        Default: False
        A flag to list model names for turbomind or pytorch.
```
####  List the supported model names for turbomind: `lmdeploy list`
```
Supported model names:
baichuan-7b
baichuan2-7b
codellama
internlm
internlm-20b
internlm-chat
internlm-chat-20b
internlm-chat-7b
internlm-chat-7b-8k
llama
llama2
puyu
qwen-14b
qwen-7b
solar
vicuna
```
####  List the supported model names for pytorch: `lmdeploy list --is_torch True`
```
Supported model names:
internlm-7b
llama
llama2
```
## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
