### PR TITLE
rm unused var

### DIFF
--- a/src/turbomind/models/llama/LlamaBatch.h
+++ b/src/turbomind/models/llama/LlamaBatch.h
@@ -47,9 +47,6 @@ struct GenerationState {
     int max_init_ctx_len;
     int step;
 
-    int sum_seq_len;
-    int max_seq_len;
-
     int partial;
     int partial_context_legnth;
 


### PR DESCRIPTION
## Motivation

In turbomind 2.1, these variables are no longer used.

## Modification

as titled

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
