### PR TITLE
Detokenize with prompt token ids

### DIFF
--- a/lmdeploy/pytorch/chat.py
+++ b/lmdeploy/pytorch/chat.py
@@ -113,15 +113,15 @@ def run_chat(model_path: str,
                       ' Please end the session.')
                 continue
 
-            print(f'{prompt} ', end='', flush=True)
-            state = DetokenizeState()
+            print(f'{prompt}', end='', flush=True)
+            state = DetokenizeState(len(input_ids))
             gen_config.random_seed = seed
             gen_config.stop_words = stop_words
             for outputs in generator.stream_infer(session_id=session_id,
                                                   input_ids=input_ids,
                                                   gen_config=gen_config,
                                                   adapter_name=adapter_name):
-                res, tokens = outputs.token_ids, outputs.num_token
+                res, tokens = input_ids + outputs.token_ids, outputs.num_token
                 # decode res
                 response, state = tokenizer.detokenize_incrementally(
                     res, state)

--- a/lmdeploy/serve/async_engine.py
+++ b/lmdeploy/serve/async_engine.py
@@ -613,7 +613,7 @@ class AsyncEngine:
         else:
             generator = await self.get_generator(False, session_id)
             async with self.safe_run(session_id):
-                state = DetokenizeState()
+                state = DetokenizeState(len(input_ids))
                 response = ''
                 async for outputs in generator.async_stream_infer(
                         session_id=session_id,
@@ -625,7 +625,7 @@ class AsyncEngine:
                         sequence_end=sequence_end,
                         step=self.id2step[str(session_id)]):
                     # decode res
-                    res, tokens = outputs.token_ids, outputs.num_token
+                    res, tokens = input_ids + outputs.token_ids, outputs.num_token  # noqa
                     if len(res) <= state.ids_offset:
                         continue
 

--- a/lmdeploy/serve/gradio/vl.py
+++ b/lmdeploy/serve/gradio/vl.py
@@ -133,7 +133,7 @@ def run_local(model_path: str,
                                           top_k=top_k,
                                           temperature=temperature)
             step = session.step
-            state = DetokenizeState()
+            state = DetokenizeState(len(input_ids))
             for outputs in generator.stream_infer(
                     session_id=session._session_id,
                     **inputs,
@@ -141,7 +141,7 @@ def run_local(model_path: str,
                     step=step,
                     gen_config=gen_config,
                     stream_output=True):
-                res, tokens = outputs.token_ids, outputs.num_token
+                res, tokens = input_ids + outputs.token_ids, outputs.num_token
                 response, state = engine.tokenizer.detokenize_incrementally(
                     res,
                     state,

--- a/lmdeploy/tokenizer.py
+++ b/lmdeploy/tokenizer.py
@@ -429,16 +429,16 @@ class HuggingFaceTokenizer:
             # Please notice that in VLLM, indexes are detokenized one by one
             # while in LMDeploy, every turn, the detokenized indexes length
             # can be different.
+            prev_tokens = tokenizer.convert_ids_to_tokens(
+                all_input_ids[:ids_offset],
+                skip_special_tokens=skip_special_tokens)
+            read_offset = len(prev_tokens)
             if skip_special_tokens and new_tokens and new_tokens[
                     0] in tokenizer.all_special_ids:
-                read_offset = 1  # skip special token
-            output_tokens = new_tokens
-            prev_tokens = new_tokens
-        else:
-            # Put new_token_id in a list so skip_special_tokens is respected
-            output_tokens = prev_tokens + new_tokens
-            prev_tokens += new_tokens
+                read_offset = read_offset + 1  # skip special token
 
+        output_tokens = prev_tokens + new_tokens
+        prev_tokens += new_tokens
         prefix_text = self._convert_tokens_to_string_with_added_encoders(
             tokenizer,
             output_tokens[prefix_offset:read_offset],

--- a/lmdeploy/turbomind/chat.py
+++ b/lmdeploy/turbomind/chat.py
@@ -122,8 +122,8 @@ def main(model_path: str,
                 sequence_start, sequence_end = True, True
                 step = 0
 
-            print(f'{prompt} ', end='', flush=True)
-            state = DetokenizeState()
+            print(f'{prompt}', end='', flush=True)
+            state = DetokenizeState(len(input_ids))
             for outputs in generator.stream_infer(
                     session_id=session_id,
                     input_ids=[input_ids],
@@ -134,7 +134,7 @@ def main(model_path: str,
                     gen_config=gen_config,
                     ignore_eos=False,
                     random_seed=seed if nth_round == 1 else None):
-                res, tokens = outputs.token_ids, outputs.num_token
+                res, tokens = input_ids + outputs.token_ids, outputs.num_token
                 # decode res
                 response, state = tokenizer.detokenize_incrementally(
                     res, state=state)


### PR DESCRIPTION
#1743

Please **note** that detokenizing with prompt token ids is slightly slower than without. The faster the model, the bigger the influence. In my testing on internlm2-chat-1_8b, it could be about 3% slower. (49.94 RPS vs 51.55 RPS).

Update: tested internlm2-chat-7b, the influence was so small that it could be dismissed (21.984 RPS vs 21.815 RPS). The current implement performs better which could be a measurement error.