### PR TITLE
Speed up torch engine w8a8 model init

### DIFF
--- a/lmdeploy/pytorch/modeling/convert_to_qmodules.py
+++ b/lmdeploy/pytorch/modeling/convert_to_qmodules.py
@@ -57,4 +57,3 @@ def convert_to_qmodules(model):
     norm_type = NORM_TYPE_MAP[type(model).__name__]
     convert(model, layer_type, norm_type)
     return
-    

--- a/lmdeploy/pytorch/modeling/convert_to_qmodules.py
+++ b/lmdeploy/pytorch/modeling/convert_to_qmodules.py
@@ -27,10 +27,10 @@ def convert_decoder_layer(module, norm_type):
     """
     for name, child in module.named_children():
         if isinstance(child, nn.Linear):
-            new_child = QLinear.from_float(child)
+            new_child = QLinear.from_float(child, initialization=False)
             setattr(module, name, new_child)
         elif type(child).__name__ == norm_type:
-            new_child = QRMSNorm.from_float(child)
+            new_child = QRMSNorm.from_float(child, initialization=False)
             setattr(module, name, new_child)
         else:
             convert_decoder_layer(child, norm_type)
@@ -57,3 +57,4 @@ def convert_to_qmodules(model):
     norm_type = NORM_TYPE_MAP[type(model).__name__]
     convert(model, layer_type, norm_type)
     return
+    

--- a/lmdeploy/pytorch/models/q_modules.py
+++ b/lmdeploy/pytorch/models/q_modules.py
@@ -107,7 +107,8 @@ class QLinear(nn.Module):
         """Class method to create a QLinear instance from a floating-point
         module.
 
-        initialization for dummy init.
+        `initialization = True` for real init.
+        `initialization = False` for dummy init.
         """
         q_mod = cls(mod.in_features,
                     mod.out_features,

--- a/lmdeploy/pytorch/models/q_modules.py
+++ b/lmdeploy/pytorch/models/q_modules.py
@@ -44,7 +44,7 @@ class QRMSNorm(nn.Module):
         """Class method to create a QRMSNorm instance from a floating-point
         module.
 
-        initialization for dummy init.
+        `initialization = True` for real init and initialization = False` for dummy init.
         """
         hidden_size = mod.weight.shape[0]
         eps = mod.variance_epsilon

--- a/lmdeploy/pytorch/models/q_modules.py
+++ b/lmdeploy/pytorch/models/q_modules.py
@@ -44,7 +44,8 @@ class QRMSNorm(nn.Module):
         """Class method to create a QRMSNorm instance from a floating-point
         module.
 
-        `initialization = True` for real init and initialization = False` for dummy init.
+        `initialization = True` for real init.
+        `initialization = False` for dummy init.
         """
         hidden_size = mod.weight.shape[0]
         eps = mod.variance_epsilon

--- a/lmdeploy/pytorch/models/q_modules.py
+++ b/lmdeploy/pytorch/models/q_modules.py
@@ -40,11 +40,12 @@ class QRMSNorm(nn.Module):
         self.variance_epsilon = eps
 
     @classmethod
-    def from_float(cls, 
-                   mod: nn.Module,
-                   initialization: bool=True):
+    def from_float(cls, mod: nn.Module, initialization: bool = True):
         """Class method to create a QRMSNorm instance from a floating-point
-        module. initialization for dummy init."""
+        module.
+
+        initialization for dummy init.
+        """
         hidden_size = mod.weight.shape[0]
         eps = mod.variance_epsilon
         q_mod = cls(hidden_size, eps)
@@ -101,23 +102,24 @@ class QLinear(nn.Module):
             self.register_parameter('bias', None)
 
     @classmethod
-    def from_float(cls, 
-                   mod: nn.Module,
-                   initialization: bool = True):
+    def from_float(cls, mod: nn.Module, initialization: bool = True):
         """Class method to create a QLinear instance from a floating-point
-        module. initialization for dummy init."""
+        module.
+
+        initialization for dummy init.
+        """
         q_mod = cls(mod.in_features,
                     mod.out_features,
                     mod.bias is not None,
                     device=mod.weight.device,
                     dtype=mod.weight.dtype)
-        
+
         if initialization:
             weight_quant, scale = per_channel_quant(mod.weight.detach(), 8,
                                                     torch.int8)
             q_mod.weight.data = weight_quant
             q_mod.scale = scale
-            
+
         if mod.bias is not None:
             q_mod.bias.data = mod.bias.detach()
         return q_mod
@@ -149,4 +151,3 @@ class QLinear(nn.Module):
     def extra_repr(self) -> str:
         return 'in_features={}, out_features={}, bias={}'.format(
             self.in_features, self.out_features, self.bias is not None)
-      


### PR DESCRIPTION
When using w8a8 model, it will cost a bunch of time for model loading. I found that when using 
```python
QRMSNorm.from_float()
## or
QLinear.from_float()
```
this func cal the per_channel_quant to get the scale and quanted weight, but it is useless. Because the para not load to model yet, it is just cal for all the zero... so I fix it when init the model on inference stage.

|      | time cost(s)           |
|--------------|------------------|
| cal the scale and weight         | 17 |
| dont cal         | 0.08 |

And I tested it on internLM and internLM2
