### PR TITLE
Color log formatter

### DIFF
--- a/lmdeploy/pytorch/engine/engine.py
+++ b/lmdeploy/pytorch/engine/engine.py
@@ -567,7 +567,8 @@ class Engine:
         with torch.inference_mode(), torch.cuda.stream(self.stream):
             logits = logits_processor(input_ids, split_logits)
             next_token_ids = logits_processor.sampling(logits)
-        self.stream.synchronize()
+        await asyncio.get_event_loop().run_in_executor(None,
+                                                       self.stream.synchronize)
         next_token_ids = next_token_ids.cpu()
 
         return next_token_ids, split_logits

--- a/lmdeploy/pytorch/engine/engine.py
+++ b/lmdeploy/pytorch/engine/engine.py
@@ -9,7 +9,7 @@ import torch
 from lmdeploy.messages import (EngineGenerationConfig, PytorchEngineConfig,
                                ResponseType)
 from lmdeploy.tokenizer import Tokenizer
-from lmdeploy.utils import get_logger, get_model
+from lmdeploy.utils import get_logger, get_model, logging_timer
 
 from ..adapter.adapter import ADAPTER_MANAGER, SchedulerAdapter
 from ..check_env import check_env, check_model
@@ -527,6 +527,7 @@ class Engine:
             return True
         return False
 
+    @logging_timer('SamplingLogits', logger)
     async def async_sampling_logits(self, logits: torch.Tensor,
                                     running: SeqList, inputs: ModelInputs):
         """sampling logits."""
@@ -570,6 +571,7 @@ class Engine:
 
         return next_token_ids, split_logits
 
+    @logging_timer('UpdateRunning', logger)
     def update_running(self, running: SeqList, next_token_ids: torch.Tensor,
                        meta: Any):
         """update scheduler."""
@@ -593,6 +595,7 @@ class Engine:
 
         return True
 
+    @logging_timer('ModelForward', logger)
     async def _async_model_forward(self, inputs: ModelInputs,
                                    swap_in_map: Dict, swap_out_map: Dict):
         """model forward."""
@@ -714,6 +717,7 @@ class Engine:
         adapters = schedule_output.adapters
         if len(running) == 0:
             return dict()
+        logger.debug(f'Step batch_size: {len(running)}')
 
         inputs = self.create_model_inputs(running, adapters)
 

--- a/lmdeploy/pytorch/engine/engine.py
+++ b/lmdeploy/pytorch/engine/engine.py
@@ -507,6 +507,8 @@ class Engine:
         """
 
         def _check_stop_word(sampling_param, next_token_id):
+            if sampling_param.ignore_eos:
+                return False
             return (sampling_param.stop_words is not None
                     and next_token_id in sampling_param.stop_words)
 

--- a/lmdeploy/pytorch/engine/request.py
+++ b/lmdeploy/pytorch/engine/request.py
@@ -13,13 +13,12 @@ logger = get_logger('lmdeploy')
 
 
 def _raise_exception_on_finish(task: asyncio.Task) -> None:
-    msg = ('Engine loop failed!')
     try:
         task.result()
     except asyncio.CancelledError:
         return
-    except Exception as exc:
-        raise RuntimeError(msg) from exc
+    except Exception as e:
+        logger.exception(f'Engine loop failed with error: {e}')
 
 
 def _ignore_exception_on_finish(task: asyncio.Task) -> None:
@@ -158,6 +157,8 @@ class RequestSender:
             except Empty:
                 continue
             except Exception as e:
+                logger.exception(
+                    f'sender[{self.sender_id}] get response failed: {e}')
                 raise e
 
     async def _async_resp_get(self):
@@ -177,6 +178,8 @@ class RequestSender:
                 except asyncio.TimeoutError:
                     continue
                 except Exception as e:
+                    logger.exception(
+                        f'sender[{self.sender_id}] get response failed: {e}')
                     raise e
 
         if self.is_thread_safe():

--- a/lmdeploy/pytorch/models/patch.py
+++ b/lmdeploy/pytorch/models/patch.py
@@ -83,8 +83,9 @@ def _find_rewrite_module_qualname(model):
         rewrite_qualname = _find_submodulename()
 
     origin_qualname = f'{module_name}.{class_name}'
-    logger.debug(
-        f'Find rewrite of module {origin_qualname}: {rewrite_qualname}.')
+    if rewrite_qualname is not None:
+        logger.debug('Find rewrite of module\n'
+                     f'{origin_qualname} <=> {rewrite_qualname}')
     return rewrite_qualname
 
 

--- a/lmdeploy/pytorch/paging/scheduler.py
+++ b/lmdeploy/pytorch/paging/scheduler.py
@@ -4,7 +4,7 @@ from collections import OrderedDict
 from dataclasses import dataclass
 from typing import Dict, List, Set, Union
 
-from lmdeploy.utils import get_logger
+from lmdeploy.utils import get_logger, logging_timer
 
 from ..adapter.adapter import ADAPTER_MANAGER, SchedulerAdapter
 from ..config import CacheConfig, SchedulerConfig
@@ -116,6 +116,7 @@ class Scheduler:
             adapter) - self.block_manager.num_gpu_blocks
         return adapter.build_weight_map(block_table)
 
+    @logging_timer('SchedulePrefilling', logger)
     def _schedule_prefill(self):
         """Schedule for prefilling."""
 
@@ -206,6 +207,7 @@ class Scheduler:
         self.running += running
         return running, swap_in_map, swap_out_map, copy_map
 
+    @logging_timer('ScheduleDecoding', logger)
     def _schedule_decoding(self):
         """schedule decoding."""
         assert len(self.running) != 0

--- a/lmdeploy/utils.py
+++ b/lmdeploy/utils.py
@@ -198,11 +198,11 @@ def logging_timer(op_name: str, logger: Logger, level: int = logging.DEBUG):
         start = time.perf_counter()
         yield
         end = time.perf_counter()
-        duration = end - start
-        logger.log(level, f'<{op_name}> take time: {duration:.5f}')
+        duration = (end - start) * 1000
+        logger.log(level, f'<{op_name}> take time: {duration:.2f} ms')
 
     def __inner(func):
-        """inner"""
+        """inner."""
 
         @functools.wraps(func)
         def __warpper(*args, **kwargs):

--- a/lmdeploy/utils.py
+++ b/lmdeploy/utils.py
@@ -11,14 +11,22 @@ from typing import List, Optional
 logger_initialized = {}
 
 
+class _ASNI_COLOR:
+    BRIGHT_RED = '\033[91m'
+    RED = '\033[31m'
+    YELLOW = '\033[33m'
+    WHITE = '\033[37m'
+    GREEN = '\033[32m'
+
+
 class ColorFormatter(logging.Formatter):
 
-    _LEVELNAME_COLOR_MAP = dict(CRITICAL='\033[91m',
-                                ERROR='\033[31m',
-                                WARN='\033[33m',
-                                WARNING='\033[33m',
-                                INFO='\033[37m',
-                                DEBUG='\033[32m')
+    _LEVELNAME_COLOR_MAP = dict(CRITICAL=_ASNI_COLOR.BRIGHT_RED,
+                                ERROR=_ASNI_COLOR.RED,
+                                WARN=_ASNI_COLOR.YELLOW,
+                                WARNING=_ASNI_COLOR.YELLOW,
+                                INFO=_ASNI_COLOR.WHITE,
+                                DEBUG=_ASNI_COLOR.GREEN)
 
     _RESET_COLOR = '\033[0m'
 
@@ -113,7 +121,6 @@ def get_logger(
         file_handler = logging.FileHandler(log_file, file_mode)
         handlers.append(file_handler)
 
-    # formatter = logging.Formatter(log_formatter)
     formatter = ColorFormatter(log_formatter)
     for handler in handlers:
         handler.setFormatter(formatter)


### PR DESCRIPTION
- log level name would be colored.
- add timer to key function in pytorch engine.

DEBUG mode could be enabled by:
```python
logger = get_logger('lmdeploy')
logger.setLevel(logging.DEBUG)
for handler in logger.handlers:
    handler.setLevel(logging.DEBUG)
```

step logs in DEBUG mode:
```log
2024-03-05 15:45:32,977 - lmdeploy - DEBUG - <ScheduleDecoding> take time: 0.01 ms
2024-03-05 15:45:32,977 - lmdeploy - DEBUG - <AsyncStep>: batch_size=1
2024-03-05 15:45:32,977 - lmdeploy - DEBUG - <CreateModelInputs> take time: 0.08 ms
2024-03-05 15:45:32,997 - lmdeploy - DEBUG - <ModelForward> take time: 19.69 ms
2024-03-05 15:45:32,998 - lmdeploy - DEBUG - <SamplingLogits> take time: 1.55 ms
2024-03-05 15:45:32,999 - lmdeploy - DEBUG - <UpdateRunning> take time: 0.04 ms
2024-03-05 15:45:32,999 - lmdeploy - DEBUG - <AsyncStep> take time: 21.76 ms
```

color table:
```python
    _LEVELNAME_COLOR_MAP = dict(CRITICAL='\033[91m',    # dark red
                                ERROR='\033[31m',    # red
                                WARN='\033[33m',    # yellow
                                WARNING='\033[33m',    # yellow
                                INFO='\033[37m',    # white
                                DEBUG='\033[32m',    # green
)
```