### PR TITLE
Fix error in python3.8.

### DIFF
--- a/lmdeploy/pytorch/engine/model_agent.py
+++ b/lmdeploy/pytorch/engine/model_agent.py
@@ -483,9 +483,8 @@ def _start_tp_process(proc_id: int,
                                 timeout=timedelta(days=35600))
         dist_ctx = DistContext(rank=rank, world_size=world_size)
         torch.cuda.set_device(rank)
-        with (get_dist_manager().context(dist_ctx),
-              get_device_manager().context(device_context),
-              torch.inference_mode()):
+        with get_dist_manager().context(dist_ctx), get_device_manager(
+        ).context(device_context), torch.inference_mode():
             args = args or tuple()
             kwargs = kwargs or dict()
             func(rank, *args, **kwargs)


### PR DESCRIPTION
## Motivation

python 3.8 don't support  syntax like this: with (ctx1, ctx2): .
 
## Modification

remove the extra parentheses.
