### PR TITLE
Fix concatenate issue in profile serving

### DIFF
--- a/benchmark/profile_serving.py
+++ b/benchmark/profile_serving.py
@@ -153,7 +153,8 @@ class Engine:
             session_id, _stats = res_queue.get()
             # print(f'\n{"-" * 50}\n'
             #       f'session {session_id} stats: \n{_stats}\n{"-" * 50}\n')
-            stats.append(np.array(_stats))
+            if len(_stats) != 0:
+                stats.append(np.array(_stats))
 
         stats = np.concatenate(stats).reshape(-1, 5)
 

--- a/lmdeploy/serve/turbomind/chatbot.py
+++ b/lmdeploy/serve/turbomind/chatbot.py
@@ -621,6 +621,7 @@ class Chatbot:
         """
         status, res, n_token = None, '', 0
         output_ids = np.zeros((1, 1, 0), dtype=np.uint32)
+        text = ''
         while True:
             result = res_queue.get()
             if result is None:


### PR DESCRIPTION
## Motivation

1. If the postprocessing grpc call failed, the `text` variable will be access but not  declared.
https://github.com/InternLM/lmdeploy/blob/e7b2833441be6a4ac374ec191001ba6ae97647e0/lmdeploy/serve/turbomind/chatbot.py#L683
3. If `num_prompts < concurrency`, the `np.concatenate()` will face issue because the array dimension in `stats` is different.

## Modification
1. Add initialization for `text` variable
2. Filter empty `stats_` array.
