### PR TITLE
Fix memory leak of DLManagedTensor

### DIFF
--- a/src/turbomind/python/bind.cpp
+++ b/src/turbomind/python/bind.cpp
@@ -121,9 +121,7 @@ DLManagedTensor* TritonTensorToDLManagedTensor(triton::Tensor& tensor)
                        reinterpret_cast<int64_t*>(const_cast<size_t*>(tensor.shape.data())),
                        (int64_t*)(nullptr),
                        0};
-    return new DLManagedTensor{dl_tensor, nullptr, [](DLManagedTensor* dlmt) {
-        delete dlmt;
-    }};
+    return new DLManagedTensor{dl_tensor, nullptr, [](DLManagedTensor* dlmt) { delete dlmt; }};
 }
 
 triton::MemoryType getMemoryType(DLDevice device)


### PR DESCRIPTION
## Motivation

https://github.com/InternLM/lmdeploy/issues/1334

This test code and `valgrind` can help debug this issue:
```python
import asyncio
from lmdeploy import GenerationConfig, TurbomindEngineConfig, pipeline

engine_config = TurbomindEngineConfig(tp=1)
engine = pipeline(model_path='/workdir/llama2_13b_chat',
                model_name='llama2',
                backend_config=engine_config)

async def infer(prompt, session_id):
    async for output in engine.generate(messages=prompt,
                                    session_id=session_id,
                                    stream_response=True,
                                    do_preprocess=False):

        print(output.response)


prompts = ['hi']*10

for i, prompt in enumerate(prompts):
    asyncio.run(infer(prompt, i))
```
```
valgrind --leak-check=full python test_lmdeploy.py > log.txt 2>&1
```
There are some `definitely lost` in `bind.cpp:125` and `bind.cpp:308`, that's about `DLManagedTensor`.

After this change, 
- rerun the `valgrind` test, there is no memory leak of `DLManagedTensor`.
- test the api_server with 5000 prompts, the memory usage will increase from `3110M` to `3330M`.

## Modification

- remove the unique pointer and add the deleter for DLManagedTensor
