### PR TITLE
Fix chunked prefill

### DIFF
--- a/lmdeploy/turbomind/deploy/target_model/base.py
+++ b/lmdeploy/turbomind/deploy/target_model/base.py
@@ -54,6 +54,7 @@ class TurbomindModelConfig:
     size_per_head: int = 128
     group_size: int = 0
     max_batch_size: int = 64
+    max_prefill_token_num: int = 8192
     max_context_token_num: int = 1
     step_length: int = 1
     cache_max_entry_count: float = 0.8

--- a/lmdeploy/turbomind/deploy/target_model/base.py
+++ b/lmdeploy/turbomind/deploy/target_model/base.py
@@ -63,7 +63,6 @@ class TurbomindModelConfig:
     enable_prefix_caching: bool = False
     num_tokens_per_iter: int = 0
     max_prefill_iters: int = 1
-    extra_tokens_per_iter: int = 0
     use_context_fmha: int = 1
     quant_policy: int = 0
     max_position_embeddings: int = 0

--- a/src/turbomind/models/llama/LlamaBatch.cc
+++ b/src/turbomind/models/llama/LlamaBatch.cc
@@ -18,7 +18,6 @@
 #include "src/turbomind/utils/constant.h"
 #include "src/turbomind/utils/cuda_utils.h"
 #include "src/turbomind/utils/debug_utils.h"
-#include "src/turbomind/utils/gemm_test/gemm_func.h"
 #include "src/turbomind/utils/logger.h"
 #include <algorithm>
 #include <cmath>
@@ -265,18 +264,24 @@ void LlamaBatch<T>::ProcessInferRequests(const Requests& requests)
         const int  input_length = r->inputs[rank_].getVal<int>("input_lengths");
         const int* input_ids    = r->inputs[rank_].getPtr<int>("input_ids");
 
-        // `output_ids` contains all token ids of the sequences
-        const auto output_ids_base = state.output_ids + session_len_ * idx;
-        auto       output_ids      = output_ids_base;
+        {
+            // `output_ids` contains all token ids of the sequences
+            const auto output_ids_base = state.output_ids + session_len_ * idx;
+            auto       output_ids      = output_ids_base;
+            // copy history tokens
+            if (!seq.tokens.empty()) {
+                output_ids = Copy(seq.tokens.data(), seq.tokens.size(), output_ids);
+            }
 
-        // copy history tokens
-        if (!seq.tokens.empty()) {
-            output_ids = Copy(seq.tokens.data(), seq.tokens.size(), output_ids);
-        }
+            // copy input tokens
+            if (input_length) {
+                output_ids = Copy(input_ids, input_length, output_ids);
+            }
 
-        // copy input tokens
-        if (input_length) {
-            output_ids = Copy(input_ids, input_length, output_ids);
+            // total context length (history + input)
+            state.h_prompt_length[idx]  = output_ids - output_ids_base;
+            state.h_context_length[idx] = output_ids - output_ids_base;
+            state.h_finished[idx]       = false;
         }
 
         // copy input tokens to prompt for prefix matching
@@ -338,11 +343,6 @@ void LlamaBatch<T>::ProcessInferRequests(const Requests& requests)
                 }
             }
         }
-
-        // total context length (history + input)
-        state.h_prompt_length[idx]  = output_ids - output_ids_base;
-        state.h_context_length[idx] = output_ids - output_ids_base;
-        state.h_finished[idx]       = false;
 
         const int request_output_len = state.requests[idx]->inputs[rank_].getVal<int>("request_output_len");
         state.seq_len_limit[idx]     = state.h_context_length[idx] + request_output_len;
@@ -424,9 +424,9 @@ void LlamaBatch<T>::ProcessInferRequests(const Requests& requests)
 }
 
 template<typename T>
-void LlamaBatch<T>::AdjustMaxInputCount(GenerationState&                    g,
-                                        const std::vector<const Sequence*>& sequences,
-                                        const std::vector<int>&             context_length)
+int LlamaBatch<T>::AdjustMaxInputCount(GenerationState&                    g,
+                                       const std::vector<const Sequence*>& sequences,
+                                       const std::vector<int>&             context_length)
 {
     int input_count = 0;
     for (int i = 0; i < sequences.size(); ++i) {
@@ -448,11 +448,12 @@ void LlamaBatch<T>::AdjustMaxInputCount(GenerationState&                    g,
         x = std::max(x, input_count);
     }
 
+    // Enlarge to satisfy `max_prefill_iters_`
     input_count = std::max(g.min_input_count.front() + batch_size, num_tokens_per_iter_);
-    input_count = std::min(input_count, max_context_token_num_);
-    // update max input count
-    g.max_input_count1 = input_count;
-    g.max_input_count2 = std::min(input_count + extra_tokens_per_iter_, max_context_token_num_);
+    // Clamp to conform memory constraint
+    input_count = std::min(input_count, max_forward_token_num_);
+
+    return input_count;
 }
 
 template<typename T>
@@ -493,10 +494,8 @@ void LlamaBatch<T>::Initialize(GenerationState& g)
     process(state_);
     process(incoming_);
 
-    auto adjust = [this, &g](const Sequences&        sequences,
-                             const std::vector<int>& context_length) -> std::pair<int, int> {
-        AdjustMaxInputCount(g, sequences, context_length);
-        return {g.max_input_count1, g.max_input_count2};
+    auto adjust = [this, &g](const Sequences& sequences, const std::vector<int>& context_length) -> int {
+        return AdjustMaxInputCount(g, sequences, context_length);
     };
 
     // TM_LOG_INFO("max_input_count %d", max_input_count);
@@ -711,19 +710,19 @@ void LlamaBatch<T>::AllocateBuffer(size_t batch_size, size_t session_len, int ca
         batch_size * ((session_len + cache_block_seq_len - 1) / cache_block_seq_len) + 1;
 
     if (model_->lora_params_.policy == LoraPolicy::kPlora) {
-        lora_mask_buf_ = (int*)allocator_->reMalloc(lora_mask_buf_, sizeof(int) * max_context_token_num_, false);
-        size_t sz      = sizeof(T) * max_context_token_num_ * (hidden_units + model_->lora_params_.max_wo_r);
+        lora_mask_buf_ = (int*)allocator_->reMalloc(lora_mask_buf_, sizeof(int) * max_forward_token_num_, false);
+        size_t sz      = sizeof(T) * max_forward_token_num_ * (hidden_units + model_->lora_params_.max_wo_r);
         context_decoder_output_buf_ = (T*)allocator_->reMalloc(context_decoder_output_buf_, sz, false);
     }
     else {
         context_decoder_output_buf_ = (T*)allocator_->reMalloc(
-            context_decoder_output_buf_, sizeof(T) * max_context_token_num_ * hidden_units, false);
+            context_decoder_output_buf_, sizeof(T) * max_forward_token_num_ * hidden_units, false);
     }
 
     context_decoder_input_buf_ =
-        (T*)allocator_->reMalloc(context_decoder_input_buf_, sizeof(T) * max_context_token_num_ * hidden_units, false);
+        (T*)allocator_->reMalloc(context_decoder_input_buf_, sizeof(T) * max_forward_token_num_ * hidden_units, false);
     context_decoder_ids_buf_ =
-        (int*)allocator_->reMalloc(context_decoder_ids_buf_, sizeof(int) * max_context_token_num_, false);
+        (int*)allocator_->reMalloc(context_decoder_ids_buf_, sizeof(int) * max_forward_token_num_, false);
 
     decoder_input_buf_  = (T*)allocator_->reMalloc(decoder_input_buf_, sizeof(T) * batchxbeam * hidden_units, false);
     decoder_output_buf_ = (T*)allocator_->reMalloc(decoder_output_buf_, sizeof(T) * batchxbeam * hidden_units, false);
@@ -932,6 +931,7 @@ void LlamaBatch<T>::FreeBuffer()
 template<typename T>
 LlamaBatch<T>::LlamaBatch(const EngineParams& params, int cache_block_seq_len, int quant_policy, LlamaV2<T>* model):
     max_batch_size_(params.max_batch_size),
+    max_forward_token_num_(params.max_prefill_token_num + params.max_batch_size),
     max_context_token_num_(params.max_context_token_num),
     session_len_(params.session_len),
     rank_(model->tensor_para_.rank_),
@@ -981,6 +981,7 @@ LlamaBatch<T>::LlamaBatch(const EngineParams& params, int cache_block_seq_len, i
     }
 
     FT_CHECK(max_context_token_num_ >= session_len_);
+    FT_CHECK(max_forward_token_num_ >= max_batch_size_);
 
     for (auto& s : states_) {
         s.requests.resize(max_batch_size_);
@@ -1459,22 +1460,17 @@ void LlamaBatch<T>::InternalThreadEntry(int device_id)
         FT_CHECK(step_length_ == 1);
 
         if (state_->active_size) {
-            for (int i = 0; i < step_length_; ++i) {
-                //
-                auto cont = Forward(g, i);
-                //
-                if (auto signals = Finish(g); !signals.empty()) {
-                    if (g.finished_count) {
-                        // Finished requests and corresponding output tensors will be released when notified
-                        // wait for all ranks to ensure no rank (except for output thread) will access related
-                        // resources
-                        shared_state->barrier->wait();
-                    }
-                    SendSignals(std::move(signals));
+            //
+            (void)Forward(g);
+            //
+            if (auto signals = Finish(g); !signals.empty()) {
+                if (g.finished_count) {
+                    // Finished requests and corresponding output tensors will be released when notified
+                    // wait for all ranks to ensure no rank (except for output thread) will access related
+                    // resources
+                    shared_state->barrier->wait();
                 }
-                if (!cont) {  // early exit
-                    break;
-                }
+                SendSignals(std::move(signals));
             }
         }
 
@@ -1540,7 +1536,7 @@ void LlamaBatch<T>::OutputThreadEntry()
 }
 
 template<typename T>
-bool LlamaBatch<T>::Forward(GenerationState& g, int iter)
+bool LlamaBatch<T>::Forward(GenerationState& g)
 {
     NvtxScope _("Forward");
 
@@ -1556,26 +1552,17 @@ bool LlamaBatch<T>::Forward(GenerationState& g, int iter)
     int               pf_offset = -1;
     std::vector<int*> input_d_ptrs(active_size);
 
-    if (iter == 0) {  // The first iter may have pre-fill tokens
-        for (int i = 0; i < active_size; ++i) {
-            const auto& seq = *state_->sequences[i];
-            // const int   missing    = state_->h_context_length[i] - seq.cache_len;
-            FT_CHECK(seq.input_length >= 1);
-            h_input_length_buf_[i] = seq.input_length;
-            input_d_ptrs[i]        = state_->output_ids + i * session_len_ + seq.cache_len;
-            if (seq.input_length > 1 && pf_offset < 0) {
-                pf_offset = i;
-            }
-        }
-        if (pf_offset < 0) {
-            pf_offset = active_size;
+    for (int i = 0; i < active_size; ++i) {
+        const auto& seq = *state_->sequences[i];
+        // const int   missing = state_->h_context_length[i] - seq.cache_len;
+        FT_CHECK(seq.input_length >= 1);
+        h_input_length_buf_[i] = seq.input_length;
+        input_d_ptrs[i]        = state_->output_ids + i * session_len_ + seq.cache_len;
+        if (seq.input_length > 1 && pf_offset < 0) {
+            pf_offset = i;
         }
     }
-    else {
-        for (int i = 0; i < active_size; ++i) {
-            h_input_length_buf_[i] = 1;
-            input_d_ptrs[i]        = state_->output_ids + i * session_len_ + state_->h_context_length[i] - 1;
-        }
+    if (pf_offset < 0) {
         pf_offset = active_size;
     }
 
@@ -1587,23 +1574,23 @@ bool LlamaBatch<T>::Forward(GenerationState& g, int iter)
 
     // Find mini-batch offsets: input length > 1 ? prefill() : decode()
     // Constraints on mini-batches
-    // - `context_decoder_input` and `context_decoder_output` can hold `max_context_token_num_` tokens w/o padding
+    //   sum(Q) <= `max_forward_token_num` && sum(K) <= `max_context_token_num`
     std::vector<int> offsets{0};
     // initialize first mini-batch with decode tokens
-    int accum_q_count = pf_offset;
-    int accum_k_count = 0;  // only for prefill
+    int sum_q = pf_offset;
+    int sum_k = 0;  // only for prefill
     for (int i = pf_offset; i < active_size; ++i) {
-        FT_CHECK(iter == 0);
-        int q_count = accum_q_count + h_input_length_buf_[i];
-        int k_count = accum_k_count + state_->h_context_length[i];
-        if (q_count <= max_context_token_num_ && k_count <= max_context_token_num_) {
-            accum_q_count = q_count;
-            accum_k_count = k_count;
+        FT_CHECK(h_input_length_buf_[i] <= max_forward_token_num_);
+        const int q = sum_q + h_input_length_buf_[i];
+        const int k = sum_k + state_->h_context_length[i];
+        if (q <= max_forward_token_num_ && k <= max_context_token_num_) {
+            sum_q = q;
+            sum_k = k;
         }
         else {
             offsets.push_back(i);
-            accum_q_count = h_input_length_buf_[i];
-            accum_k_count = state_->h_context_length[i];
+            sum_q = h_input_length_buf_[i];
+            sum_k = state_->h_context_length[i];
         }
     }
     offsets.push_back(active_size);
@@ -1621,14 +1608,18 @@ bool LlamaBatch<T>::Forward(GenerationState& g, int iter)
         std::vector<const Sequence*> sequences;
 
         BatchedCopy batched_copy;
+        int         sum_k = 0;
         for (int i = first; i < last; ++i) {
             input_ids = batched_copy.Add(input_d_ptrs[i], h_input_length_buf_[i], input_ids);
             dbg(i, h_input_length_buf_[i]);
             decode_indices.push_back(i);
             decode_lengths.push_back(h_input_length_buf_[i]);
             sequences.push_back(state_->sequences[i]);
+            if (h_input_length_buf_[i] > 1) {
+                sum_k += state_->h_context_length[i];
+            }
         }
-        int token_count = input_ids - context_decoder_ids_buf_;
+        int sum_q = input_ids - context_decoder_ids_buf_;
 
         batched_copy.Submit(stream_);
 
@@ -1639,12 +1630,13 @@ bool LlamaBatch<T>::Forward(GenerationState& g, int iter)
             if (pf_batch_size) {
                 const auto max_q = *std::max_element(h_input_length_buf_ + first, h_input_length_buf_ + last);
                 const auto max_k = *std::max_element(state_->h_context_length + first, state_->h_context_length + last);
-                TM_LOG_INFO("[Forward] [%d, %d), dc_bsz = %d, pf_bsz = %d, n_tok = %d, max_q = %d, max_k = %d",
+                TM_LOG_INFO("[Forward] [%d, %d), dc=%d, pf=%d, sum_q=%d, sum_k=%d, max_q=%d, max_k=%d",
                             first,
                             last,
                             dc_batch_size,
                             pf_batch_size,
-                            token_count,
+                            sum_q,
+                            sum_k,
                             max_q,
                             max_k);
             }
@@ -1660,16 +1652,14 @@ bool LlamaBatch<T>::Forward(GenerationState& g, int iter)
                                state_->h_context_length + first,
                                rope_theta_ + first,
                                finished_buf_ + first,
-                               token_count,
+                               sum_q,
                                dc_batch_size,
                                pf_batch_size,
                                lora_mask_buf_,
                                sequences.data());
 
-        if (iter == 0) {
-            // compute logits of inputs if requested
-            OutputContextLogits(context_decoder_output_buf_, decode_indices, decode_lengths, sequences);
-        }
+        // compute logits of inputs if requested
+        OutputContextLogits(context_decoder_output_buf_, decode_indices, decode_lengths, sequences);
     }
 
     std::fill(h_input_length_buf_, h_input_length_buf_ + active_size, 0);
@@ -1695,7 +1685,7 @@ bool LlamaBatch<T>::Forward(GenerationState& g, int iter)
 
         // TM_LOG_INFO("dyn decode bsz %d, partial %d", active_size, g.partial);
 
-        if (iter == 0 && !g.skip_init_sampling) {
+        if (!g.skip_init_sampling) {
             InitializeSampling(g);
         }
         // stop-words & bad-words require the matched tokens to be contiguous, so item size > 1 is

--- a/src/turbomind/models/llama/LlamaBatch.cc
+++ b/src/turbomind/models/llama/LlamaBatch.cc
@@ -940,7 +940,6 @@ LlamaBatch<T>::LlamaBatch(const EngineParams& params, int cache_block_seq_len, i
     model_(model),
     data_type_(getTensorType<T>()),
     num_tokens_per_iter_(params.num_tokens_per_iter),
-    extra_tokens_per_iter_(params.extra_tokens_per_iter),
     max_prefill_iters_(params.max_prefill_iters)
 {
     stream_         = model_->stream_;

--- a/src/turbomind/models/llama/LlamaBatch.h
+++ b/src/turbomind/models/llama/LlamaBatch.h
@@ -56,9 +56,7 @@ struct GenerationState {
 
     bool skip_init_sampling;
 
-    int max_input_count1;
-    int max_input_count2;
-
+    // min tokens per iter for satisfying `max_prefill_iters` constraint
     std::deque<int> min_input_count;
 
     int finished_count;
@@ -80,15 +78,15 @@ public:
 
     void ProcessInferRequests(const Requests& requests);
 
-    void AdjustMaxInputCount(GenerationState&                    g,
-                             const std::vector<const Sequence*>& sequences,
-                             const std::vector<int>&             context_length);
+    int AdjustMaxInputCount(GenerationState&                    g,
+                            const std::vector<const Sequence*>& sequences,
+                            const std::vector<int>&             context_length);
 
     void Initialize(GenerationState& g);
 
     void InitializeSampling(const GenerationState& g);
 
-    [[nodiscard]] bool Forward(GenerationState& g, int iter);
+    [[nodiscard]] bool Forward(GenerationState& g);
 
     [[nodiscard]] auto Finish(GenerationState& g) -> std::vector<Signal>;
 
@@ -189,6 +187,7 @@ private:
 
 private:
     const int  max_batch_size_;
+    const int  max_forward_token_num_;
     const int  max_context_token_num_;
     int        session_len_;
     const int  rank_;

--- a/src/turbomind/models/llama/LlamaBatch.h
+++ b/src/turbomind/models/llama/LlamaBatch.h
@@ -301,7 +301,6 @@ private:
     int* h_output_ids_{};
 
     const int num_tokens_per_iter_;
-    const int extra_tokens_per_iter_;
     const int max_prefill_iters_;
 };
 

--- a/src/turbomind/models/llama/SequenceManager.h
+++ b/src/turbomind/models/llama/SequenceManager.h
@@ -100,7 +100,7 @@ public:
         int swap_out;
     };
 
-    using AdjustInputCount = std::function<std::pair<int, int>(const Sequences&, const std::vector<int>&)>;
+    using AdjustInputCount = std::function<int(const Sequences&, const std::vector<int>&)>;
 
     [[nodiscard]] Outcome Materialize(Sequences                    sequences,
                                       std::vector<int>             context_lengths,

--- a/src/turbomind/models/llama/llama_params.h
+++ b/src/turbomind/models/llama/llama_params.h
@@ -34,6 +34,7 @@ struct EngineParams {
     bool  enable_prefix_caching;
 
     // chunking params
+    int max_prefill_token_num;
     int max_context_token_num;
     int num_tokens_per_iter;
     int extra_tokens_per_iter;

--- a/src/turbomind/models/llama/llama_params.h
+++ b/src/turbomind/models/llama/llama_params.h
@@ -37,7 +37,6 @@ struct EngineParams {
     int max_prefill_token_num;
     int max_context_token_num;
     int num_tokens_per_iter;
-    int extra_tokens_per_iter;
     int max_prefill_iters;
 };
 

--- a/src/turbomind/models/llama/unified_decoder.h
+++ b/src/turbomind/models/llama/unified_decoder.h
@@ -43,6 +43,8 @@ protected:
     UnifiedAttentionLayer<T>* attn_layer_{};
     LlamaFfnLayer<T>*         ffn_layer_{};
 
+    cudaEvent_t ev_h_cu_x_{};
+
     const DataType dtype_;
 
     // bool need_causal_mask_{false};

--- a/src/turbomind/triton_backend/llama/LlamaTritonModel.cc
+++ b/src/turbomind/triton_backend/llama/LlamaTritonModel.cc
@@ -114,6 +114,12 @@ void LlamaTritonModel<T>::handleMissingParams()
         TM_LOG_WARNING("[LlamaTritonModel] `session_len` is not set, default to %d.", (int)engine_params_.session_len);
     }
 
+    if (!engine_params_.max_prefill_token_num) {
+        engine_params_.max_prefill_token_num = 8192;
+        TM_LOG_WARNING("[LlamaTritonModel] `max_prefill_token_num` is not set, default to %d.",
+                       (int)engine_params_.max_prefill_token_num);
+    }
+
     if (!engine_params_.max_context_token_num) {
         engine_params_.max_context_token_num = engine_params_.session_len;
         TM_LOG_WARNING("[LlamaTritonModel] `max_context_token_num` is not set, default to %d.",
@@ -219,6 +225,7 @@ LlamaTritonModel<T>::LlamaTritonModel(size_t      tensor_para_size,
     attn_params_.original_max_position_embeddings = reader.GetInteger("llama", "original_max_position_embeddings", 0);
 
     engine_params_.max_batch_size        = reader.GetInteger("llama", "max_batch_size", 0);
+    engine_params_.max_prefill_token_num = reader.GetInteger("llama", "max_prefill_token_num", 0);
     engine_params_.max_context_token_num = reader.GetInteger("llama", "max_context_token_num", 0);
     engine_params_.session_len           = reader.GetInteger("llama", "session_len", 0);
     engine_params_.step_length           = reader.GetInteger("llama", "step_length", 0);
@@ -268,6 +275,8 @@ LlamaTritonModel<T>::LlamaTritonModel(size_t      tensor_para_size,
         std::cout << "[ERROR] Unsupported weight type: '" << weight_type_str << "'\n";
         ft::FT_CHECK(0);
     }
+
+    TM_LOG_INFO("%s", toString().c_str());
 }
 
 template<typename T>
@@ -433,10 +442,11 @@ template<typename T>
 std::string LlamaTritonModel<T>::toString()
 {
     std::stringstream ss;
-    ss << "Model: "
-       << "\nhead_num: " << head_num_ << "\nkv_head_num: " << kv_head_num_ << "\nsize_per_head: " << size_per_head_
-       << "\ninter_size: " << inter_size_ << "\nnum_layer: " << num_layer_ << "\nvocab_size: " << vocab_size_
-       << "\nattn_bias: " << attn_bias_ << "\nmax_batch_size: " << engine_params_.max_batch_size
+    ss << "Model: " << "\nhead_num: " << head_num_ << "\nkv_head_num: " << kv_head_num_
+       << "\nsize_per_head: " << size_per_head_ << "\ninter_size: " << inter_size_ << "\nnum_layer: " << num_layer_
+       << "\nvocab_size: " << vocab_size_ << "\nattn_bias: " << attn_bias_
+       << "\nmax_batch_size: " << engine_params_.max_batch_size
+       << "\nmax_prefill_token_num: " << engine_params_.max_prefill_token_num
        << "\nmax_context_token_num: " << engine_params_.max_context_token_num
        << "\nsession_len: " << engine_params_.session_len << "\nstep_length: " << engine_params_.step_length
        << "\ncache_max_entry_count: " << engine_params_.cache_max_block_count

--- a/src/turbomind/triton_backend/llama/LlamaTritonModel.cc
+++ b/src/turbomind/triton_backend/llama/LlamaTritonModel.cc
@@ -235,7 +235,6 @@ LlamaTritonModel<T>::LlamaTritonModel(size_t      tensor_para_size,
     engine_params_.enable_prefix_caching = reader.GetBoolean("llama", "enable_prefix_caching", false);
 
     engine_params_.num_tokens_per_iter   = reader.GetInteger("llama", "num_tokens_per_iter", 0);
-    engine_params_.extra_tokens_per_iter = reader.GetInteger("llama", "extra_tokens_per_iter", 0);
     engine_params_.max_prefill_iters     = reader.GetInteger("llama", "max_prefill_iters", 1);
 
     lora_params_.policy        = ft::getLoraPolicy(reader.Get("llama", "lora_policy", ""));

--- a/src/turbomind/triton_backend/llama/LlamaTritonModel.cc
+++ b/src/turbomind/triton_backend/llama/LlamaTritonModel.cc
@@ -442,10 +442,10 @@ template<typename T>
 std::string LlamaTritonModel<T>::toString()
 {
     std::stringstream ss;
-    ss << "Model: " << "\nhead_num: " << head_num_ << "\nkv_head_num: " << kv_head_num_
-       << "\nsize_per_head: " << size_per_head_ << "\ninter_size: " << inter_size_ << "\nnum_layer: " << num_layer_
-       << "\nvocab_size: " << vocab_size_ << "\nattn_bias: " << attn_bias_
-       << "\nmax_batch_size: " << engine_params_.max_batch_size
+    ss << "Model: "
+       << "\nhead_num: " << head_num_ << "\nkv_head_num: " << kv_head_num_ << "\nsize_per_head: " << size_per_head_
+       << "\ninter_size: " << inter_size_ << "\nnum_layer: " << num_layer_ << "\nvocab_size: " << vocab_size_
+       << "\nattn_bias: " << attn_bias_ << "\nmax_batch_size: " << engine_params_.max_batch_size
        << "\nmax_prefill_token_num: " << engine_params_.max_prefill_token_num
        << "\nmax_context_token_num: " << engine_params_.max_context_token_num
        << "\nsession_len: " << engine_params_.session_len << "\nstep_length: " << engine_params_.step_length

--- a/src/turbomind/triton_backend/llama/LlamaTritonModel.cc
+++ b/src/turbomind/triton_backend/llama/LlamaTritonModel.cc
@@ -234,8 +234,8 @@ LlamaTritonModel<T>::LlamaTritonModel(size_t      tensor_para_size,
     engine_params_.cache_chunk_size      = reader.GetInteger("llama", "cache_chunk_size", 0);
     engine_params_.enable_prefix_caching = reader.GetBoolean("llama", "enable_prefix_caching", false);
 
-    engine_params_.num_tokens_per_iter   = reader.GetInteger("llama", "num_tokens_per_iter", 0);
-    engine_params_.max_prefill_iters     = reader.GetInteger("llama", "max_prefill_iters", 1);
+    engine_params_.num_tokens_per_iter = reader.GetInteger("llama", "num_tokens_per_iter", 0);
+    engine_params_.max_prefill_iters   = reader.GetInteger("llama", "max_prefill_iters", 1);
 
     lora_params_.policy        = ft::getLoraPolicy(reader.Get("llama", "lora_policy", ""));
     lora_params_.r             = reader.GetInteger("llama", "lora_r", 0);


### PR DESCRIPTION
- Add `max_prefill_token_num`, decoupled with `max_context_token_num`
  - max_prefill_token_num (>= max_batch_size): max number of prefill tokens in a forward pass
  - max_context_token_num (>= session_len): max number of context tokens (including history) in a forward pass
- Fix data race in chunked prefill

Memory consumption is greatly reduced for large session_len.