### PR TITLE
Fix dlpack memory leak

### DIFF
--- a/src/turbomind/python/bind.cpp
+++ b/src/turbomind/python/bind.cpp
@@ -306,7 +306,7 @@ PYBIND11_MODULE(_turbomind, m)
             "__dlpack__",
             [](triton::Tensor* self, long stream) {
                 auto tensor_ptr = TritonTensorToDLManagedTensor(*self);
-                return new py::capsule(tensor_ptr.release(), kDlTensorCapsuleName, [](PyObject* obj) {
+                return py::capsule(tensor_ptr.release(), kDlTensorCapsuleName, [](PyObject* obj) {
                     DLManagedTensor* dlmt =
                         static_cast<DLManagedTensor*>(PyCapsule_GetPointer(obj, kDlTensorCapsuleName));
                     if (dlmt) {


### PR DESCRIPTION
## Motivation
In https://github.com/InternLM/lmdeploy/issues/1334#issuecomment-2017418190, there may be some memory leak in `dlpack`. 

For 5000 test prompts:
- before this change, the memory usage will increase from `3110M -> 3660M`
- after this change, the memory usage will increase from `3110M -> 3460M`

There are 200M memory reduced. 

## Modification
- Return object instead of the pointer, then Python will take over the lifecycle of this object.