### PR TITLE
fix: make exit_flag verification for ascend more general

### DIFF
--- a/lmdeploy/pytorch/engine/model_agent.py
+++ b/lmdeploy/pytorch/engine/model_agent.py
@@ -726,8 +726,7 @@ def _exit_by_sending_exit_flag(rank: int, agent: TPModelAgent):
         return
 
     import sys
-    if agent.backend_config.device_type == 'ascend' \
-            and 'uvicorn.server' in sys.modules:
+    if 'torch_npu' in sys.modules and 'uvicorn.server' in sys.modules:
         # Workaround for CLI serve mode with device_type ascend:
         # using uvicorn server causes ascend low-level backend of subprocesses
         # corrupted, and using _broadcast_inputs in this case leads to


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily receiving feedbacks. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

As some developers would develop custom device_type for Ascend npu, it's better to resolve the exit problem with tp > 2 on  ascend platform with more general check instead of `device_type =='ascend'`. We change this behavior into checking with we have already imported 'torch_npu' module.

## Modification

Change an if-branch condition to make it more general.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
