### PR TITLE
Add usage in stream response

### DIFF
--- a/lmdeploy/serve/openai/api_server.py
+++ b/lmdeploy/serve/openai/api_server.py
@@ -770,12 +770,11 @@ async def completions_v1(request: CompletionRequest,
             adapter_name=adapter_name)
         generators.append(result_generator)
 
-    def create_stream_response_json(
-            index: int,
-            text: str,
-            finish_reason: Optional[str] = None,
-            logprobs: Optional[LogProbs] = None,
-            usage: Optional[UsageInfo] = None) -> str:
+    def create_stream_response_json(index: int,
+                                    text: str,
+                                    finish_reason: Optional[str] = None,
+                                    logprobs: Optional[LogProbs] = None,
+                                    usage: Optional[UsageInfo] = None) -> str:
         choice_data = CompletionResponseStreamChoice(
             index=index,
             text=text,

--- a/lmdeploy/serve/openai/api_server.py
+++ b/lmdeploy/serve/openai/api_server.py
@@ -600,6 +600,7 @@ async def completions_v1_qos(request: CompletionRequestQos,
         index: int,
         text: str,
         finish_reason: Optional[str] = None,
+        usage: Optional[UsageInfo] = None,
     ) -> str:
         choice_data = CompletionResponseStreamChoice(
             index=index,
@@ -611,6 +612,7 @@ async def completions_v1_qos(request: CompletionRequestQos,
             created=created_time,
             model=model_name,
             choices=[choice_data],
+            usage=usage,
         )
         response_json = response.model_dump_json()
 
@@ -620,9 +622,22 @@ async def completions_v1_qos(request: CompletionRequestQos,
         # First chunk with role
         for generator in generators:
             async for res in generator:
+                usage = None
+                if res.finish_reason is not None:
+                    final_res = res
+                    total_tokens = sum([
+                        final_res.history_token_len, final_res.input_token_len,
+                        final_res.generate_token_len
+                    ])
+                    usage = UsageInfo(
+                        prompt_tokens=final_res.input_token_len,
+                        completion_tokens=final_res.generate_token_len,
+                        total_tokens=total_tokens,
+                    )
                 response_json = create_stream_response_json(
                     index=0,
                     text=res.response,
+                    usage=usage,
                 )
                 yield f'data: {response_json}\n\n'
         yield 'data: [DONE]\n\n'
@@ -759,7 +774,8 @@ async def completions_v1(request: CompletionRequest,
             index: int,
             text: str,
             finish_reason: Optional[str] = None,
-            logprobs: Optional[LogProbs] = None) -> str:
+            logprobs: Optional[LogProbs] = None,
+            usage: Optional[UsageInfo] = None) -> str:
         choice_data = CompletionResponseStreamChoice(
             index=index,
             text=text,
@@ -770,6 +786,7 @@ async def completions_v1(request: CompletionRequest,
             created=created_time,
             model=model_name,
             choices=[choice_data],
+            usage=usage,
         )
         response_json = response.model_dump_json()
 
@@ -783,17 +800,30 @@ async def completions_v1(request: CompletionRequest,
             state = DetokenizeState()
             async for res in generator:
                 logprobs = None
+                usage = None
                 if request.logprobs and res.logprobs:
                     logprobs, offset, all_token_ids, state = _create_completion_logprobs(  # noqa E501
                         VariableInterface.async_engine.tokenizer,
                         res.token_ids, res.logprobs,
                         gen_config.skip_special_tokens, offset, all_token_ids,
                         state)
+                if res.finish_reason is not None:
+                    final_res = res
+                    total_tokens = sum([
+                        final_res.history_token_len, final_res.input_token_len,
+                        final_res.generate_token_len
+                    ])
+                    usage = UsageInfo(
+                        prompt_tokens=final_res.input_token_len,
+                        completion_tokens=final_res.generate_token_len,
+                        total_tokens=total_tokens,
+                    )
                 response_json = create_stream_response_json(
                     index=0,
                     text=res.response,
                     finish_reason=res.finish_reason,
-                    logprobs=logprobs)
+                    logprobs=logprobs,
+                    usage=usage)
                 yield f'data: {response_json}\n\n'
         yield 'data: [DONE]\n\n'
 

--- a/lmdeploy/serve/openai/protocol.py
+++ b/lmdeploy/serve/openai/protocol.py
@@ -174,6 +174,7 @@ class ChatCompletionStreamResponse(BaseModel):
     choices: List[ChatCompletionResponseStreamChoice]
     usage: Optional[UsageInfo] = None
 
+
 class CompletionRequest(BaseModel):
     """Completion request."""
     model: str

--- a/lmdeploy/serve/openai/protocol.py
+++ b/lmdeploy/serve/openai/protocol.py
@@ -172,7 +172,7 @@ class ChatCompletionStreamResponse(BaseModel):
     created: int = Field(default_factory=lambda: int(time.time()))
     model: str
     choices: List[ChatCompletionResponseStreamChoice]
-
+    usage: Optional[UsageInfo] = None
 
 class CompletionRequest(BaseModel):
     """Completion request."""


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily receiving feedbacks. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Return the usage info in stream response.

## Modification

1. add `usage: Optional[UsageInfo]` in `ChatCompletionStreamResponse`
2. return `usage` in `completion_stream_generator` while `res.finish_reason is not None`

## BC-breaking (Optional)

No.

## Use cases (Optional)

No.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
3. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
4. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
5. The documentation has been modified accordingly, like docstring or example tutorials.
