### PR TITLE
fix cache inference mode

### DIFF
--- a/lmdeploy/pytorch/engine/cache_engine.py
+++ b/lmdeploy/pytorch/engine/cache_engine.py
@@ -162,6 +162,7 @@ class CacheEngine:
             cpu_cache.append((key_blocks, value_blocks))
         return cpu_cache
 
+    @torch.inference_mode()
     def _swap(self, src: List[KVCache], dst: List[KVCache],
               src_to_dst: Dict[int, int]):
         """Move caches from src memory to dst memory.


### PR DESCRIPTION
Enable adapter with TP>1 would leads to failure in place copy.

@zhulinJulia24 