### PR TITLE
Strict check for `name_map` in `InternLM2Chat7B`

### DIFF
--- a/lmdeploy/model.py
+++ b/lmdeploy/model.py
@@ -506,9 +506,10 @@ class InternLM2Chat7B(InternLMChat7B):
         for message in messages:
             role = message['role']
             content = message['content']
-            begin = box_map[role].strip(
-            ) + f" name={name_map[message['name']]}\n" if 'name' in message else box_map[
-                role]
+            if 'name' in message and message['name'] in name_map:
+                begin = box_map[role].strip() + f" name={name_map[message['name']]}\n"
+            else:
+                begin = box_map[role]
             ret += f'{begin}{content}{eox_map[role]}'
         ret += f'{self.assistant}'
         return ret

--- a/lmdeploy/model.py
+++ b/lmdeploy/model.py
@@ -507,7 +507,8 @@ class InternLM2Chat7B(InternLMChat7B):
             role = message['role']
             content = message['content']
             if 'name' in message and message['name'] in name_map:
-                begin = box_map[role].strip() + f" name={name_map[message['name']]}\n"
+                begin = box_map[role].strip(
+                ) + f" name={name_map[message['name']]}\n"
             else:
                 begin = box_map[role]
             ret += f'{begin}{content}{eox_map[role]}'

--- a/tests/test_lmdeploy/test_model.py
+++ b/tests/test_lmdeploy/test_model.py
@@ -162,6 +162,38 @@ def test_messages2prompt4internlm2_chat():
     actual_prompt = model.messages2prompt(messages, tools=tools)
     assert actual_prompt == expected_prompt
 
+    # Test with a message where 'name' is not in name_map
+    messages_invalid_name = [
+        {
+            'role': 'system',
+            'name': 'invalid_name',
+            'content': 'You have access to python environment.'
+        },
+        {
+            'role': 'user',
+            'content': 'use python draw a line'
+        },
+        {
+            'role': 'assistant',
+            'content': '\ncode\n'
+        },
+        {
+            'role': 'environment',
+            'name': 'invalid_name',
+            'content': "[{'type': 'image', 'content': 'image url'}]"
+        },
+    ]
+    expected_prompt_invalid_name = (
+        model.system.strip() +
+        '\nYou have access to python environment.' +
+        model.eosys + model.user + 'use python draw a line' + model.eoh +
+        model.assistant +
+        '\ncode\n' + model.eoa +
+        model.separator + model.environment.strip() +
+        "\n[{'type': 'image', 'content': 'image url'}]" +
+        model.eoenv + model.assistant)
+    actual_prompt_invalid_name = model.messages2prompt(messages_invalid_name)
+    assert actual_prompt_invalid_name == expected_prompt_invalid_name
 
 def test_llama3_1():
     model = MODELS.get('llama3_1')()

--- a/tests/test_lmdeploy/test_model.py
+++ b/tests/test_lmdeploy/test_model.py
@@ -184,16 +184,15 @@ def test_messages2prompt4internlm2_chat():
         },
     ]
     expected_prompt_invalid_name = (
-        model.system.strip() +
-        '\nYou have access to python environment.' +
+        model.system.strip() + '\nYou have access to python environment.' +
         model.eosys + model.user + 'use python draw a line' + model.eoh +
-        model.assistant +
-        '\ncode\n' + model.eoa +
-        model.separator + model.environment.strip() +
-        "\n[{'type': 'image', 'content': 'image url'}]" +
-        model.eoenv + model.assistant)
+        model.assistant + '\ncode\n' + model.eoa + model.separator +
+        model.environment.strip() +
+        "\n[{'type': 'image', 'content': 'image url'}]" + model.eoenv +
+        model.assistant)
     actual_prompt_invalid_name = model.messages2prompt(messages_invalid_name)
     assert actual_prompt_invalid_name == expected_prompt_invalid_name
+
 
 def test_llama3_1():
     model = MODELS.get('llama3_1')()


### PR DESCRIPTION
Make modifications to the method to avoid leaking from name check. Cooperating with langgraph agent nodes tutorial.

## Motivation

Hello, when I was following the tutorial in [LangGraph Multi Agent System](https://langchain-ai.github.io/langgraph/tutorials/multi_agent/multi-agent-collaboration/) to build a multi-agent program, I was also deploying local LLM using our LMdeploy tool with `InternLM2.5-7b-chat`. And I was using langchain's `ChatOpenAI` class to intereact with my local serving system. Like this:

```python
llm = ChatOpenAI(model="/root/.cache/modelscope/hub/Shanghai_AI_Laboratory/internlm2_5-7b-chat", 
                 api_key="test",
                 base_url="http://localhost:23333/v1")
```

And after running their code, I found error from our serving sys:

```
INFO:     127.0.0.1:40438 - "POST /v1/chat/completions HTTP/1.1" 500 Internal Server Error
ERROR:    Exception in ASGI application
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/dist-packages/uvicorn/protocols/http/httptools_impl.py", line 399, in run_asgi
    result = await app(  # type: ignore[func-returns-value]
  File "/usr/local/lib/python3.8/dist-packages/uvicorn/middleware/proxy_headers.py", line 70, in __call__
    return await self.app(scope, receive, send)
  File "/usr/local/lib/python3.8/dist-packages/fastapi/applications.py", line 1054, in __call__
    await super().__call__(scope, receive, send)
  File "/usr/local/lib/python3.8/dist-packages/starlette/applications.py", line 123, in __call__
    await self.middleware_stack(scope, receive, send)
  File "/usr/local/lib/python3.8/dist-packages/starlette/middleware/errors.py", line 186, in __call__
    raise exc
  File "/usr/local/lib/python3.8/dist-packages/starlette/middleware/errors.py", line 164, in __call__
    await self.app(scope, receive, _send)
  File "/usr/local/lib/python3.8/dist-packages/starlette/middleware/cors.py", line 85, in __call__
    await self.app(scope, receive, send)
  File "/usr/local/lib/python3.8/dist-packages/starlette/middleware/exceptions.py", line 65, in __call__
    await wrap_app_handling_exceptions(self.app, conn)(scope, receive, send)
  File "/usr/local/lib/python3.8/dist-packages/starlette/_exception_handler.py", line 64, in wrapped_app
    raise exc
  File "/usr/local/lib/python3.8/dist-packages/starlette/_exception_handler.py", line 53, in wrapped_app
    await app(scope, receive, sender)
  File "/usr/local/lib/python3.8/dist-packages/starlette/routing.py", line 756, in __call__
    await self.middleware_stack(scope, receive, send)
  File "/usr/local/lib/python3.8/dist-packages/starlette/routing.py", line 776, in app
    await route.handle(scope, receive, send)
  File "/usr/local/lib/python3.8/dist-packages/starlette/routing.py", line 297, in handle
    await self.app(scope, receive, send)
  File "/usr/local/lib/python3.8/dist-packages/starlette/routing.py", line 77, in app
    await wrap_app_handling_exceptions(app, request)(scope, receive, send)
  File "/usr/local/lib/python3.8/dist-packages/starlette/_exception_handler.py", line 64, in wrapped_app
    raise exc
  File "/usr/local/lib/python3.8/dist-packages/starlette/_exception_handler.py", line 53, in wrapped_app
    await app(scope, receive, sender)
  File "/usr/local/lib/python3.8/dist-packages/starlette/routing.py", line 72, in app
    response = await func(request)
  File "/usr/local/lib/python3.8/dist-packages/fastapi/routing.py", line 278, in app
    raw_response = await run_endpoint_function(
  File "/usr/local/lib/python3.8/dist-packages/fastapi/routing.py", line 191, in run_endpoint_function
    return await dependant.call(**values)
  File "/usr/local/lib/python3.8/dist-packages/lmdeploy/serve/openai/api_server.py", line 529, in chat_completions_v1
    async for res in result_generator:
  File "/usr/local/lib/python3.8/dist-packages/lmdeploy/serve/async_engine.py", line 571, in generate
    prompt_input = await self._get_prompt_input(prompt,
  File "/usr/local/lib/python3.8/dist-packages/lmdeploy/serve/async_engine.py", line 521, in _get_prompt_input
    prompt = chat_template.messages2prompt(prompt,
  File "/usr/local/lib/python3.8/dist-packages/lmdeploy/model.py", line 560, in messages2prompt
    ) + f" name={name_map[message['name']]}\n" if 'name' in message else box_map[
KeyError: 'Researcher'
```

And soon I checked the source code, and even print the variables:

```python
# This is in `messages2prompt` function of `InternLM2Chat7B` class, `model.py`
for message in messages:
    print(f"message: {message}")    # MODIFY
    role = message['role']
    content = message['content']
    print(f"name_map: {name_map}")  # MODIFY
    if 'name' in message:     # MODIFY
        print(f"message_name: {message['name']}")    # MODIFY
    print("=====")      # MODIFY
```

The outputs were:

```
message: {'content': "To fetch the UK's GDP over the past year, I will need to search for a reliable data source. I will then use the gathered data to create a line graph. Let's begin by searching for the UK's GDP data source.", 'name': 'user', 'role': 'assistant', 'tool_calls': [{'type': 'function', 'id': '0', 'function': {'name': 'google_search', 'arguments': '{"query": "UK GDP data source"}'}}]}
name_map: {'plugin': '<|plugin|>', 'interpreter': '<|interpreter|>'}
message_name: user
```

And I found the reason that: **the `message['name']` should be `'plugin'`, but here it turned out to be a totally different one.**

So anyway I made a modification to the code, to make a more strict dict keys check. 

And then everything works well.  :)

## Modification

Original code:

```python
begin = box_map[role].strip(
) + f" name={name_map[message['name']]}\n" if 'name' in message else box_map[
    role]
```

After modification:

```python
if 'name' in message and message['name'] in name_map:
    begin = box_map[role].strip() + f" name={name_map[message['name']]}\n"
else:
    begin = box_map[role]
```

## BC-breaking (Optional)

I think there will be no affection to down-stream repositories. It is just a tiny bug fix.

## Use cases (Optional)

None.