### PR TITLE
Use a faster format for images in VLMs

### DIFF
--- a/lmdeploy/vl/utils.py
+++ b/lmdeploy/vl/utils.py
@@ -10,7 +10,7 @@ from PIL import Image
 def encode_image_base64(image: Image.Image) -> str:
     """encode image to base64 format."""
     buffered = BytesIO()
-    image.save(buffered, format='PNG')
+    image.save(buffered, format='JPEG')
     return base64.b64encode(buffered.getvalue()).decode('utf-8')
 
 


### PR DESCRIPTION
This improves the performance in a significant way when dealing with higher batch sizes on GPU servers which have lots of 'small' cores and the operations are run in sync in the same core. PNG compression effectively becomes the bottleneck which is totally unnecessary.

For sharing some numbers, on an H100 when running `xtuner/llava-llama-3-8b-v1_1-hf` (with int8 KV cache quantization), the timings go from ~6 seconds to ~3 seconds at bs=16. Its almost doubling the performance (and reducing the unutilized GPU times). 