### PR TITLE
fix export turbomind weight bug

### DIFF
--- a/lmdeploy/turbomind/deploy/target_model/base.py
+++ b/lmdeploy/turbomind/deploy/target_model/base.py
@@ -183,7 +183,7 @@ class BaseOutputModel(ABC):
         def _tofile(tensor, path):
             """to file."""
             if tensor.dtype == torch.bfloat16:
-                tensor = tensor.view(torch.half)
+                tensor = tensor.to(torch.half)
             tensor.contiguous().cpu().numpy().tofile(path)
 
         if self.to_file:


### PR DESCRIPTION
## Motivation

fix export Turbomind weight bug

In the process of developing Medusa parameter conversion, we referred to the implementation of `export_weight` and found that there was a bug with the implementation of parameter conversion in bf16. This fix was proposed by the  new grad named baozhiwei in my group.

## Modification

use `tensor.to` rather than `tensor.view`

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
