### PR TITLE
optimize pytorch engine inference with falcon model

### DIFF
--- a/lmdeploy/pytorch/check_env/__init__.py
+++ b/lmdeploy/pytorch/check_env/__init__.py
@@ -61,7 +61,8 @@ def check_env():
     check_env_triton()
 
 
-def check_transformers_version(model_path: str):
+def check_transformers_version(model_path: str,
+                               trust_remote_code: bool = True):
     """check transformers version."""
     from packaging import version
     logger = get_logger('lmdeploy')
@@ -77,7 +78,8 @@ def check_transformers_version(model_path: str):
     model_trans_version = None
     try:
         from transformers import AutoConfig
-        config = AutoConfig.from_pretrained(model_path, trust_remote_code=True)
+        config = AutoConfig.from_pretrained(
+            model_path, trust_remote_code=trust_remote_code)
         model_trans_version = getattr(config, 'transformers_version')
     except Exception as e:
         message = (
@@ -97,7 +99,7 @@ def check_transformers_version(model_path: str):
         _handle_exception(e, 'transformers', logger, message=message)
 
 
-def check_model(model_path: str):
+def check_model(model_path: str, trust_remote_code: bool = True):
     """check model requirements."""
     logger = get_logger('lmdeploy')
     logger.info('Checking model.')

--- a/lmdeploy/pytorch/engine/cache_engine.py
+++ b/lmdeploy/pytorch/engine/cache_engine.py
@@ -201,7 +201,8 @@ class CacheEngine:
 
     @staticmethod
     def get_cache_block_size(block_size: int,
-                             model_config: ModelConfig) -> int:
+                             model_config: ModelConfig,
+                             world_size: int = 1) -> int:
         """Get the required cache size of the model.
 
         Args:
@@ -214,6 +215,8 @@ class CacheEngine:
         head_size = model_config.get_head_size()
         num_layers = model_config.num_layers
         num_heads = model_config.num_key_value_heads
+        if not model_config.multi_query_attention:
+            num_heads = num_heads // world_size
 
         key_cache_block = block_size * num_heads * head_size
         value_cache_block = key_cache_block

--- a/lmdeploy/pytorch/engine/engine.py
+++ b/lmdeploy/pytorch/engine/engine.py
@@ -160,7 +160,7 @@ class Engine:
                  engine_config: PytorchEngineConfig,
                  trust_remote_code: bool = True) -> None:
         check_env()
-        check_model(model_path)
+        check_model(model_path, trust_remote_code)
 
         self.engine_config = engine_config
         model_name = engine_config.model_name

--- a/lmdeploy/pytorch/engine/model_agent.py
+++ b/lmdeploy/pytorch/engine/model_agent.py
@@ -58,7 +58,7 @@ def _update_cache_config(model_config: ModelConfig,
     gpu_mem = gpu_mem_physical_free * cache_config.cache_max_entry_count
     cpu_mem = host_mem_size
     cache_block_size = CacheEngine.get_cache_block_size(
-        cache_config.block_size, model_config) // world_size
+        cache_config.block_size, model_config, world_size)
     if cache_config.num_cpu_blocks == 0:
         cache_config.num_cpu_blocks = int(cpu_mem / cache_block_size)
     if cache_config.num_gpu_blocks == 0:

--- a/lmdeploy/pytorch/models/falcon.py
+++ b/lmdeploy/pytorch/models/falcon.py
@@ -12,71 +12,11 @@ import torch.utils.checkpoint
 from torch.distributed._tensor import DeviceMesh
 from transformers.modeling_outputs import \
     BaseModelOutputWithPastAndCrossAttentions
-from transformers.models.falcon.modeling_falcon import build_alibi_tensor
 
 from ..dist_utils import (colwise_parallelize_linear_fn,
                           rowwise_parallelize_linear_fn)
-from ..kernels import (alibi_paged_attention_fwd, fill_kv_cache,
-                       paged_attention_fwd)
-
-
-# rotary pos emb helpers
-# (torch.jit.script does not seem to support staticmethod...)
-def rotate_half(x):
-    x1, x2 = x[..., :x.shape[-1] // 2], x[..., x.shape[-1] // 2:]
-    return torch.cat((-x2, x1), dim=-1)
-
-
-class PatchedFalconRotaryEmbedding(nn.Module):
-    """Implementation adapted from Huggingface transformers."""
-
-    def _patched_set_cos_sin_cache(self, seq_len, device, dtype):
-        self.seq_len_cached = seq_len
-        t = torch.arange(seq_len, device=device, dtype=self.inv_freq.dtype)
-        freqs = torch.einsum('i,j->ij', t, self.inv_freq)
-        emb = torch.cat((freqs, freqs), dim=-1).to(device)
-
-        if dtype in [torch.float16, torch.bfloat16]:
-            emb = emb.float()
-
-        self.cos_cached = emb.cos()[None, :, :]
-        self.sin_cached = emb.sin()[None, :, :]
-
-        self.cos_cached = self.cos_cached.type(dtype)
-        self.sin_cached = self.sin_cached.type(dtype)
-
-    def patched_cos_sin(self,
-                        position_ids_1d: torch.Tensor,
-                        device='cpu',
-                        dtype=torch.bfloat16) -> torch.Tensor:
-        total_length = int(position_ids_1d.max().item()) + 1
-
-        if (self.seq_len_cached is None) or (total_length >
-                                             self.seq_len_cached):
-            self._patched_set_cos_sin_cache(total_length, device, dtype)
-        # position_ids.shape == [1, packed_seq_len]
-        # position_ids_1d.shape == [packed_seq_len]
-        return (
-            self.cos_cached[:, position_ids_1d, None, :],
-            self.sin_cached[:, position_ids_1d, None, :],
-        )
-
-    def _contiguous_batching_forward(self, query: torch.Tensor,
-                                     key: torch.Tensor,
-                                     position_ids_1d: torch.Tensor):
-        # batch, seq_len, *_ = query.shape
-        cos, sin = self.patched_cos_sin(position_ids_1d,
-                                        device=query.device,
-                                        dtype=query.dtype)
-        return (
-            (query * cos) + (rotate_half(query) * sin),
-            (key * cos) + (rotate_half(key) * sin),
-        )
-
-    def forward(self, query, key, position_ids_or_past_key_values_length=0):
-        """forward."""
-        return self._contiguous_batching_forward(
-            query, key, position_ids_or_past_key_values_length)
+from ..kernels import (alibi_paged_attention_fwd, apply_rotary_pos_emb,
+                       fill_kv_cache, fused_rotary_emb, paged_attention_fwd)
 
 
 class PatchedFalconAttention(nn.Module):
@@ -93,7 +33,7 @@ class PatchedFalconAttention(nn.Module):
                 # e.g. 40b-instruct, GQA
                 # split qkv across groups
                 # no finer-grained partitioning
-                weight = mod.weight.reshape(
+                mod.weight.data = mod.weight.reshape(
                     -1,  # num groups
                     (self.num_heads + self.num_kv_heads * 2) * self.head_dim,
                     self.hidden_size,
@@ -101,31 +41,22 @@ class PatchedFalconAttention(nn.Module):
             elif self.multi_query:
                 # e.g. 7b-instruct, MQA
                 # split to q, copy kv
-                weight = mod.weight.reshape(
-                    -1,
-                    self.head_dim,
-                    self.hidden_size,
-                )
+                weight = mod.weight.unflatten(0, (-1, self.head_dim))
                 q_weight = weight[:self.num_heads]
-                k_weight = weight[self.num_heads:self.num_heads + 1]
-                v_weight = weight[self.num_heads + 1:self.num_heads + 2]
-                q_weight_shards = torch.tensor_split(q_weight,
-                                                     world_size,
-                                                     dim=0)
+                kv_weight = weight[-2:]
+                q_weight_shards = q_weight.chunk(world_size, 0)
                 weight_shards = []
                 for q in q_weight_shards:
                     # only shard q heads but
                     # copy single k/v head to all ranks
                     weight_shards.append(q)
-                    weight_shards.append(k_weight)
-                    weight_shards.append(v_weight)
+                    weight_shards.append(kv_weight)
                 mod.weight.data = torch.cat(weight_shards, dim=0)
                 # here we keep the weight to be 3D,
                 # so that column parallel will split it
                 # into integer-numbered heads
 
             # no bias for 7b-instruct and 40b-instruct
-
             colwise_parallelize_linear_fn(mod,
                                           device_mesh=device_mesh,
                                           to_local=True)
@@ -137,7 +68,7 @@ class PatchedFalconAttention(nn.Module):
         elif mod_name in ['dense']:
             if self.new_decoder_architecture:
                 # e.g. 40b-instruct, GQA
-                weight = mod.weight.reshape(
+                mod.weight.data = mod.weight.reshape(
                     self.hidden_size,
                     -1,  # num groups
                     self.num_heads * self.head_dim,
@@ -202,79 +133,80 @@ class PatchedFalconAttention(nn.Module):
                                                                          2, :]
         else:
             # e.g. 7b-instruct model
-            batch_size, seq_length, three_times_hidden_size = fused_qkv.shape
-            if not dist.is_initialized():
-                num_head = self.num_heads
-            else:
-                # this trick will, for example, split 11 into [4, 4, 3]
-                # following the way column parallel linear splitting
-                # non-dividable dims
-                num_head = self.num_heads - dist.get_rank() - 1
-                num_head = 1 + num_head // dist.get_world_size()
-            fused_qkv = fused_qkv.view(batch_size, seq_length, num_head + 2,
-                                       self.head_dim)
-            return fused_qkv[..., :-2, :], fused_qkv[..., [-2], :], fused_qkv[
-                ..., [-1], :]
+            fused_qkv = fused_qkv.unflatten(-1, (-1, self.head_dim))
+            split_shape = (fused_qkv.size(-2) - 2, 1, 1)
+            return fused_qkv.split(split_shape, dim=-2)
 
     def _contiguous_batching_forward(
         self,
         hidden_states: torch.Tensor,
-        position_ids: torch.Tensor,
         alibi: Optional[torch.Tensor],
-        attention_mask: torch.Tensor,
         layer_past: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
-        head_mask: Optional[torch.Tensor] = None,
-        use_cache: bool = False,
         output_attentions: bool = False,
     ):
         # prepare inputs for continuous batch forwarding
         context = self.context.context
-
-        history_lengths = context.history_lengths
         q_start_loc = context.q_start_loc
         q_seq_length = context.q_seq_length
-        history_lengths = q_seq_length.new_tensor(history_lengths)
-        kv_seq_length = q_seq_length + history_lengths
-        max_seq_len = q_seq_length.max().item()
+        history_lengths = context.history_lengths
+        kv_seq_length = context.kv_seq_length
+        max_seq_length = context.max_seq_length
+        block_offsets = context.block_offsets
+        position_ids_1d = context.position_ids_1d
 
-        fused_qkv = self.query_key_value(
-            hidden_states)  # [batch_size, seq_length, 3 x hidden_size]
+        def __maybe_rotary_fn(query_states, key_states, value_states):
+            scaling_factor = 1.0
+            inv_freq = self.maybe_rotary.inv_freq
+            query_states, key_states = fused_rotary_emb(
+                query_states[None],
+                key_states[None],
+                position_ids_1d[None],
+                inv_freq=inv_freq,
+                scaling_factor=scaling_factor,
+                out_q=query_states[None],
+                out_k=key_states[None])
+            return query_states[0], key_states[0], value_states
+
+        def __rotary_emb_fn(query_states, key_states, value_states):
+            """rotary embedding func."""
+            kv_seq_len = max_seq_length + max(history_lengths)
+
+            cos, sin = self.rotary_emb(value_states.transpose(0, 1),
+                                       kv_seq_len)
+            query_states, key_states = apply_rotary_pos_emb(
+                query_states, key_states, cos, sin, context.position_ids,
+                position_ids_1d)
+            return query_states, key_states, value_states
+
+        fused_qkv = self.query_key_value(hidden_states)
 
         # 3 x [batch_size, seq_length, num_heads, head_dim]
         (query_layer, key_layer, value_layer) = self._split_heads(fused_qkv)
 
-        batch_size, query_length, _, _ = query_layer.shape
+        query_layer = query_layer.flatten(0, 1)
+        key_layer = key_layer.flatten(0, 1)
+        value_layer = value_layer.flatten(0, 1)
+        if hasattr(self, 'maybe_rotary'):
+            query_layer, key_layer, value_layer = __maybe_rotary_fn(
+                query_layer, key_layer, value_layer)
+        elif hasattr(self, 'rotary_emb'):
+            query_layer, key_layer, value_layer = __rotary_emb_fn(
+                query_layer, key_layer, value_layer)
 
-        if isinstance(self.maybe_rotary, nn.Module):
-            position_ids_1d = self.context.context.position_ids_1d
-            query_layer, key_layer = self.maybe_rotary(query_layer, key_layer,
-                                                       position_ids_1d)
+        past_key, past_value = layer_past
+        fill_kv_cache(key_layer.contiguous(),
+                      value_layer.contiguous(),
+                      past_key,
+                      past_value,
+                      q_start_loc,
+                      q_seq_length,
+                      block_offsets=block_offsets,
+                      history_lengths=history_lengths,
+                      context=context)
 
-        if layer_past is not None:
-            past_key, past_value = layer_past
-            # concatenate along seq_length dimension:
-            #  - key: [batch_size * self.num_heads, kv_length, head_dim]
-            #  - value: [batch_size * self.num_heads, kv_length, head_dim]
+        attn_output = query_layer
 
-            fill_kv_cache(key_layer.contiguous(),
-                          value_layer.contiguous(),
-                          past_key,
-                          past_value,
-                          q_start_loc,
-                          q_seq_length,
-                          block_offsets=context.block_offsets,
-                          history_lengths=context.history_lengths,
-                          context=context)
-
-        if use_cache:
-            present = (key_layer, value_layer)
-        else:
-            present = None
-
-        attn_output = torch.empty_like(query_layer)
-        block_offsets = context.block_offsets
-
-        if alibi is None:
+        if not alibi:
             paged_attention_fwd(q=query_layer,
                                 k=past_key,
                                 v=past_value,
@@ -283,9 +215,15 @@ class PatchedFalconAttention(nn.Module):
                                 q_start_loc=q_start_loc,
                                 q_seqlens=q_seq_length,
                                 kv_seqlens=kv_seq_length,
-                                max_seqlen=max_seq_len)
+                                max_seqlen=max_seq_length)
 
         else:
+            num_heads_full = self.num_heads
+            head_offset = 0
+            if dist.is_initialized():
+                world_size = dist.get_world_size()
+                rank = dist.get_rank()
+                head_offset = self.num_heads // world_size * rank
             alibi_paged_attention_fwd(q=query_layer,
                                       k=past_key,
                                       v=past_value,
@@ -294,17 +232,18 @@ class PatchedFalconAttention(nn.Module):
                                       b_start_loc=q_start_loc,
                                       b_seq_len=q_seq_length,
                                       b_kv_seq_len=kv_seq_length,
-                                      max_input_len=max_seq_len,
+                                      max_input_len=max_seq_length,
+                                      head_offset=head_offset,
+                                      num_heads=num_heads_full,
                                       alibi_scale=self.inv_norm_factor)
 
-        attn_output = attn_output.reshape(batch_size, query_length, -1)
-
+        attn_output = attn_output[None].flatten(-2, -1)
         output_tensor = self.dense(attn_output)
 
         if output_attentions:
-            return output_tensor, present, None
+            return output_tensor, layer_past, None
         else:
-            return output_tensor, present
+            return output_tensor, layer_past
 
     def forward(
         self,
@@ -316,11 +255,8 @@ class PatchedFalconAttention(nn.Module):
         use_cache: bool = False,
         output_attentions: bool = False,
     ):
-        position_ids = self.context.context.position_ids
-        return self._contiguous_batching_forward(hidden_states, position_ids,
-                                                 alibi, attention_mask,
-                                                 layer_past, head_mask,
-                                                 use_cache, output_attentions)
+        return self._contiguous_batching_forward(hidden_states, alibi,
+                                                 layer_past)
 
 
 class PatchedFalconMLP(nn.Module):
@@ -350,40 +286,16 @@ class PatchedFalconModel(nn.Module):
     def _contiguous_batching_forward(
         self,
         input_ids: Optional[torch.LongTensor] = None,
-        # position_ids: Optional[torch.LongTensor] = None,
         past_key_values: Optional[Tuple[Tuple[torch.Tensor, torch.Tensor],
                                         ...]] = None,
-        attention_mask: Optional[torch.Tensor] = None,
         head_mask: Optional[torch.LongTensor] = None,
         inputs_embeds: Optional[torch.LongTensor] = None,
-        use_cache: Optional[bool] = None,
-        output_attentions: Optional[bool] = None,
-        output_hidden_states: Optional[bool] = None,
-        return_dict: Optional[bool] = None,
     ) -> Union[Tuple[torch.Tensor, ...],
                BaseModelOutputWithPastAndCrossAttentions]:
 
-        # history_lengths = self.context.context.history_lengths
-
-        output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions  # noqa
-        output_hidden_states = (output_hidden_states
-                                if output_hidden_states is not None else
-                                self.config.output_hidden_states)
-        use_cache = use_cache if use_cache is not None else self.config.use_cache  # noqa
-        return_dict = return_dict if return_dict is not None else self.config.use_return_dict  # noqa
+        output_attentions = False
+        use_cache = True
         use_alibi = getattr(self, 'use_alibi', getattr(self, 'alibi', False))
-
-        if input_ids is not None and inputs_embeds is not None:
-            raise ValueError(
-                'You cannot specify both input_ids and inputs_embeds at the same time'  # noqa
-            )
-        elif input_ids is not None:
-            batch_size, seq_length = input_ids.shape
-        elif inputs_embeds is not None:
-            batch_size, seq_length, _ = inputs_embeds.shape
-        else:
-            raise ValueError(
-                'You have to specify either input_ids or inputs_embeds')
 
         # Prepare head mask if needed
         # 1.0 in head_mask indicate we keep the head
@@ -397,63 +309,35 @@ class PatchedFalconModel(nn.Module):
 
         hidden_states = inputs_embeds
 
-        # presents = () if use_cache else None
-        all_self_attentions = () if output_attentions else None
-        all_hidden_states = () if output_hidden_states else None
-
         # Compute alibi tensor: check build_alibi_tensor documentation
-        if use_alibi:
-            alibi = build_alibi_tensor(attention_mask,
-                                       self.num_heads,
-                                       dtype=hidden_states.dtype)
-        else:
-            alibi = None
 
         for i, (block, layer_past) in enumerate(zip(self.h, past_key_values)):
-            if output_hidden_states:
-                all_hidden_states = all_hidden_states + (hidden_states, )
 
             outputs = block(
                 hidden_states,
-                # position_ids=position_ids,
                 layer_past=layer_past,
                 attention_mask=None,
                 head_mask=head_mask[i],
                 use_cache=use_cache,
                 output_attentions=output_attentions,
-                alibi=alibi,
+                alibi=use_alibi,
             )
 
             hidden_states = outputs[0]
 
-            if output_attentions:
-                all_self_attentions = all_self_attentions + (
-                    outputs[2 if use_cache else 1], )
-
         # Add last hidden state
-
         hidden_states = self.ln_f(hidden_states)
-
-        if output_hidden_states:
-            all_hidden_states = all_hidden_states + (hidden_states, )
-
-        if not return_dict:
-            return tuple(v for v in [
-                hidden_states, past_key_values, all_hidden_states,
-                all_self_attentions
-            ] if v is not None)
 
         return BaseModelOutputWithPastAndCrossAttentions(
             last_hidden_state=hidden_states,
             past_key_values=past_key_values,
-            hidden_states=all_hidden_states,
-            attentions=all_self_attentions,
+            hidden_states=None,
+            attentions=None,
         )
 
     def forward(
         self,
         input_ids: Optional[torch.LongTensor] = None,
-        # position_ids: Optional[torch.LongTensor] = None,
         past_key_values: Optional[Tuple[Tuple[torch.Tensor, torch.Tensor],
                                         ...]] = None,
         attention_mask: Optional[torch.Tensor] = None,
@@ -466,12 +350,7 @@ class PatchedFalconModel(nn.Module):
     ) -> Union[Tuple[torch.Tensor, ...],
                BaseModelOutputWithPastAndCrossAttentions]:
         return self._contiguous_batching_forward(
-            input_ids=input_ids,
-            past_key_values=past_key_values,
-            attention_mask=attention_mask,
-            output_attentions=output_attentions,
-            output_hidden_states=output_hidden_states,
-            return_dict=return_dict)
+            input_ids=input_ids, past_key_values=past_key_values)
 
 
 class PatchedFalconForCausalLM(nn.Module):

--- a/lmdeploy/pytorch/models/gemma.py
+++ b/lmdeploy/pytorch/models/gemma.py
@@ -100,7 +100,7 @@ class PatchedGemmaAttention(nn.Module):
                 scaling_factor=scaling_factor,
                 out_q=query_states[None],
                 out_k=key_states[None])
-            return query_states, key_states, value_states
+            return query_states[0], key_states[0], value_states
 
         query_states, key_states, value_states = __qkv_proj(hidden_states)
 

--- a/lmdeploy/pytorch/models/llama.py
+++ b/lmdeploy/pytorch/models/llama.py
@@ -245,7 +245,7 @@ class LlamaAttention(nn.Module):
                 scaling_factor=scaling_factor,
                 out_q=query_states[None],
                 out_k=key_states[None])
-            return query_states, key_states, value_states
+            return query_states[0], key_states[0], value_states
 
         def __rotary_emb_fn_438(query_states, key_states, value_states):
             rotary_name = type(self.rotary_emb).__name__

--- a/lmdeploy/pytorch/models/module_map.py
+++ b/lmdeploy/pytorch/models/module_map.py
@@ -30,8 +30,6 @@ MODULE_MAP.update({
     f'{LMDEPLOY_PYTORCH_MODEL_PATH}.falcon.PatchedFalconAttention',
     'modeling_falcon.FalconModel':
     f'{LMDEPLOY_PYTORCH_MODEL_PATH}.falcon.PatchedFalconModel',
-    'modeling_falcon.FalconRotaryEmbedding':
-    f'{LMDEPLOY_PYTORCH_MODEL_PATH}.falcon.PatchedFalconRotaryEmbedding',
     'modeling_falcon.FalconMLP':
     f'{LMDEPLOY_PYTORCH_MODEL_PATH}.falcon.PatchedFalconMLP',
     'modeling_falcon.FalconForCausalLM':

--- a/lmdeploy/pytorch/models/patch.py
+++ b/lmdeploy/pytorch/models/patch.py
@@ -212,6 +212,8 @@ def _dist_model(model: torch.nn.Module,
                 lambda mod, inputs, outputs: output_fn(outputs, device_mesh))
 
     for name, child in model.named_children():
+        if rank == 0:
+            logger.debug(f'Distribute module: <{name}>')
         new_child = _dist_model(child, rank, device_mesh)
         if new_child != child:
             model.register_module(name, child)


### PR DESCRIPTION
Fix falcon tp

before

```
concurrency: 256
elapsed_time: 184.839s

first token latency(s)(min, max, ave): 0.645, 13.974, 4.690
per-token latency(s) percentile(50, 75, 95, 99): [0.139, 0.147, 0.263, 0.414]

number of prompt tokens: 242197
number of completion tokens: 220686
token throughput (completion token): 1193.938 token/s
token throughput (prompt + completion token): 2504.254 token/s
RPS (request per second): 5.410 req/s
RPM (request per minute): 324.607 req/min


after
```
concurrency: 256
elapsed_time: 128.932s

first token latency(s)(min, max, ave): 0.270, 10.948, 3.440
per-token latency(s) percentile(50, 75, 95, 99): [0.095, 0.102, 0.232, 0.441]

number of prompt tokens: 242197
number of completion tokens: 220686
token throughput (completion token): 1711.640 token/s
token throughput (prompt + completion token): 3590.119 token/s
RPS (request per second): 7.756 req/s
RPM (request per minute): 465.360 req/min
```

Only tested on origin falcon-7b