### PR TITLE
[Docs] Fix typo in `restful_api ` user guide

### DIFF
--- a/docs/zh_cn/restful_api.md
+++ b/docs/zh_cn/restful_api.md
@@ -56,7 +56,7 @@ LMDeploy 的 `/v1/chat/interactive` api 支持将对话内容管理在服务端�
 ```python
 from lmdeploy.serve.openai.api_client import APIClient
 api_client = APIClient('http://{server_ip}:{server_port}')
-for item in api_client.generate(prompt='hi'):
+for item in api_client.chat_interactive_v1(prompt='hi'):
     print(item)
 ```
 


### PR DESCRIPTION
fix ".generate" to ".chat_interactive_v1"