### PR TITLE
Encode raw image file to base64

### DIFF
--- a/lmdeploy/vl/templates.py
+++ b/lmdeploy/vl/templates.py
@@ -8,7 +8,7 @@ import PIL.Image
 from lmdeploy.model import BaseModel
 from lmdeploy.utils import get_hf_config_content, get_logger
 from lmdeploy.vl.constants import IMAGE_TOKEN
-from lmdeploy.vl.utils import encode_file_base64, load_image
+from lmdeploy.vl.utils import encode_image_base64, load_image
 
 logger = get_logger('lmdeploy')
 
@@ -42,7 +42,7 @@ class VLChatTemplateWrapper:
                 # 'image_url': means url or local path to image.
                 # 'image_data': means PIL.Image.Image object.
                 if isinstance(image, str):
-                    image_base64_data = encode_file_base64(image)
+                    image_base64_data = encode_image_base64(image)
                     if image_base64_data == '':
                         logger.error(f'failed to load file {image}')
                         continue

--- a/lmdeploy/vl/templates.py
+++ b/lmdeploy/vl/templates.py
@@ -8,7 +8,7 @@ import PIL.Image
 from lmdeploy.model import BaseModel
 from lmdeploy.utils import get_hf_config_content, get_logger
 from lmdeploy.vl.constants import IMAGE_TOKEN
-from lmdeploy.vl.utils import encode_image_base64, load_image
+from lmdeploy.vl.utils import encode_file_base64, load_image
 
 logger = get_logger('lmdeploy')
 
@@ -42,8 +42,10 @@ class VLChatTemplateWrapper:
                 # 'image_url': means url or local path to image.
                 # 'image_data': means PIL.Image.Image object.
                 if isinstance(image, str):
-                    image = load_image(image)
-                    image_base64_data = encode_image_base64(image)
+                    image_base64_data = encode_file_base64(image)
+                    if image_base64_data == '':
+                        logger.error(f'failed to load file {image}')
+                        continue
                     item = {
                         'type': 'image_url',
                         'image_url': {

--- a/lmdeploy/vl/utils.py
+++ b/lmdeploy/vl/utils.py
@@ -8,34 +8,33 @@ import requests
 from PIL import Image
 
 
-def encode_image_base64(image: Image.Image) -> str:
-    """encode image to base64 format."""
-    buffered = BytesIO()
-    image.save(buffered, format='JPEG')
-    return base64.b64encode(buffered.getvalue()).decode('utf-8')
-
-
-def encode_file_base64(image_url: str) -> str:
+def encode_image_base64(image: Union[str, Image.Image]) -> str:
     """encode raw date to base64 format."""
     res = ''
-    if image_url.startswith('http'):
-        FETCH_TIMEOUT = int(os.environ.get('LMDEPLOY_FETCH_TIMEOUT', 10))
-        headers = {
-            'User-Agent':
-            'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 '
-            '(KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3'
-        }
-        try:
-            response = requests.get(image_url,
-                                    headers=headers,
-                                    timeout=FETCH_TIMEOUT)
-            response.raise_for_status()
-            res = base64.b64encode(response.content).decode('utf-8')
-        except Exception:
-            pass
-    elif os.path.exists(image_url):
-        with open(image_url, 'rb') as image_file:
-            res = base64.b64encode(image_file.read()).decode('utf-8')
+    if isinstance(image, str):
+        url_or_path = image
+        if url_or_path.startswith('http'):
+            FETCH_TIMEOUT = int(os.environ.get('LMDEPLOY_FETCH_TIMEOUT', 10))
+            headers = {
+                'User-Agent':
+                'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 '
+                '(KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3'
+            }
+            try:
+                response = requests.get(url_or_path,
+                                        headers=headers,
+                                        timeout=FETCH_TIMEOUT)
+                response.raise_for_status()
+                res = base64.b64encode(response.content).decode('utf-8')
+            except Exception:
+                pass
+        elif os.path.exists(url_or_path):
+            with open(url_or_path, 'rb') as image_file:
+                res = base64.b64encode(image_file.read()).decode('utf-8')
+    elif isinstance(image, Image.Image):
+        buffered = BytesIO()
+        image.save(buffered, format='PNG')
+        res = base64.b64encode(buffered.getvalue()).decode('utf-8')
     return res
 
 

--- a/lmdeploy/vl/utils.py
+++ b/lmdeploy/vl/utils.py
@@ -15,6 +15,30 @@ def encode_image_base64(image: Image.Image) -> str:
     return base64.b64encode(buffered.getvalue()).decode('utf-8')
 
 
+def encode_file_base64(image_url: str) -> str:
+    """encode raw date to base64 format."""
+    res = ''
+    if image_url.startswith('http'):
+        FETCH_TIMEOUT = int(os.environ.get('LMDEPLOY_FETCH_TIMEOUT', 10))
+        headers = {
+            'User-Agent':
+            'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 '
+            '(KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3'
+        }
+        try:
+            response = requests.get(image_url,
+                                    headers=headers,
+                                    timeout=FETCH_TIMEOUT)
+            response.raise_for_status()
+            res = base64.b64encode(response.content).decode('utf-8')
+        except Exception:
+            pass
+    elif os.path.exists(image_url):
+        with open(image_url, 'rb') as image_file:
+            res = base64.b64encode(image_file.read()).decode('utf-8')
+    return res
+
+
 def load_image_from_base64(image: Union[bytes, str]) -> Image.Image:
     """load image from base64 format."""
     return Image.open(BytesIO(base64.b64decode(image)))

--- a/tests/test_lmdeploy/test_vl_encode.py
+++ b/tests/test_lmdeploy/test_vl_encode.py
@@ -1,0 +1,10 @@
+from lmdeploy.vl.utils import (encode_image_base64, load_image,
+                               load_image_from_base64)
+
+
+def test_encode_image_base64():
+    url = 'https://raw.githubusercontent.com/open-mmlab/mmdeploy/main/tests/data/tiger.jpeg'  # noqa E501
+    im1 = load_image(url)
+    base64 = encode_image_base64(url)
+    im2 = load_image_from_base64(base64)
+    assert im1 == im2


### PR DESCRIPTION
## Motivation

- Avoid repeated encoding or decoding of images, encode raw data to base64 format directly. 
- Skip image input if failed to get the file.