### PR TITLE
Hide qos functions from swagger UI if not applied

### DIFF
--- a/lmdeploy/serve/openai/api_server.py
+++ b/lmdeploy/serve/openai/api_server.py
@@ -1052,6 +1052,11 @@ def serve(model_path: str,
                 VariableInterface.qos_engine.start()
         except FileNotFoundError:
             VariableInterface.qos_engine = None
+    else:
+        # hide qos functions if not applied
+        for i in range(len(app.router.routes)):
+            if 'qos' in app.router.routes[i].path:
+                app.router.routes[i].include_in_schema = False
 
     for i in range(3):
         print(


### PR DESCRIPTION
To make the swagger UI clean if no qos functions are applied.