### PR TITLE
Remove `session_len` and deprecated short names of the chat templates

### DIFF
--- a/lmdeploy/model.py
+++ b/lmdeploy/model.py
@@ -104,12 +104,7 @@ class ChatTemplateConfig:
 class BaseModel:
     """Base model."""
 
-    def __init__(self,
-                 session_len=2048,
-                 capability='chat',
-                 stop_words=None,
-                 **kwargs):
-        self.session_len = session_len
+    def __init__(self, capability='chat', stop_words=None, **kwargs):
         self.stop_words = stop_words
         self.capability = capability
 
@@ -361,8 +356,8 @@ class Llavav1(Vicuna):
 class MiniGemini(Vicuna):
     """Chat template of vicuna model."""
 
-    def __init__(self, session_len=4096, **kwargs):
-        super().__init__(session_len=session_len, **kwargs)
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
 
     def get_prompt(self, prompt, sequence_start=True):
         return super().get_prompt(prompt, sequence_start)[:-1]
@@ -384,8 +379,6 @@ class MiniGemini(Vicuna):
             return 'mini-gemini-vicuna'
 
 
-@MODELS.register_module(name='internlm-chat')
-@MODELS.register_module(name='internlm-chat-7b')
 @MODELS.register_module(name='internlm')
 class InternLMChat7B(BaseChatTemplate):
     """Chat template of InternLM model."""
@@ -429,48 +422,11 @@ class InternLMChat7B(BaseChatTemplate):
             return 'internlm'
 
 
-@MODELS.register_module(name='internlm-chat-20b')
-@MODELS.register_module(name='internlm-chat-7b-8k')
-class InternLMChat7B8K(InternLMChat7B):
-    """Chat template and generation parameters of InternLM-Chat-7B-8K and
-    InternLM-Chat-20B models."""
-
-    def __init__(self, session_len=8192, **kwargs):
-        super(InternLMChat7B8K, self).__init__(**kwargs)
-        self.session_len = session_len
-
-
-@MODELS.register_module(name='internlm-20b')
-class InternLMBaseModel20B(BaseChatTemplate):
-    """Generation parameters of InternLM-20B-Base model."""
-
-    def __init__(self, session_len=4096, capability='completion', **kwargs):
-        super().__init__(session_len=session_len,
-                         capability=capability,
-                         **kwargs)
-
-
-@MODELS.register_module(
-    name=['internlm2-1_8b', 'internlm2-7b', 'internlm2-20b'])
-class InternLM2BaseModel7B(BaseChatTemplate):
-    """Generation parameters of InternLM2-7B-Base model."""
-
-    def __init__(self, session_len=32768, capability='completion', **kwargs):
-        super().__init__(session_len=session_len,
-                         capability=capability,
-                         **kwargs)
-
-
-@MODELS.register_module(name=[
-    'internlm2-chat', 'internlm2-chat-1_8b', 'internlm2-chat-7b',
-    'internlm2-chat-20b'
-])
 @MODELS.register_module(name='internlm2')
 class InternLM2Chat7B(InternLMChat7B):
     """Chat template and generation parameters of InternLM2-Chat-7B."""
 
     def __init__(self,
-                 session_len=32768,
                  system='<|im_start|>system\n',
                  user='<|im_start|>user\n',
                  assistant='<|im_start|>assistant\n',
@@ -488,8 +444,7 @@ class InternLM2Chat7B(InternLMChat7B):
         self.interpreter = interpreter
         self.environment = environment
         self.eoenv = eoenv
-        super(InternLM2Chat7B, self).__init__(session_len=session_len,
-                                              system=system,
+        super(InternLM2Chat7B, self).__init__(system=system,
                                               user=user,
                                               assistant=assistant,
                                               eosys=eosys,
@@ -607,14 +562,12 @@ class InternVL2InternLM2(InternLM2Chat7B):
             return 'internvl2-internlm2'
 
 
-@MODELS.register_module(name='internlm-xcomposer2d5')
-@MODELS.register_module(name='internlm-xcomposer2')
+@MODELS.register_module(name=['internlm-xcomposer2', 'internlm-xcomposer2d5'])
 class InternLMXComposer2Chat7B(InternLMChat7B):
     """Chat template and generation parameters of InternLM-XComposer2-7b."""
 
     def __init__(
             self,
-            session_len=4096,
             system='[UNUSED_TOKEN_146]system\n',
             meta_instruction="""You are an AI assistant whose name is InternLM-XComposer (浦语·灵笔).
 - InternLM-XComposer (浦语·灵笔) is a multi-modality conversational language model that is developed by Shanghai AI Laboratory (上海人工智能实验室). It is designed to be helpful, honest, and harmless.
@@ -628,8 +581,7 @@ class InternLMXComposer2Chat7B(InternLMChat7B):
             separator='\n',
             stop_words=['[UNUSED_TOKEN_145]'],
             **kwargs):
-        super().__init__(session_len=session_len,
-                         system=system,
+        super().__init__(system=system,
                          meta_instruction=meta_instruction,
                          user=user,
                          assistant=assistant,
@@ -654,18 +606,8 @@ class InternLMXComposer2Chat7B(InternLMChat7B):
             return 'internlm-xcomposer2'
 
 
-@MODELS.register_module(name='baichuan-7b')
-@MODELS.register_module(name='baichuan-base')
-class Baichuan7B(BaseChatTemplate):
-    """Generation parameters of Baichuan-7B base model."""
-
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
-
-
-@MODELS.register_module(name='baichuan2-7b')
 @MODELS.register_module(name='baichuan2')
-class Baichuan2_7B(BaseChatTemplate):
+class Baichuan2(BaseChatTemplate):
     """Chat template and generation parameters of Baichuan2-7B-Base and
     Baichuan2-7B-Chat models."""
 
@@ -723,7 +665,7 @@ class Puyu(BaseChatTemplate):
             return 'puyu'
 
 
-@MODELS.register_module(name=['llama2', 'llama-2', 'llama-2-chat'])
+@MODELS.register_module(name='llama2')
 class Llama2(BaseChatTemplate):
     """Chat template of LLaMA2 model."""
 
@@ -773,7 +715,6 @@ class Llama3(BaseChatTemplate):
                  user='<|start_header_id|>user<|end_header_id|>\n\n',
                  eoh='<|eot_id|>',
                  stop_words=['<|eot_id|>', '<|end_of_text|>'],
-                 session_len=8192,
                  **kwargs):
         super().__init__(system=system,
                          meta_instruction=meta_instruction,
@@ -783,7 +724,6 @@ class Llama3(BaseChatTemplate):
                          user=user,
                          eoh=eoh,
                          stop_words=stop_words,
-                         session_len=session_len,
                          **kwargs)
 
     def get_prompt(self, prompt, sequence_start=True):
@@ -809,14 +749,11 @@ class Llama3(BaseChatTemplate):
             return 'llama3'
 
 
-@MODELS.register_module(name='qwen-14b')
-@MODELS.register_module(name='qwen-7b')
 @MODELS.register_module(name='qwen')
 class Qwen7BChat(BaseChatTemplate):
     """Chat template for Qwen-7B-Chat."""
 
     def __init__(self,
-                 session_len=8192,
                  system='<|im_start|>system\n',
                  meta_instruction='You are a helpful assistant.',
                  eosys='<|im_end|>\n',
@@ -836,7 +773,6 @@ class Qwen7BChat(BaseChatTemplate):
                          eoa=eoa,
                          separator=separator,
                          stop_words=stop_words,
-                         session_len=session_len,
                          **kwargs)
 
     @classmethod
@@ -855,12 +791,10 @@ class CodeLlama(Llama2):
 
     def __init__(self,
                  meta_instruction='',
-                 session_len=4096,
                  suffix_first=False,
                  stop_words=None,
                  **kwargs):
         super().__init__(meta_instruction=meta_instruction,
-                         session_len=session_len,
                          stop_words=stop_words,
                          **kwargs)
         caps = ['completion', 'infilling', 'chat', 'python']
@@ -868,7 +802,6 @@ class CodeLlama(Llama2):
             f'{self.capability} is not supported. ' \
             f'The supported capabilities are: {caps}'
         self.meta_instruction = meta_instruction
-        self.session_len = session_len
         self.suffix_first = suffix_first
         self.stop_words = stop_words
         if self.capability == 'infilling':
@@ -921,7 +854,6 @@ class Falcon(BaseModel):
             return 'falcon'
 
 
-@MODELS.register_module(name='chatglm2-6b')
 @MODELS.register_module(name='chatglm')
 class ChatGLM2(BaseModel):
 
@@ -979,7 +911,7 @@ class ChatGLM2(BaseModel):
             return 'chatglm'
 
 
-@MODELS.register_module(name=['solar', 'solar-70b'])
+@MODELS.register_module(name='solar')
 class SOLAR(BaseChatTemplate):
     """Chat template of SOLAR model.
 
@@ -993,7 +925,6 @@ class SOLAR(BaseChatTemplate):
                  eoh='\n\n',
                  assistant='### Assistant:\n',
                  meta_instruction='',
-                 session_len=2048,
                  **kwargs):
         super().__init__(**kwargs)
         self.system = system
@@ -1002,7 +933,6 @@ class SOLAR(BaseChatTemplate):
         self.eoh = eoh
         self.assistant = assistant
         self.meta_instruction = meta_instruction
-        self.session_len = session_len
 
     @classmethod
     def match(cls, model_path: str) -> Optional[str]:
@@ -1015,8 +945,7 @@ class SOLAR(BaseChatTemplate):
             return 'solar'
 
 
-@MODELS.register_module(name='ultracm')
-@MODELS.register_module(name='ultralm')
+@MODELS.register_module(name=['ultracm', 'ultralm'])
 class UltraChat(BaseChatTemplate):
     """Template of UltraCM and UltraLM models.
 
@@ -1035,7 +964,6 @@ class UltraChat(BaseChatTemplate):
             eoa='</s>',
             separator='\n',
             stop_words=['</s>'],
-            session_len=2048,
             **kwargs):
         super().__init__(system=system,
                          meta_instruction=meta_instruction,
@@ -1046,7 +974,6 @@ class UltraChat(BaseChatTemplate):
                          eoa=eoa,
                          separator=separator,
                          stop_words=stop_words,
-                         session_len=session_len,
                          **kwargs)
 
     @classmethod
@@ -1062,7 +989,7 @@ class UltraChat(BaseChatTemplate):
             return 'ultralm'
 
 
-@MODELS.register_module(name=['yi', 'yi-chat', 'yi-200k', 'yi-34b'])
+@MODELS.register_module(name=['yi'])
 class Yi(BaseChatTemplate):
     """Chat template of Yi model."""
 
@@ -1101,7 +1028,6 @@ class Yi(BaseChatTemplate):
 
 
 @MODELS.register_module(name=['mistral', 'mixtral'])
-@MODELS.register_module(name=['Mistral-7B-Instruct', 'Mixtral-8x7B-Instruct'])
 class MistralChat(BaseChatTemplate):
     """Template of Mistral and Mixtral Instruct models.
 
@@ -1109,17 +1035,8 @@ class MistralChat(BaseChatTemplate):
     `https://huggingface.co/mistralai/Mixtral-8x7B-Instruct-v0.1`
     """
 
-    def __init__(self,
-                 user='[INST] ',
-                 eoh=' [/INST]',
-                 eoa='</s>',
-                 session_len=2048,
-                 **kwargs):
-        super().__init__(user=user,
-                         eoh=eoh,
-                         eoa=eoa,
-                         session_len=session_len,
-                         **kwargs)
+    def __init__(self, user='[INST] ', eoh=' [/INST]', eoa='</s>', **kwargs):
+        super().__init__(user=user, eoh=eoh, eoa=eoa, **kwargs)
 
     @classmethod
     def match(cls, model_path: str) -> Optional[str]:
@@ -1168,7 +1085,6 @@ class Gemma(BaseChatTemplate):
             return 'gemma'
 
 
-@MODELS.register_module(name=['deepseek-chat'])
 @MODELS.register_module(name=['deepseek'])
 class Deepseek(BaseChatTemplate):
 
@@ -1210,13 +1126,11 @@ class InternVLZH(BaseChatTemplate):
                  eoh=' ',
                  assistant='<bot>: ',
                  eoa='</s>',
-                 session_len=4096,
                  **kwargs):
         super().__init__(user=user,
                          eoh=eoh,
                          assistant=assistant,
                          eoa=eoa,
-                         session_len=session_len,
                          **kwargs)
 
     def get_prompt(self, prompt, sequence_start=True):
@@ -1248,7 +1162,6 @@ class DeepseekVL(BaseChatTemplate):
             eoh='\n\n',
             assistant='Assistant: ',
             eoa='<｜end▁of▁sentence｜>',
-            session_len=16384,
             **kwargs):
         super().__init__(meta_instruction=meta_instruction,
                          eosys=eosys,
@@ -1256,7 +1169,6 @@ class DeepseekVL(BaseChatTemplate):
                          eoh=eoh,
                          assistant=assistant,
                          eoa=eoa,
-                         session_len=session_len,
                          **kwargs)
 
     def get_prompt(self, prompt, sequence_start=True):
@@ -1283,7 +1195,6 @@ class DeepSeek(BaseChatTemplate):
 
     def __init__(
             self,
-            session_len=4096,
             system='',
             meta_instruction="""You are an AI programming assistant, utilizing the Deepseek Coder model, developed by Deepseek Company, and you only answer questions related to computer science. For politically sensitive questions, security and privacy issues, and other non-computer science questions, you will refuse to answer\n""",  # noqa: E501
             eosys='',
@@ -1294,8 +1205,7 @@ class DeepSeek(BaseChatTemplate):
             separator='\n',
             stop_words=['<|EOT|>'],
             **kwargs):
-        super().__init__(session_len=session_len,
-                         system=system,
+        super().__init__(system=system,
                          meta_instruction=meta_instruction,
                          eosys=eosys,
                          user=user,
@@ -1407,8 +1317,7 @@ class DbrxInstruct(BaseChatTemplate):
             return 'dbrx'
 
 
-@MODELS.register_module(name=['internvl-zh-hermes2'])
-@MODELS.register_module(name=['llava-chatml'])
+@MODELS.register_module(name=['llava-chatml', 'internvl-zh-hermes2'])
 class ChatmlDirect(BaseChatTemplate):
 
     def __init__(self,
@@ -1420,7 +1329,6 @@ class ChatmlDirect(BaseChatTemplate):
                  assistant='<|im_start|>assistant\n',
                  eoa='<|im_end|>',
                  separator='',
-                 session_len=4096,
                  **kwargs):
         super().__init__(system,
                          meta_instruction=meta_instruction,
@@ -1430,7 +1338,6 @@ class ChatmlDirect(BaseChatTemplate):
                          assistant=assistant,
                          eoa=eoa,
                          separator=separator,
-                         session_len=session_len,
                          **kwargs)
 
     @classmethod

--- a/lmdeploy/pytorch/chat.py
+++ b/lmdeploy/pytorch/chat.py
@@ -4,9 +4,11 @@ import os
 import random
 from typing import List, Optional
 
+from lmdeploy.archs import get_model_arch
 from lmdeploy.messages import EngineGenerationConfig, PytorchEngineConfig
 from lmdeploy.model import MODELS, ChatTemplateConfig, best_match_model
 from lmdeploy.tokenizer import DetokenizeState, Tokenizer
+from lmdeploy.utils import _get_and_verify_max_len
 
 os.environ['TM_LOG_LEVEL'] = 'ERROR'
 
@@ -93,6 +95,9 @@ def run_chat(model_path: str,
         model = MODELS.get(model_name)()
     stop_words = _stop_words(model.stop_words, tokenizer)
 
+    _, model_config = get_model_arch(model_path)
+    session_len = _get_and_verify_max_len(model_config, None)
+
     while True:
         prompt = input_prompt(model_name)
         if prompt == 'exit':
@@ -105,9 +110,6 @@ def run_chat(model_path: str,
         else:
             prompt = model.get_prompt(prompt, nth_round == 1)
             input_ids = tokenizer.encode(prompt, nth_round == 1)
-            session_len = model.session_len
-            if session_len is None:
-                session_len = tm_model.session_len
             if step >= session_len:
                 print('WARNING: exceed session max length.'
                       ' Please end the session.')
@@ -143,7 +145,6 @@ def main(model_path: str,
          temperature: float = 0.8,
          repetition_penalty: float = 1.0,
          tp: int = 1,
-         stream_output: bool = True,
          adapter: str = None,
          trust_remote_code: bool = True,
          chat_template: str = None):
@@ -159,7 +160,6 @@ def main(model_path: str,
         temperature (float): sampling temperature.
         repetition_penalty (float): parameter to penalize repetition
         tp (int): GPU number used in tensor parallelism
-        stream_output (bool): indicator for streaming output or not
         adapter (str): path to lora adapter.
         trust_remote_code (bool): Trust remote code.
         chat_template (str): A JSON file or string that specifies the

--- a/lmdeploy/turbomind/chat.py
+++ b/lmdeploy/turbomind/chat.py
@@ -2,11 +2,12 @@
 import os
 import random
 
+from lmdeploy.archs import get_model_arch
 from lmdeploy.messages import EngineGenerationConfig, TurbomindEngineConfig
 from lmdeploy.model import MODELS, ChatTemplateConfig, best_match_model
 from lmdeploy.serve.async_engine import deduce_a_name
 from lmdeploy.tokenizer import DetokenizeState
-from lmdeploy.utils import _stop_words
+from lmdeploy.utils import _get_and_verify_max_len, _stop_words
 
 log_level = 'ERROR'
 if os.getenv('TM_LOG_LEVEL') is None:
@@ -91,10 +92,10 @@ def main(model_path: str,
     print('chat_template_config:\n', chat_template_config, sep='', flush=True)
     model = chat_template_config.chat_template
 
-    # engine
-    if session_len is None:
-        session_len = model.session_len
+    _, model_config = get_model_arch(model_path)
+    session_len = _get_and_verify_max_len(model_config, None)
 
+    # engine
     engine_cfg = TurbomindEngineConfig(
         max_batch_size=max_batch_size,
         model_name=model_name,

--- a/tests/test_lmdeploy/test_model.py
+++ b/tests/test_lmdeploy/test_model.py
@@ -84,31 +84,27 @@ def test_vicuna():
 
 def test_internlm_chat():
     prompt = 'hello, can u introduce yourself'
-    model = MODELS.get('internlm-chat-7b')(capability='completion')
+    model = MODELS.get('internlm')(capability='completion')
     assert model.get_prompt(prompt, sequence_start=True) == prompt
     assert model.get_prompt(prompt, sequence_start=False) == prompt
     assert model.stop_words is not None
     assert model.system == '<|System|>:'
-    assert model.session_len == 2048
 
-    model = MODELS.get('internlm-chat-7b')(capability='chat',
-                                           system='Provide answers in Python')
+    model = MODELS.get('internlm')(capability='chat',
+                                   system='Provide answers in Python')
     assert model.get_prompt(prompt, sequence_start=True) != prompt
     assert model.get_prompt(prompt, sequence_start=False) != prompt
     assert model.system == 'Provide answers in Python'
 
-    model = MODELS.get('internlm-chat-7b')(capability='voice')
+    model = MODELS.get('internlm')(capability='voice')
     _prompt = None
     with pytest.raises(AssertionError):
         _prompt = model.get_prompt(prompt, sequence_start=True)
         assert _prompt is None
 
-    model = MODELS.get('internlm-chat-7b-8k')()
-    assert model.session_len == 8192
-
 
 def test_messages2prompt4internlm2_chat():
-    model = MODELS.get('internlm2-chat-7b')()
+    model = MODELS.get('internlm2')()
     # Test with a single message
     messages = [
         {
@@ -169,14 +165,14 @@ def test_messages2prompt4internlm2_chat():
 
 def test_baichuan():
     prompt = 'hello, can u introduce yourself'
-    model = MODELS.get('baichuan-7b')(capability='completion')
+    model = MODELS.get('baichuan2')(capability='completion')
     assert model.get_prompt(prompt, sequence_start=True) == prompt
     assert model.get_prompt(prompt, sequence_start=False) == prompt
     assert model.stop_words is None
 
-    model = MODELS.get('baichuan-7b')(capability='chat')
+    model = MODELS.get('baichuan2')(capability='chat')
     _prompt = model.get_prompt(prompt, sequence_start=True)
-    assert _prompt == prompt
+    assert _prompt == '<reserved_106>' + prompt + '<reserved_107>'
 
 
 def test_llama2():
@@ -211,16 +207,16 @@ def test_llama3():
 
 def test_qwen():
     prompt = 'hello, can u introduce yourself'
-    model = MODELS.get('qwen-7b')(capability='completion')
+    model = MODELS.get('qwen')(capability='completion')
     assert model.get_prompt(prompt, sequence_start=True) == prompt
     assert model.get_prompt(prompt, sequence_start=False) == prompt
     assert model.stop_words is not None
 
-    model = MODELS.get('qwen-7b')(capability='chat')
+    model = MODELS.get('qwen')(capability='chat')
     assert model.get_prompt(prompt, sequence_start=True) != prompt
     assert model.get_prompt(prompt, sequence_start=False) != prompt
 
-    model = MODELS.get('qwen-7b')(capability='voice')
+    model = MODELS.get('qwen')(capability='voice')
     _prompt = None
     with pytest.raises(AssertionError):
         _prompt = model.get_prompt(prompt, sequence_start=True)


### PR DESCRIPTION
## Motivation

Since the triton inference server backend "turbomind_backend" was removed in #1986, the `session_len` accessed by the removed `Chatbot` can be deleted too.

