### PR TITLE
[side-effect] bring back "--cap" argument in chat cli

### DIFF
--- a/lmdeploy/cli/chat.py
+++ b/lmdeploy/cli/chat.py
@@ -75,6 +75,8 @@ class SubCliChat(object):
         ArgumentHelper.cache_block_seq_len(engine_group)
         ArgumentHelper.rope_scaling_factor(engine_group)
         ArgumentHelper.session_len(engine_group)
+        # other arguments
+        ArgumentHelper.cap(parser)
         # model args
         ArgumentHelper.revision(engine_group)
         ArgumentHelper.download_dir(engine_group)

--- a/lmdeploy/cli/cli.py
+++ b/lmdeploy/cli/cli.py
@@ -106,7 +106,6 @@ class CLI(object):
         ArgumentHelper.backend(parser)
         ArgumentHelper.trust_remote_code(parser)
         # # chat template args
-        ArgumentHelper.meta_instruction(parser)
         ArgumentHelper.cap(parser)
         ArgumentHelper.chat_template(parser)
         # model args

--- a/lmdeploy/cli/cli.py
+++ b/lmdeploy/cli/cli.py
@@ -106,6 +106,7 @@ class CLI(object):
         ArgumentHelper.backend(parser)
         ArgumentHelper.trust_remote_code(parser)
         # # chat template args
+        # ArgumentHelper.meta_instruction(parser)
         ArgumentHelper.cap(parser)
         ArgumentHelper.chat_template(parser)
         # model args

--- a/lmdeploy/cli/cli.py
+++ b/lmdeploy/cli/cli.py
@@ -106,7 +106,7 @@ class CLI(object):
         ArgumentHelper.backend(parser)
         ArgumentHelper.trust_remote_code(parser)
         # # chat template args
-        # ArgumentHelper.meta_instruction(parser)
+        ArgumentHelper.meta_instruction(parser)
         ArgumentHelper.cap(parser)
         ArgumentHelper.chat_template(parser)
         # model args


### PR DESCRIPTION

## Motivation
```
AssertionError: usage: lmdeploy [-h] [-v] {lite,serve,convert,list,check_env,chat} ...
lmdeploy: error: unrecognized arguments: --cap completion
```
