### PR TITLE
[ci] add internlm2.5 models into testcase

### DIFF
--- a/.github/scripts/eval_opencompass_config.py
+++ b/.github/scripts/eval_opencompass_config.py
@@ -275,6 +275,9 @@ engine_config_template_max_bs_128_awq = dict(session_len=MAX_SESSION_LEN,
 engine_config_template_max_bs_128_kvint4 = dict(session_len=MAX_SESSION_LEN,
                                                 max_batch_size=128,
                                                 quant_policy=4)
+engine_config_template_max_bs_128_kvint8 = dict(session_len=MAX_SESSION_LEN,
+                                                max_batch_size=128,
+                                                quant_policy=8)
 engine_config_template_max_bs_128_tp2 = dict(session_len=MAX_SESSION_LEN,
                                              max_batch_size=128,
                                              tp=2)
@@ -284,6 +287,8 @@ engine_config_template_max_bs_128_awq_tp2 = dict(session_len=MAX_SESSION_LEN,
                                                  tp=2)
 engine_config_template_max_bs_128_kvint4_tp2 = dict(
     session_len=MAX_SESSION_LEN, max_batch_size=128, quant_policy=4, tp=2)
+engine_config_template_max_bs_128_kvint8_tp2 = dict(
+    session_len=MAX_SESSION_LEN, max_batch_size=128, quant_policy=8, tp=2)
 
 # ===== Configs for internlm/internlm-chat-7b =====
 # config for internlm-chat-7b
@@ -384,6 +389,7 @@ tb_internlm2_chat_7b = dict(
     max_out_len=MAX_NEW_TOKENS,
     batch_size=128,
     run_cfg=dict(num_gpus=1),
+    stop_words=['</s>', '<|im_end|>'],
 )
 
 tb_internlm2_chat_7b_w4a16 = dict(
@@ -396,6 +402,7 @@ tb_internlm2_chat_7b_w4a16 = dict(
     max_out_len=MAX_NEW_TOKENS,
     batch_size=128,
     run_cfg=dict(num_gpus=1),
+    stop_words=['</s>', '<|im_end|>'],
 )
 
 tb_internlm2_chat_7b_kvint4 = dict(
@@ -408,6 +415,70 @@ tb_internlm2_chat_7b_kvint4 = dict(
     max_out_len=MAX_NEW_TOKENS,
     batch_size=128,
     run_cfg=dict(num_gpus=1),
+    stop_words=['</s>', '<|im_end|>'],
+)
+tb_internlm2_chat_7b_kvint8 = dict(
+    type=TurboMindModelwithChatTemplate,
+    abbr='tb_internlm2_chat_7b_kvint8',
+    path='internlm/internlm2-chat-7b',
+    engine_config=engine_config_template_max_bs_128_kvint8,
+    gen_config=gen_config_template,
+    max_seq_len=MAX_SESSION_LEN,
+    max_out_len=MAX_NEW_TOKENS,
+    batch_size=128,
+    run_cfg=dict(num_gpus=1),
+    stop_words=['</s>', '<|im_end|>'],
+)
+
+tb_internlm2_5_7b_chat = dict(
+    type=TurboMindModelwithChatTemplate,
+    abbr='tb_internlm2_5_7b_chat',
+    path='internlm/internlm2_5-7b-chat',
+    engine_config=engine_config_template_max_bs_128,
+    gen_config=gen_config_template,
+    max_seq_len=MAX_SESSION_LEN,
+    max_out_len=MAX_NEW_TOKENS,
+    batch_size=128,
+    run_cfg=dict(num_gpus=1),
+    stop_words=['</s>', '<|im_end|>'],
+)
+
+tb_internlm2_5_7b_chat_w4a16 = dict(
+    type=TurboMindModelwithChatTemplate,
+    abbr='tb_internlm2_5_7b_chat_w4a16',
+    path='internlm/internlm2_5-7b-chat-inner-4bits',
+    engine_config=engine_config_template_max_bs_128_awq,
+    gen_config=gen_config_template,
+    max_seq_len=MAX_SESSION_LEN,
+    max_out_len=MAX_NEW_TOKENS,
+    batch_size=128,
+    run_cfg=dict(num_gpus=1),
+    stop_words=['</s>', '<|im_end|>'],
+)
+
+tb_internlm2_5_chat_7b_kvint4 = dict(
+    type=TurboMindModelwithChatTemplate,
+    abbr='tb_internlm2_5_7b_chat_kvint4',
+    path='internlm/internlm2_5-7b-chat',
+    engine_config=engine_config_template_max_bs_128_kvint4,
+    gen_config=gen_config_template,
+    max_seq_len=MAX_SESSION_LEN,
+    max_out_len=MAX_NEW_TOKENS,
+    batch_size=128,
+    run_cfg=dict(num_gpus=1),
+    stop_words=['</s>', '<|im_end|>'],
+)
+tb_internlm2_5_chat_7b_kvint8 = dict(
+    type=TurboMindModelwithChatTemplate,
+    abbr='tb_internlm2_5_7b_chat_kvint8',
+    path='internlm/internlm2_5-7b-chat',
+    engine_config=engine_config_template_max_bs_128_kvint8,
+    gen_config=gen_config_template,
+    max_seq_len=MAX_SESSION_LEN,
+    max_out_len=MAX_NEW_TOKENS,
+    batch_size=128,
+    run_cfg=dict(num_gpus=1),
+    stop_words=['</s>', '<|im_end|>'],
 )
 
 # config for pt internlm-chat-7b
@@ -435,6 +506,7 @@ tb_internlm2_chat_20b = dict(
     max_out_len=MAX_NEW_TOKENS,
     batch_size=128,
     run_cfg=dict(num_gpus=2),
+    stop_words=['</s>', '<|im_end|>'],
 )
 
 tb_internlm2_chat_20b_w4a16 = dict(
@@ -447,6 +519,7 @@ tb_internlm2_chat_20b_w4a16 = dict(
     max_out_len=MAX_NEW_TOKENS,
     batch_size=128,
     run_cfg=dict(num_gpus=2),
+    stop_words=['</s>', '<|im_end|>'],
 )
 
 tb_internlm2_chat_20b_kvint4 = dict(
@@ -459,6 +532,20 @@ tb_internlm2_chat_20b_kvint4 = dict(
     max_out_len=MAX_NEW_TOKENS,
     batch_size=128,
     run_cfg=dict(num_gpus=2),
+    stop_words=['</s>', '<|im_end|>'],
+)
+
+tb_internlm2_chat_20b_kvint8 = dict(
+    type=TurboMindModelwithChatTemplate,
+    abbr='tb_internlm2_chat_7b_kvint8',
+    path='internlm/internlm2-chat-20b',
+    engine_config=engine_config_template_max_bs_128_kvint8_tp2,
+    gen_config=gen_config_template,
+    max_seq_len=MAX_SESSION_LEN,
+    max_out_len=MAX_NEW_TOKENS,
+    batch_size=128,
+    run_cfg=dict(num_gpus=2),
+    stop_words=['</s>', '<|im_end|>'],
 )
 
 # config for pt internlm-chat-20b
@@ -466,14 +553,14 @@ pt_internlm2_chat_20b = dict(
     type=LmdeployPytorchModel,
     abbr='internlm2-chat-20b-pytorch',
     path='internlm/internlm2-chat-20b',
-    engine_config=pt_engine_config_template_max_bs_64_prefill_tp2,
+    engine_config=pt_engine_config_template_max_bs_64_prefill,
     gen_config=gen_config_template,
     max_out_len=MAX_NEW_TOKENS,
     max_seq_len=MAX_SESSION_LEN,
     batch_size=64,
     concurrency=64,
     meta_template=internlm2_meta_template,
-    run_cfg=run_cfg_tp2_template,
+    run_cfg=run_cfg_tp1_template,
     end_str='<|im_end|>')
 
 # ===== Configs for Qwen/Qwen-7B-Chat =====
@@ -769,6 +856,19 @@ tb_llama_3_8b_instruct_kvint4 = dict(
     abbr='tb_llama_3_8b_instruct_kvint4',
     path='meta-llama/Meta-Llama-3-8B-Instruct',
     engine_config=engine_config_template_max_bs_128_kvint4,
+    gen_config=gen_config_template,
+    max_seq_len=MAX_SESSION_LEN,
+    max_out_len=MAX_NEW_TOKENS,
+    batch_size=128,
+    run_cfg=dict(num_gpus=1),
+    stop_words=['<|eot_id|>', '<|end_of_text|>'],
+)
+
+tb_llama_3_8b_instruct_kvint8 = dict(
+    type=TurboMindModelwithChatTemplate,
+    abbr='tb_llama_3_8b_instruct_kvint8',
+    path='meta-llama/Meta-Llama-3-8B-Instruct',
+    engine_config=engine_config_template_max_bs_128_kvint8,
     gen_config=gen_config_template,
     max_seq_len=MAX_SESSION_LEN,
     max_out_len=MAX_NEW_TOKENS,

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -63,6 +63,7 @@ env:
   TP_INFO: --tp 1
   LOOP_NUM: 1
   TRITON_PTXAS_PATH: /usr/local/cuda/bin/ptxas
+  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
 
 
 jobs:

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -171,7 +171,7 @@ jobs:
         run: |
           rm -rf ${result_dir}
           mkdir ${result_dir}
-          python3 benchmark/profile_generation.py $MODEL_PATH $MAX_ENTRY_COUNT $MODEL_FORMAT $TP_INFO -c 128 -ct 128 2048 128 -pt 128 128 2048 --csv ${result_dir}/generation.csv > ${result_dir}/generation.log
+          python3 benchmark/profile_generation.py $MODEL_PATH $MAX_ENTRY_COUNT $MODEL_FORMAT $TP_INFO -c 8,256 -ct 128 128 2048 128 -pt 1 128 128 2048 --csv ${result_dir}/generation.csv > ${result_dir}/generation.log
       - name: Run generation benchmark - longtext turbomind
         if: contains(fromJSON(github.event.inputs.backend), 'turbomind') && contains(env.LONGTEXT_BENCHMARK, 'true')
         env:
@@ -187,7 +187,7 @@ jobs:
         run: |
           rm -rf ${result_dir}
           mkdir ${result_dir}
-          python3 benchmark/profile_generation.py $MODEL_PATH $TP_INFO --backend pytorch -c 128 -ct 128 2048 128 -pt 128 128 2048 --csv ${result_dir}/generation.csv > ${result_dir}/generation.log
+          python3 benchmark/profile_generation.py $MODEL_PATH $TP_INFO --backend pytorch -c 8,256 -ct 128 128 2048 128 -pt 1 128 128 2048 --csv ${result_dir}/generation.csv > ${result_dir}/generation.log
       - name: Run generation benchmark - longtext pytorch
         if: (!contains(env.MODEL_FORMAT, 'awq') && contains(fromJSON(github.event.inputs.backend), 'pytorch') && contains(env.LONGTEXT_BENCHMARK, 'true'))
         env:
@@ -726,5 +726,5 @@ jobs:
           ref: ${{github.event.inputs.repo_ref || 'main'}}
       - name: Get overview
         run: |
-          pip install pandas fire
+          pip install pandas fire mmengine
           python3 .github/scripts/action_tools.py generate_benchmark_report $REPORT_DIR

--- a/.github/workflows/daily_ete_test.yml
+++ b/.github/workflows/daily_ete_test.yml
@@ -32,7 +32,7 @@ on:
         required: true
         description: 'Dependency packages, you can also set a specific version'
         type: string
-        default: 'packaging transformers_stream_generator transformers datasets matplotlib openai attrdict timm modelscope jmespath'
+        default: 'packaging transformers_stream_generator transformers==4.41.2 datasets matplotlib openai attrdict timm modelscope jmespath'
       tools_regression:
         required: true
         description: 'Whether start a tool regression'
@@ -123,7 +123,7 @@ jobs:
         - /usr/share/zoneinfo/Asia/Shanghai:/etc/localtime:ro
     steps:
       - name: Clone repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v2
         if: ${{github.event_name == 'schedule' || !inputs.offline_mode}}
         with:
           repository: ${{ github.event.inputs.repo_org || 'InternLM/lmdeploy' }}
@@ -142,7 +142,7 @@ jobs:
           python3 -m pip install torch==2.2.2 torchvision==0.17.2 --index-url https://download.pytorch.org/whl/cu118
       - name: Install lmdeploy - dependency
         run: |
-          python3 -m pip install ${{inputs.dependency_pkgs || 'packaging transformers_stream_generator transformers datasets matplotlib openai attrdict timm modelscope jmespath'}}
+          python3 -m pip install ${{inputs.dependency_pkgs || 'packaging transformers_stream_generator transformers==4.41.2 datasets matplotlib openai attrdict timm modelscope jmespath'}}
           # manually install flash attn
           # the install packeage from. https://github.com/Dao-AILab/flash-attention/releases
           python3 -m pip install /root/packages/flash_attn-2.5.7+cu118torch2.2cxx11abiFALSE-cp38-cp38-linux_x86_64.whl
@@ -276,7 +276,7 @@ jobs:
       GRPC_PORT: 33337
     steps:
       - name: Clone repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v2
         if: ${{github.event_name == 'schedule' || !inputs.offline_mode}}
         with:
           repository: ${{ github.event.inputs.repo_org || 'InternLM/lmdeploy' }}
@@ -439,7 +439,7 @@ jobs:
         - /usr/share/zoneinfo/Asia/Shanghai:/etc/localtime:ro
     steps:
       - name: Clone repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v2
         if: ${{github.event_name == 'schedule' || !inputs.offline_mode}}
         with:
           repository: ${{ github.event.inputs.repo_org || 'InternLM/lmdeploy' }}
@@ -458,7 +458,7 @@ jobs:
           python3 -m pip install torch==2.2.2 torchvision==0.17.2 --index-url https://download.pytorch.org/whl/cu118
       - name: Install lmdeploy - dependency
         run: |
-          python3 -m pip install ${{inputs.dependency_pkgs || 'packaging transformers_stream_generator transformers datasets matplotlib openai attrdict timm modelscope jmespath'}}
+          python3 -m pip install ${{inputs.dependency_pkgs || 'packaging transformers_stream_generator transformers==4.41.2 datasets matplotlib openai attrdict timm modelscope jmespath'}}
           # manually install flash attn
           # the install packeage from. https://github.com/Dao-AILab/flash-attention/releases
           python3 -m pip install /root/packages/flash_attn-2.5.7+cu118torch2.2cxx11abiFALSE-cp38-cp38-linux_x86_64.whl
@@ -551,7 +551,7 @@ jobs:
         - /usr/share/zoneinfo/Asia/Shanghai:/etc/localtime:ro
     steps:
       - name: Clone repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v2
         if: ${{github.event_name == 'schedule' || !inputs.offline_mode}}
         with:
           repository: ${{ github.event.inputs.repo_org || 'InternLM/lmdeploy' }}
@@ -570,7 +570,7 @@ jobs:
           python3 -m pip install torch==2.2.2 torchvision==0.17.2 --index-url https://download.pytorch.org/whl/cu118
       - name: Install lmdeploy - dependency
         run: |
-          python3 -m pip install ${{inputs.dependency_pkgs || 'packaging transformers_stream_generator transformers datasets matplotlib openai attrdict timm modelscope jmespath'}}
+          python3 -m pip install ${{inputs.dependency_pkgs || 'packaging transformers_stream_generator transformers==4.41.2 datasets matplotlib openai attrdict timm modelscope jmespath'}}
           # manually install flash attn
           # the install packeage from. https://github.com/Dao-AILab/flash-attention/releases
           python3 -m pip install /root/packages/flash_attn-2.5.7+cu118torch2.2cxx11abiFALSE-cp38-cp38-linux_x86_64.whl
@@ -593,7 +593,8 @@ jobs:
         run: |
           pytest autotest/interface/pipeline/test_pipeline_func.py -m 'not pr_test' -n 4 --alluredir=allure-results || true
           pytest autotest/interface/pipeline/test_pipeline_longtext_func.py -m 'gpu_num_1 and not pr_test' -n 8 --alluredir=allure-results || true
-          pytest autotest/interface/pipeline/test_pipeline_longtext_func.py -m 'gpu_num_2 and not pr_test' -n 4 --alluredir=allure-results
+          pytest autotest/interface/pipeline/test_pipeline_longtext_func.py -m 'gpu_num_2 and not pr_test' -n 4 --alluredir=allure-results || true
+          pytest autotest/interface/pipeline/test_pipeline_longtext_func.py -m 'gpu_num_4 and not pr_test' -n 2 --alluredir=allure-results
       - name: Generate reports
         if: always()
         run: |

--- a/.github/workflows/daily_ete_test.yml
+++ b/.github/workflows/daily_ete_test.yml
@@ -61,7 +61,7 @@ env:
   HOST_LOCALTIME: /usr/share/zoneinfo/Asia/Shanghai
   OUTPUT_FOLDER: cuda11.8_dist_${{ github.run_id }}
   TRITON_PTXAS_PATH: /usr/local/cuda/bin/ptxas
-
+  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
 
 jobs:
   linux-build:

--- a/.github/workflows/evaluate.yml
+++ b/.github/workflows/evaluate.yml
@@ -124,7 +124,7 @@ jobs:
         run: |
           git clone --depth=1 https://github.com/open-compass/opencompass.git
           cd opencompass
-          python3 -m pip install --user -e .
+          python3 -m pip install opencompass==0.2.5
           echo "OPENCOMPASS_DIR=$(pwd)" >> $GITHUB_ENV
       - name: Check env
         run: |

--- a/.github/workflows/evaluate.yml
+++ b/.github/workflows/evaluate.yml
@@ -39,6 +39,8 @@ on:
         type: string
         default: 'pynvml packaging protobuf transformers_stream_generator transformers'
 
+env:
+  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
 
 jobs:
   linux-build:

--- a/.github/workflows/pr_ete_test.yml
+++ b/.github/workflows/pr_ete_test.yml
@@ -23,6 +23,7 @@ concurrency:
 env:
   HOST_PIP_CACHE_DIR: /nvme/github-actions/pip-cache
   HOST_LOCALTIME: /usr/share/zoneinfo/Asia/Shanghai
+  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
 
 
 jobs:

--- a/autotest/config.yaml
+++ b/autotest/config.yaml
@@ -14,56 +14,76 @@ tp_config:
     Qwen2-7B-Instruct: 2
 
 turbomind_chat_model:
-    - meta-llama/Llama-2-7b-chat-hf
     - meta-llama/Meta-Llama-3-8B-Instruct
+    - meta-llama/Llama-2-7b-chat-hf
+    - internlm/internlm2_5-7b-chat
+    - internlm/internlm2_5-7b-chat-1m
     - internlm/internlm2-chat-1_8b
-    - internlm/internlm-chat-20b
     - internlm/internlm2-chat-7b
     - internlm/internlm2-chat-20b
     - internlm/internlm2-chat-7b-4bits
     - internlm/internlm2-chat-20b-4bits
+    - internlm/internlm-chat-20b
     - internlm/internlm-xcomposer2-vl-7b
     - internlm/internlm-xcomposer2-7b
     - internlm/internlm-xcomposer2-4khd-7b
     - OpenGVLab/InternVL-Chat-V1-5
-    - Qwen/Qwen-7B-Chat
-    - Qwen/Qwen-VL-Chat
+    - OpenGVLab/Mini-InternVL-Chat-2B-V1-5
+    - Qwen/Qwen2-7B-Instruct
+    - Qwen/Qwen2-7B-Instruct-AWQ
+    - Qwen/Qwen2-1.5B-Instruct
     - Qwen/Qwen1.5-7B-Chat
     - Qwen/Qwen1.5-4B-Chat-AWQ
-    - Qwen/Qwen2-7B-Instruct
-    - Qwen/Qwen2-1.5B-Instruct
+    - Qwen/Qwen-7B-Chat
+    - Qwen/Qwen-VL-Chat
+    - mistralai/Mistral-7B-Instruct-v0.1
+    - mistralai/Mistral-7B-Instruct-v0.2
+    - mistralai/Mistral-7B-Instruct-v0.3
     - lmdeploy/llama2-chat-7b-w4
     - baichuan-inc/Baichuan2-7B-Chat
     - 01-ai/Yi-6B-Chat
     - 01-ai/Yi-VL-6B
-    - liuhaotian/llava-v1.5-7b
     - liuhaotian/llava-v1.5-13b
     - liuhaotian/llava-v1.6-vicuna-7b
     - deepseek-ai/deepseek-vl-1.3b-chat
     - deepseek-ai/deepseek-coder-1.3b-instruct
     - codellama/CodeLlama-7b-Instruct-hf
+    - THUDM/glm-4-9b-chat
 
 
 pytorch_chat_model:
-    - meta-llama/Llama-2-7b-chat-hf
     - meta-llama/Meta-Llama-3-8B-Instruct
-    - internlm/internlm-chat-20b
+    - meta-llama/Llama-2-7b-chat-hf
+    - internlm/internlm2_5-7b-chat
+    - internlm/internlm2_5-7b-chat-1m
     - internlm/internlm2-chat-7b
     - internlm/internlm2-chat-20b
+    - internlm/internlm-chat-20b
     - baichuan-inc/Baichuan2-7B-Chat
     - baichuan-inc/Baichuan2-13B-Chat
     - 01-ai/Yi-6B-Chat
+    - liuhaotian/llava-v1.5-13b
+    - liuhaotian/llava-v1.6-vicuna-7b
+    - Qwen/Qwen2-7B-Instruct
+    - Qwen/Qwen2-1.5B-Instruct
     - Qwen/Qwen1.5-7B-Chat
+    - Qwen/Qwen-7B-Chat
     - Qwen/Qwen1.5-MoE-A2.7B-Chat
-    - Qwen/Qwen2-0.5B-Instruct
     - mistralai/Mistral-7B-Instruct-v0.1
+    - mistralai/Mistral-7B-Instruct-v0.2
     - mistralai/Mixtral-8x7B-Instruct-v0.1
     - google/gemma-7b-it
     - deepseek-ai/deepseek-moe-16b-chat
-    - deepseek-ai/deepseek-coder-6.7b-instruct
+    - deepseek-ai/deepseek-coder-1.3b-instruct
     - THUDM/chatglm2-6b
+    - THUDM/cogvlm-chat-hf
+    - THUDM/cogvlm2-llama3-chinese-chat-19B
+    - microsoft/Phi-3-mini-4k-instruct
+    - microsoft/Phi-3-vision-128k-instruct
+    - bigcode/starcoder2-7b
 
 turbomind_base_model:
+    - internlm/internlm2_5-7b
     - internlm/internlm2-1_8b
     - internlm/internlm2-20b
     - codellama/CodeLlama-7b-hf
@@ -75,61 +95,85 @@ pytorch_base_model:
 
 vl_model:
     - Qwen/Qwen-VL-Chat
-    - liuhaotian/llava-v1.5-7b
     - liuhaotian/llava-v1.5-13b
     - liuhaotian/llava-v1.6-vicuna-7b
     - 01-ai/Yi-VL-6B
     - deepseek-ai/deepseek-vl-1.3b-chat
     - OpenGVLab/InternVL-Chat-V1-5
+    - OpenGVLab/Mini-InternVL-Chat-2B-V1-5
     - internlm/internlm-xcomposer2-vl-7b
     - internlm/internlm-xcomposer2-7b
     - internlm/internlm-xcomposer2-4khd-7b
     - THUDM/cogvlm-chat-hf
     - THUDM/cogvlm2-llama3-chinese-chat-19B
+    - microsoft/Phi-3-vision-128k-instruct
+    - openbmb/MiniCPM-Llama3-V-2_5
 
 quatization_case_config:
     w4a16:
+        - meta-llama/Meta-Llama-3-8B-Instruct
         - meta-llama/Llama-2-7b-chat-hf
-        - internlm/internlm-chat-20b
-        - Qwen/Qwen-7B-Chat
+        - internlm/internlm2_5-7b-chat
+        - internlm/internlm2_5-7b-chat-1m
+        - internlm/internlm2_5-7b
         - internlm/internlm2-chat-20b
-        - baichuan-inc/Baichuan2-7B-Chat
         - internlm/internlm2-20b
+        - internlm/internlm-chat-20b
+        - internlm/internlm-xcomposer2-vl-7b
+        - internlm/internlm-xcomposer2-7b
+        - internlm/internlm-xcomposer2-4khd-7b
+        - OpenGVLab/InternVL-Chat-V1-5
+        - OpenGVLab/Mini-InternVL-Chat-2B-V1-5
+        - Qwen/Qwen-7B-Chat
         - Qwen/Qwen1.5-7B-Chat
         - Qwen/Qwen2-7B-Instruct
         - Qwen/Qwen2-1.5B-Instruct
         - Qwen/Qwen-VL-Chat
-        - meta-llama/Meta-Llama-3-8B-Instruct
-        - liuhaotian/llava-v1.5-7b
         - liuhaotian/llava-v1.5-13b
         - liuhaotian/llava-v1.6-vicuna-7b
         - 01-ai/Yi-VL-6B
+        - 01-ai/Yi-6B-Chat
         - deepseek-ai/deepseek-vl-1.3b-chat
-        - OpenGVLab/InternVL-Chat-V1-5
-        - internlm/internlm-xcomposer2-vl-7b
-        - internlm/internlm-xcomposer2-7b
-        - internlm/internlm-xcomposer2-4khd-7b
+        - baichuan-inc/Baichuan2-7B-Chat
+        - codellama/CodeLlama-7b-hf
+        - openbmb/MiniCPM-Llama3-V-2_5
     kvint:
-        - meta-llama/Llama-2-7b-chat-hf
         - meta-llama/Meta-Llama-3-8B-Instruct
+        - meta-llama/Llama-2-7b-chat-hf
+        - internlm/internlm2_5-7b-chat
+        - internlm/internlm2_5-7b-chat-1m
         - internlm/internlm2-chat-1_8b
-        - internlm/internlm-chat-20b
         - internlm/internlm2-chat-7b
         - internlm/internlm2-chat-20b
         - internlm/internlm2-chat-7b-4bits
         - internlm/internlm2-chat-20b-4bits
-        - Qwen/Qwen-7B-Chat
-        - Qwen/Qwen1.5-7B-Chat
+        - internlm/internlm-chat-20b
+        - internlm/internlm-xcomposer2-vl-7b
+        - internlm/internlm-xcomposer2-7b
+        - internlm/internlm-xcomposer2-4khd-7b
+        - OpenGVLab/InternVL-Chat-V1-5
         - Qwen/Qwen2-7B-Instruct
+        - Qwen/Qwen2-7B-Instruct-AWQ
+        - Qwen/Qwen2-1.5B-Instruct
+        - Qwen/Qwen1.5-7B-Chat
+        - Qwen/Qwen1.5-4B-Chat-AWQ
+        - Qwen/Qwen-7B-Chat
+        - Qwen/Qwen-VL-Chat
+        - mistralai/Mistral-7B-Instruct-v0.2
+        - mistralai/Mistral-7B-Instruct-v0.3
         - lmdeploy/llama2-chat-7b-w4
         - baichuan-inc/Baichuan2-7B-Chat
-        - internlm/internlm2-1_8b
-        - internlm/internlm2-20b
         - 01-ai/Yi-6B-Chat
+        - 01-ai/Yi-VL-6B
+        - liuhaotian/llava-v1.5-13b
+        - liuhaotian/llava-v1.6-vicuna-7b
+        - deepseek-ai/deepseek-vl-1.3b-chat
+        - deepseek-ai/deepseek-coder-1.3b-instruct
         - codellama/CodeLlama-7b-Instruct-hf
+        - THUDM/glm-4-9b-chat
     w8a8:
-        - meta-llama/Llama-2-7b-chat-hf
         - meta-llama/Meta-Llama-3-8B-Instruct
+        - meta-llama/Llama-2-7b-chat-hf
         - internlm/internlm2-chat-20b
         - internlm/internlm2-chat-7b
         - 01-ai/Yi-6B-Chat

--- a/autotest/interface/pipeline/test_pipeline_longtext_func.py
+++ b/autotest/interface/pipeline/test_pipeline_longtext_func.py
@@ -13,6 +13,7 @@ from lmdeploy import (GenerationConfig, PytorchEngineConfig,
 
 SESSION_LEN = 198000
 SESSION_LEN_PASSKEY = 168000
+SESSION_LEN_PASSKEY_1M = 1048576
 
 
 @pytest.mark.gpu_num_1
@@ -113,29 +114,57 @@ def test_long_test_passkey_tp2(config, model, backend, worker_id):
     assert_pipeline_common_log(config, log_name)
 
 
-def passkey_retrival(config, model, backend, log_name):
+@pytest.mark.gpu_num_4
+@pytest.mark.parametrize('model', ['internlm/internlm2_5-7b-chat-1m'])
+@pytest.mark.parametrize('backend', ['turbomind'])
+def test_long_test_passkey_tp4(config, model, backend, worker_id):
+    log_name = ''.join(['pipeline_longtext_passkey_', worker_id, '.log'])
+    if 'gw' in worker_id:
+        os.environ['CUDA_VISIBLE_DEVICES'] = get_cuda_id_by_workerid(worker_id,
+                                                                     tp_num=4)
+    p = Process(target=passkey_retrival,
+                args=(config, model, backend, log_name,
+                      SESSION_LEN_PASSKEY_1M))
+    p.start()
+    p.join()
+
+    assert_pipeline_common_log(config, log_name)
+
+
+def passkey_retrival(config,
+                     model,
+                     backend,
+                     log_name,
+                     session_len: int = SESSION_LEN_PASSKEY):
     tp_num = get_tp_num(config, model)
     model_path = '/'.join([config.get('model_path'), model])
     if backend == 'turbomind':
-        backend_config = TurbomindEngineConfig(rope_scaling_factor=2.0,
-                                               session_len=SESSION_LEN_PASSKEY,
-                                               use_logn_attn=True,
-                                               tp=tp_num)
+        if 'internlm2_5' in model and '-1m' in model:
+            backend_config = TurbomindEngineConfig(rope_scaling_factor=2.5,
+                                                   session_len=session_len,
+                                                   max_batch_size=1,
+                                                   cache_max_entry_count=0.7,
+                                                   tp=tp_num)
+        else:
+            backend_config = TurbomindEngineConfig(rope_scaling_factor=2.0,
+                                                   session_len=session_len,
+                                                   use_logn_attn=True,
+                                                   tp=tp_num)
     else:
-        backend_config = PytorchEngineConfig(session_len=SESSION_LEN_PASSKEY,
+        backend_config = PytorchEngineConfig(session_len=session_len,
                                              tp=tp_num)
 
     pipe = pipeline(model_path, backend_config=backend_config)
 
     gen_config = GenerationConfig(top_k=40)
     # inference
-    pass_key, prompt = get_passkey_prompt(pipe, SESSION_LEN_PASSKEY)
+    pass_key, prompt = get_passkey_prompt(pipe, session_len)
     response = pipe(prompt, gen_config=gen_config)
     save_pipeline_common_log(config, log_name,
                              str(pass_key) in response.text, str(response))
 
     # inference
-    pass_key, prompt = get_passkey_prompt(pipe, SESSION_LEN_PASSKEY)
+    pass_key, prompt = get_passkey_prompt(pipe, session_len)
     response = pipe([prompt] * 2, gen_config=gen_config)
     save_pipeline_common_log(config,
                              log_name,

--- a/autotest/interface/pipeline/test_pipeline_longtext_func.py
+++ b/autotest/interface/pipeline/test_pipeline_longtext_func.py
@@ -88,7 +88,7 @@ def test_long_test_passkey_tp1(config, model, backend, worker_id):
     if 'gw' in worker_id:
         os.environ['CUDA_VISIBLE_DEVICES'] = get_cuda_id_by_workerid(worker_id)
     p = Process(target=passkey_retrival,
-                args=(config, model, backend, log_name))
+                args=(config, model, backend, log_name, 1))
     p.start()
     p.join()
 
@@ -107,7 +107,7 @@ def test_long_test_passkey_tp2(config, model, backend, worker_id):
         os.environ['CUDA_VISIBLE_DEVICES'] = get_cuda_id_by_workerid(worker_id,
                                                                      tp_num=2)
     p = Process(target=passkey_retrival,
-                args=(config, model, backend, log_name))
+                args=(config, model, backend, log_name, 2))
     p.start()
     p.join()
 
@@ -123,7 +123,7 @@ def test_long_test_passkey_tp4(config, model, backend, worker_id):
         os.environ['CUDA_VISIBLE_DEVICES'] = get_cuda_id_by_workerid(worker_id,
                                                                      tp_num=4)
     p = Process(target=passkey_retrival,
-                args=(config, model, backend, log_name,
+                args=(config, model, backend, log_name, 4,
                       SESSION_LEN_PASSKEY_1M))
     p.start()
     p.join()
@@ -135,8 +135,8 @@ def passkey_retrival(config,
                      model,
                      backend,
                      log_name,
+                     tp_num,
                      session_len: int = SESSION_LEN_PASSKEY):
-    tp_num = get_tp_num(config, model)
     model_path = '/'.join([config.get('model_path'), model])
     if backend == 'turbomind':
         if 'internlm2_5' in model and '-1m' in model:

--- a/autotest/utils/config_utils.py
+++ b/autotest/utils/config_utils.py
@@ -127,6 +127,14 @@ def get_cuda_id_by_workerid(worker_id, tp_num: int = 1):
         elif tp_num == 2:
             cuda_num = int(worker_id.replace('gw', '')) * 2
             return ','.join([str(cuda_num), str(cuda_num + 1)])
+        elif tp_num == 4:
+            cuda_num = int(worker_id.replace('gw', '')) * 4
+            return ','.join([
+                str(cuda_num),
+                str(cuda_num + 1),
+                str(cuda_num + 2),
+                str(cuda_num + 3)
+            ])
 
 
 def get_config():

--- a/autotest/utils/get_run_config.py
+++ b/autotest/utils/get_run_config.py
@@ -89,12 +89,17 @@ def get_model_name(model):
         return 'yi-vl'
     if ('qwen' in model_name):
         return 'qwen'
+
     if ('internvl') in model_name:
         return 'internvl-internlm2'
+    if ('internlm2') in model_name:
+        return 'internlm2'
     if ('internlm-xcomposer2-4khd-7b') in model_name:
         return 'internlm-xcomposer2-4khd'
     if ('internlm-xcomposer2') in model_name:
         return 'internlm-xcomposer2'
+    if ('glm-4') in model_name:
+        return 'glm4'
     if len(model_name.split('-')) > 2 and '-'.join(
             model_name.split('-')[0:2]) in model_names:
         return '-'.join(model_name.split('-')[0:2])
@@ -124,4 +129,5 @@ def _simple_model_name(model):
         model_name = model
     model_name = model_name.replace('-inner-4bits', '')
     model_name = model_name.replace('-inner-w8a8', '')
+    model_name = model_name.replace('-4bits', '')
     return model_name

--- a/autotest/utils/pipeline_chat.py
+++ b/autotest/utils/pipeline_chat.py
@@ -12,6 +12,7 @@ from lmdeploy import pipeline
 from lmdeploy.messages import (GenerationConfig, PytorchEngineConfig,
                                TurbomindEngineConfig)
 from lmdeploy.vl import load_image
+from lmdeploy.vl.constants import IMAGE_TOKEN
 
 
 def run_pipeline_chat_test(config,
@@ -285,7 +286,12 @@ def run_pipeline_vl_chat_test(config, model_case):
     file = open(pipeline_chat_log, 'w')
 
     image = load_image(PIC1)
-    response = pipe(('describe this image', image))
+
+    if 'deepseek' in model_case:
+        prompt = f'describe this image{IMAGE_TOKEN}'
+    else:
+        prompt = 'describe this image'
+    response = pipe((prompt, image))
     result = 'tiger' in response.text.lower() or '虎' in response.text.lower()
     file.writelines('result:' + str(result) +
                     ', reason: simple example tiger not in ' + response.text +
@@ -296,7 +302,7 @@ def run_pipeline_vl_chat_test(config, model_case):
         'user',
         'content': [{
             'type': 'text',
-            'text': 'describe this image'
+            'text': prompt
         }, {
             'type': 'image_url',
             'image_url': {
@@ -312,7 +318,7 @@ def run_pipeline_vl_chat_test(config, model_case):
 
     image_urls = [PIC2, PIC1]
     images = [load_image(img_url) for img_url in image_urls]
-    response = pipe(('describe these images', images))
+    response = pipe((prompt, images))
     result = 'tiger' in response.text.lower() or 'ski' in response.text.lower(
     ) or '虎' in response.text.lower() or '滑雪' in response.text.lower()
     file.writelines('result:' + str(result) +
@@ -320,8 +326,7 @@ def run_pipeline_vl_chat_test(config, model_case):
                     response.text + '\n')
 
     image_urls = [PIC2, PIC1]
-    prompts = [('describe this image', load_image(img_url))
-               for img_url in image_urls]
+    prompts = [(prompt, load_image(img_url)) for img_url in image_urls]
     response = pipe(prompts)
     result = ('ski' in response[0].text.lower()
               or '滑雪' in response[0].text.lower()) and (
@@ -332,7 +337,7 @@ def run_pipeline_vl_chat_test(config, model_case):
                     str(response) + '\n')
 
     image = load_image(PIC2)
-    sess = pipe.chat(('describe this image', image))
+    sess = pipe.chat((prompt, image))
     result = 'ski' in sess.response.text.lower(
     ) or '滑雪' in sess.response.text.lower()
     file.writelines('result:' + str(result) +

--- a/autotest/utils/run_client_chat.py
+++ b/autotest/utils/run_client_chat.py
@@ -96,9 +96,6 @@ def command_test(config,
         file.writelines('reproduce command chat: ' + ' '.join(cmd) + '\n')
 
         spliter = '\n\n'
-        if 'CodeLlama' in model and 'api_client' not in cmd:
-            spliter = '\n!!\n'
-        # join prompt together
         prompt = ''
         for item in case_info:
             prompt += list(item.keys())[0] + spliter
@@ -155,10 +152,7 @@ def command_test(config,
 # 从输出中解析模型输出的对话内容
 def parse_dialogue(inputs: str, model: str):
     dialogues = inputs.strip()
-    if 'CodeLlama' in model:
-        sep = 'enter !! to end the input >>>'
-    else:
-        sep = 'double enter to end input >>>'
+    sep = 'double enter to end input >>>'
     dialogues = dialogues.strip()
     dialogues = dialogues.split(sep)
     dialogues = [d.strip() for d in dialogues]


### PR DESCRIPTION
1. add internlm2.5 models into testcase and oc evaluation configs
2. fix transformers's version in dailytest, cannot do vl quatization on transformers 4.42+
3. fix opencompass's version, because newest oc code need scikit_learn==1.5.0 which need python>=3.9.
4. update vl pipeline testcase for deepseek
5. add prompt length = 1 in benchmark
6. git action is unstable because of https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/ , set env to make action use node16