### PR TITLE
Update adapters cli argument

### DIFF
--- a/lmdeploy/cli/chat.py
+++ b/lmdeploy/cli/chat.py
@@ -1,6 +1,7 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 from .cli import CLI
-from .utils import ArgumentHelper, DefaultsAndTypesHelpFormatter, convert_args
+from .utils import (ArgumentHelper, DefaultsAndTypesHelpFormatter,
+                    convert_args, get_lora_adapters)
 
 
 class SubCliChat(object):
@@ -69,11 +70,11 @@ class SubCliChat(object):
         """Chat with PyTorch inference engine through terminal."""
         from lmdeploy.messages import PytorchEngineConfig
         from lmdeploy.pytorch.chat import run_chat
-
+        adapters = get_lora_adapters(args.adapters)
         engine_config = PytorchEngineConfig(model_name=args.model_name,
                                             tp=args.tp,
                                             session_len=args.session_len,
-                                            adapters=args.adapters)
+                                            adapters=adapters)
         run_chat(args.model_path,
                  engine_config,
                  trust_remote_code=args.trust_remote_code)

--- a/lmdeploy/cli/chat.py
+++ b/lmdeploy/cli/chat.py
@@ -13,6 +13,7 @@ class SubCliChat(object):
 
     @staticmethod
     def add_parser_torch():
+        """Add parser for torch command."""
         parser = SubCliChat.subparsers.add_parser(
             'torch',
             formatter_class=DefaultsAndTypesHelpFormatter,
@@ -38,6 +39,7 @@ class SubCliChat(object):
 
     @staticmethod
     def add_parser_turbomind():
+        """Add parser for turbomind command."""
         parser = SubCliChat.subparsers.add_parser(
             'turbomind',
             formatter_class=DefaultsAndTypesHelpFormatter,

--- a/lmdeploy/cli/cli.py
+++ b/lmdeploy/cli/cli.py
@@ -23,6 +23,7 @@ class CLI(object):
 
     @staticmethod
     def add_parser_convert():
+        """Add parser for convert command."""
         parser = CLI.subparsers.add_parser(
             'convert',
             formatter_class=DefaultsAndTypesHelpFormatter,
@@ -65,6 +66,7 @@ class CLI(object):
 
     @staticmethod
     def add_parser_list():
+        """Add parser for list command."""
         parser = CLI.subparsers.add_parser(
             'list',
             formatter_class=DefaultsAndTypesHelpFormatter,
@@ -76,6 +78,7 @@ class CLI(object):
 
     @staticmethod
     def add_parser_checkenv():
+        """Add parser for check_env command."""
         parser = CLI.subparsers.add_parser(
             'check_env',
             formatter_class=DefaultsAndTypesHelpFormatter,

--- a/lmdeploy/cli/lite.py
+++ b/lmdeploy/cli/lite.py
@@ -19,6 +19,7 @@ class SubCliLite(object):
 
     @staticmethod
     def add_parser_auto_awq():
+        """Add parser for auto_awq command."""
         parser = SubCliLite.subparsers.add_parser(
             'auto_awq',
             formatter_class=DefaultsAndTypesHelpFormatter,
@@ -48,6 +49,7 @@ class SubCliLite(object):
 
     @staticmethod
     def add_parser_calibrate():
+        """Add parser for calibrate command."""
         parser = SubCliLite.subparsers.add_parser(
             'calibrate',
             formatter_class=DefaultsAndTypesHelpFormatter,
@@ -65,6 +67,7 @@ class SubCliLite(object):
 
     @staticmethod
     def add_parser_smooth_quant():
+        """Add parser for smooth_quant command."""
         parser = SubCliLite.subparsers.add_parser(
             'smooth_quant',
             formatter_class=DefaultsAndTypesHelpFormatter,
@@ -86,6 +89,7 @@ class SubCliLite(object):
 
     @staticmethod
     def add_parser_kv_qparams():
+        """Add parser for kv_qparams command."""
         parser = SubCliLite.subparsers.add_parser(
             'kv_qparams',
             formatter_class=DefaultsAndTypesHelpFormatter,

--- a/lmdeploy/cli/serve.py
+++ b/lmdeploy/cli/serve.py
@@ -17,6 +17,7 @@ class SubCliServe:
 
     @staticmethod
     def add_parser_gradio():
+        """Add parser for gradio command."""
         parser = SubCliServe.subparsers.add_parser(
             'gradio',
             formatter_class=DefaultsAndTypesHelpFormatter,
@@ -67,6 +68,7 @@ class SubCliServe:
 
     @staticmethod
     def add_parser_api_server():
+        """Add parser for api_server command."""
         parser = SubCliServe.subparsers.add_parser(
             'api_server',
             formatter_class=DefaultsAndTypesHelpFormatter,
@@ -146,6 +148,7 @@ class SubCliServe:
 
     @staticmethod
     def add_parser_api_client():
+        """Add parser for api_client command."""
         parser = SubCliServe.subparsers.add_parser(
             'api_client',
             formatter_class=DefaultsAndTypesHelpFormatter,
@@ -159,6 +162,7 @@ class SubCliServe:
 
     @staticmethod
     def add_parser_triton_client():
+        """Add parser for triton_client command."""
         parser = SubCliServe.subparsers.add_parser(
             'triton_client',
             formatter_class=DefaultsAndTypesHelpFormatter,

--- a/lmdeploy/cli/utils.py
+++ b/lmdeploy/cli/utils.py
@@ -5,8 +5,10 @@ from typing import List
 
 
 class DefaultsAndTypesHelpFormatter(argparse.HelpFormatter):
+    """Formatter to output default value and type in help information."""
 
     def _get_help_string(self, action):
+        """Add default and type info into help."""
         help = action.help
         if '%(default)' not in action.help:
             if action.default is not argparse.SUPPRESS:
@@ -33,10 +35,10 @@ def get_lora_adapters(adapters: List[str]):
     """Parse lora adapers from cli input.
 
     Args:
-        adapters (List[str]): Command input string of lora adaters paths.
+        adapters (List[str]): CLI input string of lora adapter path(s).
 
     Returns:
-        Dict[str,str] or None
+        Dict[str,str] or None: Parsed lora adapter path(s).
     """
     if not adapters:
         return None
@@ -49,10 +51,10 @@ def get_lora_adapters(adapters: List[str]):
             name, path = path.split('=', 1)
         output[name] = path
     else:
-        for pairs in adapters:
-            assert '=' in pairs, f'Multiple lora paths must in format of ' \
-                                 f'xx==yy zz==ww. But given: {pairs}'
-            name, path = pairs.strip().split('=', 1)
+        for pair in adapters:
+            assert '=' in pair, f'Multiple lora paths must in format of ' \
+                                 f'xxx=yyy. But given: {pair}'
+            name, path = pair.strip().split('=', 1)
             assert name not in output, f'Multiple lora paths with ' \
                                        f'repeated lora name: {name}'
             output[name] = path
@@ -64,6 +66,8 @@ class ArgumentHelper:
 
     @staticmethod
     def model_name(parser):
+        """Add argument model_name to parser."""
+
         return parser.add_argument(
             '--model-name',
             type=str,
@@ -75,6 +79,8 @@ class ArgumentHelper:
 
     @staticmethod
     def model_format(parser):
+        """Add argument model_format to parser."""
+
         return parser.add_argument(
             '--model-format',
             type=str,
@@ -85,6 +91,8 @@ class ArgumentHelper:
 
     @staticmethod
     def tp(parser):
+        """Add argument tp to parser."""
+
         return parser.add_argument(
             '--tp',
             type=int,
@@ -93,6 +101,8 @@ class ArgumentHelper:
 
     @staticmethod
     def session_id(parser):
+        """Add argument session_id to parser."""
+
         return parser.add_argument('--session-id',
                                    type=int,
                                    default=1,
@@ -100,6 +110,8 @@ class ArgumentHelper:
 
     @staticmethod
     def session_len(parser):
+        """Add argument session_len to parser."""
+
         return parser.add_argument('--session-len',
                                    type=int,
                                    default=None,
@@ -107,6 +119,8 @@ class ArgumentHelper:
 
     @staticmethod
     def max_batch_size(parser):
+        """Add argument max_batch_size to parser."""
+
         return parser.add_argument('--max-batch-size',
                                    type=int,
                                    default=128,
@@ -114,6 +128,8 @@ class ArgumentHelper:
 
     @staticmethod
     def quant_policy(parser):
+        """Add argument quant_policy to parser."""
+
         return parser.add_argument('--quant-policy',
                                    type=int,
                                    default=0,
@@ -121,6 +137,8 @@ class ArgumentHelper:
 
     @staticmethod
     def rope_scaling_factor(parser):
+        """Add argument rope_scaling_factor to parser."""
+
         return parser.add_argument('--rope-scaling-factor',
                                    type=float,
                                    default=0.0,
@@ -128,6 +146,8 @@ class ArgumentHelper:
 
     @staticmethod
     def use_logn_attn(parser):
+        """Add argument use_logn_attn to parser."""
+
         return parser.add_argument(
             '--use-logn-attn',
             action='store_true',
@@ -136,6 +156,8 @@ class ArgumentHelper:
 
     @staticmethod
     def block_size(parser):
+        """Add argument block_size to parser."""
+
         return parser.add_argument('--block-size',
                                    type=int,
                                    default=64,
@@ -143,6 +165,8 @@ class ArgumentHelper:
 
     @staticmethod
     def top_p(parser):
+        """Add argument top_p to parser."""
+
         return parser.add_argument(
             '--top-p',
             type=float,
@@ -154,6 +178,8 @@ class ArgumentHelper:
 
     @staticmethod
     def top_k(parser):
+        """Add argument top_k to parser."""
+
         return parser.add_argument(
             '--top-k',
             type=int,
@@ -164,6 +190,8 @@ class ArgumentHelper:
 
     @staticmethod
     def temperature(parser):
+        """Add argument temperature to parser."""
+
         return parser.add_argument('--temperature',
                                    type=float,
                                    default=0.8,
@@ -171,6 +199,8 @@ class ArgumentHelper:
 
     @staticmethod
     def repetition_penalty(parser):
+        """Add argument repetition_penalty to parser."""
+
         return parser.add_argument('--repetition-penalty',
                                    type=float,
                                    default=1.0,
@@ -178,6 +208,8 @@ class ArgumentHelper:
 
     @staticmethod
     def cap(parser):
+        """Add argument cap to parser."""
+
         return parser.add_argument(
             '--cap',
             type=str,
@@ -188,6 +220,8 @@ class ArgumentHelper:
 
     @staticmethod
     def log_level(parser):
+        """Add argument log_level to parser."""
+
         import logging
         return parser.add_argument('--log-level',
                                    type=str,
@@ -197,6 +231,8 @@ class ArgumentHelper:
 
     @staticmethod
     def backend(parser):
+        """Add argument backend to parser."""
+
         return parser.add_argument('--backend',
                                    type=str,
                                    default='turbomind',
@@ -205,6 +241,8 @@ class ArgumentHelper:
 
     @staticmethod
     def engine(parser):
+        """Add argument engine to parser."""
+
         return parser.add_argument('--engine',
                                    type=str,
                                    default='turbomind',
@@ -213,6 +251,8 @@ class ArgumentHelper:
 
     @staticmethod
     def stream_output(parser):
+        """Add argument stream_output to parser."""
+
         return parser.add_argument(
             '--stream-output',
             action='store_true',
@@ -220,6 +260,8 @@ class ArgumentHelper:
 
     @staticmethod
     def calib_dataset(parser):
+        """Add argument calib_dataset to parser."""
+
         return parser.add_argument('--calib-dataset',
                                    type=str,
                                    default='ptb',
@@ -227,6 +269,8 @@ class ArgumentHelper:
 
     @staticmethod
     def calib_samples(parser):
+        """Add argument calib_samples to parser."""
+
         return parser.add_argument(
             '--calib-samples',
             type=int,
@@ -235,6 +279,8 @@ class ArgumentHelper:
 
     @staticmethod
     def calib_seqlen(parser):
+        """Add argument calib_seqlen to parser."""
+
         return parser.add_argument('--calib-seqlen',
                                    type=int,
                                    default=2048,
@@ -242,6 +288,8 @@ class ArgumentHelper:
 
     @staticmethod
     def device(parser):
+        """Add argument device to parser."""
+
         return parser.add_argument('--device',
                                    type=str,
                                    default='cuda',
@@ -250,6 +298,8 @@ class ArgumentHelper:
 
     @staticmethod
     def meta_instruction(parser):
+        """Add argument meta_instruction to parser."""
+
         return parser.add_argument('--meta-instruction',
                                    type=str,
                                    default=None,
@@ -257,6 +307,8 @@ class ArgumentHelper:
 
     @staticmethod
     def cache_max_entry_count(parser):
+        """Add argument cache_max_entry_count to parser."""
+
         return parser.add_argument(
             '--cache-max-entry-count',
             type=float,
@@ -265,18 +317,22 @@ class ArgumentHelper:
 
     @staticmethod
     def adapters(parser):
+        """Add argument adapters to parser."""
+
         return parser.add_argument(
             '--adapters',
             nargs='*',
             type=str,
             default=None,
             help='Used to set path(s) of lora adapter(s). One can input '
-            'key-values pairs in xxx=yyy format for multiple lora '
+            'key-value pairs in xxx=yyy format for multiple lora '
             'adapters. If only have one adapter, one can only input '
             'the path of the adapter.')
 
     @staticmethod
     def work_dir(parser):
+        """Add argument work_dir to parser."""
+
         return parser.add_argument(
             '--work-dir',
             type=str,


### PR DESCRIPTION

## Motivation

Update adapters cli argument to accept one adapter path without given adapter name.
Related issue: https://github.com/InternLM/lmdeploy/issues/1030

## Modification

- [x] Update adapters cli argument 
- [x] Add docstring for lmdeploy.cli

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
