### PR TITLE
fix extra colon in InternLMChat7B template

### DIFF
--- a/lmdeploy/model.py
+++ b/lmdeploy/model.py
@@ -238,7 +238,7 @@ class InternLMChat7B(BaseModel):
             role = message['role']
             content = message['content']
             ret += f'{eval(f"self.{role}")}{content}{eox_map[role]}'
-        ret += f'{self.assistant}:'
+        ret += f'{self.assistant}'
         return ret
 
 


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily receiving feedbacks. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Wrong implementation in `InternLMChat7B.messages2prompt`, because `self.assistant` already has colon at end.

## Modification

As PR

## BC-breaking (Optional)

No

## Use cases (Optional)

No

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
