### PR TITLE
misc: replace slow Jimver/cuda-toolkit

### DIFF
--- a/.github/workflows/cuda11.8-whl-release.yml
+++ b/.github/workflows/cuda11.8-whl-release.yml
@@ -67,11 +67,12 @@ jobs:
       - name: Install python packages
         run: |
           pip install pybind11 wheel
-      - uses: Jimver/cuda-toolkit@v0.2.11
+      - name: Setup CUDA Toolkit
         id: cuda-toolkit
-        with:
-          cuda: '11.8.0'
-          use-github-cache: false
+        shell: pwsh
+        run: ./builder/windows/setup_cuda.ps1
+        env:
+            INPUT_CUDA_VERSION: '11.8.0'
       - name: Build wheel
         run: |
           mkdir build

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -66,11 +66,12 @@ jobs:
       - name: Install python packages
         run: |
           pip install pybind11 wheel
-      - uses: Jimver/cuda-toolkit@v0.2.11
+      - name: Setup CUDA Toolkit
         id: cuda-toolkit
-        with:
-          cuda: '12.1.0'
-          use-github-cache: false
+        shell: pwsh
+        run: ./builder/windows/setup_cuda.ps1
+        env:
+            INPUT_CUDA_VERSION: '12.1.0'
       - name: Build wheel
         run: |
           mkdir build

--- a/.github/workflows/windows-x64-gpu.yml
+++ b/.github/workflows/windows-x64-gpu.yml
@@ -41,11 +41,12 @@ jobs:
       - name: Install python packages
         run: |
           pip install pybind11 wheel
-      - uses: Jimver/cuda-toolkit@v0.2.11
+      - name: Setup CUDA Toolkit
         id: cuda-toolkit
-        with:
-          cuda: ${{ matrix.cudaver }}
-          use-github-cache: false
+        shell: pwsh
+        run: ./builder/windows/setup_cuda.ps1
+        env:
+            INPUT_CUDA_VERSION: ${{ matrix.cudaver }}
       - name: Build wheel
         run: |
           $env:BUILD_TEST="ON"

--- a/builder/windows/setup_cuda.ps1
+++ b/builder/windows/setup_cuda.ps1
@@ -1,0 +1,102 @@
+# Adapted from https://github.com/thewh1teagle/vibe/blob/5d7b75568ca65ab635bdf0ce912bbc975a043066/scripts/setup_cuda.ps1
+
+$CUDA_VERSION_FULL = $env:INPUT_CUDA_VERSION # v12.1.0 or v11.8.0
+
+# Make sure CUDA_VERSION_FULL is set and valid, otherwise error.
+# Validate CUDA version, extracting components via regex
+$cuda_ver_matched = $CUDA_VERSION_FULL -match "^(?<major>[1-9][0-9]*)\.(?<minor>[0-9]+)\.(?<patch>[0-9]+)$"
+if(-not $cuda_ver_matched){
+    Write-Output "Invalid CUDA version specified, <major>.<minor>.<patch> required. '$CUDA_VERSION_FULL'."
+    exit 1
+}
+$CUDA_MAJOR=$Matches.major
+$CUDA_MINOR=$Matches.minor
+$CUDA_PATCH=$Matches.patch
+
+Write-Output "Selected CUDA version: $CUDA_VERSION_FULL"
+
+$src = "cuda"
+$dst = "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v$($CUDA_MAJOR).$($CUDA_MINOR)"
+$installer = "cuda.exe"
+
+if ($CUDA_VERSION_FULL -eq "12.1.0") {
+    $downloadUrl = "https://developer.download.nvidia.com/compute/cuda/12.1.0/local_installers/cuda_12.1.0_531.14_windows.exe"
+} elseif ($CUDA_VERSION_FULL -eq "11.8.0") {
+    $downloadUrl = "https://developer.download.nvidia.com/compute/cuda/11.8.0/local_installers/cuda_11.8.0_522.06_windows.exe"
+} else {
+    Write-Output "Unsupported CUDA version specified"
+    exit 1
+}
+
+# Download cuda
+Write-Output "Downloading CUDA from: $downloadUrl"
+if (-not (Test-Path -Path $installer)) {
+    Write-Output "Downloading CUDA installer..."
+    # If the file does not exist, download it
+    & "C:\msys64\usr\bin\wget" $downloadUrl -O $installer -q
+}
+
+# Extract cuda
+if (-not (Test-Path -Path $src -Type Container)) {
+    # Extract CUDA using 7-Zip
+    Write-Output "Extracting CUDA using 7-Zip..."
+    mkdir "$src"
+    & 'C:\Program Files\7-Zip\7z' x $installer -o"$src"
+}
+
+# Create destination directory if it doesn't exist
+if (-Not (Test-Path -Path $dst)) {
+    Write-Output "Creating destination directory: $dst"
+    New-Item -Path $dst -ItemType Directory
+}
+
+# Get directories to process from the source path
+$directories = Get-ChildItem -Directory -Path $src
+$whitelist = @("CUDA_Toolkit_Release_Notes.txt", "DOCS", "EULA.txt", "LICENSE", "README", "version.json")
+
+foreach ($dir in $directories) {
+    # Get all subdirectories and files in the current directory
+    $items = Get-ChildItem -Path (Join-Path $src $dir.Name)
+
+    foreach ($item in $items) {
+        if ($item.PSIsContainer) {
+            # If the item is a directory, copy its contents
+            Write-Output "Copying contents of directory $($item.FullName) to $dst"
+            Copy-Item -Path "$($item.FullName)\*" -Destination $dst -Recurse -Force
+        } else {
+            if ($whitelist -contains $item.Name) {
+                Write-Output "Copying file $($item.FullName) to $dst"
+                Copy-Item -Path $item.FullName -Destination $dst -Force
+            }
+        }
+    }
+}
+
+# Add msbuild cuda extensions
+$msBuildExtensions = (Get-ChildItem  "$src\visual_studio_integration\CUDAVisualStudioIntegration\extras\visual_studio_integration\MSBuildExtensions").fullname
+(Get-ChildItem 'C:\Program Files\Microsoft Visual Studio\2022\*\MSBuild\Microsoft\VC\*\BuildCustomizations').FullName | ForEach-Object { 
+    $destination = $_
+    $msBuildExtensions | ForEach-Object {
+        $extension = $_
+        Copy-Item $extension -Destination $destination -Force
+        Write-Output "Copied $extension to $destination"
+    }
+}
+
+# Add to Github env
+Write-Output "Setting environment variables for GitHub Actions..."
+
+Write-Output "CUDA_PATH=$dst"
+Write-Output "CUDA_PATH_V$($CUDA_MAJOR)_$($CUDA_MINOR)=$dst"
+Write-Output "CUDA_PATH_VX_Y=CUDA_PATH_V$($CUDA_MAJOR)_$($CUDA_MINOR)"
+Write-Output "CUDA_VERSION=$CUDA_VERSION_FULL"
+
+Write-Output "CUDA_PATH=$dst" >> $env:GITHUB_ENV
+Write-Output "CUDA_PATH_V$($CUDA_MAJOR)_$($CUDA_MINOR)=$dst" >> $env:GITHUB_ENV
+Write-Output "CUDA_PATH_VX_Y=CUDA_PATH_V$($CUDA_MAJOR)_$($CUDA_MINOR)" >> $env:GITHUB_ENV
+Write-Output "CudaToolkitDir=$dst" >> $env:GITHUB_ENV
+Write-Output "CMAKE_CUDA_COMPILER=$dst\bin\nvcc.exe" >> $env:GITHUB_ENV
+Write-Output "NVCC_APPEND_FLAGS=-allow-unsupported-compiler" >> $env:GITHUB_ENV
+
+Write-Output "CUDA_VERSION=$CUDA_VERSION_FULL" >> $env:GITHUB_ENV
+Write-Output "Setup completed."

--- a/builder/windows/setup_cuda.ps1
+++ b/builder/windows/setup_cuda.ps1
@@ -1,3 +1,4 @@
+# Copyright (c) OpenMMLab. All rights reserved.
 # Adapted from https://github.com/thewh1teagle/vibe/blob/5d7b75568ca65ab635bdf0ce912bbc975a043066/scripts/setup_cuda.ps1
 
 $CUDA_VERSION_FULL = $env:INPUT_CUDA_VERSION # v12.1.0 or v11.8.0
@@ -74,7 +75,7 @@ foreach ($dir in $directories) {
 
 # Add msbuild cuda extensions
 $msBuildExtensions = (Get-ChildItem  "$src\visual_studio_integration\CUDAVisualStudioIntegration\extras\visual_studio_integration\MSBuildExtensions").fullname
-(Get-ChildItem 'C:\Program Files\Microsoft Visual Studio\2022\*\MSBuild\Microsoft\VC\*\BuildCustomizations').FullName | ForEach-Object { 
+(Get-ChildItem 'C:\Program Files\Microsoft Visual Studio\2022\*\MSBuild\Microsoft\VC\*\BuildCustomizations').FullName | ForEach-Object {
     $destination = $_
     $msBuildExtensions | ForEach-Object {
         $extension = $_


### PR DESCRIPTION
## Motivation

`Jimver/cuda-toolkit` setup is too slow.

I tested this change with https://github.com/zhyncs/lmdeploy-build/commit/6df19c57cc6f8a3867460e6a229a6b30e89fda99
And the workflow time is reduced by **half an hour**. ref https://github.com/zhyncs/lmdeploy-build/actions
cc @irexyc @RunningLeon @lvhan028 

![](https://github.com/user-attachments/assets/bfb50705-b9a9-441b-84c2-6f72ed00e2b9)


## Modification

as titled

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
