### PR TITLE
Add peer-access-enabled allocator

### DIFF
--- a/src/turbomind/models/llama/LlamaBatch.cc
+++ b/src/turbomind/models/llama/LlamaBatch.cc
@@ -715,7 +715,7 @@ void LlamaBatch<T>::AllocateBuffer(size_t batch_size, size_t session_len, int ca
         context_decoder_output_buf_ = (T*)allocator_->reMalloc(context_decoder_output_buf_, sz, false);
     }
     else {
-        context_decoder_output_buf_ = (T*)allocator_->reMalloc(
+        context_decoder_output_buf_ = (T*)peer_allocator_->reMalloc(
             context_decoder_output_buf_, sizeof(T) * max_forward_token_num_ * hidden_units, false);
     }
 
@@ -850,7 +850,7 @@ void LlamaBatch<T>::FreeBuffer()
     TM_LOG_DEBUG(__PRETTY_FUNCTION__);
     if (is_allocate_buffer_) {
         allocator_->free((void**)&context_decoder_input_buf_);
-        allocator_->free((void**)&context_decoder_output_buf_);
+        peer_allocator_->free((void**)&context_decoder_output_buf_);
         allocator_->free((void**)&context_decoder_ids_buf_);
         allocator_->free((void**)&lora_mask_buf_);
 
@@ -871,7 +871,7 @@ void LlamaBatch<T>::FreeBuffer()
         allocator_->free((void**)&local_logits_buf_);
 
         if (local_context_logits_buf_) {
-            allocator_->free((void**)&local_context_logits_buf_);
+            peer_allocator_->free((void**)&local_context_logits_buf_);
         }
         if (context_logits_buf_) {
             allocator_->free((void**)&context_logits_buf_);
@@ -944,6 +944,7 @@ LlamaBatch<T>::LlamaBatch(const EngineParams& params, int cache_block_seq_len, i
 {
     stream_         = model_->stream_;
     allocator_      = model_->allocator_;
+    peer_allocator_ = model_->peer_allcator_;
     cublas_wrapper_ = model_->cublas_wrapper_;
 
     const int elem_bits = quant_policy ? quant_policy : bitsof<T>;
@@ -1172,7 +1173,7 @@ void LlamaBatch<T>::OutputContextLogits(T*                                  cont
             NcclGuard guard(model_->tensor_para_, stream_, true);
             FT_CHECK(model_->vocab_size_padded_ % tp == 0);
             const auto local_vocab_size = model_->vocab_size_padded_ / tp;
-            local_context_logits_buf_   = (float*)allocator_->reMalloc(
+            local_context_logits_buf_   = (float*)peer_allocator_->reMalloc(
                 local_context_logits_buf_, sizeof(float) * model_->vocab_size_padded_ * num_token, false);
         }
     }

--- a/src/turbomind/models/llama/LlamaBatch.cc
+++ b/src/turbomind/models/llama/LlamaBatch.cc
@@ -712,7 +712,7 @@ void LlamaBatch<T>::AllocateBuffer(size_t batch_size, size_t session_len, int ca
     if (model_->lora_params_.policy == LoraPolicy::kPlora) {
         lora_mask_buf_ = (int*)allocator_->reMalloc(lora_mask_buf_, sizeof(int) * max_forward_token_num_, false);
         size_t sz      = sizeof(T) * max_forward_token_num_ * (hidden_units + model_->lora_params_.max_wo_r);
-        context_decoder_output_buf_ = (T*)allocator_->reMalloc(context_decoder_output_buf_, sz, false);
+        context_decoder_output_buf_ = (T*)peer_allocator_->reMalloc(context_decoder_output_buf_, sz, false);
     }
     else {
         context_decoder_output_buf_ = (T*)peer_allocator_->reMalloc(

--- a/src/turbomind/models/llama/LlamaBatch.cc
+++ b/src/turbomind/models/llama/LlamaBatch.cc
@@ -737,8 +737,9 @@ void LlamaBatch<T>::AllocateBuffer(size_t batch_size, size_t session_len, int ca
     cu_block_counts_ = (int*)allocator_->reMalloc(cu_block_counts_, sizeof(int) * (batch_size + 1));
     block_ptrs_      = (uintptr_t*)allocator_->reMalloc(block_ptrs_, sizeof(uintptr_t) * max_batch_block_count);
 
-    logits_buf_       = (float*)allocator_->reMalloc(logits_buf_, sizeof(float) * batchxbeam * vocab_size, false);
-    local_logits_buf_ = (float*)allocator_->reMalloc(local_logits_buf_, sizeof(float) * batchxbeam * vocab_size, false);
+    logits_buf_ = (float*)allocator_->reMalloc(logits_buf_, sizeof(float) * batchxbeam * vocab_size, false);
+    local_logits_buf_ =
+        (float*)peer_allocator_->reMalloc(local_logits_buf_, sizeof(float) * batchxbeam * vocab_size, false);
 
     sampled_logprobs_ =
         (float*)allocator_->reMalloc(sampled_logprobs_, sizeof(float) * batchxbeam * kMaxLogProb, false);
@@ -868,7 +869,7 @@ void LlamaBatch<T>::FreeBuffer()
         allocator_->free((void**)&block_ptrs_);
 
         allocator_->free((void**)&logits_buf_);
-        allocator_->free((void**)&local_logits_buf_);
+        peer_allocator_->free((void**)&local_logits_buf_);
 
         if (local_context_logits_buf_) {
             peer_allocator_->free((void**)&local_context_logits_buf_);

--- a/src/turbomind/models/llama/LlamaBatch.h
+++ b/src/turbomind/models/llama/LlamaBatch.h
@@ -288,6 +288,7 @@ private:
     cudaStream_t     stream_{};
     cublasMMWrapper* cublas_wrapper_{};
     IAllocator*      allocator_{};
+    IAllocator*      peer_allocator_{};
 
     std::thread internal_thread_;
 

--- a/src/turbomind/models/llama/LlamaV2.cc
+++ b/src/turbomind/models/llama/LlamaV2.cc
@@ -33,6 +33,7 @@
 #include "src/turbomind/models/llama/llama_utils.h"
 #include "src/turbomind/models/llama/unified_decoder.h"
 #include "src/turbomind/utils/Tensor.h"
+#include "src/turbomind/utils/allocator.h"
 #include "src/turbomind/utils/anomaly_handler.h"
 #include "src/turbomind/utils/cuda_utils.h"
 #include "src/turbomind/utils/logger.h"
@@ -64,6 +65,7 @@ LlamaV2<T>::LlamaV2(size_t                       head_num,
                     cudaStream_t                 stream,
                     cublasMMWrapper*             cublas_wrapper,
                     IAllocator*                  allocator,
+                    IAllocator*                  peer_alloctor,
                     bool                         is_free_buffer_after_forward,
                     cudaDeviceProp*              cuda_device_prop):
     head_num_(head_num),
@@ -84,6 +86,7 @@ LlamaV2<T>::LlamaV2(size_t                       head_num,
     stream_(stream),
     cublas_wrapper_(cublas_wrapper),
     allocator_(allocator),
+    peer_allcator_(peer_alloctor),
     is_free_buffer_after_forward_(is_free_buffer_after_forward),
     cuda_device_prop_(cuda_device_prop),
     debug_(isDebug()),

--- a/src/turbomind/models/llama/LlamaV2.cc
+++ b/src/turbomind/models/llama/LlamaV2.cc
@@ -360,6 +360,7 @@ void LlamaV2<T>::postDecodeEmbedding(float* logits, float* local_logits, const T
                             tensor_para_.rank_,
                             tensor_para_,
                             stream_);
+            sync_check_cuda_error();
         }
         invokeTransposeAxis01(logits, local_logits, tensor_para_.world_size_, batch_size, local_vocab_size, stream_);
         sync_check_cuda_error();

--- a/src/turbomind/models/llama/LlamaV2.h
+++ b/src/turbomind/models/llama/LlamaV2.h
@@ -75,6 +75,7 @@ public:
             cudaStream_t                 stream,
             cublasMMWrapper*             cublas_wrapper,
             IAllocator*                  allocator,
+            IAllocator*                  peer_allocator,
             bool                         is_free_buffer_after_forward,
             cudaDeviceProp*              cuda_device_prop);
 
@@ -179,6 +180,7 @@ private:
     cudaStream_t     stream_;
     cublasMMWrapper* cublas_wrapper_;
     IAllocator*      allocator_;
+    IAllocator*      peer_allcator_;
     bool             is_free_buffer_after_forward_;
     cudaDeviceProp*  cuda_device_prop_;
 

--- a/src/turbomind/triton_backend/llama/LlamaTritonModel.cc
+++ b/src/turbomind/triton_backend/llama/LlamaTritonModel.cc
@@ -443,10 +443,10 @@ template<typename T>
 std::string LlamaTritonModel<T>::toString()
 {
     std::stringstream ss;
-    ss << "Model: " << "\nhead_num: " << head_num_ << "\nkv_head_num: " << kv_head_num_
-       << "\nsize_per_head: " << size_per_head_ << "\ninter_size: " << inter_size_ << "\nnum_layer: " << num_layer_
-       << "\nvocab_size: " << vocab_size_ << "\nattn_bias: " << attn_bias_
-       << "\nmax_batch_size: " << engine_params_.max_batch_size
+    ss << "Model: "
+       << "\nhead_num: " << head_num_ << "\nkv_head_num: " << kv_head_num_ << "\nsize_per_head: " << size_per_head_
+       << "\ninter_size: " << inter_size_ << "\nnum_layer: " << num_layer_ << "\nvocab_size: " << vocab_size_
+       << "\nattn_bias: " << attn_bias_ << "\nmax_batch_size: " << engine_params_.max_batch_size
        << "\nmax_prefill_token_num: " << engine_params_.max_prefill_token_num
        << "\nmax_context_token_num: " << engine_params_.max_context_token_num
        << "\nsession_len: " << engine_params_.session_len << "\nstep_length: " << engine_params_.step_length

--- a/src/turbomind/triton_backend/llama/LlamaTritonModelInstance.cc
+++ b/src/turbomind/triton_backend/llama/LlamaTritonModelInstance.cc
@@ -250,10 +250,6 @@ void LlamaTritonModelInstance<T>::allocateBuffer(const size_t request_batch_size
     d_output_ids_ = (int*)std::realloc(d_output_ids_, sizeof(int) * request_batch_size * beam_width * session_len);
     d_sequence_lengths_ = (int*)std::realloc(d_sequence_lengths_, sizeof(int) * request_batch_size * beam_width);
 
-    // d_output_log_probs_ = (float*)(allocator_->reMalloc(
-    //     d_output_log_probs_, sizeof(float) * request_batch_size * beam_width * session_len, false));
-    // d_cum_log_probs_ =
-    //     (float*)(allocator_->reMalloc(d_cum_log_probs_, sizeof(float) * request_batch_size * beam_width, false));
     if (is_return_logits) {
         d_output_logits_ = (float*)allocator_->reMalloc(
             d_output_logits_, sizeof(float) * request_batch_size * max_input_len * instance_->llm->vocab_size(), false);

--- a/src/turbomind/triton_backend/llama/LlamaTritonModelInstance.h
+++ b/src/turbomind/triton_backend/llama/LlamaTritonModelInstance.h
@@ -30,6 +30,7 @@ namespace ft = turbomind;
 template<typename T>
 struct LlamaTritonSharedModelInstance {
     std::unique_ptr<ft::Allocator<ft::AllocatorType::CUDA>> allocator;
+    std::unique_ptr<ft::Allocator<ft::AllocatorType::CUDA>> peer_allocator;
     std::unique_ptr<ft::cublasAlgoMap>                      cublas_algo_map;
     std::unique_ptr<std::mutex>                             cublas_wrapper_mutex;
     std::unique_ptr<ft::cublasMMWrapper>                    cublas_wrapper;

--- a/src/turbomind/utils/allocator.h
+++ b/src/turbomind/utils/allocator.h
@@ -50,13 +50,15 @@
 
 namespace turbomind {
 
-enum class AllocatorType {
+enum class AllocatorType
+{
     CUDA,
     TF,
     TH
 };
 
-enum class ReallocType {
+enum class ReallocType
+{
     INCREASE,
     REUSE,
     DECREASE,
@@ -123,7 +125,8 @@ class Allocator;
 template<>
 class Allocator<AllocatorType::CUDA>: public IAllocator {
 private:
-    enum class MemoryType {
+    enum class MemoryType
+    {
         HOST,
         DEVICE
     };
@@ -153,7 +156,8 @@ private:
     }
 
 public:
-    Allocator(int device_id, bool enable_peer_access): device_id_(device_id), enable_peer_access_(enable_peer_access)
+    Allocator(int device_id, bool enable_peer_access = false):
+        device_id_(device_id), enable_peer_access_(enable_peer_access)
     {
         TM_LOG_DEBUG(__PRETTY_FUNCTION__);
         // pointer_mapping_ = new std::unordered_map<void*, std::pair<size_t, MemoryType>>();

--- a/src/turbomind/utils/allocator.h
+++ b/src/turbomind/utils/allocator.h
@@ -160,7 +160,6 @@ public:
         device_id_(device_id), enable_peer_access_(enable_peer_access)
     {
         TM_LOG_DEBUG(__PRETTY_FUNCTION__);
-        // pointer_mapping_ = new std::unordered_map<void*, std::pair<size_t, MemoryType>>();
 #if defined(CUDA_MEMORY_POOL_DISABLED)
         TM_LOG_WARNING(
             "Async cudaMalloc/Free is not supported before CUDA 11.2. Using Sync cudaMalloc/Free."

--- a/src/turbomind/utils/allocator.h
+++ b/src/turbomind/utils/allocator.h
@@ -50,15 +50,13 @@
 
 namespace turbomind {
 
-enum class AllocatorType
-{
+enum class AllocatorType {
     CUDA,
     TF,
     TH
 };
 
-enum class ReallocType
-{
+enum class ReallocType {
     INCREASE,
     REUSE,
     DECREASE,
@@ -69,7 +67,7 @@ public:
     virtual ~IAllocator(){};
 
     virtual void*        malloc(size_t size, const bool is_set_zero = true, bool is_host = false) = 0;
-    virtual void         free(void** ptr, bool is_host = false) const                             = 0;
+    virtual void         free(void** ptr, bool is_host = false)                                   = 0;
     virtual void         setStream(cudaStream_t stream)                                           = 0;
     virtual cudaStream_t returnStream()                                                           = 0;
     virtual void         memSet(void* ptr, const int val, const size_t size)                      = 0;
@@ -125,27 +123,28 @@ class Allocator;
 template<>
 class Allocator<AllocatorType::CUDA>: public IAllocator {
 private:
-    enum class MemoryType
-    {
+    enum class MemoryType {
         HOST,
         DEVICE
     };
 
-    const int                                                 device_id_;
-    cudaStream_t                                              stream_ = 0;  // initialize as default stream
-    std::unordered_map<void*, std::pair<size_t, MemoryType>>* pointer_mapping_;
+    const int                                                device_id_;
+    bool                                                     enable_peer_access_{false};
+    cudaStream_t                                             stream_ = 0;  // initialize as default stream
+    cudaMemPool_t                                            mempool_{};
+    std::unordered_map<void*, std::pair<size_t, MemoryType>> pointer_mapping_;
 
     bool isExist(void* address) const
     {
-        return pointer_mapping_->count(address) > 0;
+        return pointer_mapping_.count(address) > 0;
     }
     ReallocType isReMalloc(void* address, size_t size) const
     {
         FT_CHECK(isExist(address));
-        if (pointer_mapping_->at(address).first < size) {
+        if (pointer_mapping_.at(address).first < size) {
             return ReallocType::INCREASE;
         }
-        else if (pointer_mapping_->at(address).first == size) {
+        else if (pointer_mapping_.at(address).first == size) {
             return ReallocType::REUSE;
         }
         else {
@@ -154,53 +153,64 @@ private:
     }
 
 public:
-    Allocator(int device_id): device_id_(device_id)
+    Allocator(int device_id, bool enable_peer_access): device_id_(device_id), enable_peer_access_(enable_peer_access)
     {
         TM_LOG_DEBUG(__PRETTY_FUNCTION__);
-        pointer_mapping_ = new std::unordered_map<void*, std::pair<size_t, MemoryType>>();
+        // pointer_mapping_ = new std::unordered_map<void*, std::pair<size_t, MemoryType>>();
 #if defined(CUDA_MEMORY_POOL_DISABLED)
         TM_LOG_WARNING(
             "Async cudaMalloc/Free is not supported before CUDA 11.2. Using Sync cudaMalloc/Free."
             "Note this may lead to hang with NCCL kernels launched in parallel; if so, try NCCL_LAUNCH_MODE=GROUP");
 #else
-        int device_count = 1;
-        check_cuda_error(cudaGetDeviceCount(&device_count));
-        cudaMemPool_t mempool;
-        check_cuda_error(cudaDeviceGetDefaultMemPool(&mempool, device_id));
-#if TM_ENABLE_CUSTOM_ALL_REDUCE
-        cudaMemAccessDesc desc                  = {};
-        int               peer_access_available = 0;
-        for (int i = 0; i < device_count; i++) {
-            if (i == device_id) {
-                continue;
+
+        if (enable_peer_access) {
+            cudaMemPoolProps props{};
+            props.allocType     = cudaMemAllocationTypePinned;
+            props.handleTypes   = cudaMemHandleTypeNone;
+            props.location.type = cudaMemLocationTypeDevice;
+            props.location.id   = device_id;
+            cudaMemPoolCreate(&mempool_, &props);
+            cudaMemAccessDesc desc                  = {};
+            int               peer_access_available = 0;
+            int               device_count          = 1;
+            check_cuda_error(cudaGetDeviceCount(&device_count));
+            for (int i = 0; i < device_count; i++) {
+                if (i == device_id) {
+                    continue;
+                }
+                check_cuda_error(cudaDeviceCanAccessPeer(&peer_access_available, device_id, i));
+                if (!peer_access_available) {
+                    TM_LOG_WARNING("Devicle " + std::to_string(device_id) + " peer access Device " + std::to_string(i)
+                                   + " is not available.");
+                    continue;
+                }
+                desc.location.type = cudaMemLocationTypeDevice;
+                desc.location.id   = i;
+                desc.flags         = cudaMemAccessFlagsProtReadWrite;
+                check_cuda_error(cudaMemPoolSetAccess(mempool_, &desc, 1));
             }
-            check_cuda_error(cudaDeviceCanAccessPeer(&peer_access_available, device_id, i));
-            if (!peer_access_available) {
-                TM_LOG_WARNING("Device " + std::to_string(device_id) + " peer access Device " + std::to_string(i)
-                               + " is not available.");
-                continue;
-            }
-            desc.location.type = cudaMemLocationTypeDevice;
-            desc.location.id   = i;
-            desc.flags         = cudaMemAccessFlagsProtReadWrite;
-            check_cuda_error(cudaMemPoolSetAccess(mempool, &desc, 1));
         }
-#endif
+        else {
+            check_cuda_error(cudaDeviceGetDefaultMemPool(&mempool_, device_id));
+        }
         // set memory pool threshold to avoid shrinking the pool
         uint64_t setVal = UINT64_MAX;
-        check_cuda_error(cudaMemPoolSetAttribute(mempool, cudaMemPoolAttrReleaseThreshold, &setVal));
+        check_cuda_error(cudaMemPoolSetAttribute(mempool_, cudaMemPoolAttrReleaseThreshold, &setVal));
 #endif
     }
 
     virtual ~Allocator()
     {
         TM_LOG_DEBUG(__PRETTY_FUNCTION__);
-        while (!pointer_mapping_->empty()) {
-            auto ptr           = pointer_mapping_->begin()->first;
-            auto size_and_type = pointer_mapping_->begin()->second;
+        while (!pointer_mapping_.empty()) {
+            auto ptr           = pointer_mapping_.begin()->first;
+            auto size_and_type = pointer_mapping_.begin()->second;
             free(&ptr, size_and_type.second == MemoryType::HOST);
         }
-        delete pointer_mapping_;
+        if (enable_peer_access_) {  // We own the pool in this case
+            cudaMemPoolDestroy(mempool_);
+            mempool_ = {};
+        }
     }
 
     void setStream(cudaStream_t stream)
@@ -230,7 +240,7 @@ public:
 #if defined(CUDA_MEMORY_POOL_DISABLED)
             check_cuda_error(cudaMalloc(&ptr, (size_t)(ceil(size / 32.)) * 32));
 #else
-            check_cuda_error(cudaMallocAsync(&ptr, (size_t)(ceil(size / 32.)) * 32, stream_));
+            check_cuda_error(cudaMallocFromPoolAsync(&ptr, (size_t)(ceil(size / 32.)) * 32, mempool_, stream_));
 #endif
         }
         if (is_set_zero) {
@@ -239,19 +249,19 @@ public:
         check_cuda_error(getSetDevice(o_device));
         TM_LOG_DEBUG("malloc buffer %p with size %ld", ptr, size);
 
-        pointer_mapping_->insert({getAddress(ptr), {size, is_host ? MemoryType::HOST : MemoryType::DEVICE}});
+        pointer_mapping_.insert({getAddress(ptr), {size, is_host ? MemoryType::HOST : MemoryType::DEVICE}});
 
         return ptr;
     }
 
-    void free(void** ptr, bool _ = false) const
+    void free(void** ptr, bool _ = false)
     {
         TM_LOG_DEBUG(__PRETTY_FUNCTION__);
         void* address = getAddress(*ptr);
         if (*ptr != nullptr) {
             int o_device = 0;
-            if (pointer_mapping_->count(address)) {
-                const auto is_host = pointer_mapping_->at(address).second == MemoryType::HOST;
+            if (pointer_mapping_.count(address)) {
+                const auto is_host = pointer_mapping_.at(address).second == MemoryType::HOST;
                 TM_LOG_DEBUG("Free buffer %p", address);
                 check_cuda_error(getSetDevice(device_id_, &o_device));
                 if (is_host) {
@@ -265,7 +275,7 @@ public:
 #endif
                 }
                 check_cuda_error(getSetDevice(o_device));
-                pointer_mapping_->erase(address);
+                pointer_mapping_.erase(address);
             }
             else {
                 TM_LOG_WARNING("pointer_mapping_ does not have information of ptr at %p.", address);

--- a/src/turbomind/utils/allocator.h
+++ b/src/turbomind/utils/allocator.h
@@ -173,7 +173,7 @@ public:
             props.handleTypes   = cudaMemHandleTypeNone;
             props.location.type = cudaMemLocationTypeDevice;
             props.location.id   = device_id;
-            cudaMemPoolCreate(&mempool_, &props);
+            check_cuda_error(cudaMemPoolCreate(&mempool_, &props));
             cudaMemAccessDesc desc                  = {};
             int               peer_access_available = 0;
             int               device_count          = 1;
@@ -212,7 +212,7 @@ public:
             free(&ptr, size_and_type.second == MemoryType::HOST);
         }
         if (enable_peer_access_) {  // We own the pool in this case
-            cudaMemPoolDestroy(mempool_);
+            check_cuda_error(cudaMemPoolDestroy(mempool_));
             mempool_ = {};
         }
     }


### PR DESCRIPTION
Add an extra allocator to allocate from peer access enabled memory pools. This may fix NCCL related errors on non-NVLink systems after #2082

#2204
#2195