### PR TITLE
Support building docker image manually in CI

### DIFF
--- a/.github/md-link-config.json
+++ b/.github/md-link-config.json
@@ -1,6 +1,8 @@
 {
   "ignorePatterns": [
-
+    {
+      "pattern": "^https://www.reddit.com/"
+    },
     {
       "pattern": "^https://developer.nvidia.com/"
     },

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -34,7 +34,6 @@ jobs:
     env:
       TAG_PREFIX: "openmmlab/lmdeploy"
       TAG: "openmmlab/lmdeploy:latest"
-      REPO_REF: ""
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -14,6 +14,18 @@ on:
       - main
     tags:
       - "v*.*.*"
+  workflow_dispatch:
+    inputs:
+      repo_ref:
+        required: true
+        description: 'Set branch or tag or commit id. Default is ""'
+        type: string
+        default: ''
+      image_tag:
+        required: true
+        description: 'Set docker image tag. Default is "latest"'
+        type: string
+        default: latest
 
 jobs:
   publish_docker_image:
@@ -21,9 +33,13 @@ jobs:
     environment: 'prod'
     env:
       TAG_PREFIX: "openmmlab/lmdeploy"
+      TAG: "openmmlab/lmdeploy:latest"
+      REPO_REF: ""
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+        with:
+          ref: ${{github.event.inputs.repo_ref}}
       - name: Free disk space
         uses: jlumbroso/free-disk-space@main
         with:
@@ -39,24 +55,28 @@ jobs:
       - name: Get docker info
         run: |
           docker info
+          # remove http extraheader
+          git config --local --unset "http.https://github.com/.extraheader"
       - name: Login to Docker Hub
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Build and push the latest Docker image
+      - name: Update docker TAG from workflow input
+        if: github.event_name == 'workflow_dispatch'
         run: |
-          export TAG=$TAG_PREFIX:latest
+          export TAG=$TAG_PREFIX:${{github.event.inputs.image_tag}}
           echo $TAG
-          docker build docker/ -t ${TAG} --no-cache
-          docker push $TAG
           echo "TAG=${TAG}" >> $GITHUB_ENV
+      - name: Build and push Docker image
+        run: |
+          echo $TAG
+          docker build . -f docker/Dockerfile -t ${TAG} --no-cache
+          docker push $TAG
       - name: Push docker image with released tag
         if: startsWith(github.ref, 'refs/tags/') == true
         run: |
-          export LMDEPLOY_VERSION=$(python3 -c "import sys; sys.path.append('lmdeploy');from version import __version__;print(__version__)")
-          echo $LMDEPLOY_VERSION
-          export RELEASE_TAG=${TAG_PREFIX}:v${LMDEPLOY_VERSION}
+          export RELEASE_TAG=${TAG_PREFIX}:${{github.ref_name}}
           echo $RELEASE_TAG
           docker tag $TAG $RELEASE_TAG
           docker push $RELEASE_TAG

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,10 +9,12 @@ RUN python3 -m pip install --no-cache-dir cmake packaging
 
 ENV NCCL_LAUNCH_MODE=GROUP
 
-ARG VERSION=main
+# Should be in the lmdeploy root directory when building docker image
+COPY . /opt/lmdeploy
 
-RUN git clone --depth=1 --branch=${VERSION} https://github.com/InternLM/lmdeploy.git &&\
-    cd lmdeploy &&\
+WORKDIR /opt/lmdeploy
+
+RUN cd /opt/lmdeploy &&\
     python3 -m pip install --no-cache-dir -r requirements.txt &&\
     mkdir -p build && cd build &&\
     cmake .. \


### PR DESCRIPTION
## Motivation

For easy building docker image.

## Modification

update dockerfile and ci

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

1. Automatically: a push to main branch or a released tag
2. Manually: can select a branch, tag, or SHA to build.

### Example run logs:
https://github.com/RunningLeon/lmdeploy/actions/runs/7176686142/job/19541954316

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
4. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
5. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
6. The documentation has been modified accordingly, like docstring or example tutorials.
