### PR TITLE
fix pipeline stop_words type error

### DIFF
--- a/lmdeploy/serve/async_engine.py
+++ b/lmdeploy/serve/async_engine.py
@@ -266,7 +266,7 @@ class AsyncEngine:
         assert isinstance(prompts, List), 'prompts should be a list'
         if gen_config is None:
             gen_config = GenerationConfig()
-        if isinstance(gen_config, GenerationConfig):
+        if type(gen_config) is GenerationConfig:
             gen_config = EngineGenerationConfig.From(gen_config,
                                                      self.tokenizer)
         prompt_num = len(prompts)

--- a/lmdeploy/serve/async_engine.py
+++ b/lmdeploy/serve/async_engine.py
@@ -333,7 +333,7 @@ class AsyncEngine:
             self.id2step[str(session_id)] = step
         if gen_config is None:
             gen_config = GenerationConfig()
-        if isinstance(gen_config, GenerationConfig):
+        if type(gen_config) is GenerationConfig:
             gen_config = EngineGenerationConfig.From(gen_config,
                                                      self.tokenizer)
         prompt = messages


### PR DESCRIPTION
Fix the runtime error of `stop_words must be a list of str but got`