### PR TITLE
Use asyncio.Lifoque for turbomind async_stream_infer

### DIFF
--- a/lmdeploy/turbomind/turbomind.py
+++ b/lmdeploy/turbomind/turbomind.py
@@ -754,6 +754,7 @@ class TurboMindInstance:
 
         seq_start = input_lengths + input_lengths.new_tensor(step)
 
+        prev_len = 0
         # generator
         while True:
             finish, tm_outputs = await que.get()
@@ -781,6 +782,10 @@ class TurboMindInstance:
                     outputs = (status, output[:-1].tolist(), len_)
                 else:
                     outputs = (status, output.tolist(), len_)
+            if outputs[-1] < prev_len and not finish:
+                continue
+            else:
+                prev_len = outputs[-1]
             yield outputs
 
             if finish:

--- a/lmdeploy/turbomind/turbomind.py
+++ b/lmdeploy/turbomind/turbomind.py
@@ -786,8 +786,6 @@ class TurboMindInstance:
             if finish:
                 for t in self.threads:
                     t.join()
-                while que.qsize() > 0:
-                    que.get_nowait()
                 break
 
         if stream_output and not stop:
@@ -838,7 +836,7 @@ class TurboMindInstance:
 
         tm_inputs = _np_dict_to_tm_dict(inputs)
         # start forward thread
-        self.que = LifoQueue()
+        self.que = Queue()
         self._forward_thread(tm_inputs)
 
         seq_start = input_lengths + input_lengths.new_tensor(step)

--- a/lmdeploy/turbomind/turbomind.py
+++ b/lmdeploy/turbomind/turbomind.py
@@ -730,7 +730,7 @@ class TurboMindInstance:
             kwargs (dict): kwargs for backward compatibility
         """
         # start forward thread
-        que = asyncio.Queue()
+        que = asyncio.LifoQueue()
         from functools import partial
         _forward_callback = partial(self._async_forward_callback, que=que)
         _forward_thread = partial(self._async_forward_thread, que=que)

--- a/lmdeploy/turbomind/turbomind.py
+++ b/lmdeploy/turbomind/turbomind.py
@@ -6,7 +6,7 @@ import os.path as osp
 import sys
 from configparser import ConfigParser
 from contextlib import contextmanager
-from queue import LifoQueue, Queue
+from queue import Queue
 from threading import Thread
 from typing import Iterable, List, Optional, Union
 
@@ -485,7 +485,7 @@ class TurboMindInstance:
             t.join()
 
         self.model_insts = model_insts
-        self.que = LifoQueue()
+        self.que = Queue()
         self.threads = [None] * self.gpu_count
 
     def _create_model_instance(self, device_id, model_insts):
@@ -843,6 +843,9 @@ class TurboMindInstance:
 
         # generator
         while True:
+            while self.que.qsize() > 1:
+                self.que.get()
+
             finish, tm_outputs = self.que.get()
 
             outputs = _tm_dict_to_torch_dict(tm_outputs)


### PR DESCRIPTION
To handle scripts like the following for testing api_server.
```python
import os
import sys
from tqdm import tqdm

from concurrent.futures import ThreadPoolExecutor

from lmdeploy.serve.openai.api_client import APIClient

questions = ['你是谁'] * 1000

num_parallel = 512

def process_one(question, url='0.0.0.0', port='23333'):
    client = APIClient('http://{}:{}'.format(url, port))
    model_name = client.available_models[0]

    msg = [dict(role='user', content=question)]

    data = client.chat_completions_v1(model=model_name, messages=msg)

    for item in data:
        response = item
    
    return response

with ThreadPoolExecutor(max_workers=num_parallel) as executor:
    for response in tqdm(executor.map(process_one, questions)):
        print(response)
```