### PR TITLE
[benchmark] optimize benchmark: counting tokenlizer tokens and error requests

### DIFF
--- a/benchmark/profile_restful_api.py
+++ b/benchmark/profile_restful_api.py
@@ -244,21 +244,19 @@ class Engine:
                 ])
 
 
-def main(
-    server_addr: str,
-    tokenizer_path: str,
-    dataset: str,
-    api_key: Optional[str] = None,
-    model_name: Optional[str] = None,
-    concurrency: int = 128,
-    num_prompts: int = 5000,
-    top_p: float = 1.0,
-    temperature: float = 1.0,
-    stream_output: bool = False,
-    csv: str = './profile_api_server.csv',
-    seed: int = 0,
-    role: str = 'user',
-):
+def main(server_addr: str,
+         tokenizer_path: str,
+         dataset: str,
+         api_key: Optional[str] = None,
+         model_name: Optional[str] = None,
+         concurrency: int = 128,
+         num_prompts: int = 5000,
+         top_p: float = 1.0,
+         temperature: float = 1.0,
+         stream_output: bool = False,
+         csv: str = './profile_api_server.csv',
+         seed: int = 0,
+         role: str = 'user'):
     """Benchmark the request througput of api server.
 
     Args:

--- a/benchmark/profile_restful_api.py
+++ b/benchmark/profile_restful_api.py
@@ -105,7 +105,7 @@ class Engine:
                     stream=stream_output,
                     session_id=session_id,
                     ignore_eos=True):
-                # Here we ignore the index of the multiple outputs and 
+                # Here we ignore the index of the multiple outputs and
                 # just put all of them together to compute tokens.
                 for choice in output.get("choices", []):
                     if stream_output:

--- a/benchmark/profile_restful_api.py
+++ b/benchmark/profile_restful_api.py
@@ -41,13 +41,10 @@ def sample_requests(
     tokenized_dataset = []
     for i in range(len(dataset)):
         output_len = len(completion_token_ids[i])
-        tokenized_dataset.append(
-            (
-                [{'role': role, 'content': prompts[i]}],
-                prompt_token_ids[i],
-                output_len
-            )
-        )
+        tokenized_dataset.append(([{
+            'role': role,
+            'content': prompts[i]
+        }], prompt_token_ids[i], output_len))
 
     # Filter out too long sequences.
     filtered_dataset: List[Tuple[str, int, int]] = []
@@ -247,20 +244,21 @@ class Engine:
                 ])
 
 
-def main(server_addr: str,
-         tokenizer_path: str,
-         dataset: str,
-         api_key: Optional[str] = None,
-         model_name: Optional[str] = None,
-         concurrency: int = 128,
-         num_prompts: int = 5000,
-         top_p: float = 1.0,
-         temperature: float = 1.0,
-         stream_output: bool = False,
-         csv: str = './profile_api_server.csv',
-         seed: int = 0,
-         role: str = 'user',
-         ):
+def main(
+    server_addr: str,
+    tokenizer_path: str,
+    dataset: str,
+    api_key: Optional[str] = None,
+    model_name: Optional[str] = None,
+    concurrency: int = 128,
+    num_prompts: int = 5000,
+    top_p: float = 1.0,
+    temperature: float = 1.0,
+    stream_output: bool = False,
+    csv: str = './profile_api_server.csv',
+    seed: int = 0,
+    role: str = 'user',
+):
     """Benchmark the request througput of api server.
 
     Args:

--- a/benchmark/profile_restful_api.py
+++ b/benchmark/profile_restful_api.py
@@ -5,6 +5,7 @@ import time
 from queue import Queue
 from threading import Thread
 from typing import List, Optional, Tuple
+from urllib.parse import urlparse
 
 import fire
 import numpy as np
@@ -241,10 +242,12 @@ def main(server_addr: str,
         csv (str, optional): The path to save the result.
         seed (int, optional): Seed used in sampling prompts from dataset. Defaults to 0.
     """    # noqa
-    if not server_addr.startswith('http://'):
+    addr_schem = urlparse(server_addr).scheme
+    if addr_schem not in ["http", "https"]:
         print(f'[WARNING] server_addr of the api_server should '
-              f'start with "http://", but got "{server_addr}"')
+              f'start with "http://" or "https://", but got "{server_addr}"')
         server_addr = 'http://' + server_addr.strip()
+    print(f'[INFO] using server_addr: {server_addr}')
 
     random.seed(seed)
 

--- a/benchmark/profile_restful_api.py
+++ b/benchmark/profile_restful_api.py
@@ -260,7 +260,7 @@ def main(server_addr: str,
         seed (int, optional): Seed used in sampling prompts from dataset. Defaults to 0.
     """    # noqa
     addr_schem = urlparse(server_addr).scheme
-    if addr_schem not in ["http", "https"]:
+    if addr_schem not in ['http', 'https']:
         print(f'[WARNING] server_addr of the api_server should '
               f'start with "http://" or "https://", but got "{server_addr}"')
         server_addr = 'http://' + server_addr.strip()

--- a/benchmark/profile_restful_api.py
+++ b/benchmark/profile_restful_api.py
@@ -94,7 +94,7 @@ class Engine:
                 req_queue.get, [None, None, None]):
             timestamps = []
             timestamps.append(time.perf_counter())
-            full_output = ""
+            full_output = ''
             for output in client.chat_completions_v1(
                     model=self.model_name,
                     messages=prompt,
@@ -107,11 +107,11 @@ class Engine:
                     ignore_eos=True):
                 # Here we ignore the index of the multiple outputs and
                 # just put all of them together to compute tokens.
-                for choice in output.get("choices", []):
+                for choice in output.get('choices', []):
                     if stream_output:
-                        full_output += choice["delta"]["content"]
+                        full_output += choice['delta']['content']
                     else:
-                        full_output += choice["message"]["content"]
+                        full_output += choice['message']['content']
                 timestamps.append(time.perf_counter())
 
             first_token_latency = np.round(timestamps[1] - timestamps[0], 3)

--- a/benchmark/profile_restful_api.py
+++ b/benchmark/profile_restful_api.py
@@ -114,7 +114,7 @@ class Engine:
                     # just put all of them together to compute tokens.
                     for choice in output.get('choices', []):
                         if stream_output:
-                            full_output += choice['delta']['content']
+                            full_output += choice['delta'].get('content', '')
                         else:
                             full_output += choice['message']['content']
                     timestamps.append(time.perf_counter())

--- a/benchmark/profile_restful_api.py
+++ b/benchmark/profile_restful_api.py
@@ -109,8 +109,10 @@ class Engine:
                         n=1,
                         max_tokens=output_seqlen,
                         stream=stream_output,
-                        session_id=session_id,
-                        ignore_eos=True):
+                        session_id=None,
+                        repetition_penalty=None,
+                        ignore_eos=None,
+                        skip_special_tokens=None):
                     # Here we ignore the index of the multiple outputs and
                     # just put all of them together to compute tokens.
                     for choice in output.get('choices', []):

--- a/benchmark/profile_restful_api.py
+++ b/benchmark/profile_restful_api.py
@@ -42,7 +42,11 @@ def sample_requests(
     for i in range(len(dataset)):
         output_len = len(completion_token_ids[i])
         tokenized_dataset.append(
-            ([{"role": role, "content": prompts[i]}], prompt_token_ids[i], output_len)
+            (
+                [{'role': role, 'content': prompts[i]}],
+                prompt_token_ids[i],
+                output_len
+            )
         )
 
     # Filter out too long sequences.

--- a/benchmark/profile_restful_api.py
+++ b/benchmark/profile_restful_api.py
@@ -19,6 +19,7 @@ def sample_requests(
     dataset_path: str,
     num_requests: int,
     tokenizer: Tokenizer,
+    role: str,
 ) -> List[Tuple[str, int, int]]:
     # Load the dataset.
     with open(dataset_path) as f:
@@ -40,7 +41,9 @@ def sample_requests(
     tokenized_dataset = []
     for i in range(len(dataset)):
         output_len = len(completion_token_ids[i])
-        tokenized_dataset.append((prompts[i], prompt_token_ids[i], output_len))
+        tokenized_dataset.append(
+            ([{"role": role, "content": prompts[i]}], prompt_token_ids[i], output_len)
+        )
 
     # Filter out too long sequences.
     filtered_dataset: List[Tuple[str, int, int]] = []
@@ -251,7 +254,9 @@ def main(server_addr: str,
          temperature: float = 1.0,
          stream_output: bool = False,
          csv: str = './profile_api_server.csv',
-         seed: int = 0):
+         seed: int = 0,
+         role: str = 'user',
+         ):
     """Benchmark the request througput of api server.
 
     Args:
@@ -269,6 +274,7 @@ def main(server_addr: str,
         stream_output (bool, optional): Indicator for streaming output. Defaults to False.
         csv (str, optional): The path to save the result.
         seed (int, optional): Seed used in sampling prompts from dataset. Defaults to 0.
+        role (str, optional): The role of the messages author in prompts. Defaults to 'user'
     """    # noqa
     addr_schem = urlparse(server_addr).scheme
     if addr_schem not in ['http', 'https']:
@@ -287,7 +293,7 @@ def main(server_addr: str,
                     api_key=api_key,
                     model_name=model_name)
 
-    requests = sample_requests(dataset, num_prompts, engine.tokenizer)
+    requests = sample_requests(dataset, num_prompts, engine.tokenizer, role)
 
     engine.process_request(requests, concurrency, stream_output)
 

--- a/lmdeploy/serve/openai/api_client.py
+++ b/lmdeploy/serve/openai/api_client.py
@@ -136,8 +136,8 @@ class APIClient:
         """
         pload = {
             k: v
-            for k, v in locals().copy().items()
-            if k[:2] != '__' and k not in ['self'] and v is not None and v != {}
+            for k, v in locals().copy().items() if k[:2] != '__'
+            and k not in ['self'] and v is not None and v != {}
         }
         response = requests.post(self.chat_completions_v1_url,
                                  headers=self.headers,

--- a/lmdeploy/serve/openai/api_client.py
+++ b/lmdeploy/serve/openai/api_client.py
@@ -137,7 +137,7 @@ class APIClient:
         pload = {
             k: v
             for k, v in locals().copy().items()
-            if k[:2] != '__' and k not in ['self'] and v != None and v != {}
+            if k[:2] != '__' and k not in ['self'] and v is not None and v != {}
         }
         response = requests.post(self.chat_completions_v1_url,
                                  headers=self.headers,

--- a/lmdeploy/serve/openai/api_client.py
+++ b/lmdeploy/serve/openai/api_client.py
@@ -137,7 +137,7 @@ class APIClient:
         pload = {
             k: v
             for k, v in locals().copy().items()
-            if k[:2] != '__' and k not in ['self']
+            if k[:2] != '__' and k not in ['self'] and v != None and v != {}
         }
         response = requests.post(self.chat_completions_v1_url,
                                  headers=self.headers,


### PR DESCRIPTION
## Motivation

1. support https shceme for benchmark
2. counting the real output tokens
3. counting local tokenlizer throughput
4. counting error requests
5. support setting role in prompt
6. support benchmark openai API

## BC-breaking (Optional)

None

## Use cases (Optional)

For better benchmark.

