### PR TITLE
Initialize vl encoder first to avoid OOM

### DIFF
--- a/lmdeploy/serve/vl_async_engine.py
+++ b/lmdeploy/serve/vl_async_engine.py
@@ -13,12 +13,12 @@ class VLAsyncEngine(AsyncEngine):
     """Visual Language Async inference engine."""
 
     def __init__(self, model_path: str, **kwargs) -> None:
+        self.vl_encoder = ImageEncoder(model_path)
         super().__init__(model_path, **kwargs)
         if self.model_name == 'base':
             raise RuntimeError(
                 'please specify chat template as guided in https://lmdeploy.readthedocs.io/en/latest/inference/vl_pipeline.html#set-chat-template'  # noqa: E501
             )
-        self.vl_encoder = ImageEncoder(model_path)
         self.vl_prompt_template = get_vl_prompt_template(
             model_path, self.chat_template, self.model_name)
 


### PR DESCRIPTION
The original implementation is easy to get OOM since there is no extra VRAM for the vl model.