### PR TITLE
Fix performance issue of chatbot

### DIFF
--- a/benchmark/profile_serving.py
+++ b/benchmark/profile_serving.py
@@ -86,6 +86,7 @@ class Engine:
                           top_k=self.top_k,
                           top_p=self.top_p,
                           temperature=self.temperature,
+                          capability='completion',
                           log_level=self.log_level)
         stats = []
         for prompt, input_seqlen, output_seqlen in iter(


### PR DESCRIPTION
## Motivation

As mentioned in https://github.com/InternLM/lmdeploy/issues/1280, the throughput of Triton inference server is only `3.4` RPS, which is unexpected.

By further investigation, we found there two factors caused the incorrect throughput:
1. The grpc result format conversion in chatbot is time consuming. By fixing it, the throughput increased to `5.0` RPS.
2. In the default setting, the prompt will be decorated by the chat template, which caused the actual prompt tokens is more than the given input. For profile setting, we'd better use fixed prompt length and output length. After disabling the prompt decoration, the throughput increased to `5.9` RPS, which is much closer to the real throughput of Triton inference server.

## Modification

1. Avoid grpc result format conversion.
2. Use `capability='completion'` to disable the prompt decoration.