### PR TITLE
feat(server): enable `seed` parameter for openai compatible server.

### DIFF
--- a/lmdeploy/serve/openai/api_server.py
+++ b/lmdeploy/serve/openai/api_server.py
@@ -355,6 +355,8 @@ async def chat_completions_v1(request: ChatCompletionRequest,
             ]
         except Exception as e:
             return create_error_response(HTTPStatus.BAD_REQUEST, str(e))
+        
+    random_seed = request.seed if request.seed else None
 
     gen_config = GenerationConfig(
         max_new_tokens=request.max_tokens,
@@ -366,7 +368,8 @@ async def chat_completions_v1(request: ChatCompletionRequest,
         ignore_eos=request.ignore_eos,
         stop_words=request.stop,
         skip_special_tokens=request.skip_special_tokens,
-        logits_processors=logits_processors)
+        logits_processors=logits_processors,
+        random_seed=random_seed)
 
     tools = None
     if request.tools and request.tool_choice != 'none':
@@ -583,6 +586,8 @@ async def completions_v1(request: CompletionRequest,
         request.prompt = [request.prompt]
     if isinstance(request.stop, str):
         request.stop = [request.stop]
+    random_seed = request.seed if request.seed else None
+    
     gen_config = GenerationConfig(
         max_new_tokens=request.max_tokens if request.max_tokens else 512,
         logprobs=request.logprobs,
@@ -592,7 +597,8 @@ async def completions_v1(request: CompletionRequest,
         repetition_penalty=request.repetition_penalty,
         ignore_eos=request.ignore_eos,
         stop_words=request.stop,
-        skip_special_tokens=request.skip_special_tokens)
+        skip_special_tokens=request.skip_special_tokens,
+        random_seed=random_seed)
     generators = []
     for i in range(len(request.prompt)):
         result_generator = VariableInterface.async_engine.generate(
@@ -831,6 +837,8 @@ async def chat_interactive_v1(request: GenerateRequest,
     if isinstance(request.stop, str):
         request.stop = [request.stop]
 
+    random_seed = request.seed if request.seed else None
+
     gen_config = GenerationConfig(
         max_new_tokens=request.request_output_len,
         top_p=request.top_p,
@@ -839,7 +847,8 @@ async def chat_interactive_v1(request: GenerateRequest,
         repetition_penalty=request.repetition_penalty,
         ignore_eos=request.ignore_eos,
         stop_words=request.stop,
-        skip_special_tokens=request.skip_special_tokens)
+        skip_special_tokens=request.skip_special_tokens,
+        random_seed=random_seed)
     if request.image_url:
         from lmdeploy.vl import load_image
         if isinstance(request.image_url, List):

--- a/lmdeploy/serve/openai/protocol.py
+++ b/lmdeploy/serve/openai/protocol.py
@@ -115,6 +115,7 @@ class ChatCompletionRequest(BaseModel):
     ignore_eos: Optional[bool] = False
     skip_special_tokens: Optional[bool] = True
     top_k: Optional[int] = 40
+    seed: Optional[int] = None
 
 
 class FunctionResponse(BaseModel):
@@ -229,6 +230,7 @@ class CompletionRequest(BaseModel):
     ignore_eos: Optional[bool] = False
     skip_special_tokens: Optional[bool] = True
     top_k: Optional[int] = 40  # for opencompass
+    seed: Optional[int] = None
 
 
 class CompletionResponseChoice(BaseModel):
@@ -315,6 +317,7 @@ class GenerateRequest(BaseModel):
     skip_special_tokens: Optional[bool] = True
     cancel: Optional[bool] = False  # cancel a responding request
     adapter_name: Optional[str] = Field(default=None, examples=[None])
+    seed: Optional[int] = None
 
 
 class GenerateResponse(BaseModel):


### PR DESCRIPTION
## Motivation

Sometimes we need `seed` parameter to do something reproducible.

## Modification

Enable `seed` parameter sets in OpenAI compatible server, including endpoints: `/v1/chat/completions`, `/v1/completions`, `/v1/chat/interactive`. 
