### PR TITLE
fix use TM_LOG_LEVEL environment variable first

### DIFF
--- a/lmdeploy/api.py
+++ b/lmdeploy/api.py
@@ -44,7 +44,8 @@ def pipeline(model_path: str,
         >>> print(response)
     """ # noqa E501
     from lmdeploy.serve.async_engine import AsyncEngine
-    os.environ['TM_LOG_LEVEL'] = log_level
+    if os.getenv('TM_LOG_LEVEL') is None:
+        os.environ['TM_LOG_LEVEL'] = log_level
     from lmdeploy.utils import get_logger
     logger = get_logger('lmdeploy')
     logger.setLevel(log_level)

--- a/lmdeploy/serve/openai/api_server.py
+++ b/lmdeploy/serve/openai/api_server.py
@@ -949,7 +949,8 @@ def serve(model_path: str,
         log_level(str): set log level whose value among [CRITICAL, ERROR, WARNING, INFO, DEBUG]
         qos_config_path (str): qos policy config path
     """ # noqa E501
-    os.environ['TM_LOG_LEVEL'] = log_level
+    if os.getenv('TM_LOG_LEVEL') is None:
+        os.environ['TM_LOG_LEVEL'] = log_level
 
     if allow_origins:
         app.add_middleware(


### PR DESCRIPTION
## Motivation

use `TM_LOG_LEVEL` environment variable first

When I want to print the `Turbomind`'s debug log, I set `TM_DEBUG_LEVEL=DEBUG` and `TM_LOG_LEVEL=DEBUG`. It doesn't work and I find that I must use the `--log-level DEBUG` command line argument. It's very unintuitive. 

## Modification

Set log level for `Turbomind` only when environment variable `TM_LOG_LEVEL` has not been set. After this modification, when environment variable `TM_LOG_LEVEL` has been set, use it first rather than the command line config or the default config.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
