### PR TITLE
better formatted table of 'lmdeploy list'

### DIFF
--- a/lmdeploy/cli/cli.py
+++ b/lmdeploy/cli/cli.py
@@ -156,10 +156,22 @@ class CLI(object):
     def list(args):
         """List the supported model names."""
         from lmdeploy.model import MODELS
-        model_names = list(MODELS.module_dict.keys())
-        model_names.sort()
-        print('The supported chat template names are:')
-        print('\n'.join(model_names))
+        builtin_templates = list(MODELS.module_dict.keys())
+        builtin_templates.sort()
+        builtin_templates.remove('base')
+        builtin_templates.remove('llama')
+        print('The built-in chat templates are:')
+        from texttable import Texttable
+        table = Texttable()
+        # model path, model type, model arch, chat_template
+        table.add_row(
+            ['chat_template', 'representative', 'model_type', 'architecture'])
+        for name in builtin_templates:
+            chat_template = MODELS.get(name)()
+            if hasattr(chat_template, 'meta'):
+                model_path, model_type, architecture = chat_template.meta()
+                table.add_row([name, model_path, model_type, architecture])
+        print(table.draw())
 
     @staticmethod
     def check_env(args):

--- a/lmdeploy/model.py
+++ b/lmdeploy/model.py
@@ -262,6 +262,11 @@ class CogVLM(BaseChatTemplate):
         if 'cogvlm' in path and 'cogvlm2' not in path:
             return 'cogvlm'
 
+    def meta(self):
+        """Return (model_repo_id, model_type, architecture) of a model who uses
+        this chat template."""
+        return 'THUDM/cogvlm-chat-hf', 'MLLM', 'CogVLMForCausalLM'
+
 
 @MODELS.register_module(name='cogvlm2')
 class CogVLM2(CogVLM):
@@ -283,6 +288,11 @@ class CogVLM2(CogVLM):
         path = model_path.lower()
         if 'cogvlm2' in path:
             return 'cogvlm2'
+
+    def meta(self):
+        """Return typical (model_path, model_type, model_architecture) of a
+        model who uses this chat template."""
+        return 'TTHUDM/cogvlm2-llama3-chat-19B', 'MLLM', 'CogVLMForCausalLM'
 
 
 @MODELS.register_module(name='wizardlm')

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -12,6 +12,7 @@ pynvml
 safetensors
 sentencepiece
 shortuuid
+texttable
 tiktoken
 torch<=2.3.1,>=2.0.0
 torchvision<=0.18.1,>=0.15.0


### PR DESCRIPTION

```
The built-in chat templates are:
+---------------+-----------------------------+------------+-------------------+
| chat_template | representative              | model_type | architecture      |
+---------------+-----------------------------+------------+-------------------+
| cogvlm        | THUDM/cogvlm-chat-hf        | MLLM       | CogVLMForCausalLM |
+---------------+-----------------------------+------------+-------------------+
| cogvlm2       | TTHUDM/cogvlm2-llama3-chat- | MLLM       | CogVLMForCausalLM |
|               | 19B                         |            |                   |
+---------------+-----------------------------+------------+-------------------+
```