### PR TITLE
fix mixtral and mistral cache_position

### DIFF
--- a/lmdeploy/pytorch/models/mixtral.py
+++ b/lmdeploy/pytorch/models/mixtral.py
@@ -139,6 +139,7 @@ class PatchedMixtralAttention(nn.Module):
         past_key_value: Optional[Tuple[torch.Tensor]] = None,
         output_attentions: bool = False,
         use_cache: bool = False,
+        **kwargs,
     ) -> Tuple[torch.Tensor, Optional[torch.Tensor],
                Optional[Tuple[torch.Tensor]]]:
         """Rewrite of MistralAttention.forward."""


### PR DESCRIPTION
## Motivation

as titled cc @grimoire @RunningLeon @lvhan028 

tested with `Mixtral-8x7B-Instruct-v0.1` https://huggingface.co/mistralai/Mixtral-8x7B-Instruct-v0.1
```bash
python3 -m lmdeploy serve api_server /workdir/Mixtral-8x7B-Instruct-v0.1 --tp 2
```
transformers version: 4.42.3

## Modification

same as https://github.com/InternLM/lmdeploy/pull/1886

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
