### PR TITLE
fix installation requirements for windows

### DIFF
--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -14,5 +14,5 @@ shortuuid
 tiktoken
 torch<=2.2.2,>=2.0.0
 transformers
-triton>=2.1.0,<=2.2.0
+triton>=2.1.0,<=2.2.0; sys_platform == "linux"
 uvicorn


### PR DESCRIPTION
## Motivation

pip install lmdeploy will fail on windows because triton doesn't support windows.
https://pypi.org/project/triton/#files

