### PR TITLE
update contribution guide

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -210,7 +210,7 @@ The config for a pre-commit hook is stored in [.pre-commit-config](../.pre-commi
 
 #### C++ and CUDA
 
-The clang-format config is stored in [.clang-format](../.clang-format).
+The clang-format config is stored in [.clang-format](../.clang-format). And it's recommended to use clang-format version **11**. Please do not use older or newer versions as they will result in differences after formatting, which can cause the [lint](https://github.com/InternLM/lmdeploy/blob/main/.github/workflows/lint.yml#L25) to fail.
 
 ### PR Specs
 


### PR DESCRIPTION
## Motivation

remind developers to use the correct version of clang-format

## Modification

update contribution guide

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
