### PR TITLE
Add tensor core GQA dispatch for `[4,5,6,8]`

### DIFF
--- a/src/turbomind/kernels/attention/decoding.cu
+++ b/src/turbomind/kernels/attention/decoding.cu
@@ -68,11 +68,14 @@ void dispatchDecoding(const AttentionParams<T>& params)
             else if (query_group_sz % 8 == 0) {
                 return invokeDecoding<typename DecodingConfig<arch::Sm80, T, T, 8, kHeadDim>::Kernel>(params);
             }
+            else if (query_group_sz % 6 == 0) {
+                return invokeDecoding<typename DecodingConfig<arch::Sm80, T, T, 6, kHeadDim>::Kernel>(params);
+            }
+            else if (query_group_sz % 5 == 0) {
+                return invokeDecoding<typename DecodingConfig<arch::Sm80, T, T, 5, kHeadDim>::Kernel>(params);
+            }
             else if (query_group_sz % 4 == 0) {
                 return invokeDecoding<typename DecodingConfig<arch::Sm80, T, T, 4, kHeadDim>::Kernel>(params);
-            }
-            else if (query_group_sz % 2 == 0) {
-                return invokeDecoding<typename DecodingConfig<arch::Sm80, T, T, 2, kHeadDim>::Kernel>(params);
             }
             else {
                 return invokeDecoding<typename DecodingConfig<arch::Sm80, T, T, 1, kHeadDim>::Kernel>(params);
@@ -128,13 +131,17 @@ void dispatchDecoding(const AttentionParams<nv_bfloat16>& params)
                 return invokeDecoding<
                     typename DecodingConfig<arch::Sm80, nv_bfloat16, nv_bfloat16, 8, kHeadDim>::Kernel>(params);
             }
+            else if (query_group_sz % 6 == 0) {
+                return invokeDecoding<
+                    typename DecodingConfig<arch::Sm80, nv_bfloat16, nv_bfloat16, 6, kHeadDim>::Kernel>(params);
+            }
+            else if (query_group_sz % 5 == 0) {
+                return invokeDecoding<
+                    typename DecodingConfig<arch::Sm80, nv_bfloat16, nv_bfloat16, 5, kHeadDim>::Kernel>(params);
+            }
             else if (query_group_sz % 4 == 0) {
                 return invokeDecoding<
                     typename DecodingConfig<arch::Sm80, nv_bfloat16, nv_bfloat16, 4, kHeadDim>::Kernel>(params);
-            }
-            else if (query_group_sz % 2 == 0) {
-                return invokeDecoding<
-                    typename DecodingConfig<arch::Sm80, nv_bfloat16, nv_bfloat16, 2, kHeadDim>::Kernel>(params);
             }
             else {
                 return invokeDecoding<

--- a/src/turbomind/kernels/attention/decoding_128_bf16_sm80.cu
+++ b/src/turbomind/kernels/attention/decoding_128_bf16_sm80.cu
@@ -10,11 +10,14 @@ using namespace attention;
 using sm80_bf16_bf16_g1_d128 = Decoding<arch::Sm80, nv_bfloat16, nv_bfloat16, 1, 128>;
 template void invokeDecoding<sm80_bf16_bf16_g1_d128>(const typename sm80_bf16_bf16_g1_d128::ParamType& params);
 
-using sm80_bf16_f16_g2_d128 = Decoding<arch::Sm80, nv_bfloat16, nv_bfloat16, 2, 128>;
-template void invokeDecoding<sm80_bf16_f16_g2_d128>(const typename sm80_bf16_f16_g2_d128::ParamType& params);
-
 using sm80_bf16_bf16_g4_d128 = Decoding<arch::Sm80, nv_bfloat16, nv_bfloat16, 4, 128>;
 template void invokeDecoding<sm80_bf16_bf16_g4_d128>(const typename sm80_bf16_bf16_g4_d128::ParamType& params);
+
+using sm80_bf16_bf16_g5_d128 = Decoding<arch::Sm80, nv_bfloat16, nv_bfloat16, 5, 128>;
+template void invokeDecoding<sm80_bf16_bf16_g5_d128>(const typename sm80_bf16_bf16_g5_d128::ParamType& params);
+
+using sm80_bf16_bf16_g6_d128 = Decoding<arch::Sm80, nv_bfloat16, nv_bfloat16, 6, 128>;
+template void invokeDecoding<sm80_bf16_bf16_g6_d128>(const typename sm80_bf16_bf16_g6_d128::ParamType& params);
 
 using sm80_bf16_bf16_g8_d128 = Decoding<arch::Sm80, nv_bfloat16, nv_bfloat16, 8, 128>;
 template void invokeDecoding<sm80_bf16_bf16_g8_d128>(const typename sm80_bf16_bf16_g8_d128::ParamType& params);

--- a/src/turbomind/kernels/attention/decoding_128_f16_sm80.cu
+++ b/src/turbomind/kernels/attention/decoding_128_f16_sm80.cu
@@ -10,11 +10,14 @@ using namespace attention;
 using sm80_f16_f16_g1_d128 = Decoding<arch::Sm80, half, half, 1, 128>;
 template void invokeDecoding<sm80_f16_f16_g1_d128>(const typename sm80_f16_f16_g1_d128::ParamType& params);
 
-using sm80_f16_f16_g2_d128 = Decoding<arch::Sm80, half, half, 2, 128>;
-template void invokeDecoding<sm80_f16_f16_g2_d128>(const typename sm80_f16_f16_g2_d128::ParamType& params);
-
 using sm80_f16_f16_g4_d128 = Decoding<arch::Sm80, half, half, 4, 128>;
 template void invokeDecoding<sm80_f16_f16_g4_d128>(const typename sm80_f16_f16_g4_d128::ParamType& params);
+
+using sm80_f16_f16_g5_d128 = Decoding<arch::Sm80, half, half, 5, 128>;
+template void invokeDecoding<sm80_f16_f16_g5_d128>(const typename sm80_f16_f16_g4_d128::ParamType& params);
+
+using sm80_f16_f16_g6_d128 = Decoding<arch::Sm80, half, half, 6, 128>;
+template void invokeDecoding<sm80_f16_f16_g6_d128>(const typename sm80_f16_f16_g4_d128::ParamType& params);
 
 using sm80_f16_f16_g8_d128 = Decoding<arch::Sm80, half, half, 8, 128>;
 template void invokeDecoding<sm80_f16_f16_g8_d128>(const typename sm80_f16_f16_g8_d128::ParamType& params);


### PR DESCRIPTION
Benchmarks results of various `CTA_H`

A100 80G, batch size 128, seq len 1024, w/o split-kv, in microseconds

| 32:8 | 1      | 2      | 4      |
|------|--------|--------|--------|
| SIMT | 513.70 | 316.26 | 319.70 |
| TC   | 509.66 | 318.91 | 308.35 |

| 48:8 | 1      | 2      | 3      | 6      |
|------|--------|--------|--------|--------|
| SIMT | 755.17 | 382.27 | 354.37 | 367.46<sup>*</sup> |
| TC   | 756.35 | 401.28 | 319.58 | 309.31 |

| 64:8 | 1      | 2      | 4      | 8      |
|------|--------|--------|--------|--------|
| SIMT | 1020   | 497.92 | 406.27 | 985.82<sup>*</sup> |
| TC   | 993.98 | 517.86 | 319.39 | 305.12 |

| 80:8 | 1    | 2      | 5      |
|------|------|--------|--------|
| SIMT | 1260 | 616    | 485.70 |
| TC   | 1230 | 635.52 | 318.75 |

<sup>*</sup>register spill

Conclusion: use TC when `head_num / kv_head_num > 2`