### PR TITLE
make logging.logger's behavior consistent with MMLogger

### DIFF
--- a/lmdeploy/pytorch/modeling/modeling_baichuan.py
+++ b/lmdeploy/pytorch/modeling/modeling_baichuan.py
@@ -33,7 +33,7 @@ from lmdeploy.utils import get_logger
 
 from .configuration_baichuan import BaiChuanConfig
 
-logger = get_logger(__name__)
+logger = get_logger('lmdeploy')
 
 
 # Copied from transformers.models.bart.modeling_bart._make_causal_mask

--- a/lmdeploy/pytorch/modeling/modeling_internlm.py
+++ b/lmdeploy/pytorch/modeling/modeling_internlm.py
@@ -41,7 +41,7 @@ from lmdeploy.utils import get_logger
 
 from .configuration_internlm import InternLMConfig
 
-logger = get_logger(__name__)
+logger = get_logger('lmdeploy')
 
 _CONFIG_FOR_DOC = 'InternLMConfig'
 

--- a/lmdeploy/pytorch/modeling/modeling_internlm2.py
+++ b/lmdeploy/pytorch/modeling/modeling_internlm2.py
@@ -47,7 +47,7 @@ except:  # noqa # pylint: disable=bare-except
 
 from .configuration_internlm import InternLMConfig as InternLM2Config
 
-logger = get_logger(__name__)
+logger = get_logger('lmdeploy')
 
 _CONFIG_FOR_DOC = 'InternLM2Config'
 

--- a/lmdeploy/pytorch/modeling/modeling_llama.py
+++ b/lmdeploy/pytorch/modeling/modeling_llama.py
@@ -38,7 +38,7 @@ from transformers.utils import (add_start_docstrings,
 from lmdeploy.pytorch.modeling.convert_to_qmodules import convert_to_qmodules
 from lmdeploy.utils import get_logger
 
-logger = get_logger(__name__)
+logger = get_logger('lmdeploy')
 
 _CONFIG_FOR_DOC = 'LlamaConfig'
 

--- a/lmdeploy/serve/qos_engine/inner_group_schd.py
+++ b/lmdeploy/serve/qos_engine/inner_group_schd.py
@@ -3,7 +3,7 @@ import collections
 
 from lmdeploy.utils import get_logger
 
-logger = get_logger(__name__)
+logger = get_logger('lmdeploy')
 
 
 class UserRequestQueue:

--- a/lmdeploy/serve/qos_engine/qos_engine.py
+++ b/lmdeploy/serve/qos_engine/qos_engine.py
@@ -12,7 +12,7 @@ from lmdeploy.serve.qos_engine.inner_group_schd import UserRequestQueue
 from lmdeploy.serve.qos_engine.usage_stats import UsageStats
 from lmdeploy.utils import get_logger
 
-logger = get_logger(__name__)
+logger = get_logger('lmdeploy')
 
 
 class QosConfig:

--- a/lmdeploy/turbomind/turbomind.py
+++ b/lmdeploy/turbomind/turbomind.py
@@ -35,7 +35,7 @@ lmdeploy_dir = osp.split(lmdeploy.__file__)[0]
 sys.path.append(osp.join(lmdeploy_dir, 'lib'))
 import _turbomind as _tm  # noqa: E402
 
-logger = get_logger(__name__)
+logger = get_logger('lmdeploy')
 
 
 def _construct_stop_or_bad_words(words: List[int] = None):

--- a/lmdeploy/turbomind/utils.py
+++ b/lmdeploy/turbomind/utils.py
@@ -8,7 +8,7 @@ from transformers.utils import ExplicitEnum
 
 from lmdeploy.utils import get_logger
 
-logger = get_logger(__name__)
+logger = get_logger('lmdeploy')
 
 
 class ModelSource(ExplicitEnum):

--- a/lmdeploy/utils.py
+++ b/lmdeploy/utils.py
@@ -1,10 +1,39 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import logging
 import sys
-from logging import Logger
+from logging import Logger, LogRecord
 from typing import List, Optional
 
 logger_initialized = {}
+
+
+class FilterDuplicateWarning(logging.Filter):
+    """Filter the repeated warning message.
+
+    Args:
+        name (str): name of the filter.
+    """
+
+    def __init__(self, name: str = 'mmengine'):
+        super().__init__(name)
+        self.seen: set = set()
+
+    def filter(self, record: LogRecord) -> bool:
+        """Filter the repeated warning message.
+
+        Args:
+            record (LogRecord): The log record.
+
+        Returns:
+            bool: Whether to output the log record.
+        """
+        if record.levelno != logging.WARNING:
+            return True
+
+        if record.msg not in self.seen:
+            self.seen.add(record.msg)
+            return True
+        return False
 
 
 def get_logger(
@@ -56,7 +85,6 @@ def get_logger(
         file_handler = logging.FileHandler(log_file, file_mode)
         handlers.append(file_handler)
 
-    from mmengine.logging.logger import FilterDuplicateWarning
     formatter = logging.Formatter(log_formatter)
     for handler in handlers:
         handler.setFormatter(formatter)

--- a/lmdeploy/utils.py
+++ b/lmdeploy/utils.py
@@ -14,7 +14,7 @@ class FilterDuplicateWarning(logging.Filter):
         name (str): name of the filter.
     """
 
-    def __init__(self, name: str = 'mmengine'):
+    def __init__(self, name: str = 'lmdeploy'):
         super().__init__(name)
         self.seen: set = set()
 

--- a/lmdeploy/utils.py
+++ b/lmdeploy/utils.py
@@ -1,5 +1,6 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import logging
+import sys
 from logging import Logger
 from typing import List, Optional
 
@@ -45,7 +46,7 @@ def get_logger(
         if type(handler) is logging.StreamHandler:
             handler.setLevel(logging.ERROR)
 
-    stream_handler = logging.StreamHandler()
+    stream_handler = logging.StreamHandler(stream=sys.stdout)
     handlers = [stream_handler]
 
     if log_file is not None:
@@ -55,13 +56,16 @@ def get_logger(
         file_handler = logging.FileHandler(log_file, file_mode)
         handlers.append(file_handler)
 
+    from mmengine.logging.logger import FilterDuplicateWarning
     formatter = logging.Formatter(log_formatter)
     for handler in handlers:
         handler.setFormatter(formatter)
         handler.setLevel(log_level)
+        handler.addFilter(FilterDuplicateWarning(name))
         logger.addHandler(handler)
 
     logger.setLevel(log_level)
+    logger.propagate = False
     logger_initialized[name] = True
 
     return logger


### PR DESCRIPTION
## Motivation

This PR https://github.com/InternLM/lmdeploy/pull/1064 replace MMLogger with logging.Logger, but there are two differences.

1) MMLogger has [FilterDuplicateWarning](https://github.com/open-mmlab/mmengine/blob/f79111ecc0eea9fbb1b7d1361a79f7062ca1ac10/mmengine/logging/logger.py#L223)

2) MMLogger doesn't propagate
https://github.com/open-mmlab/mmengine/blob/main/mmengine/logging/logger.py#L292-L306
https://github.com/python/cpython/blob/main/Lib/logging/__init__.py#L1707-L1735


