### PR TITLE
feat: support fused_bias_residual_activation for medusa

### DIFF
--- a/src/turbomind/kernels/activation_kernels.cu
+++ b/src/turbomind/kernels/activation_kernels.cu
@@ -329,4 +329,68 @@ INSTANTIATE_GENERIC_ACTIVATION(SiluActivation, half, half);
 INSTANTIATE_GENERIC_ACTIVATION(SiluActivation, __nv_bfloat16, __nv_bfloat16);
 #endif
 
+template<template<typename T> class Activation, typename T, typename BT>
+__global__ void
+fused_bias_residual_activation(T* out, const BT* __restrict bias, const T* __restrict residual, int m, int n)
+{
+    const bool with_bias     = bias != nullptr;
+    const bool with_residual = residual != nullptr;
+
+    for (int64_t id = blockIdx.x * blockDim.x + threadIdx.x; id < 1LL * m * n; id += blockDim.x * gridDim.x) {
+        T val;
+
+        val = out[id];
+
+        if (with_bias) {
+            T bias_val = static_cast<T>(bias[id % n]);
+            val        = add(val, bias_val);
+        }
+
+        val = cuda_cast<T>(Activation<T>::apply(val));
+
+        if (with_residual) {
+            T residual_val = static_cast<T>(residual[id]);
+            val            = add(val, residual_val);
+        }
+
+        out[id] = val;
+    }
+}
+
+template<template<typename T> class Activation, typename T, typename BT>
+void invokeFusedBiasResidualActivation(
+    T* out, const BT* bias, const T* residual, const int m, const int n, cudaStream_t stream)
+{
+    TM_LOG_DEBUG(__PRETTY_FUNCTION__);
+    using PT                   = typename packed_type<T>::type;
+    constexpr int packed_elems = num_elems<PT>::value;
+    using PBT                  = typename packed_as<BT, packed_elems>::type;
+
+    dim3 block, grid;
+    if (n / 4 / packed_elems <= 1024) {
+        block.x = n / 4 / packed_elems;
+        grid.x  = m;
+    }
+    else {
+        block.x = 1024;
+        grid.x  = ceil(m * n / 1024.);
+    }
+    fused_bias_residual_activation<Activation><<<grid, block, 0, stream>>>(reinterpret_cast<PT*>(out),
+                                                                           reinterpret_cast<const PBT*>(bias),
+                                                                           reinterpret_cast<const PT*>(residual),
+                                                                           m,
+                                                                           n / packed_elems);
+    sync_check_cuda_error();
+}
+
+#define INSTANTIATE_FUSED_BIAS_RESIDUAL_ACTIVATION(Activation, T, BT)                                                  \
+    template void invokeFusedBiasResidualActivation<Activation, T, BT>(                                                \
+        T * out, const BT* bias, const T* residual, const int m, const int n, cudaStream_t stream);
+
+INSTANTIATE_FUSED_BIAS_RESIDUAL_ACTIVATION(SiluActivation, float, float);
+INSTANTIATE_FUSED_BIAS_RESIDUAL_ACTIVATION(SiluActivation, half, half);
+#ifdef ENABLE_BF16
+INSTANTIATE_FUSED_BIAS_RESIDUAL_ACTIVATION(SiluActivation, __nv_bfloat16, __nv_bfloat16);
+#endif
+
 }  // namespace turbomind

--- a/src/turbomind/kernels/activation_kernels.h
+++ b/src/turbomind/kernels/activation_kernels.h
@@ -107,4 +107,8 @@ void invokeAddBiasTanh(T* out, const T* bias, const int m, const int n, cudaStre
 template<typename T>
 void invokeSigmoid(T* data, const int size, const float scale, cudaStream_t stream);
 
+template<template<typename T> class Activation, typename T, typename BT>
+void invokeFusedBiasResidualActivation(
+    T* out, const BT* bias, const T* residual, const int m, const int n, cudaStream_t stream);
+
 }  // namespace turbomind


### PR DESCRIPTION
## Motivation

To support the ResBlock in FasterDecoding/Medusa https://github.com/FasterDecoding/Medusa/blob/700ff848f4cbfc66dfc2da30485130d64904241f/medusa/model/medusa_model.py#L43-L72, @b4b4o and I implemented fused_bias_residual_activation by referencing and porting the implementation from FasterTransformer https://github.com/NVIDIA/FasterTransformer/blob/df4a7534860137e060e18d2ebf019906120ea204/src/fastertransformer/kernels/activation_kernels.cu#L166-L284. Since this kernel is a relatively independent component, we created a separate pull request for it to be submitted first.

Hi all @lvhan028 @lzhangzz @grimoire @irexyc We have confirmed the accuracy of the entire ResBlock unit in the unit test. The corresponding code will be included in an upcoming PR, which is still undergoing refinement. Do you have any feedback or suggestions for this PR? Thanks.

## Modification

add fused_bias_residual_activation in `src/turbomind/kernels` activation_kernels

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
