### PR TITLE
Add exception handler to imge encoder

### DIFF
--- a/lmdeploy/messages.py
+++ b/lmdeploy/messages.py
@@ -298,7 +298,9 @@ class VisionConfig:
         max_batch_size (int): the max image size passed to the model, since
             some models will use image patch, the actual running batch could
             be larger than this value.
-        thread_safe (bool): thread safe engine instance.
+        thread_safe (bool): Specifies whether the engine instance is
+            thread-safe. Please set it to True when using the pipeline
+            in a multi-threaded environment.
     """
     max_batch_size: int = 1
     thread_safe: bool = False

--- a/lmdeploy/messages.py
+++ b/lmdeploy/messages.py
@@ -298,5 +298,7 @@ class VisionConfig:
         max_batch_size (int): the max image size passed to the model, since
             some models will use image patch, the actual running batch could
             be larger than this value.
+        thread_safe (bool): thread safe engine instance.
     """
     max_batch_size: int = 1
+    thread_safe: bool = False

--- a/lmdeploy/vl/engine.py
+++ b/lmdeploy/vl/engine.py
@@ -62,11 +62,11 @@ class Record:
         outputs = self.done[:num_images]
         self.done = self.done[num_images:]
         que = self.res_que.pop(0)
+        self.log('done', num_images)
         if self.thread_safe:
             que._loop.call_soon_threadsafe(que.put_nowait, outputs)
         else:
             que.put_nowait(outputs)
-        self.log('done', num_images)
         return True
 
     def log(self, task: str, num: int):


### PR DESCRIPTION
## Motivation

- thread-safe image encoder for multi-threaded use of pipeline api
- add exception handler to `run_in_executor`

some issues that may be related :
https://github.com/InternLM/lmdeploy/issues/1981
https://github.com/InternLM/lmdeploy/issues/1992
https://github.com/InternLM/lmdeploy/issues/2004
 


