### PR TITLE
fix and change all logger using get_logger

### DIFF
--- a/benchmark/profile_generation.py
+++ b/benchmark/profile_generation.py
@@ -169,7 +169,7 @@ def profile_throughput(model_path: str, concurrency: int, input_seqlen: int,
     ]
 
     throughput = np.round(token_latency_stats.size / elapsed_time, 2)
-    print(f'\n{"-" * 50}\ntotal time: {elapsed_time:.2f}s\n'
+    print(f'\n{' - ' * 50}\ntotal time: {elapsed_time:.2f}s\n'
           f'concurrency: {concurrency}, test_round: {test_round}\n'
           f'input_tokens: {input_seqlen}, output_tokens: {output_seqlen}\n'
           f'first_token latency(min, max, ave): '
@@ -178,7 +178,7 @@ def profile_throughput(model_path: str, concurrency: int, input_seqlen: int,
           f'{token_latency_min}s, {token_latency_max}s, '
           f'{token_latency_ave}s\n'
           f'token_latency percentiles(50%,75%,95%,99%)(s): {percentiles}\n'
-          f'throughput: {throughput} token/s\n{"-" * 50}')
+          f'throughput: {throughput} token/s\n{' - ' * 50}')
     return tm_model.model_name, \
         [first_token_latency_min, first_token_latency_max,
          first_token_latency_ave], \

--- a/benchmark/profile_hf_generation.py
+++ b/benchmark/profile_hf_generation.py
@@ -75,8 +75,9 @@ import torch
 from transformers import AutoModelForCausalLM, GenerationConfig
 
 from lmdeploy.pytorch.accel import LoadNoInit
+from lmdeploy.utils import get_logger
 
-logger = logging.getLogger(__file__)
+logger = get_logger(__file__)
 logger.setLevel(logging.DEBUG)
 info = logger.info
 warning = logger.warning

--- a/benchmark/profile_restful_api.py
+++ b/benchmark/profile_restful_api.py
@@ -166,7 +166,7 @@ class Engine:
                   f'Request {request_output_tokens:.0f}, '
                   f'but got {completion_tokens:.0f}')
 
-        print(f'\n{"-" * 50}\nconcurrency: {concurrency}\n'
+        print(f'\n{' - ' * 50}\nconcurrency: {concurrency}\n'
               f'elapsed_time: {elapsed_time:.3f}s\n')
         if stream_output:
             print(f'first_token latency(min, max, ave): '
@@ -180,7 +180,7 @@ class Engine:
             f'token throughput (prompt + completion token): {total_token_throughput:.3f} token/s\n'  # noqa
             f'RPS (request per second): {rps:.3f} req/s\n'
             f'RPM (request per minute): {rpm:.3f} req/min\n'
-            f'{"-" * 50}\n')
+            f'{' - ' * 50}\n')
 
         if self.csv:
             with open(self.csv, 'w') as csvfile:

--- a/benchmark/profile_serving.py
+++ b/benchmark/profile_serving.py
@@ -171,7 +171,7 @@ class Engine:
                   f'Request {request_output_tokens:.0f}, '
                   f'but got {completion_tokens:.0f}')
 
-        print(f'\n{"-" * 50}\nconcurrency: {concurrency}\n'
+        print(f'\n{' - ' * 50}\nconcurrency: {concurrency}\n'
               f'elapsed_time: {elapsed_time:.3f}s\n')
         if stream_output:
             print(f'first_token latency(min, max, ave): '
@@ -185,7 +185,7 @@ class Engine:
             f'token throughput (prompt + completion token): {total_token_throughput:.3f} token/s\n'  # noqa
             f'RPS (request per second): {rps:.3f} req/s\n'
             f'RPM (request per minute): {rpm:.3f} req/min\n'
-            f'{"-" * 50}\n')
+            f'{' - ' * 50}\n')
 
         if self.csv:
             with open(self.csv, 'w') as csvfile:

--- a/benchmark/profile_throughput.py
+++ b/benchmark/profile_throughput.py
@@ -183,7 +183,7 @@ class Engine:
             for percent in [0.5, 0.75, 0.95, 0.99]
         ]
 
-        print(f'\n{"-" * 50}\nconcurrency: {concurrency}\n'
+        print(f'\n{' - ' * 50}\nconcurrency: {concurrency}\n'
               f'elapsed_time: {elapsed_time:.3f}s\n')
         if stream_output:
             print(f'first token latency(s)(min, max, ave): '
@@ -199,7 +199,7 @@ class Engine:
             f'token throughput (prompt + completion token): {total_token_throughput:.3f} token/s\n'  # noqa
             f'RPS (request per second): {rps:.3f} req/s\n'
             f'RPM (request per minute): {rpm:.3f} req/min\n'
-            f'{"-" * 50}\n')
+            f'{' - ' * 50}\n')
 
         if self.csv:
             with open(self.csv, 'w') as csvfile:

--- a/benchmark/profile_torch_generation.py
+++ b/benchmark/profile_torch_generation.py
@@ -181,7 +181,7 @@ def profile_throughput(model_path: str, concurrency: int, input_seqlen: int,
     ]
 
     throughput = np.round(token_latency_stats.size / elapsed_time, 2)
-    print(f'\n{"-" * 50}\ntotal time: {elapsed_time:.2f}s\n'
+    print(f'\n{' - ' * 50}\ntotal time: {elapsed_time:.2f}s\n'
           f'concurrency: {concurrency}, test_round: {test_round}\n'
           f'input_tokens: {input_seqlen}, output_tokens: {output_seqlen}\n'
           f'first_token latency(min, max, ave): '
@@ -190,7 +190,7 @@ def profile_throughput(model_path: str, concurrency: int, input_seqlen: int,
           f'{token_latency_min}s, {token_latency_max}s, '
           f'{token_latency_ave}s\n'
           f'token_latency percentiles(50%,75%,95%,99%)(s): {percentiles}\n'
-          f'throughput: {throughput} token/s\n{"-" * 50}')
+          f'throughput: {throughput} token/s\n{' - ' * 50}')
     return tm_model.model_name, \
         [first_token_latency_min, first_token_latency_max,
          first_token_latency_ave], \

--- a/benchmark/profile_torch_throughput.py
+++ b/benchmark/profile_torch_throughput.py
@@ -187,7 +187,7 @@ class Engine:
             for percent in [0.5, 0.75, 0.95, 0.99]
         ]
 
-        print(f'\n{"-" * 50}\nconcurrency: {concurrency}\n'
+        print(f'\n{' - ' * 50}\nconcurrency: {concurrency}\n'
               f'elapsed_time: {elapsed_time:.3f}s\n')
         if stream_output:
             print(f'first token latency(s)(min, max, ave): '
@@ -203,7 +203,7 @@ class Engine:
             f'token throughput (prompt + completion token): {total_token_throughput:.3f} token/s\n'  # noqa
             f'RPS (request per second): {rps:.3f} req/s\n'
             f'RPM (request per minute): {rpm:.3f} req/min\n'
-            f'{"-" * 50}\n')
+            f'{' - ' * 50}\n')
 
         if self.csv:
             with open(self.csv, 'w') as csvfile:

--- a/lmdeploy/legacy/pytorch/adapters/__init__.py
+++ b/lmdeploy/legacy/pytorch/adapters/__init__.py
@@ -1,14 +1,13 @@
 # Copyright (c) OpenMMLab. All rights reserved.
-
-import logging
-
 import torch.nn as nn
+
+from lmdeploy.utils import get_logger
 
 from .base import BasicAdapter, BasicAdapterFast
 from .internlm import InternLMAdapter
 from .llama2 import Llama2Adapter
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 def _get_default_adapter(tokenizer):

--- a/lmdeploy/legacy/pytorch/adapters/base.py
+++ b/lmdeploy/legacy/pytorch/adapters/base.py
@@ -7,7 +7,9 @@ import re
 from transformers import (PreTrainedTokenizer, PreTrainedTokenizerBase,
                           PreTrainedTokenizerFast)
 
-logger = logging.getLogger(__name__)
+from lmdeploy.utils import get_logger
+
+logger = get_logger(__name__)
 
 
 class BaseAdapter:

--- a/lmdeploy/legacy/pytorch/adapters/internlm.py
+++ b/lmdeploy/legacy/pytorch/adapters/internlm.py
@@ -6,9 +6,11 @@ import torch
 from transformers import (PreTrainedTokenizerFast, StoppingCriteria,
                           StoppingCriteriaList)
 
+from lmdeploy.utils import get_logger
+
 from .base import BaseAdapter
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 class InternLMStoppingCriteria(StoppingCriteria):

--- a/lmdeploy/legacy/pytorch/adapters/llama2.py
+++ b/lmdeploy/legacy/pytorch/adapters/llama2.py
@@ -1,12 +1,13 @@
 # Copyright (c) OpenMMLab. All rights reserved.
-import logging
 import re
 
 from transformers import PreTrainedTokenizerFast
 
+from lmdeploy.utils import get_logger
+
 from .base import BasicAdapterFast
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 B_INST, E_INST = '[INST]', '[/INST]'
 B_SYS, E_SYS = '<<SYS>>\n', '\n<</SYS>>\n\n'

--- a/lmdeploy/legacy/pytorch/chat.py
+++ b/lmdeploy/legacy/pytorch/chat.py
@@ -54,13 +54,13 @@ from typing import Optional
 import torch
 from transformers import GenerationConfig, PreTrainedModel
 
+from lmdeploy.utils import get_logger
+
 from .adapters import init_adapter
 from .dist import get_local_rank, get_rank, get_world_size
 from .model import accel_model, init_model
 from .session import BasicSessionManagerWithHistory
 from .utils import BasicStreamer, TerminalIO, control
-
-logger = logging.getLogger(__name__)
 
 
 def set_logging(log_file: str, debug: bool):
@@ -69,15 +69,14 @@ def set_logging(log_file: str, debug: bool):
     log_file = log_file or 'chat.log'
     if r := get_rank() != 0:
         log_file = log_file + f'.{r}'
-    logging.basicConfig(level=level,
-                        format=('%(filename)s: '
-                                '%(levelname)s: '
-                                '%(funcName)s(): '
-                                '%(lineno)d:\t'
-                                '%(message)s'),
-                        filename=log_file,
-                        filemode='w')
+    format = '%(filename)s: %(levelname)s: %(funcName)s(): %(lineno)d:\t %(message)s'
+    logger = get_logger(__name__,
+                        log_file=log_file,
+                        log_level=level,
+                        file_mode='w',
+                        log_formatter=format)
     print(f'Worker {get_rank()} logging to {log_file}')
+    return logger
 
 
 def main(
@@ -120,7 +119,7 @@ def main(
             based on `LlamaforCausalLM` class, this argument is required.
             Currently, only "llama1" is acceptable for llama1 models.
     """  # noqa: E501
-    set_logging(log_file, debug)
+    logger = set_logging(log_file, debug)
 
     # workers should sync in sampling
     torch.manual_seed(seed)

--- a/lmdeploy/legacy/pytorch/decode.py
+++ b/lmdeploy/legacy/pytorch/decode.py
@@ -1,6 +1,5 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import argparse
-import logging
 import queue
 import warnings
 from typing import List, Optional
@@ -11,6 +10,8 @@ import torch.multiprocessing as mp
 from torch.nn.utils.rnn import pad_sequence
 from transformers import (AutoTokenizer, PreTrainedModel,
                           PreTrainedTokenizerBase)
+
+from lmdeploy.utils import get_logger
 
 from .model import accel_model, init_model
 
@@ -371,7 +372,7 @@ if __name__ == '__main__':
     test_path = args.test_path
     prompts = args.prompts
 
-    logger = logging.getLogger(__name__)
+    logger = get_logger(__name__)
     # logging.basicConfig(level=logging.DEBUG)
 
     # Use test file preferentially

--- a/lmdeploy/legacy/pytorch/model.py
+++ b/lmdeploy/legacy/pytorch/model.py
@@ -1,5 +1,4 @@
 # Copyright (c) OpenMMLab. All rights reserved.
-import logging
 import time
 import warnings
 from typing import Optional
@@ -7,9 +6,11 @@ from typing import Optional
 import torch
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
+from lmdeploy.utils import get_logger
+
 from .dist import get_local_rank
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 class LoadWoInit:

--- a/lmdeploy/legacy/pytorch/session.py
+++ b/lmdeploy/legacy/pytorch/session.py
@@ -1,10 +1,10 @@
 # Copyright (c) OpenMMLab. All rights reserved.
-import logging
-
 import torch
 from transformers.generation.utils import ModelOutput
 
-logger = logging.getLogger(__name__)
+from lmdeploy.utils import get_logger
+
+logger = get_logger(__name__)
 
 
 class BasicSessionManager:

--- a/lmdeploy/legacy/pytorch/utils.py
+++ b/lmdeploy/legacy/pytorch/utils.py
@@ -1,8 +1,7 @@
 # Copyright (c) OpenMMLab. All rights reserved.
-
-import logging
-
 from transformers.generation.streamers import BaseStreamer
+
+from lmdeploy.utils import get_logger
 
 from .dist import get_rank, master_only, master_only_and_broadcast_general
 
@@ -11,7 +10,7 @@ try:
 except ImportError:  # readline not available
     pass
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 class TerminalIO:

--- a/lmdeploy/pytorch/modeling/modeling_baichuan.py
+++ b/lmdeploy/pytorch/modeling/modeling_baichuan.py
@@ -27,13 +27,13 @@ from transformers import PreTrainedModel
 from transformers.activations import ACT2FN
 from transformers.modeling_outputs import (BaseModelOutputWithPast,
                                            CausalLMOutputWithPast)
-from transformers.utils import logging
 
 from lmdeploy.pytorch.modeling.convert_to_qmodules import convert_to_qmodules
+from lmdeploy.utils import get_logger
 
 from .configuration_baichuan import BaiChuanConfig
 
-logger = logging.get_logger(__name__)
+logger = get_logger(__name__)
 
 
 # Copied from transformers.models.bart.modeling_bart._make_causal_mask

--- a/lmdeploy/pytorch/modeling/modeling_internlm.py
+++ b/lmdeploy/pytorch/modeling/modeling_internlm.py
@@ -33,14 +33,15 @@ from transformers.modeling_outputs import (BaseModelOutputWithPast,
                                            SequenceClassifierOutputWithPast)
 from transformers.modeling_utils import PreTrainedModel
 from transformers.utils import (add_start_docstrings,
-                                add_start_docstrings_to_model_forward, logging,
+                                add_start_docstrings_to_model_forward,
                                 replace_return_docstrings)
 
 from lmdeploy.pytorch.modeling.convert_to_qmodules import convert_to_qmodules
+from lmdeploy.utils import get_logger
 
 from .configuration_internlm import InternLMConfig
 
-logger = logging.get_logger(__name__)
+logger = get_logger(__name__)
 
 _CONFIG_FOR_DOC = 'InternLMConfig'
 

--- a/lmdeploy/pytorch/modeling/modeling_internlm2.py
+++ b/lmdeploy/pytorch/modeling/modeling_internlm2.py
@@ -34,10 +34,11 @@ from transformers.modeling_outputs import (BaseModelOutputWithPast,
                                            SequenceClassifierOutputWithPast)
 from transformers.modeling_utils import PreTrainedModel
 from transformers.utils import (add_start_docstrings,
-                                add_start_docstrings_to_model_forward, logging,
+                                add_start_docstrings_to_model_forward,
                                 replace_return_docstrings)
 
 from lmdeploy.pytorch.modeling.convert_to_qmodules import convert_to_qmodules
+from lmdeploy.utils import get_logger
 
 try:
     from transformers.generation.streamers import BaseStreamer
@@ -46,7 +47,7 @@ except:  # noqa # pylint: disable=bare-except
 
 from .configuration_internlm import InternLMConfig as InternLM2Config
 
-logger = logging.get_logger(__name__)
+logger = get_logger(__name__)
 
 _CONFIG_FOR_DOC = 'InternLM2Config'
 

--- a/lmdeploy/pytorch/modeling/modeling_llama.py
+++ b/lmdeploy/pytorch/modeling/modeling_llama.py
@@ -32,12 +32,13 @@ from transformers.modeling_outputs import (BaseModelOutputWithPast,
 from transformers.modeling_utils import PreTrainedModel
 from transformers.models.llama.configuration_llama import LlamaConfig
 from transformers.utils import (add_start_docstrings,
-                                add_start_docstrings_to_model_forward, logging,
+                                add_start_docstrings_to_model_forward,
                                 replace_return_docstrings)
 
 from lmdeploy.pytorch.modeling.convert_to_qmodules import convert_to_qmodules
+from lmdeploy.utils import get_logger
 
-logger = logging.get_logger(__name__)
+logger = get_logger(__name__)
 
 _CONFIG_FOR_DOC = 'LlamaConfig'
 

--- a/lmdeploy/pytorch/models/falcon.py
+++ b/lmdeploy/pytorch/models/falcon.py
@@ -3,7 +3,6 @@
 # https://huggingface.co/tiiuae/falcon-7b-instruct
 # https://github.com/huggingface/transformers/blob/v4.33-release/src/transformers/models/falcon/modeling_falcon.py  # noqa
 
-import logging
 from typing import Optional, Tuple, Union
 
 import torch
@@ -19,8 +18,6 @@ from ..dist_utils import (colwise_parallelize_linear_fn,
                           rowwise_parallelize_linear_fn)
 from ..kernels import (alibi_paged_attention_fwd, fill_kv_cache,
                        paged_attention_fwd)
-
-logger = logging.getLogger()
 
 
 # rotary pos emb helpers

--- a/lmdeploy/serve/qos_engine/inner_group_schd.py
+++ b/lmdeploy/serve/qos_engine/inner_group_schd.py
@@ -1,8 +1,9 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import collections
-import logging
 
-logger = logging.getLogger(__name__)
+from lmdeploy.utils import get_logger
+
+logger = get_logger(__name__)
 
 
 class UserRequestQueue:

--- a/lmdeploy/serve/qos_engine/qos_engine.py
+++ b/lmdeploy/serve/qos_engine/qos_engine.py
@@ -1,7 +1,6 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import asyncio
 import json
-import logging
 import threading
 import time
 from typing import List
@@ -11,8 +10,9 @@ from lmdeploy.serve.openai.protocol import (ChatCompletionRequestQos,
                                             GenerateRequestQos)
 from lmdeploy.serve.qos_engine.inner_group_schd import UserRequestQueue
 from lmdeploy.serve.qos_engine.usage_stats import UsageStats
+from lmdeploy.utils import get_logger
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 class QosConfig:

--- a/lmdeploy/serve/turbomind/chatbot.py
+++ b/lmdeploy/serve/turbomind/chatbot.py
@@ -18,7 +18,7 @@ from tritonclient.grpc.service_pb2 import ModelInferResponse
 from lmdeploy.model import MODELS
 from lmdeploy.serve.turbomind.utils import (Postprocessor, Preprocessor,
                                             prepare_tensor)
-from lmdeploy.utils import filter_suffix
+from lmdeploy.utils import filter_suffix, get_logger
 
 
 @dataclass
@@ -49,13 +49,6 @@ def stream_callback(que, result, error):
         que.put(dict(errcode=StatusCode.TRITON_SERVER_ERR, errmsg=f'{error}'))
     else:
         que.put(result.get_response(as_json=True))
-
-
-def get_logger(log_file=None, log_level=logging.INFO):
-    """Return the logger."""
-    from lmdeploy.utils import get_logger
-    logger = get_logger('service.ft', log_file=log_file, log_level=log_level)
-    return logger
 
 
 class Chatbot:
@@ -130,7 +123,7 @@ class Chatbot:
         assert isinstance(session_id, int), \
             f'INT session id is required, but got {type(session_id)}'
 
-        logger = get_logger(log_level=self.log_level)
+        logger = get_logger('service.ft', log_level=self.log_level)
         logger.info(f'session {session_id}, request_id {request_id}, '
                     f'request_output_len {request_output_len}')
 
@@ -180,7 +173,7 @@ class Chatbot:
         assert isinstance(session_id, int), \
             f'INT session id is required, but got {type(session_id)}'
 
-        logger = get_logger(log_level=self.log_level)
+        logger = get_logger('service.ft', log_level=self.log_level)
         logger.info(f'end session: {session_id}')
 
         if self._session is None:
@@ -218,7 +211,7 @@ class Chatbot:
         """
         assert isinstance(session_id, int), \
             f'INT session id is required, but got {type(session_id)}'
-        logger = get_logger(log_level=self.log_level)
+        logger = get_logger('service.ft', log_level=self.log_level)
         logger.info(f'cancel session: {session_id}')
 
         if self._session is None:
@@ -267,7 +260,7 @@ class Chatbot:
         assert isinstance(session_id, int), \
             f'INT session id is required, but got {type(session_id)}'
 
-        logger = get_logger(log_level=self.log_level)
+        logger = get_logger('service.ft', log_level=self.log_level)
         logger.info(f'resume session: {session_id}')
 
         if self._session is None:
@@ -320,7 +313,7 @@ class Chatbot:
         assert isinstance(session_id, int), \
             f'INT session id is required, but got {type(session_id)}'
 
-        logger = get_logger(log_level=self.log_level)
+        logger = get_logger('service.ft', log_level=self.log_level)
         logger.info(f'session {session_id}, request_id {request_id}, '
                     f'request_output_len {request_output_len}')
 
@@ -434,7 +427,7 @@ class Chatbot:
         Yields:
             tuple: status, text, generated token number
         """
-        logger = get_logger(log_level=self.log_level)
+        logger = get_logger('service.ft', log_level=self.log_level)
         logger.info(f'session {session.session_id}, '
                     f'request id {session.request_id}, '
                     f'request_output_len {request_output_len}, '

--- a/lmdeploy/turbomind/turbomind.py
+++ b/lmdeploy/turbomind/turbomind.py
@@ -34,7 +34,7 @@ lmdeploy_dir = osp.split(lmdeploy.__file__)[0]
 sys.path.append(osp.join(lmdeploy_dir, 'lib'))
 import _turbomind as _tm  # noqa: E402
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 def _construct_stop_or_bad_words(words: List[int] = None):
@@ -71,9 +71,8 @@ def _update_engine_config(config: TurbomindEngineConfig, **kwargs):
     for k, v in kwargs.items():
         if v and hasattr(config, k):
             setattr(config, k, v)
-            get_logger('turbomind').warning(
-                f'kwargs {k} is deprecated to initialize model, '
-                'use TurbomindEngineConfig instead.')
+            logger.warning(f'kwargs {k} is deprecated to initialize model, '
+                           'use TurbomindEngineConfig instead.')
     return config
 
 
@@ -171,7 +170,7 @@ class TurboMind:
                                model_format=model_format,
                                tp=tp)
             if len(args) > 0:
-                get_logger('turbomind').warning(
+                logger.warning(
                     f'loading from workspace, ignore args {args} '
                     'please use TurbomindEngineConfig or modify config.ini')
 
@@ -370,8 +369,7 @@ class TurboMind:
         # check whether input tp is valid
         if cfg.tensor_para_size != 1 and \
                 self.gpu_count != cfg.tensor_para_size:
-            get_logger('turbomind').info(
-                f'found tp={cfg.tensor_para_size} in config.ini.')
+            logger.info(f'found tp={cfg.tensor_para_size} in config.ini.')
             self.gpu_count = cfg.tensor_para_size
 
         # update cfg
@@ -553,9 +551,8 @@ class TurboMindInstance:
             config.max_new_tokens = kwargs['request_output_len']
             deprecated_kwargs.append('request_output_len')
         for k in deprecated_kwargs:
-            get_logger('turbomind').warning(
-                f'kwargs {k} is deprecated for inference, '
-                'use GenerationConfig instead.')
+            logger.warning(f'kwargs {k} is deprecated for inference, '
+                           'use GenerationConfig instead.')
         return config
 
     def end(self, session_id: int):

--- a/lmdeploy/turbomind/utils.py
+++ b/lmdeploy/turbomind/utils.py
@@ -1,13 +1,14 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import dataclasses
 import json
-import logging
 import os
 
 from huggingface_hub import hf_hub_download
 from transformers.utils import ExplicitEnum
 
-logger = logging.getLogger(__name__)
+from lmdeploy.utils import get_logger
+
+logger = get_logger(__name__)
 
 
 class ModelSource(ExplicitEnum):

--- a/lmdeploy/utils.py
+++ b/lmdeploy/utils.py
@@ -1,14 +1,18 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import logging
+from logging import Logger
 from typing import List, Optional
 
 logger_initialized = {}
 
 
-def get_logger(name: str,
-               log_file: Optional[str] = None,
-               log_level: int = logging.INFO,
-               file_mode: str = 'w'):
+def get_logger(
+    name: Optional[str] = None,
+    log_file: Optional[str] = None,
+    log_level: int = logging.INFO,
+    file_mode: str = 'w',
+    log_formatter: str = '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+) -> Logger:
     """Initialize and get a logger by name.
 
     If the logger has not been initialized, this method will initialize the
@@ -22,25 +26,10 @@ def get_logger(name: str,
         log_level (int): The logger level.
         file_mode (str): The file mode used in opening log file.
             Defaults to 'w'.
+        log_formatter (str): The logger output format.
     Returns:
         logging.Logger: The expected logger.
     """
-    # use logger in mmengine if exists.
-    try:
-        from mmengine.logging import MMLogger
-        if MMLogger.check_instance_created(name):
-            logger = MMLogger.get_instance(name)
-        else:
-            logger = MMLogger.get_instance(name,
-                                           logger_name=name,
-                                           log_file=log_file,
-                                           log_level=log_level,
-                                           file_mode=file_mode)
-        return logger
-
-    except Exception:
-        pass
-
     logger = logging.getLogger(name)
     if name in logger_initialized:
         return logger
@@ -66,8 +55,7 @@ def get_logger(name: str,
         file_handler = logging.FileHandler(log_file, file_mode)
         handlers.append(file_handler)
 
-    formatter = logging.Formatter(
-        '%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+    formatter = logging.Formatter(log_formatter)
     for handler in handlers:
         handler.setFormatter(formatter)
         handler.setLevel(log_level)


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily receiving feedbacks. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

1.The get_logger function use mmengine get_logger, It will initialize CUDA, causing TurboMind to fail the second CUDA initialization.
2.Standardize the logger for all lmdeploy.

## Modification


1. modify the get_logger at lmdeploy/utils.py
2. change 
```python
from transformers import logging
logger = logging.get_logger("name")

### and

import logging
logger = logging.getLogger("name")

### to

from lmdeploy.utils import get_logger
logger = get_logger("name")
```
3.change get_logger implement
```python
def get_logger(
    name: Optional[str] = None,
    log_file: Optional[str] = None,
    log_level: int = logging.INFO,
    file_mode: str = 'w',
    log_formatter: str = '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
) -> Logger:
```
I add the log_formatter that it can easily change the format for the instance.

## BC-breaking (Optional)

no

## Use cases (Optional)

We can use the get_logger like
```python
from lmdeploy.utils import get_logger
## just make a logger
logger = get_logger("name")
## change log level
logger = get_logger("name", log_level=xxx)
## save log
logger = get_logger("name", log_file="xx", file_mode="xx")
## change format
logger = get_logger("name", log_formatter="xxx")
```
                       

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
4. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
5. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
6. The documentation has been modified accordingly, like docstring or example tutorials.
