### PR TITLE
better cache allocation in pytorch engine

### DIFF
--- a/lmdeploy/messages.py
+++ b/lmdeploy/messages.py
@@ -176,7 +176,7 @@ class PytorchEngineConfig:
     num_cpu_blocks: int = 0
     num_gpu_blocks: int = 0
     adapters: Dict[str, str] = None
-    max_prefill_token_num: int = 8192
+    max_prefill_token_num: int = 4096
     thread_safe: bool = False
     download_dir: str = None
     revision: str = None

--- a/lmdeploy/pytorch/config.py
+++ b/lmdeploy/pytorch/config.py
@@ -28,7 +28,6 @@ class SchedulerConfig:
     eviction_type: str = 'recompute'
     prefill_interval: int = 16
     max_active_adapters: int = 64
-    max_prefill_token_num: int = 8192
 
 
 @dataclass
@@ -40,7 +39,7 @@ class CacheConfig:
     num_gpu_blocks: int
     window_size: int = -1
     cache_max_entry_count: float = 0.8
-    max_prefill_token_num: int = 8192
+    max_prefill_token_num: int = 4096
 
 
 @dataclass

--- a/lmdeploy/pytorch/config.py
+++ b/lmdeploy/pytorch/config.py
@@ -40,6 +40,7 @@ class CacheConfig:
     num_gpu_blocks: int
     window_size: int = -1
     cache_max_entry_count: float = 0.8
+    max_prefill_token_num: int = 8192
 
 
 @dataclass
@@ -56,6 +57,7 @@ class ModelConfig:
     sliding_window: int = -1
     dtype: torch.dtype = torch.float16
     multi_query_attention: bool = False
+    vocab_size: int = 40000
     json_config: dict = field(default_factory=dict)
     hf_config: Any = None
     init_kwargs: Dict[str, Any] = field(default_factory=dict)
@@ -102,6 +104,7 @@ class ModelConfig:
                 eos_token_id=hf_config.eos_token_id,
                 head_dim=head_dim,
                 multi_query_attention=hf_config.multi_query,
+                vocab_size=hf_config.vocab_size,
             )
 
         def __build_chatglm():
@@ -119,6 +122,7 @@ class ModelConfig:
                 bos_token_id=bos_token_id,
                 eos_token_id=hf_config.eos_token_id,
                 head_dim=head_dim,
+                vocab_size=hf_config.padded_vocab_size,
                 init_kwargs=init_kwargs)
 
         def __build_gemma():
@@ -129,7 +133,8 @@ class ModelConfig:
                 num_key_value_heads=hf_config.num_key_value_heads,
                 bos_token_id=hf_config.bos_token_id,
                 eos_token_id=hf_config.eos_token_id,
-                head_dim=hf_config.head_dim)
+                head_dim=hf_config.head_dim,
+                vocab_size=hf_config.vocab_size)
 
         def __build_default():
             head_dim = hf_config.hidden_size // hf_config.num_attention_heads
@@ -149,7 +154,8 @@ class ModelConfig:
                 bos_token_id=hf_config.bos_token_id,
                 eos_token_id=hf_config.eos_token_id,
                 sliding_window=sliding_window,
-                head_dim=head_dim)
+                head_dim=head_dim,
+                vocab_size=hf_config.vocab_size)
 
         if 'falcon' in model_path:
             model_config = __build_falcon()

--- a/lmdeploy/pytorch/engine/engine.py
+++ b/lmdeploy/pytorch/engine/engine.py
@@ -184,7 +184,8 @@ class Engine:
             block_size=engine_config.block_size,
             num_cpu_blocks=engine_config.num_cpu_blocks,
             num_gpu_blocks=engine_config.num_gpu_blocks,
-            cache_max_entry_count=engine_config.cache_max_entry_count)
+            cache_max_entry_count=engine_config.cache_max_entry_count,
+            max_prefill_token_num=engine_config.max_prefill_token_num)
 
         if not os.path.exists(model_path):
             model_path = get_model(model_path, engine_config.download_dir,

--- a/lmdeploy/pytorch/engine/engine.py
+++ b/lmdeploy/pytorch/engine/engine.py
@@ -723,9 +723,10 @@ class Engine:
         adapters = schedule_output.adapters
         if len(running) == 0:
             return dict()
-        logger.debug(f'<AsyncStep>: batch_size={len(running)}')
 
         inputs = self.create_model_inputs(running, adapters)
+        logger.debug(f'<AsyncStep>: batch_size={len(running)} '
+                     f'num_tokens={inputs.input_ids.size(-1)}')
 
         # inference
         output = await self._async_model_forward(inputs,

--- a/lmdeploy/pytorch/engine/engine.py
+++ b/lmdeploy/pytorch/engine/engine.py
@@ -175,8 +175,7 @@ class Engine:
             max_batches=engine_config.max_batch_size,
             max_session_len=engine_config.session_len,
             eviction_type=engine_config.eviction_type,
-            prefill_interval=engine_config.prefill_interval,
-            max_prefill_token_num=engine_config.max_prefill_token_num)
+            prefill_interval=engine_config.prefill_interval)
 
         # block_size = 1 to enable unified paging
         adapters = engine_config.adapters
@@ -604,7 +603,7 @@ class Engine:
     async def _async_model_forward(self, inputs: ModelInputs,
                                    swap_in_map: Dict, swap_out_map: Dict):
         """model forward."""
-        max_prefill_token_num = self.scheduler_config.max_prefill_token_num
+        max_prefill_token_num = self.cache_config.max_prefill_token_num
         swap_done = False
 
         class _LogitsGather:

--- a/lmdeploy/pytorch/engine/model_agent.py
+++ b/lmdeploy/pytorch/engine/model_agent.py
@@ -63,8 +63,8 @@ def _update_cache_config(model_config: ModelConfig,
                      f' {gpu_mem_physical_free>>20} mb')
         vocal_size = model_config.vocab_size
         max_prefill_token_num = cache_config.max_prefill_token_num
-        # lm_head input and output(half and float)
-        intermediate_cache_size = int(max_prefill_token_num * vocal_size * 6)
+        # lm_head output(2) + to float(4) + estimated misc(1) = 7
+        intermediate_cache_size = int(max_prefill_token_num * vocal_size * 7)
         logger.debug('estimated max runtime memory:'
                      f' {intermediate_cache_size>>20} mb')
         gpu_mem_physical_free -= intermediate_cache_size

--- a/lmdeploy/pytorch/engine/model_agent.py
+++ b/lmdeploy/pytorch/engine/model_agent.py
@@ -54,9 +54,23 @@ def _update_cache_config(model_config: ModelConfig,
         cache_config (CacheConfig): The config of the cache info.
         gpu_id (int): The GPU id to use.
     """
-    torch.cuda.empty_cache()
-    gpu_mem_physical_free, _ = get_gpu_memory(gpu_id)
-    gpu_mem = gpu_mem_physical_free * cache_config.cache_max_entry_count
+
+    def __get_free_gpu_mem_size():
+        """get free gpu memory size."""
+        torch.cuda.empty_cache()
+        gpu_mem_physical_free, _ = get_gpu_memory(gpu_id)
+        logger.debug(f'device<{gpu_id}> free gpu memory:'
+                     f' {gpu_mem_physical_free>>20} mb')
+        vocal_size = model_config.vocab_size
+        max_prefill_token_num = cache_config.max_prefill_token_num
+        # lm_head input and output(half and float)
+        intermediate_cache_size = int(max_prefill_token_num * vocal_size * 6)
+        logger.debug('estimated max runtime memory:'
+                     f' {intermediate_cache_size>>20} mb')
+        gpu_mem_physical_free -= intermediate_cache_size
+        return gpu_mem_physical_free * cache_config.cache_max_entry_count
+
+    gpu_mem = __get_free_gpu_mem_size()
     cpu_mem = host_mem_size
     cache_block_size = CacheEngine.get_cache_block_size(
         cache_config.block_size, model_config, world_size)

--- a/lmdeploy/utils.py
+++ b/lmdeploy/utils.py
@@ -214,7 +214,7 @@ def logging_timer(op_name: str, logger: Logger, level: int = logging.DEBUG):
         @functools.wraps(func)
         def __func_warpper(*args, **kwargs):
             """func warpper."""
-            if not logger.isEnabledFor(level):
+            if logger.level > level:
                 return func(*args, **kwargs)
             with __timer():
                 return func(*args, **kwargs)
@@ -224,7 +224,7 @@ def logging_timer(op_name: str, logger: Logger, level: int = logging.DEBUG):
             """async warpper."""
 
             async def __tmp():
-                if not logger.isEnabledFor(level):
+                if logger.level > level:
                     return (await func(*args, **kwargs))
                 with __timer():
                     return (await func(*args, **kwargs))


### PR DESCRIPTION
runtime intermediate memory usage might lead to OOM if too many cache blocks are using.
Since most intermediate cache are used by `lm_head` in `ModelForCausalLM`, we would leave enough space for the cache and allocate paged cache with rest of the memory.

Tested on V100, prompts with 10k+ input ids.

```python
def main():

    model_path = 'Qwen1.5-7B-Chat'
    backend_config = PytorchEngineConfig(
        session_len=200000,
        cache_max_entry_count=0.99)
    pipe = pipeline(model_path, backend_config=backend_config)

    print('processing...')
    gen_config = GenerationConfig(max_new_tokens=1000)
    result = pipe([prompt], gen_config=gen_config)
    print(result[0].text)
```