### PR TITLE
feat: auto set awq model_format from hf

### DIFF
--- a/lmdeploy/turbomind/turbomind.py
+++ b/lmdeploy/turbomind/turbomind.py
@@ -225,7 +225,9 @@ class TurboMind:
             if quant_config:
                 quant_method = quant_config.get('quant_method')
                 group_size = int(quant_config.get('group_size', 0))
-                if quant_method == 'awq' and group_size == 128:
+                version = quant_config.get('version')
+                if quant_method == 'awq' and group_size == 128 and \
+                        version == 'gemm':
                     engine_config.model_format = 'awq'
 
         assert is_supported(model_path), (

--- a/lmdeploy/turbomind/turbomind.py
+++ b/lmdeploy/turbomind/turbomind.py
@@ -17,7 +17,8 @@ from lmdeploy.messages import (EngineGenerationConfig, EngineOutput,
 from lmdeploy.model import (MODELS, BaseModel, ChatTemplateConfig,
                             best_match_model)
 from lmdeploy.tokenizer import Tokenizer
-from lmdeploy.utils import _stop_words, get_logger, get_model
+from lmdeploy.utils import (_stop_words, get_hf_config_content, get_logger,
+                            get_model)
 
 from .deploy.converter import (SUPPORTED_FORMATS,
                                get_input_model_registered_name,
@@ -217,6 +218,15 @@ class TurboMind:
         if osp.exists(osp.join(model_path, 'outputs_stats.pth')) and \
                 engine_config.model_format is None:
             engine_config.model_format = 'awq'
+
+        if engine_config.model_format is None:
+            cfg = get_hf_config_content(model_path)
+            quant_config = cfg.get('quantization_config')
+            if quant_config:
+                quant_method = quant_config.get('quant_method')
+                group_size = int(quant_config.get('group_size', 0))
+                if quant_method == 'awq' and group_size == 128:
+                    engine_config.model_format = 'awq'
 
         assert is_supported(model_path), (
             f'turbomind does not support {model_path}. '


### PR DESCRIPTION
## Motivation

as titled

When the hf model is in awq format, there is no need to explicitly specify the model-format as awq.

```bash
# tested with https://huggingface.co/01-ai/Yi-6B-Chat-4bits
python3 -m lmdeploy serve api_server /workdir/Yi-6B-Chat-4bits
```

@lvhan028 @AllentDan May you help review this pr? Thanks.

## Modification

The modification is simple. I didn't write it as a function, but if needed, I am more than happy to make the changes.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
