### PR TITLE
[Fix] Add safety check for incremental decode

### DIFF
--- a/lmdeploy/tokenizer.py
+++ b/lmdeploy/tokenizer.py
@@ -415,9 +415,9 @@ class HuggingFaceTokenizer:
         if prev_tokens is None:
             # Please notice that in VLLM, indexes are detokenized one by one
             # while in LMDeploy, every turn, the detokenized indexes length
-            # can be different.
-            if skip_special_tokens and new_tokens[
-                    0] in tokenizer.all_special_ids:
+            # can be different or even zero.
+            if skip_special_tokens and len(
+                    new_tokens) and new_tokens[0] in tokenizer.all_special_ids:
                 read_offset = 1  # skip special token
             output_tokens = new_tokens
             prev_tokens = new_tokens

--- a/tests/test_lmdeploy/test_tokenizer.py
+++ b/tests/test_lmdeploy/test_tokenizer.py
@@ -1,3 +1,5 @@
+import random
+
 import pytest
 
 from lmdeploy.tokenizer import DetokenizeState, HuggingFaceTokenizer
@@ -23,8 +25,13 @@ def test_tokenizer(model_path, input, interval, skip_special_tokens):
     output = ''
     state = DetokenizeState()
     for i in range(0, len(encoded), interval):
+        offset = i + interval
+        if offset < len(encoded):
+            # lmdeploy may decode nothing when concurrency is high
+            if random.randint(1, 10) < 4:
+                offset -= interval
         decoded, state = tokenizer.detokenize_incrementally(
-            encoded, state, skip_special_tokens)
+            encoded[:offset], state, skip_special_tokens)
         output += decoded
     assert input == output, 'input string should equal to output after enc-dec'
 


### PR DESCRIPTION
When concurrency is high, Turbomind may decode nothing in stream mode. Which is a risk for api_server. A side effect of #992 