### PR TITLE
[Feature] Support w8a8 tp

### DIFF
--- a/lmdeploy/lite/apis/smooth_quant.py
+++ b/lmdeploy/lite/apis/smooth_quant.py
@@ -115,7 +115,9 @@ def smooth_quant(model: str,
     else:
         model.config.auto_map = AUTO_MAP[type(model).__name__]
 
-    model.save_pretrained(work_dir)
+    model.save_pretrained(work_dir,
+                          max_shard_size='2GB',
+                          safe_serialization=False)
     tokenizer.save_pretrained(work_dir)
 
     shutil.copy(MODEL_PATH_MAP[type(model).__name__], work_dir)

--- a/lmdeploy/pytorch/dist_utils.py
+++ b/lmdeploy/pytorch/dist_utils.py
@@ -64,6 +64,7 @@ def rowwise_parallelize_linear_fn(module: nn.Module,
         dist_param = torch.nn.Parameter(dist_tensor)
         module.register_parameter(name, dist_param)
 
+    # Weight, bias and scale are registered as buffer in QLinear
     for name, buffer in module.named_buffers():
         dist_spec = ([Shard(1)] if name == 'weight' else
                      [Replicate()]  # type: ignore[list-item]
@@ -107,6 +108,7 @@ def colwise_parallelize_linear_fn(module: nn.Module,
         dist_param = torch.nn.Parameter(dist_tensor)
         module.register_parameter(name, dist_param)
 
+    # Weight, bias and scale are registered as buffer in QLinear
     for name, buffer in module.named_buffers():
         dist_tensor = distribute_tensor(buffer, device_mesh, [Shard(0)])
         if to_local:

--- a/lmdeploy/pytorch/dist_utils.py
+++ b/lmdeploy/pytorch/dist_utils.py
@@ -28,7 +28,12 @@ def module_to_local(module: nn.Module):
         module_to_local(mod)
 
     for name, param in module.named_parameters(recurse=False):
-        module.register_parameter(name, nn.Parameter(try_to_local(param)))
+        dist_param = torch.Tensor._make_subclass(nn.Parameter,
+                                                 try_to_local(param), False)
+        if dist_param.dtype == torch.int8:
+            dist_param.__dict__.update({'requires_grad': False})
+        module.register_parameter(name, dist_param)
+        # module.register_parameter(name, nn.Parameter(try_to_local(param)))
 
     for name, buf in module.named_buffers(recurse=False):
         module.register_buffer(name, try_to_local(buf))
@@ -61,8 +66,20 @@ def rowwise_parallelize_linear_fn(module: nn.Module,
             if name == 'bias':
                 # rowwise linear would add bias more than ones.
                 dist_tensor /= device_mesh.size()
-        dist_param = torch.nn.Parameter(dist_tensor)
+        dist_param = torch.Tensor._make_subclass(nn.Parameter, dist_tensor,
+                                                 False)
+        if dist_param.dtype == torch.int8:
+            dist_param.__dict__.update({'requires_grad': False})
+        # dist_param = torch.nn.Parameter(dist_tensor)
         module.register_parameter(name, dist_param)
+
+    for name, buffer in module.named_buffers():
+        dist_spec = [Replicate()]
+
+        dist_tensor = distribute_tensor(buffer, device_mesh, dist_spec)
+        if to_local:
+            dist_tensor = try_to_local(dist_tensor)
+        module.register_buffer(name, dist_tensor)
 
 
 def colwise_parallelize_linear_fn(module: nn.Module,
@@ -86,8 +103,18 @@ def colwise_parallelize_linear_fn(module: nn.Module,
         dist_tensor = distribute_tensor(param, device_mesh, [Shard(0)])
         if to_local:
             dist_tensor = try_to_local(dist_tensor)
-        dist_param = torch.nn.Parameter(dist_tensor)
+        dist_param = torch.Tensor._make_subclass(nn.Parameter, dist_tensor,
+                                                 False)
+        if dist_param.dtype == torch.int8:
+            dist_param.__dict__.update({'requires_grad': False})
+        # dist_param = torch.nn.Parameter(dist_tensor)
         module.register_parameter(name, dist_param)
+
+    for name, buffer in module.named_buffers():
+        dist_tensor = distribute_tensor(buffer, device_mesh, [Shard(0)])
+        if to_local:
+            dist_tensor = try_to_local(dist_tensor)
+        module.register_buffer(name, dist_tensor)
 
 
 def _partition_module(
@@ -154,7 +181,10 @@ def replicate_module(model: nn.Module, device_mesh: DeviceMesh):
         param = distribute_tensor(param,
                                   device_mesh=device_mesh,
                                   placements=[Replicate()]).to_local()
-        param = nn.Parameter(param)
+        param = torch.Tensor._make_subclass(nn.Parameter, param, False)
+        # param = nn.Parameter(param)
+        if param.dtype == torch.int8:
+            param.__dict__.update({'requires_grad': False})
         model.register_parameter(name, param)
 
     for name, buf in model.named_buffers(recurse=False):

--- a/lmdeploy/pytorch/engine/model_agent.py
+++ b/lmdeploy/pytorch/engine/model_agent.py
@@ -355,36 +355,36 @@ def _tp_build_model(
         dist.broadcast_object_list(config_list)
         return config_list[0]
 
-    try:
-        config = AutoConfig.from_pretrained(
-            model_path, trust_remote_code=trust_remote_code)
-        torch_dtype = _get_torch_dtype(config)
-        with init_empty_weights():
-            model = AutoModelForCausalLM.from_config(
-                config,
-                torch_dtype=torch_dtype,
-                trust_remote_code=trust_remote_code)
-            model.eval()
-            model.config.use_cache = True
+    # try:
+    config = AutoConfig.from_pretrained(model_path,
+                                        trust_remote_code=trust_remote_code)
+    torch_dtype = _get_torch_dtype(config)
+    with init_empty_weights():
+        model = AutoModelForCausalLM.from_config(
+            config,
+            torch_dtype=torch_dtype,
+            trust_remote_code=trust_remote_code)
+        model.eval()
+        model.config.use_cache = True
 
-        checkpoints = _get_checkpoints(model_path)
-        patched_model = patch(
-            model,
-            extra_args=_PATCH_ARG_NAMES,
-            rank=rank,
-            world_size=world_size,
-            checkpoints=checkpoints,
-        )
+    checkpoints = _get_checkpoints(model_path)
+    patched_model = patch(
+        model,
+        extra_args=_PATCH_ARG_NAMES,
+        rank=rank,
+        world_size=world_size,
+        checkpoints=checkpoints,
+    )
 
-        _update_cache_config(model_config, cache_config)
-        cache_config = _broadcast_config(cache_config)
-        cache_engine = CacheEngine(cache_config,
-                                   model_config,
-                                   rank=rank,
-                                   world_size=world_size)
-    except Exception as e:
-        error_code = 1
-        error_type = e
+    _update_cache_config(model_config, cache_config)
+    cache_config = _broadcast_config(cache_config)
+    cache_engine = CacheEngine(cache_config,
+                               model_config,
+                               rank=rank,
+                               world_size=world_size)
+    # except Exception as e:
+    #     error_code = 1
+    #     error_type = e
 
     # response
     error_code = torch.tensor(error_code).cuda(rank)

--- a/lmdeploy/pytorch/engine/model_agent.py
+++ b/lmdeploy/pytorch/engine/model_agent.py
@@ -355,36 +355,36 @@ def _tp_build_model(
         dist.broadcast_object_list(config_list)
         return config_list[0]
 
-    # try:
-    config = AutoConfig.from_pretrained(model_path,
-                                        trust_remote_code=trust_remote_code)
-    torch_dtype = _get_torch_dtype(config)
-    with init_empty_weights():
-        model = AutoModelForCausalLM.from_config(
-            config,
-            torch_dtype=torch_dtype,
-            trust_remote_code=trust_remote_code)
-        model.eval()
-        model.config.use_cache = True
+    try:
+        config = AutoConfig.from_pretrained(
+            model_path, trust_remote_code=trust_remote_code)
+        torch_dtype = _get_torch_dtype(config)
+        with init_empty_weights():
+            model = AutoModelForCausalLM.from_config(
+                config,
+                torch_dtype=torch_dtype,
+                trust_remote_code=trust_remote_code)
+            model.eval()
+            model.config.use_cache = True
 
-    checkpoints = _get_checkpoints(model_path)
-    patched_model = patch(
-        model,
-        extra_args=_PATCH_ARG_NAMES,
-        rank=rank,
-        world_size=world_size,
-        checkpoints=checkpoints,
-    )
+        checkpoints = _get_checkpoints(model_path)
+        patched_model = patch(
+            model,
+            extra_args=_PATCH_ARG_NAMES,
+            rank=rank,
+            world_size=world_size,
+            checkpoints=checkpoints,
+        )
 
-    _update_cache_config(model_config, cache_config)
-    cache_config = _broadcast_config(cache_config)
-    cache_engine = CacheEngine(cache_config,
-                               model_config,
-                               rank=rank,
-                               world_size=world_size)
-    # except Exception as e:
-    #     error_code = 1
-    #     error_type = e
+        _update_cache_config(model_config, cache_config)
+        cache_config = _broadcast_config(cache_config)
+        cache_engine = CacheEngine(cache_config,
+                                   model_config,
+                                   rank=rank,
+                                   world_size=world_size)
+    except Exception as e:
+        error_code = 1
+        error_type = e
 
     # response
     error_code = torch.tensor(error_code).cuda(rank)

--- a/lmdeploy/pytorch/models/patch.py
+++ b/lmdeploy/pytorch/models/patch.py
@@ -240,6 +240,16 @@ def _load_state_dict(
                                                    requires_grad=False)
                 model.register_parameter(k, new_param)
 
+            buffer_names = [
+                name for name, _ in model.named_buffers(recurse=False)
+            ]
+            if k in buffer_names:
+                if rank == 0:
+                    new_buffer = state_dict[full_k].to(v.dtype).to(device)
+                else:
+                    new_buffer = torch.empty_like(v, device=device)
+                model.register_buffer(k, new_buffer)
+
     def _check_need_dist(model):
         """check need dist."""
         need_dist = not getattr(model, '__tp_distributed__', False)

--- a/lmdeploy/pytorch/models/patch.py
+++ b/lmdeploy/pytorch/models/patch.py
@@ -240,6 +240,7 @@ def _load_state_dict(
                                                    requires_grad=False)
                 model.register_parameter(k, new_param)
 
+            # Weight, bias and scale are registered as buffer in QLinear
             buffer_names = [
                 name for name, _ in model.named_buffers(recurse=False)
             ]

--- a/lmdeploy/pytorch/models/q_modules.py
+++ b/lmdeploy/pytorch/models/q_modules.py
@@ -47,7 +47,6 @@ class QRMSNorm(nn.Module):
         eps = mod.variance_epsilon
         q_mod = cls(hidden_size, eps)
         q_mod.weight = nn.Parameter(mod.weight.detach())
-        # q_mod.to('cpu')
         return q_mod
 
     def forward(self, hidden_states):
@@ -84,20 +83,17 @@ class QLinear(nn.Module):
         super().__init__()
         self.in_features = in_features
         self.out_features = out_features
-        q_weight = torch.Tensor._make_subclass(
-            nn.Parameter,
+        self.register_buffer(
+            'weight',
             torch.empty((out_features, in_features),
                         device=device,
-                        dtype=torch.int8), False)
-        q_weight.__dict__.update({'requires_grad': False})
-        self.weight = q_weight
+                        dtype=torch.int8))
         self.register_buffer(
             'scale',
             torch.empty((out_features, 1), device=device, dtype=torch.float32))
         if bias:
-            self.bias = nn.Parameter(torch.empty(out_features,
-                                                 **factory_kwargs),
-                                     requires_grad=False)
+            self.register_buffer('bias',
+                                 torch.empty(out_features, **factory_kwargs))
         else:
             self.register_parameter('bias', None)
 
@@ -116,7 +112,6 @@ class QLinear(nn.Module):
         q_mod.scale = scale
         if mod.bias is not None:
             q_mod.bias.data = mod.bias.detach()
-        # q_mod.to('cpu')
         return q_mod
 
     def forward(self, input):


### PR DESCRIPTION
## Modification

主要修改为在切分权重的时候需要考虑到 buffer ，因为在 QLinear 中，Weight, Bias, Scale 都是以 buffer 形式存储的。

如果把 Weight, Bias, Scale 都注册为 Parameter ，可能需要统一修改 register parameter 的逻辑。因为 Weight 需要是 int8 类型的，将其注册为 Parameter 的时候需要将requires_grad 设为False，而 accelerator 的 [init_on_device](https://github.com/huggingface/accelerate/blob/main/src/accelerate/big_modeling.py#L123) 中重写了注册 Parameter 的机制，导致 ``` self.weight = nn.Parameter(a_int8_tensor, requires_grad=False)```这种写法是不起效果的。可能需要将所有涉及注册 Parameter 的地方都改成下面这种写法：
```
param = torch.Tensor._make_subclass(nn.Parameter, param, False)
if param.dtype == torch.int8:
      param.__dict__.update({'requires_grad': False})
module.register_parameter(name, param)
```
