### PR TITLE
Optimize sampling

### DIFF
--- a/lmdeploy/pytorch/engine/engine.py
+++ b/lmdeploy/pytorch/engine/engine.py
@@ -556,17 +556,12 @@ class Engine:
             """forward."""
             nonlocal swap_done, swap_in_map, swap_out_map
             if swap_done:
-                ret = self.model_agent.forward(inputs,
-                                               swap_in_map=dict(),
-                                               swap_out_map=dict())
+                return await self.model_agent.async_forward(
+                    inputs, swap_in_map=dict(), swap_out_map=dict())
             else:
                 swap_done = True
-                ret = self.model_agent.forward(inputs,
-                                               swap_in_map=swap_in_map,
-                                               swap_out_map=swap_out_map)
-            await asyncio.get_event_loop().run_in_executor(
-                None, self.stream.synchronize)
-            return ret
+                return await self.model_agent.async_forward(
+                    inputs, swap_in_map=swap_in_map, swap_out_map=swap_out_map)
 
         async def __long_context_single_forward(inputs):
             """one large sequence."""

--- a/lmdeploy/pytorch/engine/model_agent.py
+++ b/lmdeploy/pytorch/engine/model_agent.py
@@ -1,4 +1,5 @@
 # Copyright (c) OpenMMLab. All rights reserved.
+import asyncio
 import os
 import warnings
 from dataclasses import dataclass, field, fields
@@ -659,6 +660,7 @@ class BaseModelAgent(AutoModelAgent):
         _update_cache_config(model_config, cache_config)
 
         self.cache_engine = CacheEngine(cache_config, model_config)
+        self.stream = torch.cuda.Stream()
 
     def _build_model(self,
                      model_path: str,
@@ -723,6 +725,7 @@ class BaseModelAgent(AutoModelAgent):
             inputs,
             self.cache_engine,
             world_size=1,
+            stream=self.stream,
         )
         return output
 
@@ -738,7 +741,34 @@ class BaseModelAgent(AutoModelAgent):
         output = self._forward_impl(inputs,
                                     swap_in_map=swap_in_map,
                                     swap_out_map=swap_out_map)
+        self.stream.synchronize()
         return output
+
+    async def async_forward(self, inputs: ModelInputs, swap_in_map: SwapMap,
+                            swap_out_map: SwapMap):
+        """model forward.
+
+        Args:
+            inputs (Dict): The input data comes from _make_inputs.
+            swap_in_map (SwapMap): Cache maps to swap in.
+            swap_out_map (SwapMap): Cache maps to swap out.
+        """
+        output = self._forward_impl(inputs,
+                                    swap_in_map=swap_in_map,
+                                    swap_out_map=swap_out_map)
+        await asyncio.get_event_loop().run_in_executor(None,
+                                                       self.stream.synchronize)
+        return output
+
+
+def _get_model_memory_usage(model: torch.nn.Module) -> int:
+    """get model memory usage."""
+    size = 0
+    for _, param in model.named_parameters():
+        size += param.element_size() * param.numel()
+    for _, buf in model.named_buffers():
+        size += buf.element_size() * param.numel()
+    return size
 
 
 def _create_device_map(model: torch.nn.Module,
@@ -853,13 +883,14 @@ def _tp_build_model(
     return patched_model, cache_engine, cache_config
 
 
-def _broadcast_inputs(rank: int, inputs: Any):
+def _broadcast_inputs(rank: int, inputs: Any, stream: torch.cuda.Stream):
     """get input tensor parallel."""
     # broadcast meta info
     if rank != 0:
         inputs = [None, None, None]
 
-    dist.broadcast_object_list(inputs)
+    with torch.cuda.stream(stream):
+        dist.broadcast_object_list(inputs)
     return inputs
 
 
@@ -940,8 +971,8 @@ def _tp_model_loop(
                             weight_map=None)
 
     while True:
-        with torch.cuda.stream(stream):
-            inputs, swap_in_map, swap_out_map = _broadcast_inputs(rank, None)
+        inputs, swap_in_map, swap_out_map = _broadcast_inputs(
+            rank, None, stream)
 
         cache_swapping(cache_engine,
                        swap_in_map=swap_in_map,
@@ -1074,6 +1105,7 @@ class TPModelAgent(AutoModelAgent):
         self.patched_model = model
         self.cache_config = cache_config
         self.cache_engine = cache_engine
+        self.stream = torch.cuda.Stream()
 
     def _start_sub_process(self, model_path: str, model_config: ModelConfig,
                            cache_config: CacheConfig, adapters: Dict[str, str],
@@ -1168,7 +1200,8 @@ class TPModelAgent(AutoModelAgent):
         """forward impl."""
         _check_context_alive(self.mp_context)
         rank = 0
-        _broadcast_inputs(rank, [inputs, swap_in_map, swap_out_map])
+        _broadcast_inputs(rank, [inputs, swap_in_map, swap_out_map],
+                          self.stream)
         cache_swapping(self.cache_engine,
                        swap_in_map=swap_in_map,
                        swap_out_map=swap_out_map)
@@ -1177,6 +1210,7 @@ class TPModelAgent(AutoModelAgent):
             inputs,
             self.cache_engine,
             world_size=1,
+            stream=self.stream,
         )
         return output
 
@@ -1192,6 +1226,23 @@ class TPModelAgent(AutoModelAgent):
         output = self._forward_impl(inputs,
                                     swap_in_map=swap_in_map,
                                     swap_out_map=swap_out_map)
+        self.stream.synchronize()
+        return output
+
+    async def async_forward(self, inputs: ModelInputs, swap_in_map: SwapMap,
+                            swap_out_map: SwapMap):
+        """model forward.
+
+        Args:
+            inputs (Dict): The input data comes from _make_inputs.
+            swap_in_map (SwapMap): Cache maps to swap in.
+            swap_out_map (SwapMap): Cache maps to swap out.
+        """
+        output = self._forward_impl(inputs,
+                                    swap_in_map=swap_in_map,
+                                    swap_out_map=swap_out_map)
+        await asyncio.get_event_loop().run_in_executor(None,
+                                                       self.stream.synchronize)
         return output
 
 

--- a/lmdeploy/pytorch/kernels/cuda/multinomial_sampling.py
+++ b/lmdeploy/pytorch/kernels/cuda/multinomial_sampling.py
@@ -72,8 +72,8 @@ def multinomial_sampling(scores: torch.Tensor,
 
     outputs = indices[:, 0].clone()
 
-    BLOCK = 32
-    BLOCK_N = 64
+    BLOCK = 8
+    BLOCK_N = 128
 
     grid = [triton.cdiv(batch_size, BLOCK)]
     kernel_meta = get_kernel_meta(scores)
@@ -90,6 +90,7 @@ def multinomial_sampling(scores: torch.Tensor,
                                        num_tokens=num_tokens,
                                        BLOCK=BLOCK,
                                        BLOCK_N=BLOCK_N,
+                                       num_warps=8,
                                        **kernel_meta)
 
     return outputs


### PR DESCRIPTION
sort logits of large vocab size would take long time on GPU.
This PR gather topk logits and slice scores after topp

llama2-13b (vocab_size=32000):

before

```
token throughput (completion token): 1462.612 token/s
token throughput (prompt + completion token): 3031.211 token/s
RPS (request per second): 6.131 req/s
RPM (request per minute): 367.831 req/min
```

after

```
token throughput (completion token): 1482.363 token/s
token throughput (prompt + completion token): 3072.144 token/s
RPS (request per second): 6.213 req/s
RPM (request per minute): 372.799 req/min
```

half the sampling time. Larger vocab_size would have better performance since radix sort has O(nk) complexity