### PR TITLE
update base image to support cuda12.4 in dockerfile

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -80,6 +80,13 @@ jobs:
           echo $TAG
           docker build . -f docker/Dockerfile -t ${TAG} --build-arg CUDA_VERSION=${CUDA_VERSION}
           docker push $TAG
+      - name: Push docker image latest-cu12 as latest
+        if: endsWith(env.TAG, 'latest-cu12') == true
+        run: |
+          export latest_TAG=${TAG_PREFIX}:latest
+          echo $latest_TAG
+          docker tag $TAG $latest_TAG
+          docker push $latest_TAG
       - name: Push docker image with released tag
         if: startsWith(github.ref, 'refs/tags/') == true
         run: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -10,6 +10,10 @@ on:
       - "benchmark/**"
       - "tests/**"
       - "**/*.md"
+      - "autotest/**"
+      - "builder/**"
+      - "k8s/**"
+
     branches:
       - main
     tags:
@@ -70,7 +74,7 @@ jobs:
       - name: Build and push Docker image
         run: |
           echo $TAG
-          docker build . -f docker/Dockerfile -t ${TAG} --no-cache
+          docker build . -f docker/Dockerfile -t ${TAG}
           docker push $TAG
       - name: Push docker image with released tag
         if: startsWith(github.ref, 'refs/tags/') == true

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -35,9 +35,13 @@ jobs:
   publish_docker_image:
     runs-on: ubuntu-latest
     environment: 'prod'
+    strategy:
+      matrix:
+        cuda_version: [cu12, cu11]
     env:
+      CUDA_VERSION: ${{ matrix.cuda_version }}
       TAG_PREFIX: "openmmlab/lmdeploy"
-      TAG: "openmmlab/lmdeploy:latest"
+      TAG: "openmmlab/lmdeploy:latest-${{matrix.cuda_version}}"
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -68,18 +72,18 @@ jobs:
       - name: Update docker TAG from workflow input
         if: github.event_name == 'workflow_dispatch'
         run: |
-          export TAG=$TAG_PREFIX:${{github.event.inputs.image_tag}}
+          export TAG=$TAG_PREFIX:${{github.event.inputs.image_tag}}-${CUDA_VERSION}
           echo $TAG
           echo "TAG=${TAG}" >> $GITHUB_ENV
       - name: Build and push Docker image
         run: |
           echo $TAG
-          docker build . -f docker/Dockerfile -t ${TAG}
+          docker build . -f docker/Dockerfile -t ${TAG} --build-arg CUDA_VERSION=${CUDA_VERSION}
           docker push $TAG
       - name: Push docker image with released tag
         if: startsWith(github.ref, 'refs/tags/') == true
         run: |
-          export RELEASE_TAG=${TAG_PREFIX}:${{github.ref_name}}
+          export RELEASE_TAG=${TAG_PREFIX}:${{github.ref_name}}-${CUDA_VERSION}
           echo $RELEASE_TAG
           docker tag $TAG $RELEASE_TAG
           docker push $RELEASE_TAG

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -27,7 +27,7 @@ RUN python3 -m pip install --no-cache-dir --upgrade pip setuptools==69.5.1 &&\
 # install openmpi
 RUN wget https://download.open-mpi.org/release/open-mpi/v4.1/openmpi-4.1.5.tar.gz &&\
     tar xf openmpi-4.1.5.tar.gz && cd openmpi-4.1.5 && ./configure --prefix=/usr/local/openmpi &&\
-    make -j$(nproc) && make install && rm -rf openmpi-4.1.5*
+    make -j$(nproc) && make install && cd .. && rm -rf openmpi-4.1.5*
 
 ENV PATH=$PATH:/usr/local/openmpi/bin
 ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/openmpi/lib

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,7 +15,7 @@ ARG TORCHVISION_VERSION=0.18.0
 
 RUN rm /etc/apt/sources.list.d/cuda*.list && apt-get update -y && apt-get install -y software-properties-common wget vim &&\
     add-apt-repository ppa:deadsnakes/ppa -y && apt-get update -y && apt-get install -y --no-install-recommends \
-    rapidjson-dev libgoogle-glog-dev gdb python${PYTHON_VERSION} python${PYTHON_VERSION}-dev python${PYTHON_VERSION}-venv \
+    ninja-build rapidjson-dev libgoogle-glog-dev gdb python${PYTHON_VERSION} python${PYTHON_VERSION}-dev python${PYTHON_VERSION}-venv \
     && apt-get clean -y && rm -rf /var/lib/apt/lists/* && cd /opt && python3 -m venv py3
 
 ENV PATH=/opt/py3/bin:$PATH
@@ -42,17 +42,8 @@ WORKDIR /opt/lmdeploy
 RUN cd /opt/lmdeploy &&\
     python3 -m pip install --no-cache-dir -r requirements.txt &&\
     mkdir -p build && cd build &&\
-    cmake .. \
-        -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-        -DCMAKE_EXPORT_COMPILE_COMMANDS=1 \
-        -DCMAKE_INSTALL_PREFIX=/opt/lmdeploy/install \
-        -DBUILD_PY_FFI=ON \
-        -DBUILD_MULTI_GPU=ON \
-        -DBUILD_CUTLASS_MOE=OFF \
-        -DBUILD_CUTLASS_MIXED_GEMM=OFF \
-        -DCMAKE_CUDA_FLAGS="-lineinfo" \
-        -DUSE_NVTX=ON &&\
-    make -j$(nproc) && make install &&\
+    sh ../generate.sh &&\
+    ninja -j$(nproc) && ninja install &&\
     cd .. &&\
     python3 -m pip install -e . &&\
     rm -rf build

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,7 +9,10 @@ ENV CUDA_VERSION_SHORT=cu118
 FROM ${CUDA_VERSION} AS final
 
 ARG PYTHON_VERSION=3.10
+
+ARG TORCH_VERSION=2.3.0
 ARG TRITON_VERSION=2.1.0
+ARG TORCHVISION_VERSION=0.18.0
 
 RUN rm /etc/apt/sources.list.d/cuda*.list && apt-get update -y && apt-get install -y software-properties-common wget vim &&\
     add-apt-repository ppa:deadsnakes/ppa -y && apt-get update -y && apt-get install -y --no-install-recommends \
@@ -19,7 +22,7 @@ RUN rm /etc/apt/sources.list.d/cuda*.list && apt-get update -y && apt-get instal
 ENV PATH=/opt/py3/bin:$PATH
 
 RUN python3 -m pip install --no-cache-dir --upgrade pip setuptools==69.5.1 &&\
-    python3 -m pip install --no-cache-dir torch==2.3.0 torchvision==0.18.0 --index-url https://download.pytorch.org/whl/${CUDA_VERSION_SHORT} &&\
+    python3 -m pip install --no-cache-dir torch==${TORCH_VERSION} torchvision==${TORCHVISION_VERSION} --index-url https://download.pytorch.org/whl/${CUDA_VERSION_SHORT} &&\
     python3 -m pip install --no-cache-dir cmake packaging wheel
 
 # install openmpi

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,14 +1,25 @@
-FROM nvcr.io/nvidia/tritonserver:22.12-py3
+FROM nvidia/cuda:12.4.1-devel-ubuntu22.04
 
-RUN rm /etc/apt/sources.list.d/cuda*.list && apt-get update && apt-get install -y --no-install-recommends \
-    rapidjson-dev libgoogle-glog-dev gdb python3.8-venv \
-    && rm -rf /var/lib/apt/lists/* && cd /opt && python3 -m venv py38
+ARG PYTHON_VERSION=3.10
 
-ENV PATH=/opt/py38/bin:$PATH
+RUN rm /etc/apt/sources.list.d/cuda*.list && apt-get update -y && apt-get install -y software-properties-common wget vim &&\
+    add-apt-repository ppa:deadsnakes/ppa -y && apt-get update -y && apt-get install -y --no-install-recommends \
+    rapidjson-dev libgoogle-glog-dev gdb python${PYTHON_VERSION} python${PYTHON_VERSION}-dev python${PYTHON_VERSION}-venv \
+    && apt-get clean -y && rm -rf /var/lib/apt/lists/* && cd /opt && python3 -m venv py3
+
+ENV PATH=/opt/py3/bin:$PATH
 
 RUN python3 -m pip install --no-cache-dir --upgrade pip setuptools==69.5.1 &&\
-    python3 -m pip install --no-cache-dir torch==2.1.0 torchvision==0.16.0 --index-url https://download.pytorch.org/whl/cu118 &&\
+    python3 -m pip install --no-cache-dir torch==2.3.0 torchvision==0.18.0 --index-url https://download.pytorch.org/whl/cu121 &&\
     python3 -m pip install --no-cache-dir cmake packaging wheel
+
+# install openmpi
+RUN wget https://download.open-mpi.org/release/open-mpi/v4.1/openmpi-4.1.5.tar.gz &&\
+    tar xf openmpi-4.1.5.tar.gz && cd openmpi-4.1.5 && ./configure --prefix=/usr/local/openmpi &&\
+    make -j$(nproc) && make install && rm -rf openmpi-4.1.5*
+
+ENV PATH=$PATH:/usr/local/openmpi/bin
+ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/openmpi/lib
 
 ENV NCCL_LAUNCH_MODE=GROUP
 
@@ -33,8 +44,8 @@ RUN cd /opt/lmdeploy &&\
     make -j$(nproc) && make install &&\
     cd .. &&\
     python3 -m pip install -e . &&\
+    python3 -m pip install --no-cache-dir triton==2.1.0 &&\
     rm -rf build
 
-ENV LD_LIBRARY_PATH=/opt/tritonserver/lib:$LD_LIBRARY_PATH
 # explicitly set ptxas path for triton
 ENV TRITON_PTXAS_PATH=/usr/local/cuda/bin/ptxas

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,7 +11,6 @@ FROM ${CUDA_VERSION} AS final
 ARG PYTHON_VERSION=3.10
 
 ARG TORCH_VERSION=2.3.0
-ARG TRITON_VERSION=2.1.0
 ARG TORCHVISION_VERSION=0.18.0
 
 RUN rm /etc/apt/sources.list.d/cuda*.list && apt-get update -y && apt-get install -y software-properties-common wget vim &&\
@@ -46,7 +45,7 @@ RUN cd /opt/lmdeploy &&\
     cmake .. \
         -DCMAKE_BUILD_TYPE=RelWithDebInfo \
         -DCMAKE_EXPORT_COMPILE_COMMANDS=1 \
-        -DCMAKE_INSTALL_PREFIX=/opt/tritonserver \
+        -DCMAKE_INSTALL_PREFIX=/opt/lmdeploy/install \
         -DBUILD_PY_FFI=ON \
         -DBUILD_MULTI_GPU=ON \
         -DBUILD_CUTLASS_MOE=OFF \
@@ -56,8 +55,10 @@ RUN cd /opt/lmdeploy &&\
     make -j$(nproc) && make install &&\
     cd .. &&\
     python3 -m pip install -e . &&\
-    python3 -m pip install --no-cache-dir triton==${TRITON_VERSION} &&\
     rm -rf build
+
+ENV LD_LIBRARY_PATH=/opt/lmdeploy/install/lib:$LD_LIBRARY_PATH
+ENV PATH=/opt/lmdeploy/install/bin:$PATH
 
 # explicitly set ptxas path for triton
 ENV TRITON_PTXAS_PATH=/usr/local/cuda/bin/ptxas

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,15 @@
-FROM nvidia/cuda:12.4.1-devel-ubuntu22.04
+ARG CUDA_VERSION=cu12
+
+FROM nvidia/cuda:12.4.1-devel-ubuntu22.04 AS cu12
+ENV CUDA_VERSION_SHORT=cu121
+
+FROM nvidia/cuda:11.8.0-devel-ubuntu22.04 AS cu11
+ENV CUDA_VERSION_SHORT=cu118
+
+FROM ${CUDA_VERSION} AS final
 
 ARG PYTHON_VERSION=3.10
+ARG TRITON_VERSION=2.1.0
 
 RUN rm /etc/apt/sources.list.d/cuda*.list && apt-get update -y && apt-get install -y software-properties-common wget vim &&\
     add-apt-repository ppa:deadsnakes/ppa -y && apt-get update -y && apt-get install -y --no-install-recommends \
@@ -10,7 +19,7 @@ RUN rm /etc/apt/sources.list.d/cuda*.list && apt-get update -y && apt-get instal
 ENV PATH=/opt/py3/bin:$PATH
 
 RUN python3 -m pip install --no-cache-dir --upgrade pip setuptools==69.5.1 &&\
-    python3 -m pip install --no-cache-dir torch==2.3.0 torchvision==0.18.0 --index-url https://download.pytorch.org/whl/cu121 &&\
+    python3 -m pip install --no-cache-dir torch==2.3.0 torchvision==0.18.0 --index-url https://download.pytorch.org/whl/${CUDA_VERSION_SHORT} &&\
     python3 -m pip install --no-cache-dir cmake packaging wheel
 
 # install openmpi
@@ -44,7 +53,7 @@ RUN cd /opt/lmdeploy &&\
     make -j$(nproc) && make install &&\
     cd .. &&\
     python3 -m pip install -e . &&\
-    python3 -m pip install --no-cache-dir triton==2.1.0 &&\
+    python3 -m pip install --no-cache-dir triton==${TRITON_VERSION} &&\
     rm -rf build
 
 # explicitly set ptxas path for triton

--- a/generate.sh
+++ b/generate.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+WORKSPACE_PATH=$(dirname "$(readlink -f "$0")")
 
 builder="-G Ninja"
 
@@ -9,7 +10,7 @@ fi
 cmake ${builder} .. \
     -DCMAKE_BUILD_TYPE=RelWithDebInfo \
     -DCMAKE_EXPORT_COMPILE_COMMANDS=1 \
-    -DCMAKE_INSTALL_PREFIX=./install \
+    -DCMAKE_INSTALL_PREFIX=${WORKSPACE_PATH}/install \
     -DBUILD_PY_FFI=ON \
     -DBUILD_MULTI_GPU=ON \
     -DCMAKE_CUDA_FLAGS="-lineinfo" \


### PR DESCRIPTION
## Motivation

update base image to cuda12.4

requested in https://github.com/InternLM/lmdeploy/issues/2164

## Modification

Change dockerfile base image and support cu118 and cu124

### build cu12
```
cd ~/lmdeploy
docker build . -f docker/Dockerfile -t lmdeploy:cu12 --build-arg CUDA_VERSION=cu12
```

### build cu11
```
cd ~/lmdeploy
docker build . -f docker/Dockerfile -t lmdeploy:cu11 --build-arg CUDA_VERSION=cu11
```

###  docker build ci example

https://github.com/RunningLeon/lmdeploy/actions/runs/10211052906

![image](https://github.com/user-attachments/assets/2bd8a0e7-8764-4c77-8941-84c7eb2a99cb)

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
