### PR TITLE
torch optmize chatglm3

### DIFF
--- a/docs/en/inference/pipeline.md
+++ b/docs/en/inference/pipeline.md
@@ -145,8 +145,12 @@ print(response)
 
 ## FAQs
 
-- *RuntimeError: context has already been set*. If you got this for tp>1 in pytorch backend. Please make sure the python script has following
+- **RuntimeError: An attempt has been made to start a new process before the current process has finished its bootstrapping phase**.
+
+  If you got this for tp>1 in pytorch backend. Please make sure the python script has following
+
   ```python
   if __name__ == '__main__':
   ```
+
   Generally, in the context of multi-threading or multi-processing, it might be necessary to ensure that initialization code is executed only once. In this case, `if __name__ == '__main__':` can help to ensure that these initialization codes are run only in the main program, and not repeated in each newly created process or thread.

--- a/docs/zh_cn/inference/pipeline.md
+++ b/docs/zh_cn/inference/pipeline.md
@@ -147,8 +147,12 @@ print(response)
 
 ## FAQs
 
-- *RuntimeError: context has already been set*. 如果你在使用 tp>1 和 pytorch 后端的时候，遇到了这个错误。请确保 python 脚本中有下面内容作为入口
+- **RuntimeError: An attempt has been made to start a new process before the current process has finished its bootstrapping phase**.
+
+  如果你在使用 tp>1 和 pytorch 后端的时候，遇到了这个错误。请确保 python 脚本中有下面内容作为入口
+
   ```python
   if __name__ == '__main__':
   ```
+
   一般来说，在多线程或多进程上下文中，可能需要确保初始化代码只执行一次。这时候，`if __name__ == '__main__':` 可以帮助确保这些初始化代码只在主程序执行，而不会在每个新创建的进程或线程中重复执行。

--- a/lmdeploy/pytorch/config.py
+++ b/lmdeploy/pytorch/config.py
@@ -1,6 +1,6 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, Dict
 
 import torch
 
@@ -58,6 +58,7 @@ class ModelConfig:
     multi_query_attention: bool = False
     json_config: dict = field(default_factory=dict)
     hf_config: Any = None
+    init_kwargs: Dict[str, Any] = field(default_factory=dict)
 
     def get_head_size(self):
         """get head size."""
@@ -109,6 +110,7 @@ class ModelConfig:
             bos_token_id = hf_config.bos_token_id
             if bos_token_id is None:
                 bos_token_id = hf_config.pad_token_id
+            init_kwargs = dict(empty_init=False)
             return ModelConfig(
                 hidden_size=hf_config.hidden_size,
                 num_layers=hf_config.num_layers,
@@ -116,7 +118,8 @@ class ModelConfig:
                 num_key_value_heads=hf_config.multi_query_group_num,
                 bos_token_id=bos_token_id,
                 eos_token_id=hf_config.eos_token_id,
-                head_dim=head_dim)
+                head_dim=head_dim,
+                init_kwargs=init_kwargs)
 
         def __build_gemma():
             return ModelConfig(

--- a/lmdeploy/pytorch/engine/model_agent.py
+++ b/lmdeploy/pytorch/engine/model_agent.py
@@ -478,7 +478,8 @@ class BaseModelAgent(AutoModelAgent):
             hf_model = AutoModelForCausalLM.from_pretrained(
                 model_path,
                 torch_dtype=torch_dtype,
-                trust_remote_code=trust_remote_code)
+                trust_remote_code=trust_remote_code,
+                **self.model_config.init_kwargs)
             hf_model.eval()
             hf_model.config.use_cache = True
 
@@ -671,7 +672,8 @@ def _tp_build_model(
             model = AutoModelForCausalLM.from_config(
                 config,
                 torch_dtype=torch_dtype,
-                trust_remote_code=trust_remote_code)
+                trust_remote_code=trust_remote_code,
+                **model_config.init_kwargs)
             if rank == 0:
                 device_map = _create_device_map(model, world_size)
             _add_adapters(model, adapters)
@@ -688,7 +690,8 @@ def _tp_build_model(
                     model_path,
                     torch_dtype=torch_dtype,
                     device_map=device_map,
-                    trust_remote_code=trust_remote_code)
+                    trust_remote_code=trust_remote_code,
+                    **model_config.init_kwargs)
                 _load_adapters(param_model, adapters, device_map=device_map)
                 __load_state_dict_assign(param_model, model)
                 param_model = param_model.to('meta')


### PR DESCRIPTION
- optimize performance
- chatglm adapter TP support

before
```
concurrency: 256
elapsed_time: 306.702s

first token latency(s)(min, max, ave): 0.281, 10.159, 1.888
per-token latency(s) percentile(50, 75, 95, 99): [0.083, 0.088, 0.271, 0.444]

number of prompt tokens: 724392
number of completion tokens: 662960
token throughput (completion token): 2161.578 token/s
token throughput (prompt + completion token): 4523.455 token/s
RPS (request per second): 9.781 req/s
RPM (request per minute): 586.889 req/min
```

after
```
concurrency: 256
elapsed_time: 261.317s

first token latency(s)(min, max, ave): 0.203, 9.053, 1.658
per-token latency(s) percentile(50, 75, 95, 99): [0.069, 0.077, 0.242, 0.409]

number of prompt tokens: 724392
number of completion tokens: 662960
token throughput (completion token): 2536.999 token/s
token throughput (prompt + completion token): 5309.085 token/s
RPS (request per second): 11.480 req/s
RPM (request per minute): 688.820 req/min
```