### PR TITLE
bump version to v0.4.1

### DIFF
--- a/lmdeploy/version.py
+++ b/lmdeploy/version.py
@@ -1,7 +1,7 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 from typing import Tuple
 
-__version__ = '0.4.0'
+__version__ = '0.4.1'
 short_version = __version__
 
 


### PR DESCRIPTION
## Motivation

1. There are strong requests to release the inference support of internvl v1.5 soon
2. Several critical issues were resolved
    - An overflow error occurred in turbomind when the context length was large
    - setup error on the Windows platform
    - empty chunk returned by the api_server
    - inefficient pipeline

