### PR TITLE
print help for cli in case of failure

### DIFF
--- a/lmdeploy/cli/cli.py
+++ b/lmdeploy/cli/cli.py
@@ -17,7 +17,9 @@ class CLI(object):
                         action='version',
                         version=__version__)
     subparsers = parser.add_subparsers(
-        title='Commands', description='lmdeploy has following commands:')
+        title='Commands',
+        description='lmdeploy has following commands:',
+        dest='command')
 
     @staticmethod
     def add_parser_convert():

--- a/lmdeploy/cli/entrypoint.py
+++ b/lmdeploy/cli/entrypoint.py
@@ -17,4 +17,15 @@ def run():
     if 'run' in dir(args):
         args.run(args)
     else:
-        args.print_help()
+        try:
+            args.print_help()
+        except AttributeError:
+            command = args.command
+            if command == 'serve':
+                SubCliServe.parser.print_help()
+            elif command == 'lite':
+                SubCliLite.parser.print_help()
+            elif command == 'chat':
+                SubCliChat.parser.print_help()
+            else:
+                parser.print_help()


### PR DESCRIPTION

## Motivation

run `lmdeploy`  without other args

### before this PR
```
Traceback (most recent call last):
  File "/data/conda-envs/envs/pt2.0py38/bin/lmdeploy", line 33, in <module>
    sys.exit(load_entry_point('lmdeploy', 'console_scripts', 'lmdeploy')())
  File "/data/mm2.0/lmdeploy/lmdeploy/cli/entrypoint.py", line 20, in run
    args.print_help()
AttributeError: 'Namespace' object has no attribute 'print_help'

```

### after this PR
```
usage: lmdeploy [-h] [-v] {chat,lite,serve,convert,list,check_env} ...

The CLI provides a unified API for converting, compressing and deploying large language models.

optional arguments:
  -h, --help            show this help message and exit
  -v, --version         show program's version number and exit

Commands:
  lmdeploy has following commands:

  {chat,lite,serve,convert,list,check_env}
    chat                Chat with pytorch or turbomind engine.
    lite                Compressing and accelerating LLMs with lmdeploy.lite module
    serve               Serve LLMs with gradio, openai API or triton server.
    convert             Convert LLMs to turbomind format.
    list                List the supported model names.
    check_env           Check the environmental information.
```

## Modification

Please briefly describe what modification is made in this PR.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
