### PR TITLE
Optimize GQA/MQA

### DIFF
--- a/lmdeploy/pytorch/kernels/pagedattention.py
+++ b/lmdeploy/pytorch/kernels/pagedattention.py
@@ -609,7 +609,7 @@ def paged_attention_fwd(
     kernel_meta = _kernel_meta()
     is_decoding = q.shape[-3] == q_seqlens.size(0)
     if not is_decoding:
-        num_warps = 4 if Lk <= 64 else 8
+        num_warps = 4
         grid = (batch, head, triton.cdiv(max_seqlen, BLOCK_M))
         _fwd_kernel[grid](q,
                           k,
@@ -686,7 +686,7 @@ def paged_attention_fwd(
                                     num_stages=1,
                                     **kernel_meta)
         else:
-            BLOCK_H = 16
+            BLOCK_H = max(16, min(BLOCK, kv_group_num))
             grid = (batch, head // min(BLOCK_H, kv_group_num), SPLIT_K)
             _fwd_grouped_split_kernel[grid](
                 q,

--- a/lmdeploy/pytorch/kernels/pagedattention.py
+++ b/lmdeploy/pytorch/kernels/pagedattention.py
@@ -570,7 +570,7 @@ def paged_attention_fwd(
     max_seqlen: int,
     window_size: int = None,
     sm_scale: float = None,
-    shared_kv: int = False,
+    shared_kv: bool = False,
 ):
     """Paged Attention forward.
 

--- a/tests/pytorch/kernel/test_paged_attention.py
+++ b/tests/pytorch/kernel/test_paged_attention.py
@@ -27,13 +27,14 @@ def _make_bias(seq_lens, history_lens, neg_val):
 
 
 def _make_blocked_cache(batched_k, batched_v, seq_lens, history_lens,
-                        block_offsets, block_size, num_heads_k, feat_dim):
+                        block_offsets, block_size, num_heads_k, feat_dim,
+                        feat_dim_v):
     max_blocks_nums = block_offsets.max() + 1
     full_seq_lens = seq_lens + history_lens
     blocked_k = batched_k.new_zeros(max_blocks_nums, block_size, num_heads_k,
                                     feat_dim)
     blocked_v = batched_v.new_zeros(max_blocks_nums, block_size, num_heads_k,
-                                    feat_dim)
+                                    feat_dim_v)
 
     for batch_id, offset in enumerate(block_offsets):
         ori_k = batched_k[batch_id]
@@ -113,6 +114,10 @@ class TestPagedAttention:
         yield 16
 
     @pytest.fixture
+    def feat_dim_v(self, request):
+        yield request.param
+
+    @pytest.fixture
     def num_heads_q(self, request):
         yield request.param
 
@@ -152,7 +157,8 @@ class TestPagedAttention:
         yield inputs
 
     @pytest.fixture
-    def batched_kv(self, seq_lens, history_lens, num_heads_k, feat_dim, dtype):
+    def batched_kv(self, seq_lens, history_lens, num_heads_k, feat_dim,
+                   feat_dim_v, dtype):
         torch.manual_seed(123)
         batch_size = len(seq_lens)
         full_seq_lens = seq_lens + history_lens
@@ -166,7 +172,7 @@ class TestPagedAttention:
         v = torch.rand(batch_size,
                        max_seq_len,
                        num_heads_k,
-                       feat_dim,
+                       feat_dim_v,
                        dtype=dtype,
                        device='cuda')
         yield k, v
@@ -202,11 +208,11 @@ class TestPagedAttention:
 
     @pytest.fixture
     def blocked_kv(self, batched_kv, seq_lens, history_lens, block_offsets,
-                   block_size, num_heads_k, feat_dim):
+                   block_size, num_heads_k, feat_dim, feat_dim_v):
         batched_k, batched_v = batched_kv
         yield _make_blocked_cache(batched_k, batched_v, seq_lens, history_lens,
                                   block_offsets, block_size, num_heads_k,
-                                  feat_dim)
+                                  feat_dim, feat_dim_v)
 
     @pytest.fixture
     def mask(self, seq_lens, history_lens):
@@ -221,21 +227,23 @@ class TestPagedAttention:
     def conti_gt(self, gt, seq_lens):
         yield _conti_input(gt, seq_lens)
 
-    @pytest.mark.parametrize(['num_heads_q', 'num_heads_k'], [(4, 2)],
+    @pytest.mark.parametrize('feat_dim_v', [32], indirect=True)
+    @pytest.mark.parametrize(['num_heads_q', 'num_heads_k'], [(8, 2), (2, 2)],
                              indirect=True)
     @pytest.mark.parametrize(['seq_lens', 'history_lens'],
                              [([30, 50, 70, 90], [50, 40, 30, 20]),
                               ([1, 1, 1, 1], [50, 40, 30, 20])],
                              indirect=True)
-    @pytest.mark.parametrize('block_size', [2, 16], indirect=True)
+    @pytest.mark.parametrize('block_size', [16], indirect=True)
     def test_paged_attention(self, conti_q, blocked_kv, block_offsets,
-                             start_loc, seq_lens, history_lens, conti_gt):
+                             start_loc, seq_lens, history_lens, feat_dim_v,
+                             conti_gt):
         from lmdeploy.pytorch.kernels import paged_attention_fwd
         kv_seq_lens = seq_lens + history_lens
         max_seq_len = seq_lens.max().item()
 
         blocked_k, blocked_v = blocked_kv
-        out = torch.empty_like(conti_q)
+        out = conti_q.new_empty(*conti_q.shape[:-1], feat_dim_v)
 
         paged_attention_fwd(conti_q,
                             blocked_k,
@@ -262,6 +270,7 @@ class TestPagedAttention:
                                       kv_lens,
                                       window_size=(win_size, win_size))
 
+    @pytest.mark.parametrize('feat_dim_v', [16], indirect=True)
     @pytest.mark.parametrize(['num_heads_q', 'num_heads_k'], [(4, 2)],
                              indirect=True)
     @pytest.mark.parametrize(['seq_lens', 'history_lens'], [
@@ -272,14 +281,14 @@ class TestPagedAttention:
     @pytest.mark.parametrize('win_size', (32, ), indirect=True)
     @pytest.mark.parametrize('block_size', [16], indirect=True)
     def test_window_attention(self, conti_q, blocked_kv, block_offsets,
-                              start_loc, seq_lens, history_lens, win_size,
-                              window_gt):
+                              start_loc, seq_lens, history_lens, feat_dim_v,
+                              win_size, window_gt):
         from lmdeploy.pytorch.kernels import paged_attention_fwd
         kv_seq_lens = seq_lens + history_lens
         max_seq_len = seq_lens.max().item()
 
         blocked_k, blocked_v = blocked_kv
-        out = torch.empty_like(conti_q)
+        out = conti_q.new_empty(*conti_q.shape[:-1], feat_dim_v)
         paged_attention_fwd(conti_q,
                             blocked_k,
                             blocked_v,


### PR DESCRIPTION
enable tensorcore in decoding MHA kernel.

## internlm2-chat-20b tp=2 batch_size=256 num_reqs=3000

### origin 

```
first token latency(s)(min, max, ave): 1.151, 20.570, 5.350
per-token latency(s) percentile(50, 75, 95, 99): [0.074, 0.087, 0.387, 0.515]

number of prompt tokens: 684711
number of completion tokens: 624144
token throughput (completion token): 1647.393 token/s
token throughput (prompt + completion token): 3454.650 token/s
RPS (request per second): 7.918 req/s
RPM (request per minute): 475.100 req/min
```

### This PR
```
concurrency: 256
elapsed_time: 346.817s

first token latency(s)(min, max, ave): 2.643, 21.116, 5.051
per-token latency(s) percentile(50, 75, 95, 99): [0.065, 0.083, 0.407, 0.504]

number of prompt tokens: 684711
number of completion tokens: 624144
token throughput (completion token): 1799.636 token/s
token throughput (prompt + completion token): 3773.910 token/s
RPS (request per second): 8.650 req/s
RPM (request per minute): 519.006 req/min
```


## internlm2-chat-20b tp=1 batch_size=128 num_reqs=3000

### origin 
```
concurrency: 128
elapsed_time: 566.050s

first token latency(s)(min, max, ave): 1.929, 12.539, 3.287
per-token latency(s) percentile(50, 75, 95, 99): [0.064, 0.066, 0.288, 0.609]

number of prompt tokens: 684711
number of completion tokens: 624144
token throughput (completion token): 1102.630 token/s
token throughput (prompt + completion token): 2312.260 token/s
RPS (request per second): 5.300 req/s
RPM (request per minute): 317.993 req/min
```

### This PR
```
concurrency: 128
elapsed_time: 480.266s

first token latency(s)(min, max, ave): 1.489, 10.305, 2.808
per-token latency(s) percentile(50, 75, 95, 99): [0.051, 0.053, 0.251, 0.571]

number of prompt tokens: 684711
number of completion tokens: 624144
token throughput (completion token): 1299.579 token/s
token throughput (prompt + completion token): 2725.268 token/s
RPS (request per second): 6.247 req/s
RPM (request per minute): 374.792 req/min
```

## LLama-3-8b-instruct tp=1 batch_size=128 num_reqs=3000

### origin

```
concurrency: 256
elapsed_time: 260.775s

first token latency(s)(min, max, ave): 1.044, 15.817, 3.555
per-token latency(s) percentile(50, 75, 95, 99): [0.056, 0.06, 0.315, 0.379]

number of prompt tokens: 676779
number of completion tokens: 612685
token throughput (completion token): 2349.476 token/s
token throughput (prompt + completion token): 4944.734 token/s
RPS (request per second): 11.504 req/s
RPM (request per minute): 690.250 req/min
```

### This PR

```
concurrency: 256
elapsed_time: 246.199s

first token latency(s)(min, max, ave): 2.152, 13.018, 3.580
per-token latency(s) percentile(50, 75, 95, 99): [0.051, 0.065, 0.316, 0.361]

number of prompt tokens: 676779
number of completion tokens: 612685
token throughput (completion token): 2488.573 token/s
token throughput (prompt + completion token): 5237.481 token/s
RPS (request per second): 12.185 req/s
RPM (request per minute): 731.115 req/min
```