### PR TITLE
Support Triton inference server python backend

### DIFF
--- a/.github/scripts/check_lmdeploy.py
+++ b/.github/scripts/check_lmdeploy.py
@@ -20,6 +20,8 @@ def check_module_init(root: str):
             continue
         elif d.startswith('lmdeploy/serve/turbomind/triton_models'):
             continue
+        elif d.startswith('lmdeploy/serve/turbomind/triton_python_backend'):
+            continue
         init_file = os.path.join(d, '__init__.py')
         if not os.path.exists(init_file):
             not_exist.append(init_file)

--- a/benchmark/profile_triton_python_backend.py
+++ b/benchmark/profile_triton_python_backend.py
@@ -1,0 +1,300 @@
+import csv
+import json
+import random
+import threading
+import time
+from functools import partial
+from queue import Queue
+from threading import Thread
+from typing import List, Tuple
+
+import fire
+import numpy as np
+import tritonclient.grpc as grpcclient
+from tqdm import tqdm
+
+from lmdeploy.serve.turbomind.utils import prepare_tensor
+from lmdeploy.tokenizer import Tokenizer
+
+
+def sample_requests(
+    dataset_path: str,
+    num_requests: int,
+    tokenizer: Tokenizer,
+) -> List[Tuple[str, int, int]]:
+    # Load the dataset.
+    with open(dataset_path) as f:
+        dataset = json.load(f)
+    # Filter out the conversations with less than 2 turns.
+    dataset = [data for data in dataset if len(data['conversations']) >= 2]
+    # Only keep the first two turns of each conversation.
+    dataset = [(data['conversations'][0]['value'],
+                data['conversations'][1]['value']) for data in dataset]
+
+    # pre-sample to avoid go through all the dataset
+    dataset = random.sample(dataset, max(int(num_requests * 1.2), 1000))
+
+    # Tokenize the prompts and completions.
+    prompts = [prompt for prompt, _ in dataset]
+    prompt_token_ids = tokenizer(prompts).input_ids
+    completions = [completion for _, completion in dataset]
+    completion_token_ids = tokenizer(completions).input_ids
+    tokenized_dataset = []
+    for i in range(len(dataset)):
+        output_len = len(completion_token_ids[i])
+        tokenized_dataset.append((prompts[i], prompt_token_ids[i], output_len))
+
+    # Filter out too long sequences.
+    filtered_dataset: List[Tuple[str, int, int]] = []
+    for prompt, prompt_token_ids, output_len in tokenized_dataset:
+        prompt_len = len(prompt_token_ids)
+        if prompt_len < 4 or output_len < 4:
+            # Prune too short sequences.
+            continue
+        if prompt_len > 1024 or prompt_len + output_len > 2048:
+            # Prune too long sequences.
+            continue
+        filtered_dataset.append((prompt, prompt_len, output_len))
+
+    # Sample the requests.
+    sampled_requests = random.sample(filtered_dataset, num_requests)
+    return sampled_requests
+
+
+def stream_callback(que, result, error):
+    """Callback function invoked by triton."""
+    que.put((result, error))
+
+
+class Engine:
+
+    def __init__(self,
+                 server_addr: str,
+                 tokenzier_path: str,
+                 temperature: float = 0.8,
+                 top_k: int = 1,
+                 top_p: float = 1.0,
+                 csv: str = '',
+                 log_level: str = 'ERROR',
+                 **kwargs):
+        self.server_addr = server_addr
+        self.tokenizer = Tokenizer(tokenzier_path)
+        self.temperature = temperature
+        self.top_k = top_k
+        self.top_p = top_p
+        self.csv = csv
+        self.log_level = log_level
+        self.pbar = None
+
+    def _inference(self, req_queue: Queue, res_queue: Queue, session_id: int,
+                   stream_output: bool):
+
+        stats = []
+        for prompt, input_seqlen, output_seqlen in iter(
+                req_queue.get, [None, None, None]):
+            res_que = Queue()
+            t = threading.Thread(target=self._call_triton_server,
+                                 args=(prompt, self.server_addr, session_id,
+                                       output_seqlen, stream_output, res_que))
+            t.start()
+            timestamps = self._process_result(res_que)
+            t.join()
+
+            # record statistics
+            first_token_latency = np.round(timestamps[1] - timestamps[0], 3)
+            token_latency = np.round(timestamps[-1] - timestamps[0], 3)
+
+            total_tokens = input_seqlen + output_seqlen
+            stats.append([
+                first_token_latency, output_seqlen, output_seqlen,
+                total_tokens, token_latency
+            ])
+            self.pbar.update(1)
+        res_queue.put((session_id, stats))
+
+    def _process_result(self, que):
+        timestamps = []
+        timestamps.append(time.perf_counter())
+        while True:
+            res = que.get()
+            if res is not None:
+                _, err = res
+                if err is not None:
+                    print(err)
+                else:
+                    timestamps.append(time.perf_counter())
+            else:
+                return timestamps
+
+    def _call_triton_server(self, prompts, tritonserver_addr, session_id,
+                            request_output_len, stream_output, res_que):
+
+        with grpcclient.InferenceServerClient(tritonserver_addr) as client:
+            inputs = [
+                prepare_tensor('prompt',
+                               np.array([prompts.encode()], dtype=np.object_)),
+                prepare_tensor('max_tokens',
+                               np.array([request_output_len], dtype=np.int32)),
+                prepare_tensor('temperature',
+                               np.array([self.temperature], dtype=np.float_)),
+                prepare_tensor('top_p', np.array([self.top_p],
+                                                 dtype=np.float_)),
+                prepare_tensor('top_k', np.array([self.top_k],
+                                                 dtype=np.int32)),
+                prepare_tensor('ignore_eos', np.array([True], dtype=np.bool_)),
+                prepare_tensor('stream',
+                               np.array([stream_output], dtype=np.bool_)),
+                prepare_tensor('skip_special_tokens',
+                               np.array([False], dtype=np.bool_)),
+            ]
+
+            # async_stream
+            client.start_stream(partial(stream_callback, res_que))
+            client.async_stream_infer('lmdeploy_model',
+                                      inputs,
+                                      sequence_id=session_id,
+                                      sequence_start=True,
+                                      sequence_end=True)
+        res_que.put(None)
+        return
+
+    def process_request(self,
+                        requests,
+                        concurrency: int = 1,
+                        stream_output: bool = True):
+        res_queue = Queue()
+        req_queue = Queue()
+        threads = []
+
+        self.pbar = tqdm(total=len(requests))
+
+        # feed request to q
+        for req in requests:
+            req_queue.put(req)
+        for i in range(concurrency):
+            req_queue.put([None, None, None])
+
+        start = time.time()
+
+        # start threads
+        for i in range(concurrency):
+            t = Thread(target=self._inference,
+                       args=(req_queue, res_queue, i, stream_output))
+            t.start()
+            threads.append(t)
+
+        # wait for finish
+        for t in threads:
+            t.join()
+
+        elapsed_time = time.time() - start
+
+        stats = []
+        while not res_queue.empty():
+            _, _stats = res_queue.get()
+            if len(_stats) != 0:
+                stats.append(np.array(_stats))
+
+        stats = np.concatenate(stats).reshape(-1, 5)
+
+        first_token_latency_min = np.min(stats[:, 0], axis=0)
+        first_token_latency_max = np.max(stats[:, 0], axis=0)
+        first_token_latency_ave = np.mean(stats[:, 0], axis=0)
+        completion_tokens = np.sum(stats[:, 1], axis=0)
+        request_output_tokens = np.sum(stats[:, 2], axis=0)
+        total_tokens = np.sum(stats[:, 3], axis=0)
+        prompt_tokens = total_tokens - completion_tokens
+        completion_token_throughput = completion_tokens / elapsed_time
+        total_token_throughput = total_tokens / elapsed_time
+        rps = len(requests) / elapsed_time
+        rpm = rps * 60
+
+        if (np.abs(stats[:, 1] - stats[:, 2]) <= 1).min() is False:
+            print(f'Did not generate requested number of tokens. '
+                  f'Request {request_output_tokens:.0f}, '
+                  f'but got {completion_tokens:.0f}')
+
+        print(f'\n{"-" * 50}\nconcurrency: {concurrency}\n'
+              f'elapsed_time: {elapsed_time:.3f}s\n')
+        if stream_output:
+            print(f'first_token latency(min, max, ave): '
+                  f'{first_token_latency_min:.3f}s, '
+                  f'{first_token_latency_max:.3f}s, '
+                  f'{first_token_latency_ave:.3f}s\n')
+        print(
+            f'number of prompt tokens: {prompt_tokens:.0f}\n'
+            f'number of completion tokens: {completion_tokens:.0f}\n'
+            f'token throughput (completion token): {completion_token_throughput:.3f} token/s\n'  # noqa
+            f'token throughput (prompt + completion token): {total_token_throughput:.3f} token/s\n'  # noqa
+            f'RPS (request per second): {rps:.3f} req/s\n'
+            f'RPM (request per minute): {rpm:.3f} req/min\n'
+            f'{"-" * 50}\n')
+
+        if self.csv:
+            with open(self.csv, 'w') as csvfile:
+                writer = csv.writer(csvfile)
+                writer.writerow([
+                    'batch', 'num_prompts', 'RPS', 'RPM', 'FTL(ave)(s)',
+                    'FTL(min)(s)', 'FTL(max)(s)', 'throughput(out tok/s)',
+                    'throughput(total tok/s)'
+                ])
+                writer.writerow([
+                    concurrency,
+                    len(requests), f'{rps:.3f}', f'{rpm:.3f}',
+                    f'{first_token_latency_ave:.3f}' if stream_output else '-',
+                    f'{first_token_latency_min:.3f}' if stream_output else '-',
+                    f'{first_token_latency_max:.3f}' if stream_output else '-',
+                    f'{completion_token_throughput:.3f}',
+                    f'{total_token_throughput:.3f}'
+                ])
+
+
+def main(server_addr: str,
+         tokenizer_path: str,
+         dataset: str,
+         concurrency: int = 32,
+         num_prompts: int = 1000,
+         top_k: int = 1,
+         top_p: float = 1.0,
+         temperature: float = 1.0,
+         stream_output: bool = True,
+         csv: str = './profile_tis_python.csv',
+         seed: int = 0):
+    """Benchmark the request througput of the triton inference server Python
+    backend.
+
+    Args:
+        server_addr (str): Address of the triton inference server with format 0.0.0.0:0
+        tokenizer_path (str): Path to the tokenizer model in localhost
+        dataset (str): Path to the dataset
+        concurrency (int, optional): Number of working threads to process the sampled prompts.
+            Defaults to 32.
+        num_prompts (int, optional): Number of prompts to process. Defaults to 1000.
+        top_k (int, optional): The number of highest probability vocabulary tokens
+            to keep for top-k-filtering. Defaults to 1.
+        top_p (float, optional): the set of most probable tokens with
+            probabilities that add up to top_p or higher
+            are kept for generation. Defaults to 1.0.
+        temperature (float, optional): The value used to modulate the next token probabilities.
+            Defaults to 1.0.
+        stream_output (bool, optional): Indicator for streaming output. Defaults to True.
+        seed (int, optional): Seed used in sampling prompts from dataset. Defaults to 0.
+    """    # noqa
+
+    random.seed(seed)
+
+    engine = Engine(server_addr,
+                    tokenizer_path,
+                    top_k=top_k,
+                    top_p=top_p,
+                    temperature=temperature,
+                    log_level='ERROR',
+                    csv=csv)
+
+    requests = sample_requests(dataset, num_prompts, engine.tokenizer)
+
+    engine.process_request(requests, concurrency, stream_output)
+
+
+if __name__ == '__main__':
+    fire.Fire(main)

--- a/lmdeploy/serve/turbomind/triton_python_backend/README.md
+++ b/lmdeploy/serve/turbomind/triton_python_backend/README.md
@@ -1,0 +1,59 @@
+# LMDeploy Triton Python Backend
+
+This is an efficient [Triton Python Backend](https://github.com/triton-inference-server/python_backend/tree/main) for LMDeploy.
+
+## Deployment Procedure
+
+### 1. Specify the folder layout
+
+The folder layout of Triton Inference Server model repository should be as follows. More details can be found in the [user guide](https://docs.nvidia.com/deeplearning/triton-inference-server/user-guide/docs/user_guide/model_repository.html).
+
+```
+model_repository
+└── lmdeploy_model
+    ├── 1
+    │   ├── model.py
+    │   └── weights
+    └── config.pbtxt
+```
+
+- The `model.py` and `config.pbtxt` are provided here.
+- The `weights` folder contains the weights of models. You should download the model weights at first. And then move it to the `weights` folder. You also can use soft link to avoid moving, for example:
+
+```
+ln -s /model_download_path/llama2_13b_chat /model_repository_path/lmdeploy_model/1/weights
+```
+
+### 2. Run the Triton server
+
+```
+tritonserver \
+    --model-repository=/path/to/your/model_repository \
+    --backend-directory /opt/tritonserver/backends \
+    --allow-http=0 \
+    --allow-grpc=1 \
+    --grpc-port=33337 \
+    --allow-metrics=1 \
+    --log-info=1 \
+    --log-dir /path/to/put/your/logs
+```
+
+In the above command, you should specify the path of your `model_repository` prepared in step 1.
+
+## Client Test
+
+Once the deployment done, we can use the provided `client.py` to test the deployed Triton server.
+
+```
+python3 client.py
+```
+
+You should make sure the server address and port are configured correctly in the client file.
+
+## Profile
+
+`profile_triton_python_backend.py` under benchmark folder is provided to profile this Triton Python backend.
+
+```
+python3 benchmark/profile_triton_python_backend.py 0.0.0.0:33337 /model_path/llama2_13b_chat/ /dataset_path/ShareGPT_V3_unfiltered_cleaned_split.json --num_prompts 1000 --concurrency=128
+```

--- a/lmdeploy/serve/turbomind/triton_python_backend/README.md
+++ b/lmdeploy/serve/turbomind/triton_python_backend/README.md
@@ -16,7 +16,10 @@ The Triton Inference Server requires a specific folder structure for serving mod
 
 4. Place the `model.py` file inside the `1/` directory. This file contains the logic for your model's inference.
 
-5. The model weights should be placed in a folder named `weights/` inside the `1/` directory. You can either move the downloaded model weights to this folder or use a symbolic link to reference them.
+5. The model weights should be placed in a folder named `weights/` inside the `1/` directory.
+
+   - If you use Huggingface model, you can copy the whole downloaded model folder to `1/` and rename it to `weights`.
+   - If you use [converted Turbomind workspace](https://github.com/InternLM/lmdeploy/blob/main/docs/en/inference/load_hf.md#3-a-model-converted-by-lmdeploy-convert), you can copy the generated `workspace` folder to `1/` and rename it to `weights`.
 
 6. Place the `config.pbtxt` file directly inside the `lmdeploy_model/` directory. This configuration file is essential for Triton to understand how to serve your model. For advanced usage, you can modify the `config.pbtxt` to load your customized configurations.
 

--- a/lmdeploy/serve/turbomind/triton_python_backend/README.md
+++ b/lmdeploy/serve/turbomind/triton_python_backend/README.md
@@ -21,7 +21,12 @@ The Triton Inference Server requires a specific folder structure for serving mod
    - If you use Huggingface model, you can copy the whole downloaded model folder to `1/` and rename it to `weights`.
    - If you use [converted Turbomind workspace](https://github.com/InternLM/lmdeploy/blob/main/docs/en/inference/load_hf.md#3-a-model-converted-by-lmdeploy-convert), you can copy the generated `workspace` folder to `1/` and rename it to `weights`.
 
-6. Place the `config.pbtxt` file directly inside the `lmdeploy_model/` directory. This configuration file is essential for Triton to understand how to serve your model. For advanced usage, you can modify the `config.pbtxt` to load your customized configurations.
+6. Place the `config.pbtxt` file directly inside the `lmdeploy_model/` directory. This configuration file is essential for Triton to understand how to serve your model.
+
+7. For advanced usage, you can modify the `config.pbtxt` to use your customized configurations. There are two important parameters you may change:
+
+   - `model_name`: The name of the to-be-deployed model, such as `llama`, `llama2`, `internlm2`, `baichuan2` and etc. You can run `lmdeploy list` to get the supported model names.
+   - `tp`: GPU number used in tensor parallelism. Should be 2^n.
 
 The final folder structure should look like this:
 

--- a/lmdeploy/serve/turbomind/triton_python_backend/client.py
+++ b/lmdeploy/serve/turbomind/triton_python_backend/client.py
@@ -1,0 +1,79 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+import threading
+from functools import partial
+from queue import Queue
+
+import numpy as np
+import tritonclient.grpc as grpcclient
+from tritonclient.utils import np_to_triton_dtype
+
+
+def prepare_tensor(name, input_tensor):
+    """Create grpcclient's InferInput instance according to a given tensor."""
+    t = grpcclient.InferInput(name, list(input_tensor.shape),
+                              np_to_triton_dtype(input_tensor.dtype))
+    t.set_data_from_numpy(input_tensor)
+    return t
+
+
+def stream_callback(que, result, error):
+    """Callback function invoked by triton."""
+    que.put((result, error))
+
+
+def process_result(que):
+    """Process and print results in queue."""
+    while True:
+        res = que.get()
+        if res is not None:
+            result, err = res
+            if err is not None:
+                print(err)
+            else:
+                response = result.as_numpy('response')
+                print(f'generated text: {response}')
+        else:
+            break
+
+
+if __name__ == '__main__':
+    model_name = 'lmdeploy_model'
+    prompts = 'please introduce yourself'
+    max_tokens = 512
+    temperature = 1.0
+    top_p = 1.0
+    top_k = 1
+    ignore_eos = False
+    stream = True
+    bad_words = ['User:', 'GPT:']
+
+    res_que = Queue()
+
+    process_thread = threading.Thread(target=process_result, args=(res_que, ))
+    process_thread.start()
+
+    with grpcclient.InferenceServerClient('0.0.0.0:33337') as client:
+        inputs = [
+            prepare_tensor('prompt',
+                           np.array([prompts.encode()], dtype=np.object_)),
+            prepare_tensor('max_tokens', np.array([max_tokens],
+                                                  dtype=np.int32)),
+            prepare_tensor('temperature',
+                           np.array([temperature], dtype=np.float_)),
+            prepare_tensor('top_p', np.array([top_p], dtype=np.float_)),
+            prepare_tensor('top_k', np.array([top_k], dtype=np.int32)),
+            prepare_tensor('ignore_eos', np.array([ignore_eos],
+                                                  dtype=np.bool_)),
+            prepare_tensor('stream', np.array([stream], dtype=np.bool_)),
+            prepare_tensor('bad_words', np.array(bad_words, dtype=np.object_)),
+        ]
+
+        # async_stream
+        client.start_stream(partial(stream_callback, res_que))
+        client.async_stream_infer(model_name,
+                                  inputs,
+                                  sequence_start=True,
+                                  sequence_end=True)
+
+    res_que.put(None)
+    process_thread.join()

--- a/lmdeploy/serve/turbomind/triton_python_backend/config.pbtxt
+++ b/lmdeploy/serve/turbomind/triton_python_backend/config.pbtxt
@@ -1,0 +1,102 @@
+name: "lmdeploy_model"
+backend: "python"
+max_batch_size: 0
+
+model_transaction_policy {
+  decoupled: True
+}
+
+instance_group [
+  {
+    # max concurrent instances
+    count: 1
+    kind: KIND_CPU
+  }
+]
+
+input [
+  {
+    name: "prompt"
+    data_type: TYPE_STRING
+    dims: [ -1 ]
+  },
+  {
+    name: "max_tokens"
+    data_type: TYPE_INT32
+    dims: [ 1 ]
+  },
+  {
+    name: "ignore_eos"
+    data_type: TYPE_BOOL
+    dims: [ 1 ]
+  },
+  {
+    name: "stream"
+    data_type: TYPE_BOOL
+    dims: [ 1 ]
+  },
+  {
+    name: "temperature"
+    data_type: TYPE_FP64
+    dims: [ 1 ]
+    optional: true
+  },
+  {
+    name: "top_p"
+    data_type: TYPE_FP64
+    dims: [ 1 ]
+    optional: true
+  },
+  {
+    name: "top_k"
+    data_type: TYPE_INT32
+    dims: [ 1 ]
+    optional: true
+  },
+  {
+    name: "repetition_penalty"
+    data_type: TYPE_FP64
+    dims: [ 1 ]
+    optional: true
+  },
+  {
+    name: "stop_words"
+    data_type: TYPE_STRING
+    dims: [ -1 ]
+    optional: true
+  },
+  {
+    name: "bad_words"
+    data_type: TYPE_STRING
+    dims: [ -1 ]
+    optional: true
+  },
+  {
+    name: "skip_special_tokens"
+    data_type: TYPE_BOOL
+    dims: [ 1 ]
+    optional: true
+  }
+]
+
+output [
+  {
+    name: "response"
+    data_type: TYPE_STRING
+    dims: [ -1 ]
+  }
+]
+
+parameters {
+  key: "model_name"
+  value: {
+    string_value: "llama2"
+  }
+}
+
+parameters {
+  key: "tp"
+  value: {
+    string_value: "1"
+  }
+}

--- a/lmdeploy/serve/turbomind/triton_python_backend/model.py
+++ b/lmdeploy/serve/turbomind/triton_python_backend/model.py
@@ -1,0 +1,170 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+import asyncio
+import json
+import os
+import threading
+
+import numpy as np
+import triton_python_backend_utils as pb_utils
+
+from lmdeploy import GenerationConfig, TurbomindEngineConfig, pipeline
+
+
+class TritonPythonModel:
+
+    def initialize(self, args):
+        self.logger = pb_utils.Logger
+
+        # parse model configs
+        self.model_config = json.loads(args['model_config'])
+
+        # make sure use decoupled mode
+        using_decoupled = pb_utils.using_decoupled_model_transaction_policy(
+            self.model_config)
+        assert (using_decoupled
+                ), 'LMDeploy model should be configured to decoupled mode'
+
+        # parse parameters
+        parameters = self.model_config['parameters']
+        model_name = parameters['model_name']['string_value']
+        tp = int(parameters['tp']['string_value'])
+
+        # start lmdeploy engine
+        model_path = os.path.join(args['model_repository'],
+                                  args['model_version'], 'weights')
+        engine_config = TurbomindEngineConfig(tp=tp)
+        self.engine = pipeline(model_path=model_path,
+                               model_name=model_name,
+                               backend_config=engine_config)
+
+        self.request_id = 0
+
+        # create event loop to process requests asynchronously
+        self.event_loop = asyncio.get_event_loop()
+        self.engine_thread = threading.Thread(target=self._engine_loop)
+        self.shutdown_event = asyncio.Event()
+        self.engine_thread.start()
+
+        self.logger.log_info('LMDeploy backend started')
+
+    def _engine_loop(self):
+        self.logger.log_info('Engine loop started')
+        self.event_loop.run_until_complete(self._await_shutdown())
+        self.event_loop.close()
+        self.logger.log_info('Engine loop closed')
+
+    async def _await_shutdown(self):
+        # await the shutdown signal
+        await self.shutdown_event.wait()
+        self.logger.log_info('Get shutdown signal')
+
+        # cancel unfinished tasks
+        for task in asyncio.all_tasks(loop=self.event_loop):
+            if task is not asyncio.current_task(loop=self.event_loop):
+                task.cancel()
+                try:
+                    await task
+                except asyncio.CancelledError:
+                    self.logger.log_info('Unfinished task is cancelled')
+
+    def _get_optional_configs(self, request):
+        optional_configs = {}
+        config_names = [
+            'temperature', 'top_p', 'top_k', 'stop_words', 'bad_words',
+            'repetition_penalty', 'skip_special_tokens'
+        ]
+        for config_name in config_names:
+            input_tensor = pb_utils.get_input_tensor_by_name(
+                request, config_name)
+            if input_tensor is not None:
+                if config_name == 'stop_words' or config_name == 'bad_words':
+                    optional_configs[config_name] = [
+                        obj.decode() if isinstance(obj, bytes) else obj
+                        for obj in input_tensor.as_numpy().tolist()
+                    ]
+                else:
+                    optional_configs[config_name] = input_tensor.as_numpy(
+                    ).item()
+        return optional_configs
+
+    async def _process_request(self, request_id, request):
+        response_sender = request.get_response_sender()
+
+        try:
+            # parse request
+            prompt = pb_utils.get_input_tensor_by_name(
+                request, 'prompt').as_numpy().item()
+            if isinstance(prompt, bytes):
+                prompt = prompt.decode()
+            max_tokens = pb_utils.get_input_tensor_by_name(
+                request, 'max_tokens').as_numpy().item()
+            ignore_eos = pb_utils.get_input_tensor_by_name(
+                request, 'ignore_eos').as_numpy().item()
+            stream = pb_utils.get_input_tensor_by_name(
+                request, 'stream').as_numpy().item()
+
+            optional_configs = self._get_optional_configs(request)
+
+            gen_config = GenerationConfig(max_new_tokens=max_tokens,
+                                          ignore_eos=ignore_eos,
+                                          **optional_configs)
+
+            outputs = []
+            async for output in self.engine.generate(messages=prompt,
+                                                     session_id=request_id,
+                                                     stream_response=stream,
+                                                     gen_config=gen_config,
+                                                     do_preprocess=False):
+
+                if stream:
+                    # for stream mode, send the partial response one by one
+                    triton_output_tensor = pb_utils.Tensor(
+                        'response',
+                        np.asarray(output.response, dtype=np.object_))
+                    resp = pb_utils.InferenceResponse(
+                        output_tensors=[triton_output_tensor])
+                    if output.finish_reason is not None:
+                        response_sender.send(
+                            resp,
+                            flags=pb_utils.TRITONSERVER_RESPONSE_COMPLETE_FINAL
+                        )
+                    else:
+                        response_sender.send(resp)
+                else:
+                    outputs.append(output.response)
+
+            if not stream:
+                # for non-stream mode, send concatenated response at one time
+                triton_output_tensor = pb_utils.Tensor(
+                    'response', np.asarray(''.join(outputs), dtype=np.object_))
+                resp = pb_utils.InferenceResponse(
+                    output_tensors=[triton_output_tensor])
+                response_sender.send(
+                    resp, flags=pb_utils.TRITONSERVER_RESPONSE_COMPLETE_FINAL)
+
+        except Exception as e:
+            # error handling
+            self.logger.log_info(f'Error when processing request: {e}')
+            error = pb_utils.TritonError(f'Error when processing request: {e}')
+            triton_output_tensor = pb_utils.Tensor(
+                'response', np.asarray(['N/A'], dtype=np.object_))
+            resp = pb_utils.InferenceResponse(
+                output_tensors=[triton_output_tensor], error=error)
+            response_sender.send(
+                resp, flags=pb_utils.TRITONSERVER_RESPONSE_COMPLETE_FINAL)
+            raise e
+
+    def execute(self, requests):
+        for request in requests:
+            asyncio.run_coroutine_threadsafe(
+                self._process_request(self.request_id, request),
+                self.event_loop)
+            self.request_id += 1
+        return None
+
+    def finalize(self):
+        self.logger.log_info('Finalizing LMDeploy backend')
+        self.event_loop.call_soon_threadsafe(self.shutdown_event.set)
+        if self.engine_thread is not None:
+            self.engine_thread.join()
+            self.engine_thread = None


### PR DESCRIPTION
## Motivation

As mentioned in https://github.com/InternLM/lmdeploy/issues/1309, the Turbomind triton backend is facing some performance issues. So we propose this Python backend. 

We have conducted performance test and OpenCompass evaluation, the results are shown in https://github.com/InternLM/lmdeploy/issues/1309. Its performance is as efficient as the api_server and the evaluation result is also fine.

@lvhan028 @zhyncs 

## Modification

- [x] Add Python backend model file and config file
- [x] Add client and profile script for test
- [x] Add doc

