### PR TITLE
support Internvl chat v1.1, v1.2 and v1.2-plus

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ For detailed inference benchmarks in more devices and more settings, please refe
 |      Mistral       |     7B     |
 |    DeepSeek-MoE    |    16B     |
 |    DeepSeek-VL     |     7B     |
+|   InternVL-Chat    |     -      |
 |      Mixtral       |    8x7B    |
 |       Gemma        |   2B-7B    |
 |        Dbrx        |    132B    |

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -108,6 +108,7 @@ LMDeploy TurboMind 引擎拥有卓越的推理能力，在各种规模的模型�
 |      Mistral       |     7B     |
 |    DeepSeek-MoE    |    16B     |
 |    DeepSeek-VL     |     7B     |
+|   InternVL-Chat    |     -      |
 |      Mixtral       |    8x7B    |
 |       Gemma        |   2B-7B    |
 |        Dbrx        |    132B    |

--- a/docs/en/supported_models/supported_models.md
+++ b/docs/en/supported_models/supported_models.md
@@ -16,6 +16,7 @@
 |     Baichuan2      |     7B     |    Yes    |   Yes   |  Yes  |
 |     Code Llama     |  7B - 34B  |    Yes    |   No    |  No   |
 |         YI         |  6B - 34B  |    Yes    |   No    |  No   |
+|   InternVL-Chat    |     -      |    Yes    |   No    |  No   |
 
 ```{note}
 The TurboMind engine doesn't support window attention. Therefore, for models that have applied window attention and have the corresponding switch "use_sliding_window" enabled, please choose the PyTorch engine for inference.

--- a/docs/zh_cn/supported_models/supported_models.md
+++ b/docs/zh_cn/supported_models/supported_models.md
@@ -16,6 +16,7 @@
 |     Baichuan2      |     7B     |    Yes    |   Yes   |  Yes  |
 |     Code Llama     |  7B - 34B  |    Yes    |   No    |  No   |
 |         YI         |  6B - 34B  |    Yes    |   No    |  No   |
+|   InternVL-Chat    |     -      |    Yes    |   No    |  No   |
 
 ```{note}
 turbomind 引擎不支持 window attention。所以，对于应用了 window attention，并开启了对应的开关"use_sliding_window"的模型，在推理时，请选择 pytorch engine

--- a/lmdeploy/archs.py
+++ b/lmdeploy/archs.py
@@ -120,6 +120,8 @@ def check_vl_llm(config: dict) -> bool:
         return True
     elif arch == 'MultiModalityCausalLM' and 'language_config' in config:
         return True
+    elif arch == 'InternVLChatModel':
+        return True
     return False
 
 

--- a/lmdeploy/model.py
+++ b/lmdeploy/model.py
@@ -869,6 +869,41 @@ class Deepseek(BaseChatTemplate):
             return 'deepseek'
 
 
+@MODELS.register_module(name=['internvl_zh'])
+class InternVLZH(BaseChatTemplate):
+
+    def __init__(self,
+                 user='<human>: ',
+                 eoh=' ',
+                 assistant='<bot>: ',
+                 eoa='</s>',
+                 session_len=4096,
+                 **kwargs):
+        super().__init__(user=user,
+                         eoh=eoh,
+                         assistant=assistant,
+                         eoa=eoa,
+                         session_len=session_len,
+                         **kwargs)
+
+    def get_prompt(self, prompt, sequence_start=True):
+        return super().get_prompt(prompt, sequence_start)[:-1]
+
+    def messages2prompt(self, messages, sequence_start=True):
+        return super().messages2prompt(messages, sequence_start)[:-1]
+
+    @classmethod
+    def match(cls, model_path: str) -> Optional[str]:
+        """Return the model_name that was registered to MODELS.
+
+        Args:
+            model_path (str): the model path used for matching.
+        """
+        path = model_path.lower()
+        if 'internvl-chat-chinese' in path and 'v1-1' in path:
+            return 'internvl_zh'
+
+
 @MODELS.register_module(name=['deepseek-vl'])
 class DeepseekVL(BaseChatTemplate):
 
@@ -1031,6 +1066,7 @@ class DbrxInstruct(BaseChatTemplate):
             return 'dbrx'
 
 
+@MODELS.register_module(name=['hermes2'])
 @MODELS.register_module(name=['llava-chatml'])
 class ChatmlDirect(BaseChatTemplate):
 
@@ -1064,7 +1100,9 @@ class ChatmlDirect(BaseChatTemplate):
             model_path (str): the model path used for matching.
         """
         path = model_path.lower()
-        if 'llava' in path and 'v1.6-34b' in path:
+        if ('llava' in path
+                and 'v1.6-34b' in path) or ('internvl-chat-chinese' in path
+                                            and 'v1-2' in path):
             return 'llava-chatml'
 
 

--- a/lmdeploy/model.py
+++ b/lmdeploy/model.py
@@ -869,7 +869,7 @@ class Deepseek(BaseChatTemplate):
             return 'deepseek'
 
 
-@MODELS.register_module(name=['internvl_zh'])
+@MODELS.register_module(name=['internvl-zh'])
 class InternVLZH(BaseChatTemplate):
 
     def __init__(self,
@@ -901,7 +901,7 @@ class InternVLZH(BaseChatTemplate):
         """
         path = model_path.lower()
         if 'internvl-chat-chinese' in path and 'v1-1' in path:
-            return 'internvl_zh'
+            return 'internvl-zh'
 
 
 @MODELS.register_module(name=['deepseek-vl'])
@@ -1066,7 +1066,7 @@ class DbrxInstruct(BaseChatTemplate):
             return 'dbrx'
 
 
-@MODELS.register_module(name=['hermes2'])
+@MODELS.register_module(name=['internvl-zh-hermes2'])
 @MODELS.register_module(name=['llava-chatml'])
 class ChatmlDirect(BaseChatTemplate):
 
@@ -1100,10 +1100,10 @@ class ChatmlDirect(BaseChatTemplate):
             model_path (str): the model path used for matching.
         """
         path = model_path.lower()
-        if ('llava' in path
-                and 'v1.6-34b' in path) or ('internvl-chat-chinese' in path
-                                            and 'v1-2' in path):
+        if 'llava' in path and 'v1.6-34b' in path:
             return 'llava-chatml'
+        if 'internvl-chat-chinese' in path and 'v1-2' in path:
+            return 'internvl-zh-hermes2'
 
 
 def best_match_model(query: str) -> Optional[str]:

--- a/lmdeploy/turbomind/deploy/converter.py
+++ b/lmdeploy/turbomind/deploy/converter.py
@@ -21,7 +21,8 @@ special_input_model_map = {
     'baichuan': 'baichuan',
     'baichuan2': 'baichuan2',
     'internlm2': 'internlm2',
-    'deepseekvl': 'deepseekvl'
+    'deepseekvl': 'deepseekvl',
+    'internvl': 'internvl'
 }
 
 

--- a/lmdeploy/turbomind/deploy/source_model/__init__.py
+++ b/lmdeploy/turbomind/deploy/source_model/__init__.py
@@ -3,6 +3,7 @@ from .baichuan import Baichuan2Model, BaichuanModel  # noqa: F401
 from .baichuan_awq import Baichuan2AwqModel, BaichuanAwqModel  # noqa: F401
 from .deepseek_vl import DeepSeekVLModel  # noqa: F401
 from .internlm2 import InternLM2AwqModel, InternLM2Model  # noqa: F401
+from .internvl import InternVLModel  # noqa: F401
 from .llama import LlamaModel  # noqa: F401
 from .llama_awq import LlamaAwqModel  # noqa: F401
 from .meta_llama import MetaLlamaModel  # noqa: F401

--- a/lmdeploy/turbomind/deploy/source_model/internvl.py
+++ b/lmdeploy/turbomind/deploy/source_model/internvl.py
@@ -1,0 +1,59 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+import json
+import os.path as osp
+
+from .base import INPUT_MODELS
+from .llama import LlamaModel, LlamaReader
+
+
+class InternVLReader(LlamaReader):
+    """InternVLReader."""
+
+    attn_layer_prefix = 'language_model.model.layers'
+    attn_layer_patten = r'language_model.model.layers.([0-9]+).'
+    tok_embeddings_key = 'language_model.model.embed_tokens.weight'
+    norm_weight_key = 'language_model.model.norm.weight'
+    output_weight_key = 'language_model.lm_head.weight'
+
+
+@INPUT_MODELS.register_module(name='internvl')
+class InternVLModel(LlamaModel):
+    """InternVLReader model in hf format."""
+
+    Reader = InternVLReader
+
+    def __init__(self, model_path: str, tokenizer_path: str, **kwargs):
+        super().__init__(model_path, tokenizer_path, **kwargs)
+
+    def model_info(self):
+        """Read model info."""
+        params_path = osp.join(self.model_path, 'config.json')
+        with open(params_path) as f:
+            model_arg = json.load(f)['llm_config']
+            num_layer = model_arg['num_hidden_layers']
+            norm_eps = model_arg['rms_norm_eps']
+            attn_head_num = model_arg['num_attention_heads']
+            if 'num_key_value_heads' in model_arg:
+                kv_head_num = model_arg['num_key_value_heads']
+            else:
+                kv_head_num = model_arg['num_attention_heads']
+            rope_theta = float(model_arg.get('rope_theta', 10000.0))
+            max_position_embeddings = int(
+                model_arg.get('max_position_embeddings', 0))
+            rope_scaling = model_arg.get('rope_scaling', None)
+            scaling_factor = 0.0
+            use_dynamic_ntk = 0
+            if isinstance(rope_scaling, dict):
+                scaling_type = model_arg['rope_scaling'].get('type', '')
+                scaling_factor = model_arg['rope_scaling'].get('factor', '')
+                if scaling_type == 'dynamic':
+                    use_dynamic_ntk = 1
+
+        return dict(num_layer=num_layer,
+                    norm_eps=norm_eps,
+                    attn_head_num=attn_head_num,
+                    kv_head_num=kv_head_num,
+                    rope_theta=rope_theta,
+                    max_position_embeddings=max_position_embeddings,
+                    use_dynamic_ntk=use_dynamic_ntk,
+                    rope_scaling_factor=scaling_factor)

--- a/lmdeploy/turbomind/deploy/source_model/llama.py
+++ b/lmdeploy/turbomind/deploy/source_model/llama.py
@@ -15,6 +15,7 @@ from .base import INPUT_MODELS, BaseInputModel, BaseReader
 class LlamaReader(BaseReader):
     """LlamaReader."""
 
+    attn_layer_prefix = 'model.layers'
     attn_layer_patten = r'model.layers.([0-9]+).'
     tok_embeddings_key = 'model.embed_tokens.weight'
     norm_weight_key = 'model.norm.weight'
@@ -64,7 +65,7 @@ class LlamaReader(BaseReader):
         result = []
         for key in ['q', 'k', 'v', 'o']:
             tensor = self.params.get(
-                f'model.layers.{i}.self_attn.{key}_proj.{kind}')
+                f'{self.attn_layer_prefix}.{i}.self_attn.{key}_proj.{kind}')
             if not allow_none:
                 assert tensor is not None
             result.append(tensor)
@@ -88,13 +89,15 @@ class LlamaReader(BaseReader):
 
     def attn_norm(self, i: int):
         """Get attn norm for layer i."""
-        return self.params[f'model.layers.{i}.input_layernorm.weight']
+        return self.params[
+            f'{self.attn_layer_prefix}.{i}.input_layernorm.weight']
 
     def _ffn(self, i: int, kind: str):
         """Get ffn kind for layer i."""
         result = []
         for key in ['gate', 'down', 'up']:
-            tensor = self.params[f'model.layers.{i}.mlp.{key}_proj.{kind}']
+            tensor = self.params[
+                f'{self.attn_layer_prefix}.{i}.mlp.{key}_proj.{kind}']
             result.append(tensor)
         return (*result, )
 
@@ -112,7 +115,8 @@ class LlamaReader(BaseReader):
 
     def ffn_norm(self, i: int):
         """Get ffn norm for layer i."""
-        return self.params[f'model.layers.{i}.post_attention_layernorm.weight']
+        return self.params[
+            f'{self.attn_layer_prefix}.{i}.post_attention_layernorm.weight']
 
 
 @INPUT_MODELS.register_module(name='hf')

--- a/lmdeploy/turbomind/supported_models.py
+++ b/lmdeploy/turbomind/supported_models.py
@@ -25,6 +25,8 @@ SUPPORTED_ARCHS = dict(
     Qwen2ForCausalLM='qwen2',
     # llava
     LlavaLlamaForCausalLM='llama',
+    # internvl
+    InternVLChatModel='internvl',
     # deepseek-vl
     MultiModalityCausalLM='deepseekvl')
 

--- a/lmdeploy/vl/model/builder.py
+++ b/lmdeploy/vl/model/builder.py
@@ -4,6 +4,7 @@ import os
 from lmdeploy.utils import get_hf_config_content, get_model
 
 from .deepseek import DeepSeekVisionModel
+from .internvl import InternVLVisionModel
 from .llava import LlavaVisionModel
 from .qwen import QwenVisionModel
 from .yi import YiVisionModel
@@ -25,4 +26,6 @@ def load_vl_model(model_path: str):
             return LlavaVisionModel(model_path)
     if arch == 'MultiModalityCausalLM':
         return DeepSeekVisionModel(model_path)
+    if arch == 'InternVLChatModel':
+        return InternVLVisionModel(model_path)
     raise ValueError(f'unsupported vl model with arch {arch}')

--- a/lmdeploy/vl/model/internvl.py
+++ b/lmdeploy/vl/model/internvl.py
@@ -1,0 +1,47 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+
+from typing import List
+
+import torch
+from PIL.Image import Image
+from transformers import AutoConfig, AutoModel, CLIPImageProcessor
+
+from lmdeploy.vl.model.base import VisonModel
+from lmdeploy.vl.model.utils import load_model_from_weight_files
+
+
+class InternVLVisionModel(VisonModel):
+    """InternVL vision model."""
+
+    def __init__(self, model_path, device='cuda:0'):
+        self.model_path = model_path
+        self.device = device
+        self.build_model()
+
+    def build_model(self):
+        """Load model."""
+        from accelerate import init_empty_weights
+        with init_empty_weights():
+            config = AutoConfig.from_pretrained(self.model_path,
+                                                trust_remote_code=True)
+            model = AutoModel.from_config(config, trust_remote_code=True)
+            del model.language_model
+            model.half()
+
+        model.to_empty(device='cpu')
+        load_model_from_weight_files(model, self.model_path)
+        self.model = model
+        self.model.to(self.device).eval()
+        self.image_processor = CLIPImageProcessor.from_pretrained(
+            self.model_path)
+
+    @torch.no_grad()
+    def forward(self, images: List[Image]) -> List[torch.Tensor]:
+        """forward."""
+        pixel_values = self.image_processor(images=images,
+                                            return_tensors='pt').pixel_values
+        pixel_values = pixel_values.to(self.device, dtype=torch.float16)
+        outputs = self.model.extract_feature(pixel_values)
+        outputs = torch.split(outputs, 1, dim=0)
+        outputs = [x.squeeze() for x in outputs]
+        return outputs

--- a/lmdeploy/vl/templates.py
+++ b/lmdeploy/vl/templates.py
@@ -119,6 +119,15 @@ class YiVLChatTemplateWrapper(VLChatTemplateWrapper):
     pass
 
 
+class InternVLChatTemplateWrapper(VLChatTemplateWrapper):
+    """InternVL chat template."""
+
+    def append_image_token(self, prompt, num_images: int):
+        """append image tokens to user prompt."""
+        # not sure whether support multi images.
+        return f'<img>{IMAGE_TOKEN}</img>\n' * num_images + prompt
+
+
 class DeepSeekVLChatTemplateWrapper(VLChatTemplateWrapper):
     """DeepSeek vl chat template."""
 
@@ -159,4 +168,6 @@ def get_vl_prompt_template(model_path: str, chat_template: BaseModel,
         return LlavaVLChatTemplateWrapper(chat_template)
     elif arch == 'MultiModalityCausalLM':  # deepseek-vl
         return DeepSeekVLChatTemplateWrapper(chat_template)
+    elif arch == 'InternVLChatModel':
+        return InternVLChatTemplateWrapper(chat_template)
     raise ValueError(f'unsupported vl_prompt_template with arch {arch}')

--- a/src/turbomind/models/llama/LlamaWeight.cc
+++ b/src/turbomind/models/llama/LlamaWeight.cc
@@ -117,17 +117,20 @@ TensorMap LlamaWeight<T>::getParams()
 {
     TensorMap output;
 
-    output.insert(
-        "tok_embeddings.weight",
-        Tensor{MEMORY_GPU, getTensorType<T>(), {vocab_size_ * hidden_units_ * sizeof(T)}, pre_decoder_embedding_table});
+    output.insert("tok_embeddings.weight",
+                  Tensor{MEMORY_GPU,
+                         getTensorType<T>(),
+                         {vocab_size_padded_ * hidden_units_ * sizeof(T)},
+                         pre_decoder_embedding_table});
 
     output.insert("norm.weight",
                   Tensor{MEMORY_GPU, getTensorType<T>(), {hidden_units_ * sizeof(T)}, output_norm_weight});
 
-    output.insert(
-        "output.weight",
-        Tensor{
-            MEMORY_GPU, getTensorType<T>(), {hidden_units_ * vocab_size_ * sizeof(T)}, post_decoder_embedding_kernel});
+    output.insert("output.weight",
+                  Tensor{MEMORY_GPU,
+                         getTensorType<T>(),
+                         {hidden_units_ * vocab_size_padded_ * sizeof(T)},
+                         post_decoder_embedding_kernel});
 
     // transformer layers
     for (size_t i = 0; i < num_layer_; i++) {


### PR DESCRIPTION
## Motivation

support

- https://huggingface.co/OpenGVLab/InternVL-Chat-Chinese-V1-2
- https://huggingface.co/OpenGVLab/InternVL-Chat-Chinese-V1-2-Plus
- https://huggingface.co/OpenGVLab/InternVL-Chat-Chinese-V1-1

## Modification

- add chat template (internvl_zh)
- add source model (InternVLModel)
- add vision model (InternVLVisionModel)
- add InternVLChatTemplateWrapper

## Usage:

The vision model is big, so we need to reduce kv-cache in order to load the vision model on single gpu. 

With 4 x A100, the memory usage is about 47G x 1 and  35G x 3 when using the following setting. (InternVL-Chat-Chinese-V1-2-Plus)

```
from lmdeploy import pipeline, TurbomindEngineConfig
from lmdeploy.vl import load_image

pipe = pipeline('/home/chenxin/InternVL-Chat-Chinese-V1-2-Plus/', log_level='INFO',
    backend_config=TurbomindEngineConfig(cache_max_entry_count=0.3, tp=4))

im = load_image('tiger.jpeg')
out = pipe(('描述这个图片', im))
```

## TODO

The vision model is big compraed with qwen / llava which use about 12G gpu memory. I will make another PR to improve it.
