### PR TITLE
[Feature]Merge `lmdeploy lite calibrate` and `lmdeploy lite auto_awq`

### DIFF
--- a/docs/en/quantization/w4a16.md
+++ b/docs/en/quantization/w4a16.md
@@ -76,32 +76,17 @@ python benchmark/profile_generation.py \
 
 ## 4-bit Weight Quantization
 
-It includes two steps:
-
-- generate quantization parameter
-- quantize model according to the parameter
-
-### Step 1: Generate Quantization Parameter
-
-```shell
-lmdeploy lite calibrate \
-  --model $HF_MODEL \
-  --calib_dataset 'c4' \             # Calibration dataset, supports c4, ptb, wikitext2, pileval
-  --calib_samples 128 \              # Number of samples in the calibration set, if memory is insufficient, you can appropriately reduce this
-  --calib_seqlen 2048 \              # Length of a single piece of text, if memory is insufficient, you can appropriately reduce this
-  --work_dir $WORK_DIR \             # Folder storing Pytorch format quantization statistics parameters and post-quantization weight
-```
-
-### Step2: Quantize Weights
-
 LMDeploy employs AWQ algorithm for model weight quantization.
+
+After the quantization is complete, the quantized model is saved to `$WORK_DIR`. Then you can proceed with model inference according to the instructions in the ["4-Bit Weight Model Inference"](#4-bit-llm-model-inference) section.
 
 ```shell
 lmdeploy lite auto_awq \
   --model $HF_MODEL \
+  --calib_dataset 'c4' \             # Calibration dataset, supports c4, ptb, wikitext2, pileval
+  --calib_samples 128 \              # Number of samples in the calibration set, if memory is insufficient, you can appropriately reduce this
+  --calib_seqlen 2048 \              # Length of a single piece of text, if memory is insufficient, you can appropriately reduce this
   --w_bits 4 \                       # Bit number for weight quantization
   --w_group_size 128 \               # Group size for weight quantization statistics
-  --work_dir $WORK_DIR \             # Directory saving quantization parameters from Step 1
+  --work_dir $WORK_DIR \             # Folder storing Pytorch format quantization statistics parameters and post-quantization weight
 ```
-
-After the quantization is complete, the quantized model is saved to `$WORK_DIR`. Then you can proceed with model inference according to the instructions in the ["4-Bit Weight Model Inference"](#4-bit-llm-model-inference) section.

--- a/docs/zh_cn/quantization/w4a16.md
+++ b/docs/zh_cn/quantization/w4a16.md
@@ -74,30 +74,15 @@ python benchmark/profile_generation.py \
 
 ## 4bit 权重量化
 
-4bit 权重量化包括 2 步：
-
-- 生成量化参数
-- 根据量化参数，量化模型权重
-
-### 第一步：生成量化参数
-
-```shell
-lmdeploy lite calibrate \
-  --model $HF_MODEL \
-  --calib_dataset 'c4' \             # 校准数据集，支持 c4, ptb, wikitext2, pileval
-  --calib_samples 128 \              # 校准集的样本数，如果显存不够，可以适当调小
-  --calib_seqlen 2048 \              # 单条的文本长度，如果显存不够，可以适当调小
-  --work_dir $WORK_DIR \             # 保存 Pytorch 格式量化统计参数和量化后权重的文件夹
-```
-
-### 第二步：量化权重模型
-
-LMDeploy 使用 AWQ 算法对模型权重进行量化。在执行下面的命令时，需要把步骤1的`$WORK_DIR`传入。量化结束后，权重文件也会存放在这个目录中。然后就可以根据 ["4bit权重模型推理"](#4bit-权重模型推理)章节的说明，进行模型推理。
+LMDeploy 使用 AWQ 算法对模型权重进行量化。量化结束后，权重文件也会存放在`$WORK_DIR`中。然后就可以根据 ["4bit权重模型推理"](#4bit-权重模型推理)章节的说明，进行模型推理。
 
 ```shell
 lmdeploy lite auto_awq \
   --model $HF_MODEL \
+  --calib_dataset 'c4' \             # 校准数据集，支持 c4, ptb, wikitext2, pileval
+  --calib_samples 128 \              # 校准集的样本数，如果显存不够，可以适当调小
+  --calib_seqlen 2048 \              # 单条的文本长度，如果显存不够，可以适当调小
   --w_bits 4 \                       # 权重量化的 bit 数
   --w_group_size 128 \               # 权重量化分组统计尺寸
-  --work_dir $WORK_DIR \             # 步骤 1 保存量化参数的目录
+  --work_dir $WORK_DIR \             # 保存 Pytorch 格式量化统计参数和量化后权重的文件夹
 ```

--- a/lmdeploy/cli/lite.py
+++ b/lmdeploy/cli/lite.py
@@ -7,6 +7,9 @@ class SubCliLite(object):
     def auto_awq(self,
                  model: str,
                  work_dir: str,
+                 calib_dataset: str = 'c4',
+                 calib_samples: int = 128,
+                 calib_seqlen: int = 2048,
                  w_bits: int = 4,
                  w_sym: bool = False,
                  w_group_size: int = 128,
@@ -16,6 +19,12 @@ class SubCliLite(object):
         Args:
             model (str): The path of model in hf format.
             work_dir (str): The working directory to save results.
+            calib_dataset (str, optional): The calibration dataset name.
+                Defaults to 'c4'.
+            calib_samples (int, optional): The number of samples for
+                calibration. Defaults to 128.
+            calib_seqlen (int, optional): The sequence length for calibration.
+                Defaults to 2048.
             w_bits (int): Bit number for weight quantization.
             w_sym (bool): Whether to do symmetric quantization.
             w_group_size (int): Group size for weight quantization statistics.

--- a/lmdeploy/lite/apis/calibrate.py
+++ b/lmdeploy/lite/apis/calibrate.py
@@ -119,6 +119,11 @@ def calibrate(model: str,
             Defaults to './work_dir'.
         device (str, optional): The device to be used for calculation.
             Defaults to 'cuda'.
+
+    Returns:
+        model (nn.Module): The loaded huggingface model.
+        tokenizer : The loaded hugginface tokenizer.
+        work_dir (str): The working directory for outputs.
     """
 
     assert calib_dataset in ['c4', 'ptb', 'wikitext2', 'pileval'], \


### PR DESCRIPTION
Before this PR, AWQ quantization needs to execute two commands
```bash
lmdeploy lite calibrate  $HF_MODEL
lmdeploy lite auto_awq $HF_MODEL
```
In this PR, AWQ quantization only needs to execute one command
```bash
lmdeploy lite auto_awq $HF_MODEL
```