### PR TITLE
export "num_tokens_per_iter", "max_prefill_iters" and etc when converting a model

### DIFF
--- a/lmdeploy/turbomind/deploy/target_model/base.py
+++ b/lmdeploy/turbomind/deploy/target_model/base.py
@@ -54,7 +54,6 @@ class TurbomindModelConfig:
     cache_block_seq_len: int = 128
     cache_chunk_size: int = -1
     num_tokens_per_iter: int = 1
-    num_tokens_per_iter: int = 1
     max_prefill_iters: int = 1
     extra_tokens_per_iter: int = 0
     use_context_fmha: int = 1

--- a/lmdeploy/turbomind/deploy/target_model/base.py
+++ b/lmdeploy/turbomind/deploy/target_model/base.py
@@ -53,7 +53,7 @@ class TurbomindModelConfig:
     cache_max_entry_count: float = 0.5
     cache_block_seq_len: int = 128
     cache_chunk_size: int = -1
-    num_tokens_per_iter: int = 1
+    num_tokens_per_iter: int = 0
     max_prefill_iters: int = 1
     extra_tokens_per_iter: int = 0
     use_context_fmha: int = 1

--- a/lmdeploy/turbomind/deploy/target_model/base.py
+++ b/lmdeploy/turbomind/deploy/target_model/base.py
@@ -52,7 +52,11 @@ class TurbomindModelConfig:
     step_length: int = 1
     cache_max_entry_count: float = 0.5
     cache_block_seq_len: int = 128
-    cache_chunk_size: int = 1
+    cache_chunk_size: int = -1
+    num_tokens_per_iter: int = 1
+    num_tokens_per_iter: int = 1
+    max_prefill_iters: int = 1
+    extra_tokens_per_iter: int = 0
     use_context_fmha: int = 1
     quant_policy: int = 0
     max_position_embeddings: int = 0


### PR DESCRIPTION
## Motivation
```
    num_tokens_per_iter: int = 1
    max_prefill_iters: int = 1
    extra_tokens_per_iter: int = 0
```
are used to adjust the performance of prefill

## Modification

base.py

## BC-breaking (Optional)

No

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
