### PR TITLE
Expose cache_block_seq_len to API

### DIFF
--- a/benchmark/profile_generation.py
+++ b/benchmark/profile_generation.py
@@ -339,6 +339,7 @@ def parse_args():
     tb_group._group_actions.append(session_len_act)
     tb_group._group_actions.append(cache_count_act)
     ArgumentHelper.model_format(tb_group, default='hf')
+    ArgumentHelper.cache_block_seq_len(tb_group)
     args = parser.parse_args()
     return args
 
@@ -390,6 +391,7 @@ def main():
             if args.backend == 'turbomind':
                 engine_config = TurbomindEngineConfig(
                     cache_max_entry_count=args.cache_max_entry_count,
+                    cache_block_seq_len=args.cache_block_seq_len,
                     model_format=args.model_format,
                     session_len=session_len,
                     tp=args.tp)

--- a/benchmark/profile_generation.py
+++ b/benchmark/profile_generation.py
@@ -331,6 +331,7 @@ def parse_args():
     pt_group = parser.add_argument_group('PyTorch engine arguments')
     tp_act = ArgumentHelper.tp(pt_group)
     cache_count_act = ArgumentHelper.cache_max_entry_count(pt_group)
+    cache_block_seq_len_act = ArgumentHelper.cache_block_seq_len(pt_group)
     session_len_act = ArgumentHelper.session_len(pt_group, default=2048)
 
     # turbomind engine args
@@ -338,8 +339,8 @@ def parse_args():
     tb_group._group_actions.append(tp_act)
     tb_group._group_actions.append(session_len_act)
     tb_group._group_actions.append(cache_count_act)
+    tb_group._group_actions.append(cache_block_seq_len_act)
     ArgumentHelper.model_format(tb_group, default='hf')
-    ArgumentHelper.cache_block_seq_len(tb_group)
     args = parser.parse_args()
     return args
 
@@ -398,6 +399,7 @@ def main():
             elif args.backend == 'pytorch':
                 engine_config = PytorchEngineConfig(
                     cache_max_entry_count=args.cache_max_entry_count,
+                    block_size=args.cache_block_seq_len,
                     session_len=session_len,
                     tp=args.tp,
                     thread_safe=True)

--- a/benchmark/profile_throughput.py
+++ b/benchmark/profile_throughput.py
@@ -289,6 +289,7 @@ def parse_args():
     tb_group._group_actions.append(session_len_act)
     tb_group._group_actions.append(cache_count_act)
     ArgumentHelper.model_format(tb_group, default='hf')
+    ArgumentHelper.cache_block_seq_len(tb_group)
 
     args = parser.parse_args()
     return args
@@ -304,6 +305,7 @@ def main():
             max_batch_size=args.concurrency,
             tp=args.tp,
             cache_max_entry_count=args.cache_max_entry_count,
+            cache_block_seq_len=args.cache_block_seq_len,
             model_format=args.model_format)
     elif args.backend == 'pytorch':
         engine_config = PytorchEngineConfig(

--- a/benchmark/profile_throughput.py
+++ b/benchmark/profile_throughput.py
@@ -282,14 +282,15 @@ def parse_args():
     tp_act = ArgumentHelper.tp(pt_group)
     session_len_act = ArgumentHelper.session_len(pt_group, default=4096)
     cache_count_act = ArgumentHelper.cache_max_entry_count(pt_group)
+    cache_block_seq_len_act = ArgumentHelper.cache_block_seq_len(pt_group)
 
     # turbomind engine args
     tb_group = parser.add_argument_group('TurboMind engine argument')
     tb_group._group_actions.append(tp_act)
     tb_group._group_actions.append(session_len_act)
     tb_group._group_actions.append(cache_count_act)
+    tb_group._group_actions.append(cache_block_seq_len_act)
     ArgumentHelper.model_format(tb_group, default='hf')
-    ArgumentHelper.cache_block_seq_len(tb_group)
 
     args = parser.parse_args()
     return args
@@ -311,6 +312,7 @@ def main():
         engine_config = PytorchEngineConfig(
             session_len=args.session_len,
             cache_max_entry_count=args.cache_max_entry_count,
+            block_size=args.cache_block_seq_len,
             max_batch_size=args.concurrency,
             tp=args.tp,
             thread_safe=True)

--- a/lmdeploy/archs.py
+++ b/lmdeploy/archs.py
@@ -75,8 +75,16 @@ def autoget_backend_config(
     else:
         config = TurbomindEngineConfig()
     if backend_config is not None:
-        data = asdict(backend_config)
-        for k, v in data.items():
-            if v and hasattr(config, k):
-                setattr(config, k, v)
+        if type(backend_config) == type(config):
+            return backend_config
+        else:
+            data = asdict(backend_config)
+            for k, v in data.items():
+                if v and hasattr(config, k):
+                    setattr(config, k, v)
+            # map attributes with different names
+            if type(backend_config) is TurbomindEngineConfig:
+                config.block_size = backend_config.cache_block_seq_len
+            else:
+                config.cache_block_seq_len = backend_config.block_size
     return config

--- a/lmdeploy/cli/chat.py
+++ b/lmdeploy/cli/chat.py
@@ -31,6 +31,7 @@ class SubCliChat(object):
         ArgumentHelper.session_len(engine_group)
         ArgumentHelper.adapters(engine_group)
         ArgumentHelper.cache_max_entry_count(engine_group)
+        ArgumentHelper.cache_block_seq_len(engine_group)
 
         # other args
         parser.add_argument('--trust-remote-code',
@@ -80,6 +81,7 @@ class SubCliChat(object):
             tp=args.tp,
             session_len=args.session_len,
             cache_max_entry_count=args.cache_max_entry_count,
+            block_size=args.cache_block_seq_len,
             adapters=adapters)
         run_chat(args.model_path,
                  engine_config,

--- a/lmdeploy/cli/chat.py
+++ b/lmdeploy/cli/chat.py
@@ -62,6 +62,7 @@ class SubCliChat(object):
         ArgumentHelper.quant_policy(engine_group)
         ArgumentHelper.model_name(engine_group)
         ArgumentHelper.cache_max_entry_count(engine_group)
+        ArgumentHelper.cache_block_seq_len(engine_group)
         ArgumentHelper.rope_scaling_factor(engine_group)
         ArgumentHelper.session_len(engine_group)
         # other arguments

--- a/lmdeploy/cli/serve.py
+++ b/lmdeploy/cli/serve.py
@@ -66,6 +66,7 @@ class SubCliServe:
         ArgumentHelper.model_format(tb_group)
         ArgumentHelper.quant_policy(tb_group)
         ArgumentHelper.rope_scaling_factor(tb_group)
+        ArgumentHelper.cache_block_seq_len(tb_group)
 
     @staticmethod
     def add_parser_api_server():
@@ -149,6 +150,7 @@ class SubCliServe:
         ArgumentHelper.model_format(tb_group)
         ArgumentHelper.quant_policy(tb_group)
         ArgumentHelper.rope_scaling_factor(tb_group)
+        ArgumentHelper.cache_block_seq_len(tb_group)
 
     @staticmethod
     def add_parser_api_client():
@@ -215,7 +217,8 @@ class SubCliServe:
                 model_format=args.model_format,
                 quant_policy=args.quant_policy,
                 rope_scaling_factor=args.rope_scaling_factor,
-                cache_max_entry_count=args.cache_max_entry_count)
+                cache_max_entry_count=args.cache_max_entry_count,
+                cache_block_seq_len=args.cache_block_seq_len)
         chat_template_config = ChatTemplateConfig(
             model_name=args.model_name,
             meta_instruction=args.meta_instruction,
@@ -256,7 +259,8 @@ class SubCliServe:
                 model_format=args.model_format,
                 quant_policy=args.quant_policy,
                 rope_scaling_factor=args.rope_scaling_factor,
-                cache_max_entry_count=args.cache_max_entry_count)
+                cache_max_entry_count=args.cache_max_entry_count,
+                cache_block_seq_len=args.cache_block_seq_len)
         chat_template_config = ChatTemplateConfig(
             model_name=args.model_name,
             meta_instruction=args.meta_instruction,

--- a/lmdeploy/cli/serve.py
+++ b/lmdeploy/cli/serve.py
@@ -149,7 +149,7 @@ class SubCliServe:
         tb_group._group_actions.append(session_len_act)
         tb_group._group_actions.append(max_batch_size_act)
         tb_group._group_actions.append(cache_max_entry_act)
-        tb_group._action_groups.append(cache_block_seq_len_act)
+        tb_group._group_actions.append(cache_block_seq_len_act)
         ArgumentHelper.model_format(tb_group)
         ArgumentHelper.quant_policy(tb_group)
         ArgumentHelper.rope_scaling_factor(tb_group)

--- a/lmdeploy/cli/serve.py
+++ b/lmdeploy/cli/serve.py
@@ -54,6 +54,7 @@ class SubCliServe:
         session_len_act = ArgumentHelper.session_len(pt_group)
         max_batch_size_act = ArgumentHelper.max_batch_size(pt_group)
         cache_max_entry_act = ArgumentHelper.cache_max_entry_count(pt_group)
+        cache_block_seq_len_act = ArgumentHelper.cache_block_seq_len(pt_group)
 
         # turbomind args
         tb_group = parser.add_argument_group('TurboMind engine arguments')
@@ -63,10 +64,10 @@ class SubCliServe:
         tb_group._group_actions.append(session_len_act)
         tb_group._group_actions.append(max_batch_size_act)
         tb_group._group_actions.append(cache_max_entry_act)
+        tb_group._group_actions.append(cache_block_seq_len_act)
         ArgumentHelper.model_format(tb_group)
         ArgumentHelper.quant_policy(tb_group)
         ArgumentHelper.rope_scaling_factor(tb_group)
-        ArgumentHelper.cache_block_seq_len(tb_group)
 
     @staticmethod
     def add_parser_api_server():
@@ -138,6 +139,7 @@ class SubCliServe:
         session_len_act = ArgumentHelper.session_len(pt_group)
         max_batch_size_act = ArgumentHelper.max_batch_size(pt_group)
         cache_max_entry_act = ArgumentHelper.cache_max_entry_count(pt_group)
+        cache_block_seq_len_act = ArgumentHelper.cache_block_seq_len(pt_group)
 
         # turbomind args
         tb_group = parser.add_argument_group('TurboMind engine arguments')
@@ -147,10 +149,10 @@ class SubCliServe:
         tb_group._group_actions.append(session_len_act)
         tb_group._group_actions.append(max_batch_size_act)
         tb_group._group_actions.append(cache_max_entry_act)
+        tb_group._action_groups.append(cache_block_seq_len_act)
         ArgumentHelper.model_format(tb_group)
         ArgumentHelper.quant_policy(tb_group)
         ArgumentHelper.rope_scaling_factor(tb_group)
-        ArgumentHelper.cache_block_seq_len(tb_group)
 
     @staticmethod
     def add_parser_api_client():
@@ -207,6 +209,7 @@ class SubCliServe:
                 model_name=args.model_name,
                 max_batch_size=args.max_batch_size,
                 cache_max_entry_count=args.cache_max_entry_count,
+                block_size=args.cache_block_seq_len,
                 session_len=args.session_len)
         else:
             backend_config = TurbomindEngineConfig(
@@ -248,6 +251,7 @@ class SubCliServe:
                 model_name=args.model_name,
                 max_batch_size=args.max_batch_size,
                 cache_max_entry_count=args.cache_max_entry_count,
+                block_size=args.cache_block_seq_len,
                 session_len=args.session_len)
         else:
             from lmdeploy.messages import TurbomindEngineConfig

--- a/lmdeploy/cli/utils.py
+++ b/lmdeploy/cli/utils.py
@@ -354,3 +354,13 @@ class ArgumentHelper:
             type=str,
             default='./work_dir',
             help='The working directory to save results')
+
+    @staticmethod
+    def cache_block_seq_len(parser):
+        """Add argument cache_block_seq_len to parser."""
+
+        return parser.add_argument(
+            '--cache-block-seq-len',
+            type=int,
+            default=128,
+            help='The length of the token sequence in a k/v block')

--- a/lmdeploy/cli/utils.py
+++ b/lmdeploy/cli/utils.py
@@ -363,4 +363,9 @@ class ArgumentHelper:
             '--cache-block-seq-len',
             type=int,
             default=64,
-            help='The length of the token sequence in a k/v block')
+            help='The length of the token sequence in a k/v block. '
+            'For Turbomind Engine, if the GPU compute capability '
+            'is >= 8.0, it should be a multiple of 32, otherwise '
+            'it should be a multiple of 64. For Pytorch Engine, '
+            'if Lora Adapter is specified, this parameter will '
+            'be ignored')

--- a/lmdeploy/cli/utils.py
+++ b/lmdeploy/cli/utils.py
@@ -362,5 +362,5 @@ class ArgumentHelper:
         return parser.add_argument(
             '--cache-block-seq-len',
             type=int,
-            default=128,
+            default=64,
             help='The length of the token sequence in a k/v block')

--- a/lmdeploy/messages.py
+++ b/lmdeploy/messages.py
@@ -112,7 +112,8 @@ class TurbomindEngineConfig:
         cache_max_entry_count (float): the percentage of gpu memory occupied by the k/v cache.
             For versions of lmdeploy between `v0.2.0` and `v0.2.1`, it defaults to 0.5, depicting the percentage of TOTAL GPU memory to be allocated to the k/v cache.
             For lmdeploy versions greater than `v0.2.1`, it defaults to 0.8, signifying the percentage of FREE GPU memory to be reserved for the k/v cache
-        quant_policy (int): , default to 0. When k/v is quantized into 8 bit, set it to 4
+        cache_block_seq_len (int): the length of the token sequence in a k/v block, default to 128
+        quant_policy (int): default to 0. When k/v is quantized into 8 bit, set it to 4
         rope_scaling_factor (int): scaling factor used for dynamic ntk, default to 0. TurboMind follows the implementation of transformer LlamaAttention
         use_logn_attn (bool): whether or not to use log attn: default to False
         download_dir (str): Directory to download and load the weights, default to the default cache directory of huggingface.
@@ -126,6 +127,7 @@ class TurbomindEngineConfig:
     session_len: Optional[int] = None
     max_batch_size: int = 128
     cache_max_entry_count: float = 0.8
+    cache_block_seq_len: int = 128
     quant_policy: int = 0
     rope_scaling_factor: float = 0.0
     use_logn_attn: bool = False

--- a/lmdeploy/messages.py
+++ b/lmdeploy/messages.py
@@ -112,7 +112,7 @@ class TurbomindEngineConfig:
         cache_max_entry_count (float): the percentage of gpu memory occupied by the k/v cache.
             For versions of lmdeploy between `v0.2.0` and `v0.2.1`, it defaults to 0.5, depicting the percentage of TOTAL GPU memory to be allocated to the k/v cache.
             For lmdeploy versions greater than `v0.2.1`, it defaults to 0.8, signifying the percentage of FREE GPU memory to be reserved for the k/v cache
-        cache_block_seq_len (int): the length of the token sequence in a k/v block, default to 128
+        cache_block_seq_len (int): the length of the token sequence in a k/v block, default to 64
         quant_policy (int): default to 0. When k/v is quantized into 8 bit, set it to 4
         rope_scaling_factor (int): scaling factor used for dynamic ntk, default to 0. TurboMind follows the implementation of transformer LlamaAttention
         use_logn_attn (bool): whether or not to use log attn: default to False
@@ -127,7 +127,7 @@ class TurbomindEngineConfig:
     session_len: Optional[int] = None
     max_batch_size: int = 128
     cache_max_entry_count: float = 0.8
-    cache_block_seq_len: int = 128
+    cache_block_seq_len: int = 64
     quant_policy: int = 0
     rope_scaling_factor: float = 0.0
     use_logn_attn: bool = False

--- a/lmdeploy/turbomind/chat.py
+++ b/lmdeploy/turbomind/chat.py
@@ -2,8 +2,7 @@
 import os
 import random
 
-from lmdeploy.messages import EngineGenerationConfig
-from lmdeploy.messages import TurbomindEngineConfig
+from lmdeploy.messages import EngineGenerationConfig, TurbomindEngineConfig
 from lmdeploy.model import ChatTemplateConfig
 from lmdeploy.tokenizer import DetokenizeState
 

--- a/lmdeploy/turbomind/chat.py
+++ b/lmdeploy/turbomind/chat.py
@@ -75,7 +75,6 @@ def main(model_path: str,
         model_path,
         model_name=model_name,
         engine_config=engine_cfg,
-        tp=tp,
         capability=cap,
         chat_template_config=chat_template_cfg,
         **kwargs)

--- a/lmdeploy/turbomind/chat.py
+++ b/lmdeploy/turbomind/chat.py
@@ -67,7 +67,10 @@ def main(model_path: str,
                 new_kwargs[k] = v
         kwargs = new_kwargs
 
-    engine_cfg = TurbomindEngineConfig(**kwargs)
+    engine_cfg = TurbomindEngineConfig(model_name=model_name, tp=tp)
+    for k, v in kwargs.items():
+        if hasattr(engine_cfg, k):
+            setattr(engine_cfg, k, v)
 
     tm_model = tm.TurboMind.from_pretrained(
         model_path,

--- a/lmdeploy/turbomind/chat.py
+++ b/lmdeploy/turbomind/chat.py
@@ -31,17 +31,6 @@ def valid_str(string, coding='utf-8'):
     return ret
 
 
-def fill_config(cfg, kwargs):
-    """Fill config attributes with kwargs."""
-    new_kwargs = {}
-    for k, v in kwargs.items():
-        if hasattr(cfg, k):
-            setattr(cfg, k, v)
-        else:
-            new_kwargs[k] = v
-    return new_kwargs
-
-
 def main(model_path: str,
          model_name: str = None,
          session_id: int = 1,
@@ -50,7 +39,6 @@ def main(model_path: str,
          stream_output: bool = True,
          request_output_len: int = 1024,
          chat_template_cfg: ChatTemplateConfig = None,
-         engine_cfg: TurbomindEngineConfig = None,
          **kwargs):
     """An example to perform model inference through the command line
     interface.
@@ -71,10 +59,15 @@ def main(model_path: str,
     if chat_template_cfg is None:
         chat_template_cfg = ChatTemplateConfig(model_name=model_name,
                                                capability=cap)
-        kwargs = fill_config(chat_template_cfg, kwargs)
-    if engine_cfg is None:
-        engine_cfg = TurbomindEngineConfig(model_name=model_name)
-        kwargs = fill_config(engine_cfg, kwargs)
+        new_kwargs = {}
+        for k, v in kwargs.items():
+            if hasattr(chat_template_cfg, k):
+                setattr(chat_template_cfg, k, v)
+            else:
+                new_kwargs[k] = v
+        kwargs = new_kwargs
+
+    engine_cfg = TurbomindEngineConfig(**kwargs)
 
     tm_model = tm.TurboMind.from_pretrained(
         model_path,

--- a/lmdeploy/turbomind/chat.py
+++ b/lmdeploy/turbomind/chat.py
@@ -3,6 +3,7 @@ import os
 import random
 
 from lmdeploy.messages import EngineGenerationConfig
+from lmdeploy.messages import TurbomindEngineConfig
 from lmdeploy.model import ChatTemplateConfig
 from lmdeploy.tokenizer import DetokenizeState
 
@@ -30,6 +31,17 @@ def valid_str(string, coding='utf-8'):
     return ret
 
 
+def fill_config(cfg, kwargs):
+    """Fill config attributes with kwargs."""
+    new_kwargs = {}
+    for k, v in kwargs.items():
+        if hasattr(cfg, k):
+            setattr(cfg, k, v)
+        else:
+            new_kwargs[k] = v
+    return new_kwargs
+
+
 def main(model_path: str,
          model_name: str = None,
          session_id: int = 1,
@@ -38,6 +50,7 @@ def main(model_path: str,
          stream_output: bool = True,
          request_output_len: int = 1024,
          chat_template_cfg: ChatTemplateConfig = None,
+         engine_cfg: TurbomindEngineConfig = None,
          **kwargs):
     """An example to perform model inference through the command line
     interface.
@@ -58,16 +71,15 @@ def main(model_path: str,
     if chat_template_cfg is None:
         chat_template_cfg = ChatTemplateConfig(model_name=model_name,
                                                capability=cap)
-        new_kwargs = {}
-        for k, v in kwargs.items():
-            if hasattr(chat_template_cfg, k):
-                setattr(chat_template_cfg, k, v)
-            else:
-                new_kwargs[k] = v
-        kwargs = new_kwargs
+        kwargs = fill_config(chat_template_cfg, kwargs)
+    if engine_cfg is None:
+        engine_cfg = TurbomindEngineConfig(model_name=model_name)
+        kwargs = fill_config(engine_cfg, kwargs)
+
     tm_model = tm.TurboMind.from_pretrained(
         model_path,
         model_name=model_name,
+        engine_config=engine_cfg,
         tp=tp,
         capability=cap,
         chat_template_config=chat_template_cfg,

--- a/lmdeploy/turbomind/deploy/target_model/base.py
+++ b/lmdeploy/turbomind/deploy/target_model/base.py
@@ -56,7 +56,7 @@ class TurbomindModelConfig:
     max_context_token_num: int = 1
     step_length: int = 1
     cache_max_entry_count: float = 0.8
-    cache_block_seq_len: int = 128
+    cache_block_seq_len: int = 64
     cache_chunk_size: int = -1
     num_tokens_per_iter: int = 0
     max_prefill_iters: int = 1

--- a/tests/test_lmdeploy/test_auto_backend.py
+++ b/tests/test_lmdeploy/test_auto_backend.py
@@ -75,3 +75,10 @@ class TestAutoBackend:
         assert type(
             autoget_backend_config(
                 'mistralai/Mistral-7B-Instruct-v0.1')) is PytorchEngineConfig
+        backend_config = TurbomindEngineConfig(max_batch_size=64,
+                                               cache_block_seq_len=128)
+        config = autoget_backend_config('mistralai/Mistral-7B-Instruct-v0.1',
+                                        backend_config)
+        assert type(config) is PytorchEngineConfig
+        assert config.max_batch_size == 64
+        assert config.block_size == 128


### PR DESCRIPTION
## Motivation

As mentioned in https://github.com/InternLM/lmdeploy/issues/1195, `cache_block_seq_len` is an important parameter for performance. We should expose it to users.

## Modification
Added argument `--cache-block-seq-len` for serve and chat api, and some benchmark scripts. The default value is 128, which is consistent with the previous internal setting.