### PR TITLE
fix: set PYTHONIOENCODING to UTF-8 before start tritonserver

### DIFF
--- a/lmdeploy/serve/turbomind/triton_python_backend/README.md
+++ b/lmdeploy/serve/turbomind/triton_python_backend/README.md
@@ -48,6 +48,8 @@ The [memory leak](https://github.com/triton-inference-server/python_backend/pull
 Use the following command to start the Triton Inference Server with the specified model repository:
 
 ```
+export PYTHONIOENCODING=UTF-8
+
 tritonserver \
     --model-repository=/path/to/your/model_repository \
     --allow-grpc=1 \


### PR DESCRIPTION
## Motivation

as titled ref https://github.com/triton-inference-server/server/issues/4996

cc @lvhan028 @zhulinJulia24 @AllentDan @grimoire @ispobock 

## Modification

as titled

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
