### PR TITLE
Fix "TypeError: Got unsupported ScalarType BFloat16"

### DIFF
--- a/lmdeploy/serve/utils.py
+++ b/lmdeploy/serve/utils.py
@@ -216,7 +216,7 @@ class LogitsMixin:
                                        steps=steps,
                                        sequence_start=(i == 0),
                                        sequence_end=(i == n_max_iter - 1))
-            _logits = _logits.cpu()
+            _logits = _logits.float().cpu()
             padding_token_id = -100
             target_ids = [(x + [padding_token_id])[1:] for x in _input_ids]
             target_ids = [


### PR DESCRIPTION

## Motivation

This PR is to solve the following issue,
- #2453

## Modification

Following the discussion in the above issue, I just modified one line as follows, 
https://github.com/InternLM/lmdeploy/blob/main/lmdeploy/serve/utils.py#L219

`_logits = _logits.cpu()`   
-> `_logits = _logits.float().cpu()`


## How it works

I tried the same code introduced in #2453 and confirmed it works well.

```
$ ipython
Python 3.10.12 (main, Jun 11 2023, 05:26:28) [GCC 11.4.0]
Type 'copyright', 'credits' or 'license' for more information
IPython 8.15.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: from transformers import AutoTokenizer
   ...: from lmdeploy import pipeline
   ...: model_repoid_or_path='internlm/internlm2_5-7b-chat'
   ...: pipe = pipeline(model_repoid_or_path)
   ...: tokenizer = AutoTokenizer.from_pretrained(model_repoid_or_path, trust_remote_code=True)
   ...: 
   ...: # logits
   ...: messages = [
   ...:    {"role": "user", "content": "Hello, how are you?"},
   ...: ]
   ...: input_ids = tokenizer.apply_chat_template(messages)
   ...: logits = pipe.get_logits(input_ids)
   ...: 
   ...: # ppl
   ...: ppl = pipe.get_ppl(input_ids)
Fetching 20 files: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 20/20 [00:00<00:00, 273244.56it/s]

In [2]: ppl
Out[2]: array([4.489496], dtype=float32)
```