### PR TITLE
Fix unable to set model format to qwen

### DIFF
--- a/lmdeploy/turbomind/deploy/converter.py
+++ b/lmdeploy/turbomind/deploy/converter.py
@@ -22,7 +22,10 @@ special_input_model_map = {
     'baichuan2': 'baichuan2',
     'internlm2': 'internlm2'
 }
-supported_formats = ['llama', 'hf', 'awq', *special_input_model_map.keys(), None]
+
+supported_formats = [
+    'llama', 'hf', 'awq', *special_input_model_map.keys(), None
+]
 
 
 def get_package_root_path():

--- a/lmdeploy/turbomind/deploy/converter.py
+++ b/lmdeploy/turbomind/deploy/converter.py
@@ -15,13 +15,14 @@ from lmdeploy.turbomind.utils import create_hf_download_args
 from .source_model.base import INPUT_MODELS
 from .target_model.base import OUTPUT_MODELS, TurbomindModelConfig
 
-supported_formats = ['llama', 'hf', 'awq', None]
+
 special_input_model_map = {
     'qwen': 'qwen',
     'baichuan': 'baichuan',
     'baichuan2': 'baichuan2',
     'internlm2': 'internlm2'
 }
+supported_formats = ['llama', 'hf', 'awq', *special_input_model_map.keys(), None]
 
 
 def get_package_root_path():


### PR DESCRIPTION
## Motivation

This PR fixes the inability to set model format for qwen compatible models.

## Modification

Merge the keys of special_input_model_map to supported_formats.
