### PR TITLE
refine pre-post-process

### DIFF
--- a/lmdeploy/pytorch/engine/engine.py
+++ b/lmdeploy/pytorch/engine/engine.py
@@ -162,7 +162,7 @@ class Engine:
         self.scheduler_config = scheduler_config
         self.cache_config = cache_config
         self.backend_config = backend_config
-        self.stream = torch.cuda.Stream()
+        self.stream = torch.cuda.current_stream()
 
         self.req_manager = self._bind_request_manager()
 
@@ -526,7 +526,7 @@ class Engine:
             last_idx = seq_length.cumsum(-1) - 1
             return logits[last_idx, :]
 
-        split_logits = __get_last_logits().cuda()
+        split_logits = __get_last_logits()
         logits_processor = FusedLogitsProcessor(sampling_inputs, ignore_eos,
                                                 self.tokenizer.model.model)
         logits = logits_processor(all_ids, guided_input_ids, split_logits)
@@ -731,7 +731,6 @@ class Engine:
         if guided_input_ids is not None:
             guided_input_ids = guided_input_ids.cuda()
         sampling_inputs = sampling_inputs.to_device('cuda')
-        num_appendable_ids = num_appendable_ids.cuda()
         num_ignore_eos = num_ignore_eos.cuda()
 
         for idx in range(loop_count):

--- a/lmdeploy/pytorch/engine/engine.py
+++ b/lmdeploy/pytorch/engine/engine.py
@@ -731,6 +731,7 @@ class Engine:
         if guided_input_ids is not None:
             guided_input_ids = guided_input_ids.cuda()
         sampling_inputs = sampling_inputs.to_device('cuda')
+        num_appendable_ids = num_appendable_ids.cuda()
         num_ignore_eos = num_ignore_eos.cuda()
 
         for idx in range(loop_count):

--- a/lmdeploy/pytorch/engine/engine.py
+++ b/lmdeploy/pytorch/engine/engine.py
@@ -162,7 +162,7 @@ class Engine:
         self.scheduler_config = scheduler_config
         self.cache_config = cache_config
         self.backend_config = backend_config
-        self.stream = torch.cuda.current_stream()
+        self.stream = self.model_agent.stream
 
         self.req_manager = self._bind_request_manager()
 

--- a/lmdeploy/pytorch/engine/logits_process.py
+++ b/lmdeploy/pytorch/engine/logits_process.py
@@ -308,7 +308,6 @@ class FusedLogitsProcessor(LogitsWarper):
 
         """
         sampling_inputs = self.sampling_inputs
-        scores = scores.clone()
 
         custom_logits_processors = self.sampling_inputs.logits_processors
         if any(custom_logits_processors):

--- a/lmdeploy/pytorch/engine/model_agent.py
+++ b/lmdeploy/pytorch/engine/model_agent.py
@@ -236,7 +236,7 @@ class BaseModelAgent(AutoModelAgent):
 
         self.cache_engine = CacheEngine(cache_config, model_config)
 
-        self.stream = torch.cuda.Stream()
+        self.stream = torch.cuda.current_stream()
 
     def _build_model(self,
                      model_path: str,

--- a/lmdeploy/pytorch/engine/model_agent.py
+++ b/lmdeploy/pytorch/engine/model_agent.py
@@ -236,7 +236,7 @@ class BaseModelAgent(AutoModelAgent):
 
         self.cache_engine = CacheEngine(cache_config, model_config)
 
-        self.stream = torch.cuda.current_stream()
+        self.stream = torch.cuda.Stream()
 
     def _build_model(self,
                      model_path: str,


### PR DESCRIPTION
## Motivation

After we use graph mode on Ascend device, we saw a big overhead on pre and post process. 

## Modification

1. remove unnecessary to(cuda)/clone
2. only use one cuda stream

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
