### PR TITLE
support frequency penalty

### DIFF
--- a/examples/cpp/llama/llama_config.ini
+++ b/examples/cpp/llama/llama_config.ini
@@ -16,6 +16,7 @@ top_p=0.0 ; p value for top p sampling
 temperature=1.0 ; Use for sampling
 repetition_penalty=1.00 ; Use for sampling
 presence_penalty=0.0 ; Only one of repetition_penalty and presence_penalty are allowed.
+frequency_penalty=0.0
 len_penalty=0.0
 beam_search_diversity_rate=0.0
 ; PJLM start/end ids

--- a/examples/cpp/llama/llama_triton_example.cc
+++ b/examples/cpp/llama/llama_triton_example.cc
@@ -47,6 +47,7 @@ struct RequestParam {
     float                  len_penalty;
     float                  repetition_penalty;
     float                  presence_penalty;
+    float                  frequency_penalty;
     int                    min_length;
     unsigned long long int random_seed;
     int                    start_id;
@@ -225,6 +226,13 @@ broadCastRequest(const std::vector<int>& v_start_ids,
                 {"presence_penalty",
                  triton::Tensor{triton::MEMORY_CPU, triton::TYPE_FP32, std::vector<size_t>{1}, presence_penalty_ptr}});
         }
+        if (param.frequency_penalty != 0.0f) {
+            float* frequency_penalty_ptr = new float(param.frequency_penalty);
+            pointer_record->push_back(frequency_penalty_ptr);
+            request_list[device_id]->insert(
+                {"frequency_penalty",
+                 triton::Tensor{triton::MEMORY_CPU, triton::TYPE_FP32, std::vector<size_t>{1}, frequency_penalty_ptr}});
+        }
         int* min_length_ptr = new int(param.min_length);
         pointer_record->push_back(min_length_ptr);
         request_list[device_id]->insert(
@@ -300,6 +308,7 @@ prepareRequest(std::string ini_name, const int node_id, const int gpu_count, std
     param.len_penalty                = reader.GetFloat("request", "len_penalty");
     param.repetition_penalty         = reader.GetFloat("request", "repetition_penalty", 1.0f);
     param.presence_penalty           = reader.GetFloat("request", "presence_penalty", 0.0f);
+    param.frequency_penalty           = reader.GetFloat("request", "frequency_penalty", 0.0f);
     param.min_length                 = reader.GetInteger("request", "min_length", 0);
     param.random_seed                = (unsigned long long int)0;
     param.start_id                   = start_id;

--- a/src/turbomind/kernels/penalty_types.h
+++ b/src/turbomind/kernels/penalty_types.h
@@ -27,6 +27,7 @@ enum class RepetitionPenaltyType
 {
     Additive,        // the presence penalty
     Multiplicative,  // the repetition penalty
+    MultiAdditive,   // the frequency penalty
     None             // No repetition penalty.
 };
 
@@ -37,6 +38,8 @@ inline float getDefaultPenaltyValue(RepetitionPenaltyType penalty_type)
             return 0.0f;
         case RepetitionPenaltyType::Multiplicative:
             return 1.0f;
+        case RepetitionPenaltyType::MultiAdditive:
+            return 0.0f;
         default:
             break;
     }

--- a/src/turbomind/kernels/sampling_penalty_kernels.h
+++ b/src/turbomind/kernels/sampling_penalty_kernels.h
@@ -51,6 +51,18 @@ void invokeBatchApplyRepetitionPenalty(T*                          logits,
                                        cudaStream_t                stream);
 
 template<typename T>
+void invokeBatchApplyFrequencyPenalty(T*                          logits,
+                                      const float*                penalties,
+                                      const int*                  output_ids,
+                                      const int                   batch_size,
+                                      const int                   local_batch_size,
+                                      const int                   vocab_size,
+                                      const int*                  input_lengths,
+                                      const int                   max_input_length,
+                                      const int                   step,
+                                      cudaStream_t                stream);
+
+template<typename T>
 void invokeApplyTemperaturePenalty(T*           logits,
                                    const T*     bias,
                                    const float  temperature,

--- a/src/turbomind/models/llama/LlamaBatch.cc
+++ b/src/turbomind/models/llama/LlamaBatch.cc
@@ -624,6 +624,8 @@ void LlamaBatch<T>::AllocatePersistantBuffer(size_t max_batch_size)
         {"runtime_top_p", (std::byte*)h_runtime_top_p_, nullptr},
         {"temperature", (std::byte*)h_temperature_, nullptr},
         {"repetition_penalty", (std::byte*)h_repetition_penalty_, nullptr},
+        {"presence_penalty", (std::byte*)h_repetition_penalty_, nullptr},
+        {"frequency_penalty", (std::byte*)h_repetition_penalty_, nullptr},
     };
 
     for (auto& s : states_) {


### PR DESCRIPTION
## Motivation

support more sampling ways, like presence_penalty(already implemented but never used) and frequency_penalty(supported in vllm).

## Modification

I mainly add a kernal function in `src/turbomind/kernels/sampling_penalty_kernels.cu`, which implemented frequency penalty sampling method. Then enable it by add `presence_penalty` and `frequency_penalty` param in `src/turbomind/models/llama/LlamaBatch.cc`, where I just reuse the buffer `h_repetition_penalty_`.