### PR TITLE
 when num_required_blocks > num_drop_blocks, num_used_blocks < 0

### DIFF
--- a/lmdeploy/pytorch/paging/block_manager/window_block_manager.py
+++ b/lmdeploy/pytorch/paging/block_manager/window_block_manager.py
@@ -118,13 +118,18 @@ class WindowBlockManager(DefaultBlockManager):
             """reuse dropped blocks."""
             num_used_blocks = min(num_drop_blocks - num_required_blocks,
                                   num_required_blocks)
-            reused_blocks = droped_blocks[:num_used_blocks]
+            if num_used_blocks > 0:
+                reused_blocks = droped_blocks[:num_used_blocks]
+            else:
+                # when num_required_blocks > num_drop_blocks, all blocks in num_drop_blocks is used
+                reused_blocks = droped_blocks
             logical_blocks.append(reused_blocks)
 
             num_drop_blocks = num_drop_blocks - num_used_blocks
             if num_used_blocks > 0:
                 droped_blocks = droped_blocks[num_used_blocks:]
             else:
+                num_used_blocks = num_drop_blocks
                 droped_blocks = None
             num_required_blocks = num_required_blocks - num_used_blocks
             return num_required_blocks, droped_blocks


### PR DESCRIPTION
[Bug Fix]  when num_required_blocks > num_drop_blocks, num_used_blocks < 0. This behavior is wrong

Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily receiving feedbacks. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Please describe the motivation of this PR and the goal you want to achieve through this PR.

## Modification

Please briefly describe what modification is made in this PR.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
