### PR TITLE
miss --trust-remote-code in converter, which is side effect brought by pr #1406

### DIFF
--- a/.github/workflows/daily_ete_test.yml
+++ b/.github/workflows/daily_ete_test.yml
@@ -401,6 +401,7 @@ jobs:
             internlm-chat-20b \
             /root/workspace/hf_model \
             --tp 2 \
+            --trust-remote-code \
             --dst-path /root/workspace/workdir/${TB_MODEL}
       - name: Start triton server service
         run: |

--- a/autotest/tools/convert/test_convert.py
+++ b/autotest/tools/convert/test_convert.py
@@ -37,7 +37,7 @@ def convert(config, model_case, cuda_prefix):
     if 'w4' in model_case or '4bits' in model_case:
         cmd = get_command_with_extra(' '.join([
             'lmdeploy convert', model_name, origin_model_path, '--dst-path',
-            dst_path, '--model-format awq --group-size 128'
+            dst_path, '--model-format awq --group-size 128 --trust-remote-code'
         ]),
                                      config,
                                      model_name,
@@ -46,7 +46,7 @@ def convert(config, model_case, cuda_prefix):
     else:
         cmd = get_command_with_extra(' '.join([
             'lmdeploy convert', model_name, origin_model_path, '--dst-path',
-            dst_path
+            dst_path, '--trust-remote-code'
         ]),
                                      config,
                                      model_name,

--- a/docs/en/benchmark/profile_triton_server.md
+++ b/docs/en/benchmark/profile_triton_server.md
@@ -40,7 +40,7 @@ In this section, we take [internlm/internlm-7b](https://huggingface.co/internlm/
 Before launching the server, the LLM model must be converted to the turbomind format in advance.
 
 ```shell
-lmdeploy convert internlm internlm/internlm-7b --dst-path ./internlm-7b
+lmdeploy convert internlm internlm/internlm-7b --dst-path ./internlm-7b --trust-remote-code
 ```
 
 Then, the triton inference server can be launched by:

--- a/docs/zh_cn/benchmark/profile_triton_server.md
+++ b/docs/zh_cn/benchmark/profile_triton_server.md
@@ -43,7 +43,7 @@ $$
 启动服务之前，必须先把模型转换为 turbomind 模型格式：
 
 ```shell
-lmdeploy convert internlm internlm/internlm-7b --dst-path ./internlm-7b
+lmdeploy convert internlm internlm/internlm-7b --dst-path ./internlm-7b --trust-remote-code
 ```
 
 然后，执行如下命令，启动服务：

--- a/lmdeploy/cli/cli.py
+++ b/lmdeploy/cli/cli.py
@@ -62,6 +62,9 @@ class CLI(object):
             default=0,
             help='A parameter used in awq to quantize fp16 weights '
             'to 4 bits')
+        parser.add_argument('--trust-remote-code',
+                            action='store_true',
+                            help='trust remote code from huggingface')
 
         parser.set_defaults(run=CLI.convert)
 

--- a/lmdeploy/turbomind/deploy/converter.py
+++ b/lmdeploy/turbomind/deploy/converter.py
@@ -85,7 +85,7 @@ def copy_triton_model_templates(_path: str):
 
 
 def copy_tokenizer(model_path: str, tokenizer_path: str,
-                   triton_models_path: str):
+                   triton_models_path: str, trust_remote_code: bool):
     """Copy tokenizer."""
     if tokenizer_path is not None:
         assert osp.exists(tokenizer_path), f'{tokenizer_path} does not exists.'
@@ -97,7 +97,8 @@ def copy_tokenizer(model_path: str, tokenizer_path: str,
     else:
         from transformers import AutoTokenizer
         try:
-            _ = AutoTokenizer.from_pretrained(model_path)
+            _ = AutoTokenizer.from_pretrained(
+                model_path, trust_remote_code=trust_remote_code)
         except Exception:
             assert 0, (
                 f'Failed to load tokenizer model from path {model_path}.'
@@ -208,6 +209,7 @@ def main(model_name: str,
          tp: int = 1,
          quant_path: str = None,
          group_size: int = 0,
+         trust_remote_code: bool = False,
          **kwargs):
     """deploy llama family models via turbomind.
 
@@ -227,6 +229,8 @@ def main(model_name: str,
         quant_path (str): Path of the quantized model, which can be None.
         group_size (int): a parameter used in AWQ to quantize fp16 weights
             to 4 bits
+        trust_remote_code (bool):  Whether or not to allow for custom models
+            defined on the Hub in their own modeling files. Defaults to False
         kwargs (dict): other params for convert
     """
 
@@ -271,7 +275,8 @@ def main(model_name: str,
 
     triton_models_path = copy_triton_model_templates(dst_path)
 
-    copy_tokenizer(model_path, tokenizer_path, triton_models_path)
+    copy_tokenizer(model_path, tokenizer_path, triton_models_path,
+                   trust_remote_code)
 
     # turbomind config
     cfg = TurbomindModelConfig.from_dict({}, allow_none=True)


### PR DESCRIPTION
The following cases are verified.
```shell
lmdeploy convert llama2 /workspace/models-140/llama2/huggingface/llama-2-7b-chat/ --dst-path workspace/test-converter
lmdeploy convert internlm2 /workspace/models-140/InternLM/internlm2-chat-7b/ --dst-path workspace/test-converter --trust-remote-code
lmdeploy convert qwen /workspace/models-140/Qwen/Qwen-7B-Chat/ --dst-path workspace/test-converter/ --trust-remote-code
lmdeploy convert qwen /workspace/models-140/Qwen/Qwen1.5-7B-Chat/ --dst-path workspace/test-converter
```