### PR TITLE
[Fix] Adapt to the pyTorch poc branch

### DIFF
--- a/lmdeploy/lite/apis/smooth_quant.py
+++ b/lmdeploy/lite/apis/smooth_quant.py
@@ -13,7 +13,7 @@ from lmdeploy.lite.quantization import CalibrationContext
 from lmdeploy.lite.quantization.awq import (FC_FCS_MAP, NORM_FCS_MAP,
                                             smooth_layers)
 from lmdeploy.lite.utils import collect_target_modules, get_calib_loaders
-from lmdeploy.pytorch_poc.models import QLinear, QRMSNorm
+from lmdeploy.pytorch.models import QLinear, QRMSNorm
 
 LAYER_TYPE_MAP = {
     'InternLMForCausalLM': 'InternLMDecoderLayer',
@@ -29,11 +29,9 @@ NORM_TYPE_MAP = {
 }
 
 MODEL_PATH_MAP = {
-    'InternLMForCausalLM':
-    './lmdeploy/pytorch_poc/modeling/modeling_internlm.py',
-    'LlamaForCausalLM': './lmdeploy/pytorch_poc/modeling/modeling_llama.py',
-    'BaiChuanForCausalLM':
-    './lmdeploy/pytorch_poc/modeling/modeling_baichuan.py'
+    'InternLMForCausalLM': './lmdeploy/pytorch/modeling/modeling_internlm.py',
+    'LlamaForCausalLM': './lmdeploy/pytorch/modeling/modeling_llama.py',
+    'BaiChuanForCausalLM': './lmdeploy/pytorch/modeling/modeling_baichuan.py'
 }
 
 AUTO_MAP = {

--- a/lmdeploy/lite/apis/smooth_quant.py
+++ b/lmdeploy/lite/apis/smooth_quant.py
@@ -4,15 +4,14 @@ import shutil
 
 import fire
 import torch
-from accelerate import (infer_auto_device_map, init_empty_weights,
-                        load_checkpoint_in_model)
 from torch import nn
-from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer
+from transformers import AutoTokenizer
 
 from lmdeploy.lite.quantization import CalibrationContext
 from lmdeploy.lite.quantization.awq import (FC_FCS_MAP, NORM_FCS_MAP,
                                             smooth_layers)
-from lmdeploy.lite.utils import collect_target_modules, get_calib_loaders
+from lmdeploy.lite.utils import (collect_target_modules, get_calib_loaders,
+                                 load_hf_from_pretrained)
 from lmdeploy.pytorch.models import QLinear, QRMSNorm
 
 LAYER_TYPE_MAP = {
@@ -114,35 +113,31 @@ def smooth_quant(model: str,
     tokenizer = AutoTokenizer.from_pretrained(model,
                                               use_fast=False,
                                               trust_remote_code=True)
-    hf_config = AutoConfig.from_pretrained(model, trust_remote_code=True)
-    checkpoint = hf_config._name_or_path
 
-    with init_empty_weights():
-        # Load model
-        model = AutoModelForCausalLM.from_pretrained(model,
-                                                     torch_dtype=torch.float16,
-                                                     trust_remote_code=True)
-        model.config.use_cache = False
+    model = load_hf_from_pretrained(model,
+                                    torch_dtype=torch.float16,
+                                    trust_remote_code=True)
+
+    model_type = type(model).__name__
+    if model_type not in LAYER_TYPE_MAP or model_type not in NORM_TYPE_MAP:
+        raise RuntimeError(
+            f'Currently, quantification and calibration of {model_type} are '
+            f'not supported. The supported model types are '
+            f"{', '.join(LAYER_TYPE_MAP.keys())}.")
+
+    if model_type == 'QWenLMHeadModel':
+        try:
+            import flash_attn  # noqa: F401
+        except ImportError:
+            raise RuntimeError(
+                'When using Qwen, you need to `pip install flash-attn` first, '
+                'otherwise calibration and quantification will not work '
+                'properly.')
 
     layer_type = LAYER_TYPE_MAP[type(model).__name__]
     norm_type = NORM_TYPE_MAP[type(model).__name__]
     fc2fcs = FC_FCS_MAP[layer_type]
     norm2fcs = NORM_FCS_MAP[layer_type]
-
-    decoder_layers = collect_target_modules(model, layer_type)
-
-    # Infer device map
-    device_map = infer_auto_device_map(model,
-                                       no_split_module_classes=[layer_type])
-    for name in device_map.keys():
-        if name in decoder_layers or 'lm_head' in name:
-            device_map[name] = 'cpu'
-        else:
-            device_map[name] = 0
-    load_checkpoint_in_model(model,
-                             checkpoint,
-                             device_map,
-                             dtype=torch.float16)
 
     inp_stats = calibrate(model, tokenizer, calib_dataset, calib_samples,
                           calib_seqlen, device)

--- a/lmdeploy/lite/utils/load.py
+++ b/lmdeploy/lite/utils/load.py
@@ -4,8 +4,8 @@ import torch
 from accelerate import infer_auto_device_map, init_empty_weights
 from transformers import AutoConfig, AutoModelForCausalLM
 
-from lmdeploy.legacy.pytorch.model import LoadWoInit
 from lmdeploy.lite.utils import collect_target_modules
+from lmdeploy.pytorch.accel import LoadNoInit
 
 LAYER_TYPE_MAP = {
     'InternLMForCausalLM': 'InternLMDecoderLayer',
@@ -44,7 +44,7 @@ def load_hf_from_pretrained(pretrained_model_name_or_path, **kwargs):
             device_map[name] = 0
     if 'device_map' in kwargs:
         kwargs.pop('device_map')
-    with LoadWoInit():
+    with LoadNoInit():
         model = AutoModelForCausalLM.from_pretrained(
             pretrained_model_name_or_path,
             device_map=device_map,

--- a/lmdeploy/lite/utils/load.py
+++ b/lmdeploy/lite/utils/load.py
@@ -4,8 +4,8 @@ import torch
 from accelerate import infer_auto_device_map, init_empty_weights
 from transformers import AutoConfig, AutoModelForCausalLM
 
+from lmdeploy.legacy.pytorch.model import LoadWoInit
 from lmdeploy.lite.utils import collect_target_modules
-from lmdeploy.pytorch.model import LoadWoInit
 
 LAYER_TYPE_MAP = {
     'InternLMForCausalLM': 'InternLMDecoderLayer',

--- a/lmdeploy/pytorch/chat.py
+++ b/lmdeploy/pytorch/chat.py
@@ -2,6 +2,7 @@
 
 import os
 import random
+from typing import List
 
 import fire
 
@@ -29,6 +30,21 @@ def valid_str(string, coding='utf-8'):
         bstr = bstr.replace(invalid_char, b'')
     ret = bstr.decode(encoding=coding, errors='ignore')
     return ret
+
+
+def _stop_words(stop_words: List[str], tokenizer: Tokenizer):
+    """Return a list of token ids corresponding to stop-words."""
+    if stop_words is None:
+        return None
+    assert isinstance(stop_words, List) and \
+        all(isinstance(elem, str) for elem in stop_words), \
+        f'stop_words must be a list but got {type(stop_words)}'
+    stop_words = [
+        tokenizer.encode(stop_word, False)[-1] for stop_word in stop_words
+    ]
+    assert isinstance(stop_words, List) and all(
+        isinstance(elem, int) for elem in stop_words), 'invalid stop_words'
+    return stop_words
 
 
 def main(
@@ -63,6 +79,7 @@ def main(
     step = 0
     seed = random.getrandbits(64)
     model = MODELS.get(model_name)()
+    stop_words = _stop_words(model.stop_words, tokenizer)
 
     while True:
         prompt = input_prompt()
@@ -91,7 +108,7 @@ def main(
                 repetition_penalty=repetition_penalty,
                 ignore_eos=False,
                 random_seed=seed,
-                stop_words=model.stop_words)
+                stop_words=stop_words)
             for outputs in generator.stream_infer(
                     session_id=session_id,
                     input_ids=input_ids,


### PR DESCRIPTION
## Usage
### Step 1 Obtain the SmoothQuant-processed W8A8 Quantized Model
In this step, we will run the smooth_quant.py script to generate a W8A8 quantized model that is processed by SmoothQuant. Execute the following command:

```
python3 -m lmdeploy.lite.apis.smooth_quant internlm/internlm-chat-7b ./work_dir/internlm-chat-7b-quant
```
This command generates a quantized model and saves it in the `./work_dir` directory.

### Step 2 Chat with quantized model
Once you have the quantized model, you can interact with it using the chat.py script. Run the following command:
```
python3 -m lmdeploy.pytorch.chat work_dir/internlm-chat-7b-quant internlm-chat
```
Upon executing this command, an interactive session starts where you can converse with your quantized model.
![image](https://github.com/InternLM/lmdeploy/assets/41630003/682d7b68-a4c8-4184-ab8e-f85887f58368)


## Procedure for Applying W8A8
1. **Smooth Weights**: Start by smoothing the weights of the Language Model (LLM). This process makes the weights more amenable to quantizing.
2. **Replace Modules**: Locate DecoderLayers and replace the modules RSMNorm and nn.Linear with QRSMNorm and QLinear modules respectively. These 'Q' modules are available in the lmdeploy/pytorch/models/q_modules.py file.
3. **Save the Quantized Model**: Once you've made the necessary replacements, save the new quantized model.

The script `lmdeploy/lite/apis/smooth_quant.py` accomplishes all three tasks detailed above. After saving, you can instantiate the quantized model by calling the `from_pretrained` interface.
