### PR TITLE
fix: tcp port can not change

### DIFF
--- a/lmdeploy/pytorch/engine/model_agent.py
+++ b/lmdeploy/pytorch/engine/model_agent.py
@@ -1040,7 +1040,7 @@ def _check_context_alive(mp_context: mp.ProcessContext):
 def _find_available_port() -> bool:
     """find available port."""
     import socket
-    port = 29500
+    port = int(os.environ.get("MASTER_PORT",29500))
     while True:
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
             if s.connect_ex(('localhost', port)) != 0:


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily receiving feedbacks. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

官方代码部署时，PytorchEngine 多卡部署情况下会出现 TCP Error，原因是端口号已经被占用。发现 
```
114         port = _find_available_port()
1115         os.environ.setdefault('MASTER_ADDR', '127.0.0.1')
1116         os.environ.setdefault('MASTER_PORT', str(port))
1117         addr = os.environ['MASTER_ADDR']
1118         port = os.environ['MASTER_PORT']
1119         logger.info(f'MASTER_ADDR={addr}, MASTER_PORT={port}')
```
由于重置了MASTER PORT 导致外部设置无效
```def _find_available_port() ```

固定了端口号 29500，导致上述错误

## Modification

修改代码中写死端口号为外部可配置MASTER_PORT，和 torchrun 使用一致；

