### PR TITLE
check pytorch engine environment

### DIFF
--- a/lmdeploy/pytorch/check_env/__init__.py
+++ b/lmdeploy/pytorch/check_env/__init__.py
@@ -1,0 +1,53 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+from logging import Logger
+
+from lmdeploy.utils import get_logger
+
+
+def _handle_exception(e: Exception, mod_name: str, logger: Logger):
+    logger.debug('Exception', exc_info=1)
+    logger.error(f'{type(e).__name__}: {e}')
+    logger.error(f'<{mod_name}> environment test failed. '
+                 'Please ensure it has been installed correctly.')
+    exit(1)
+
+
+def check_env_torch():
+    """check PyTorch environment."""
+    logger = get_logger('lmdeploy')
+
+    try:
+        logger.debug('Checking <PyTorch> environment.')
+        import torch
+
+        a = torch.tensor([1, 2], device='cuda')
+        b = a.new_tensor([3, 4], device='cuda')
+        c = a + b
+        torch.testing.assert_close(c, a.new_tensor([4, 6]))
+    except Exception as e:
+        _handle_exception(e, 'PyTorch', logger)
+
+
+def check_env_triton():
+    """check OpenAI Triton environment."""
+    logger = get_logger('lmdeploy')
+
+    try:
+        logger.debug('Checking <Triton> environment.')
+        import torch
+
+        from .triton_custom_add import custom_add
+        a = torch.tensor([1, 2], device='cuda')
+        b = a.new_tensor([3, 4], device='cuda')
+        c = custom_add(a, b)
+        torch.testing.assert_close(c, a + b)
+    except Exception as e:
+        _handle_exception(e, 'Triton', logger)
+
+
+def check_env():
+    """check all environment."""
+    logger = get_logger('lmdeploy')
+    logger.info('Checking environment for PyTorch Engine.')
+    check_env_torch()
+    check_env_triton()

--- a/lmdeploy/pytorch/check_env/__init__.py
+++ b/lmdeploy/pytorch/check_env/__init__.py
@@ -5,10 +5,13 @@ from lmdeploy.utils import get_logger
 
 
 def _handle_exception(e: Exception, mod_name: str, logger: Logger):
+    red_color = '\033[31m'
+    reset_color = '\033[0m'
     logger.debug('Exception', exc_info=1)
     logger.error(f'{type(e).__name__}: {e}')
-    logger.error(f'<{mod_name}> environment test failed. '
-                 'Please ensure it has been installed correctly.')
+    logger.error(f'{red_color}<{mod_name}> environment test failed. '
+                 'Please ensure it has been installed correctly.'
+                 f'{reset_color}')
     exit(1)
 
 

--- a/lmdeploy/pytorch/check_env/__main__.py
+++ b/lmdeploy/pytorch/check_env/__main__.py
@@ -1,0 +1,4 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+from . import check_env
+
+check_env()

--- a/lmdeploy/pytorch/check_env/__main__.py
+++ b/lmdeploy/pytorch/check_env/__main__.py
@@ -1,4 +1,0 @@
-# Copyright (c) OpenMMLab. All rights reserved.
-from . import check_env
-
-check_env()

--- a/lmdeploy/pytorch/check_env/triton_custom_add.py
+++ b/lmdeploy/pytorch/check_env/triton_custom_add.py
@@ -1,0 +1,25 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _add_kernel(A, B, C, size, BLOCK: tl.constexpr):
+    """add kernel."""
+    prog_id = tl.program_id(0)
+    offs = prog_id * BLOCK + tl.arange(0, BLOCK)
+    a = tl.load(A + offs, mask=offs < size)
+    b = tl.load(B + offs, mask=offs < size)
+    tl.store(C + offs, a + b, mask=offs < size)
+
+
+def custom_add(a, b):
+    """custom add one."""
+    c = torch.empty_like(a)
+    size = c.size(0)
+    BLOCK = 16
+
+    grid = [triton.cdiv(size, BLOCK)]
+    _add_kernel[grid](a, b, c, size, BLOCK=BLOCK)
+    return c

--- a/lmdeploy/pytorch/engine/engine.py
+++ b/lmdeploy/pytorch/engine/engine.py
@@ -14,6 +14,7 @@ from lmdeploy.tokenizer import Tokenizer
 from lmdeploy.utils import get_logger
 
 from ..adapter.adapter import ADAPTER_MANAGER, SchedulerAdapter
+from ..check_env import check_env
 from ..config import CacheConfig, SchedulerConfig
 from ..messages import (MessageStatus, SamplingParam, SchedulerSequence,
                         SchedulerSession)
@@ -93,6 +94,8 @@ class Engine:
                  model_path: str,
                  engine_config: PytorchEngineConfig,
                  trust_remote_code: bool = True) -> None:
+        check_env()
+
         self.engine_config = engine_config
         model_name = engine_config.model_name
         tp = engine_config.tp


### PR DESCRIPTION
Check the environment (PyTorch, Triton) before starting the engine.

If there are any dependency failed, the processing exit(1) with error logs:

```bash
2024-02-02 16:41:23,750 - lmdeploy - ERROR - RuntimeError: Triton Error [CUDA]: device kernel image is invalid
2024-02-02 16:41:23,750 - lmdeploy - ERROR - <Triton> environment test failed. Please ensure it has been installed correctly.
```

Tested on `chat` and `profile_pytorch_generation` with/wo tp.
Traceback info has been removed since too many logs might hide the ERROR info.
It would be better if we can change the color of the error info.