### PR TITLE
Fix table rendering for readthedocs

### DIFF
--- a/docs/en/conf.py
+++ b/docs/en/conf.py
@@ -50,7 +50,6 @@ extensions = [
     'sphinx.ext.autosectionlabel',
     'sphinx.ext.intersphinx',
     'sphinx_tabs.tabs',
-    'sphinx_markdown_tables',
     'myst_parser',
     'sphinx_copybutton',
     'sphinxcontrib.mermaid',

--- a/docs/zh_cn/conf.py
+++ b/docs/zh_cn/conf.py
@@ -50,7 +50,6 @@ extensions = [
     'sphinx.ext.autosectionlabel',
     'sphinx.ext.intersphinx',
     'sphinx_tabs.tabs',
-    'sphinx_markdown_tables',
     'myst_parser',
     'sphinx_copybutton',
     'sphinxcontrib.mermaid',

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -4,5 +4,4 @@ sphinx
 sphinx-book-theme
 sphinx-copybutton
 sphinx-tabs
-sphinx_markdown_tables>=0.0.16
 sphinxcontrib-mermaid


### PR DESCRIPTION
## Motivation

Fix table rendering for readthedocs


### rendered table 

before: https://lmdeploy.readthedocs.io/en/latest/supported_models/supported_models.html#models-supported-by-turbomind

after:  https://lmdeploy--1998.org.readthedocs.build/en/1998/supported_models/supported_models.html#models-supported-by-turbomind

## Modification

- remove `sphinx_markdown_tables` in `conf.py` for docs

## BC-breaking (Optional)

None

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
