### PR TITLE
Accelerate sample request in benchmark script

### DIFF
--- a/benchmark/profile_restful_api.py
+++ b/benchmark/profile_restful_api.py
@@ -28,6 +28,9 @@ def sample_requests(
     dataset = [(data['conversations'][0]['value'],
                 data['conversations'][1]['value']) for data in dataset]
 
+    # pre-sample to avoid go through all the dataset
+    dataset = random.sample(dataset, num_requests * 2)
+
     # Tokenize the prompts and completions.
     prompts = [prompt for prompt, _ in dataset]
     prompt_token_ids = tokenizer(prompts).input_ids

--- a/benchmark/profile_restful_api.py
+++ b/benchmark/profile_restful_api.py
@@ -29,7 +29,7 @@ def sample_requests(
                 data['conversations'][1]['value']) for data in dataset]
 
     # pre-sample to avoid go through all the dataset
-    dataset = random.sample(dataset, num_requests * 2)
+    dataset = random.sample(dataset, max(int(num_requests * 1.2), 1000))
 
     # Tokenize the prompts and completions.
     prompts = [prompt for prompt, _ in dataset]

--- a/benchmark/profile_serving.py
+++ b/benchmark/profile_serving.py
@@ -28,6 +28,9 @@ def sample_requests(
     dataset = [(data['conversations'][0]['value'],
                 data['conversations'][1]['value']) for data in dataset]
 
+    # pre-sample to avoid go through all the dataset
+    dataset = random.sample(dataset, num_requests * 2)
+
     # Tokenize the prompts and completions.
     prompts = [prompt for prompt, _ in dataset]
     prompt_token_ids = tokenizer(prompts).input_ids

--- a/benchmark/profile_serving.py
+++ b/benchmark/profile_serving.py
@@ -29,7 +29,7 @@ def sample_requests(
                 data['conversations'][1]['value']) for data in dataset]
 
     # pre-sample to avoid go through all the dataset
-    dataset = random.sample(dataset, num_requests * 2)
+    dataset = random.sample(dataset, max(int(num_requests * 1.2), 1000))
 
     # Tokenize the prompts and completions.
     prompts = [prompt for prompt, _ in dataset]

--- a/benchmark/profile_throughput.py
+++ b/benchmark/profile_throughput.py
@@ -34,7 +34,7 @@ def sample_requests(
                 data['conversations'][1]['value']) for data in dataset]
 
     # pre-sample to avoid go through all the dataset
-    dataset = random.sample(dataset, num_requests * 2)
+    dataset = random.sample(dataset, max(int(num_requests * 1.2), 1000))
 
     # Tokenize the prompts and completions.
     prompts = [prompt for prompt, _ in dataset]

--- a/benchmark/profile_throughput.py
+++ b/benchmark/profile_throughput.py
@@ -33,6 +33,9 @@ def sample_requests(
     dataset = [(data['conversations'][0]['value'],
                 data['conversations'][1]['value']) for data in dataset]
 
+    # pre-sample to avoid go through all the dataset
+    dataset = random.sample(dataset, num_requests * 2)
+
     # Tokenize the prompts and completions.
     prompts = [prompt for prompt, _ in dataset]
     prompt_token_ids = tokenizer(prompts).input_ids


### PR DESCRIPTION
## Motivation

The sampling request progress is time consuming in the benchmark script. 

## Modification

Refer to [vllm script](https://github.com/vllm-project/vllm/blob/1ece1ae829dcbc4b1b19b3e2d3042457615e862f/benchmarks/benchmark_serving.py#L70), we can pre-sample the dataset before the filter step to avoid go through all the dataset.