### PR TITLE
dependency version check & fix `ignore_eos` logic

### DIFF
--- a/benchmark/profile_torch_throughput.py
+++ b/benchmark/profile_torch_throughput.py
@@ -83,7 +83,7 @@ class Engine:
         for prompt, input_seqlen, output_seqlen in iter(
                 req_queue.get, [None, None, None]):
             _per_token_latency_stats = [0] * (output_seqlen + 1)
-            state = DetokenizeState
+            state = DetokenizeState()
             prev = time.perf_counter()
             n_prev_token = 0
 

--- a/lmdeploy/pytorch/engine/logits_process.py
+++ b/lmdeploy/pytorch/engine/logits_process.py
@@ -61,6 +61,7 @@ class FusedLogitsProcessor(LogitsWarper):
         # bad words
         bad_words = self.sampling_param.bad_words
         if bad_words:
+            bad_words = list(set(bad_words))
             bad_words_bias = new_scores.new_zeros(new_scores.size(1))
             bad_words_bias[bad_words] = filter_value
             new_scores += bad_words_bias[None]

--- a/lmdeploy/pytorch/messages.py
+++ b/lmdeploy/pytorch/messages.py
@@ -35,14 +35,18 @@ class SamplingParam:
     def from_gen_config(self, gen_config: EngineGenerationConfig):
         """from gen config."""
 
+        stop_words = gen_config.stop_words or []
+        bad_words = gen_config.bad_words or []
+        if gen_config.ignore_eos:
+            bad_words += stop_words
         return SamplingParam(top_p=gen_config.top_p,
                              top_k=gen_config.top_k,
                              temperature=gen_config.temperature,
                              repetition_penalty=gen_config.repetition_penalty,
                              ignore_eos=gen_config.ignore_eos,
                              random_seed=gen_config.random_seed,
-                             stop_words=gen_config.stop_words,
-                             bad_words=gen_config.bad_words)
+                             stop_words=stop_words,
+                             bad_words=bad_words)
 
 
 class MessageStatus(enum.Enum):

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -3,7 +3,7 @@ fire
 fuzzywuzzy
 mmengine-lite
 numpy
-peft
+peft==0.7.1
 pydantic>2.0.0
 pynvml
 safetensors

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -10,6 +10,7 @@ safetensors
 sentencepiece
 shortuuid
 tiktoken
-torch
-transformers>=4.33.0
+torch<=2.1.2,>=2.0.0
+transformers>=4.33.0,<=4.37.1
+triton>=2.1.0,<2.2.0
 uvicorn


### PR DESCRIPTION
add version check
- torch [2.0.0, 2.1.2]
- triton [2.1.0, 2.2.0)
- transformers [4.33.0, 4.37.1]
- peft [0.7.1]

fix `ignore_eos`, model eos and stop words would be moved to bad words when ignore_eos is True.
Tested on `chat` (with manually set `ignore_eos=True`), `benchmark_pytorch_throughput`