### PR TITLE
Change install prefix from ./install to /opt/tritonserver in daily build script

### DIFF
--- a/.github/workflows/daily_ete_test.yml
+++ b/.github/workflows/daily_ete_test.yml
@@ -151,7 +151,7 @@ jobs:
             $CONTAINER_ID  cmake .. \
                -DCMAKE_BUILD_TYPE=RelWithDebInfo \
                -DCMAKE_EXPORT_COMPILE_COMMANDS=1 \
-               -DCMAKE_INSTALL_PREFIX=./install \
+               -DCMAKE_INSTALL_PREFIX=/opt/tritonserver \
                -DBUILD_PY_FFI=ON \
                -DBUILD_MULTI_GPU=ON \
                -DCMAKE_CUDA_FLAGS="-lineinfo" \


### PR DESCRIPTION
## Motivation

In daily test, lmdeploy is built in a docker container.
Its installation path MUST set to `opt/tritonserver`, so that `tritonserver` can load the built libs correctly.

## Modification

`-DCMAKE_INSTALL_PREFIX=/opt/tritonserver`

