### PR TITLE
fix embedding copy size

### DIFF
--- a/src/turbomind/models/llama/LlamaV2.cc
+++ b/src/turbomind/models/llama/LlamaV2.cc
@@ -177,12 +177,18 @@ void LlamaV2<T>::updateEmbedding(T* decoder_input, const int bsz, const int* h_i
         for (int j = embeddings.size() - 1; j >= 0; j--) {
             int begin = ranges[j].first;
             int end   = ranges[j].second;
+            if (seq.cache_len + h_input_length[i] - 1 < begin) {
+                continue;
+            }
             if (end <= seq.cache_len) {
                 break;
             }
-            int    off_dst   = std::max(0, begin - seq.cache_len);
-            int    off_src   = std::max(0, seq.cache_len - begin);
-            size_t byte_size = (end - begin - off_src) * hidden_units_ * sizeof(T);
+            int off_dst = std::max(0, begin - seq.cache_len);
+            int off_src = std::max(0, seq.cache_len - begin);
+            // calculate union of [begin, end) and [seq.cache_len, seq.cache_len + h_input_length[i])
+            begin            = std::max(begin, seq.cache_len);
+            end              = std::min(end, seq.cache_len + h_input_length[i]);
+            size_t byte_size = (end - begin) * hidden_units_ * sizeof(T);
             T*     dst_ptr   = decoder_input + off_dst * hidden_units_;
             auto   src_ptr   = embeddings[j].data() + off_src * hidden_units_ * sizeof(T);
             cudaMemcpyAsync(dst_ptr, src_ptr, byte_size, cudaMemcpyDefault, stream_);

--- a/src/turbomind/models/llama/LlamaV2.cc
+++ b/src/turbomind/models/llama/LlamaV2.cc
@@ -182,7 +182,7 @@ void LlamaV2<T>::updateEmbedding(T* decoder_input, const int bsz, const int* h_i
             }
             int    off_dst   = std::max(0, begin - seq.cache_len);
             int    off_src   = std::max(0, seq.cache_len - begin);
-            size_t byte_size = (end - begin) * hidden_units_ * sizeof(T);
+            size_t byte_size = (end - begin - off_src) * hidden_units_ * sizeof(T);
             T*     dst_ptr   = decoder_input + off_dst * hidden_units_;
             auto   src_ptr   = embeddings[j].data() + off_src * hidden_units_ * sizeof(T);
             cudaMemcpyAsync(dst_ptr, src_ptr, byte_size, cudaMemcpyDefault, stream_);

--- a/src/turbomind/models/llama/LlamaV2.cc
+++ b/src/turbomind/models/llama/LlamaV2.cc
@@ -185,7 +185,7 @@ void LlamaV2<T>::updateEmbedding(T* decoder_input, const int bsz, const int* h_i
             }
             int off_dst = std::max(0, begin - seq.cache_len);
             int off_src = std::max(0, seq.cache_len - begin);
-            // calculate union of [begin, end) and [seq.cache_len, seq.cache_len + h_input_length[i])
+            // calculate intersection of [begin, end) and [seq.cache_len, seq.cache_len + h_input_length[i])
             begin            = std::max(begin, seq.cache_len);
             end              = std::min(end, seq.cache_len + h_input_length[i]);
             size_t byte_size = (end - begin) * hidden_units_ * sizeof(T);


### PR DESCRIPTION
## Motivation

embedding 的拷贝逻辑有两个问题：

1) 靠后的embedding不需要拷贝
2) byte_size 的计算有问题，因为不一定拷贝完整的embedding

考虑下面的情况

```
cacheed: C, length=7
h_input: X, length=5
normal token: A
embedding token: B
embedding offset: [4, 9), [12, 16)

CCCCCXXXXXXX        // cached + h_input
AAAABBBBBAAABBBBAAA // context
```

针对1), 第二个embedding, 7 + 5 - 1 < 12，所以不需要拷贝
针对2), 要更新 begin, end. begin = max(4, 5) = 5; (end - begin) = 4, 拷贝4个元素


