### PR TITLE
Stop synchronizing for `length_criterion`

### DIFF
--- a/src/turbomind/layers/DynamicDecodeLayer.cc
+++ b/src/turbomind/layers/DynamicDecodeLayer.cc
@@ -352,7 +352,7 @@ void DynamicDecodeLayer<T>::forward(TensorMap* output_tensors, TensorMap* input_
 
     if (input_tensors->isExist("sequence_limit_length")) {
         invokeLengthCriterion(output_tensors->at("finished").getPtr<bool>(),
-                              output_tensors->at("should_stop").getPtr<bool>(),
+                              output_tensors->getPtr<bool>("should_stop", nullptr),
                               h_pinned_finished_sum_,
                               input_tensors->at("sequence_limit_length").getPtr<const uint32_t>(),
                               batch_size,

--- a/src/turbomind/models/llama/LlamaBatch.cc
+++ b/src/turbomind/models/llama/LlamaBatch.cc
@@ -1682,8 +1682,6 @@ bool LlamaBatch<T>::Forward(GenerationState& g, int iter)
         }
     }
 
-    bool should_stop{};
-
     if (active_size > g.partial) {
         model_->postDecodeEmbedding(logits_buf_, local_logits_buf_, decoder_output_buf_, active_size - g.partial);
 
@@ -1703,7 +1701,7 @@ bool LlamaBatch<T>::Forward(GenerationState& g, int iter)
         model_->dynamicDecode(token_ids_buf_,
                               finished_buf_,
                               sequence_lengths_,
-                              &should_stop,
+                              nullptr,
                               state_->curand_state,
                               &inputs_,
                               &outputs_,
@@ -1748,7 +1746,7 @@ bool LlamaBatch<T>::Forward(GenerationState& g, int iter)
 
     // PrintDecodeTokens(token_ids_buf_, g.step, active_size, stream_, "Forward");
 
-    return !should_stop;
+    return true;
 }
 
 template class LlamaBatch<half>;


### PR DESCRIPTION
as we don't need the value of `should_stop` at all.