### PR TITLE
fix use engine_config.tp when tp is None

### DIFF
--- a/lmdeploy/turbomind/turbomind.py
+++ b/lmdeploy/turbomind/turbomind.py
@@ -146,8 +146,12 @@ class TurboMind:
                  chat_template_config: Optional[ChatTemplateConfig] = None,
                  **kwargs):
         # check memory equality when tp
-        if tp is not None and tp > 1:
-            _compare_individual_gpu_memory(tp)
+        if tp is not None:
+            if tp > 1:
+                _compare_individual_gpu_memory(tp)
+        elif engine_config is not None and engine_config.tp is not None:
+            if engine_config.tp > 1:
+                _compare_individual_gpu_memory(engine_config.tp)
         # check model_name equal in engine_config and passed in
         if engine_config is not None and engine_config.model_name is not None:
             if model_name is not None:


### PR DESCRIPTION
## Motivation

fix memory equality check

## Modification

use engine_config.tp when tp is None

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
