### PR TITLE
fix free repetition_penalty_workspace_ buffer

### DIFF
--- a/src/turbomind/layers/sampling_layers/BaseSamplingLayer.h
+++ b/src/turbomind/layers/sampling_layers/BaseSamplingLayer.h
@@ -33,7 +33,7 @@ protected:
     size_t vocab_size_;
     size_t vocab_size_padded_;
 
-    int* repetition_penalty_workspace_;
+    int* repetition_penalty_workspace_ = nullptr;
 
     size_t sampling_workspace_size_;
     void*  sampling_workspace_ = nullptr;


### PR DESCRIPTION
## Motivation

Topk, Topp layers are initialized by `new TopKSamplingLayer` and `new TopPSamplingLayer` and repetition_penalty_workspace_ may has a invalid ptr. When invoke `allocator_->free((void**)(&repetition_penalty_workspace_)); ` there maybe a warning `TM_LOG_WARNING("pointer_mapping_ does not have information of ptr at %p.", address);`


