### PR TITLE
add protobuf to runtime.txt

### DIFF
--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -4,6 +4,7 @@ mmengine-lite
 numpy
 peft<=0.9.0
 pillow
+protobuf
 pydantic>2.0.0
 pynvml
 safetensors


### PR DESCRIPTION
Error occurred when performing internlm2 model inference

<img width="761" alt="26eb0b9e135f86c7c4dc75d5a379711" src="https://github.com/InternLM/lmdeploy/assets/4560679/247d3346-9fe4-483d-a23a-e4721bc95c89">
