### PR TITLE
build nccl in dockerfile for cuda11.8

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -29,6 +29,19 @@ RUN wget https://download.open-mpi.org/release/open-mpi/v4.1/openmpi-4.1.5.tar.g
 ENV PATH=$PATH:/usr/local/openmpi/bin
 ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/openmpi/lib
 
+# install nccl manually for cuda11.8
+RUN if [ "$CUDA_VERSION_SHORT" = "cu118" ]; then \
+    git clone --depth=1 --branch v2.22.3-1 https://github.com/NVIDIA/nccl.git &&\
+    cd nccl && make -j$(nproc) src.build &&\
+    mv build/include/* /usr/local/include &&\
+    mkdir -p /usr/local/nccl/lib &&\
+    mv build/lib/lib* /usr/local/nccl/lib/ &&\
+    cd .. && rm -rf nccl ; \
+    fi
+
+ENV LD_LIBRARY_PATH=/usr/local/nccl/lib:$LD_LIBRARY_PATH
+
+
 RUN --mount=type=cache,target=/root/.cache/pip python3 -m pip install --upgrade pip setuptools==69.5.1 &&\
     python3 -m pip install torch==${TORCH_VERSION} torchvision==${TORCHVISION_VERSION} --index-url https://download.pytorch.org/whl/${CUDA_VERSION_SHORT} &&\
     python3 -m pip install cmake packaging wheel
@@ -48,6 +61,9 @@ RUN --mount=type=cache,target=/root/.cache/pip cd /opt/lmdeploy &&\
     cd .. &&\
     python3 -m pip install -e . &&\
     rm -rf build
+
+# use locally built nccl for cuda11.8
+RUN if [ "$CUDA_VERSION_SHORT" = "cu118" ]; then python3 -m pip uninstall -y nvidia-nccl-cu11 ; fi
 
 ENV LD_LIBRARY_PATH=/opt/lmdeploy/install/lib:$LD_LIBRARY_PATH
 ENV PATH=/opt/lmdeploy/install/bin:$PATH


### PR DESCRIPTION


## Motivation

nvidia-nccl-cu11 is built on cuda11.0 which is not met to capture cudagraph in TP mode.

Error log from PR #2104
```
Traceback (most recent call last):
  File "/opt/py3/lib/python3.10/site-packages/torch/distributed/c10d_logger.py", line 75, in wrapper
    return func(*args, **kwargs)
  File "/opt/py3/lib/python3.10/site-packages/torch/distributed/distributed_c10d.py", line 2219, in all_reduce
    work = group.allreduce([tensor], opts)
torch.distributed.DistBackendError: NCCL error in: ../torch/csrc/distributed/c10d/ProcessGroupNCCL.cpp:2395, invalid usage (run with NCCL_DEBUG=WARN for details), NCCL version 2.19.3
ncclInvalidUsage: This usually reflects invalid usage of NCCL library.
Last error:
NCCL cannot be captured in a graph if either it wasn't built with CUDA runtime >= 11.3 or if the installed CUDA driver < R465.
```


## Modification

Please briefly describe what modification is made in this PR.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
