### PR TITLE
fix local variable 'response' referenced before assignment in async_engine.generate

### DIFF
--- a/lmdeploy/serve/async_engine.py
+++ b/lmdeploy/serve/async_engine.py
@@ -609,6 +609,7 @@ class AsyncEngine:
             generator = await self.get_generator(False, session_id)
             async with self.safe_run(session_id):
                 state = DetokenizeState()
+                response = ''
                 async for outputs in generator.async_stream_infer(
                         session_id=session_id,
                         **prompt_input,


### PR DESCRIPTION
## Motivation

When input is long or the chat template doesn't match, the first output token id with turbomind backend may be eos_id or in stop_words. In this case, the `async_engine.generate` will meet the following error. 

```bash
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/chenxin/ws3/vl/lmdeploy/serve/async_engine.py", line 325, in __call__
    return self.batch_infer(prompts,
  File "/home/chenxin/ws3/vl/lmdeploy/serve/async_engine.py", line 441, in batch_infer
    _get_event_loop().run_until_complete(gather())
  File "/home/chenxin/miniconda3/envs/38/lib/python3.8/asyncio/base_events.py", line 616, in run_until_complete
    return future.result()
  File "/home/chenxin/ws3/vl/lmdeploy/serve/async_engine.py", line 436, in gather
    await asyncio.gather(*[
  File "/home/chenxin/ws3/vl/lmdeploy/serve/async_engine.py", line 423, in _inner_call
    async for out in generator:
  File "/home/chenxin/ws3/vl/lmdeploy/serve/async_engine.py", line 648, in generate
    if not response.endswith('�'):
UnboundLocalError: local variable 'response' referenced before assignment
```

**reproduce**
```python
from lmdeploy import pipeline
pipe = pipeline('/mnt/140/Qwen/Qwen1.5-7B-Chat')
pipe('hello ' * 7500)
```