### PR TITLE
Move `api_server` dependencies from serve.txt to runtime.txt

### DIFF
--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -1,8 +1,12 @@
+fastapi
 fire
 mmengine-lite
 numpy
+pydantic>2.0.0
 safetensors
 sentencepiece
+shortuuid
 tiktoken
 torch
 transformers>=4.33.0
+uvicorn

--- a/requirements/serve.txt
+++ b/requirements/serve.txt
@@ -1,2 +1,3 @@
 gradio<4.0.0
+protobuf
 tritonclient[grpc]

--- a/requirements/serve.txt
+++ b/requirements/serve.txt
@@ -1,6 +1,2 @@
-fastapi
 gradio<4.0.0
-pydantic>2.0.0
-shortuuid
 tritonclient[grpc]
-uvicorn


### PR DESCRIPTION
## Motivation

To simplify the installation section in README, which will be modified later

