### PR TITLE
[ascend] add ascend graph mode

### DIFF
--- a/lmdeploy/pytorch/backends/dlinfer/activation.py
+++ b/lmdeploy/pytorch/backends/dlinfer/activation.py
@@ -1,10 +1,7 @@
 # Copyright (c) OpenMMLab. All rights reserved.
-from torch import nn
-
 from lmdeploy.pytorch.kernels.dlinfer.activation import silu_and_mul
 
-from ..activation import (GeluAndMulBuilder, GeluAndMulImpl, SiluAndMulBuilder,
-                          SiluAndMulImpl)
+from ..activation import SiluAndMulBuilder, SiluAndMulImpl
 
 
 class AscendSiluAndMulImpl(SiluAndMulImpl):
@@ -13,6 +10,7 @@ class AscendSiluAndMulImpl(SiluAndMulImpl):
     def forward(self, x):
         """forward."""
         return silu_and_mul(x)
+
 
 class AscendSiluAndMulBuilder(SiluAndMulBuilder):
     """silu and mul implementation builder."""

--- a/lmdeploy/pytorch/backends/dlinfer/activation.py
+++ b/lmdeploy/pytorch/backends/dlinfer/activation.py
@@ -1,0 +1,23 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+from torch import nn
+
+from lmdeploy.pytorch.kernels.dlinfer.activation import silu_and_mul
+
+from ..activation import (GeluAndMulBuilder, GeluAndMulImpl, SiluAndMulBuilder,
+                          SiluAndMulImpl)
+
+
+class AscendSiluAndMulImpl(SiluAndMulImpl):
+    """silu + multiple fused implementation."""
+
+    def forward(self, x):
+        """forward."""
+        return silu_and_mul(x)
+
+class AscendSiluAndMulBuilder(SiluAndMulBuilder):
+    """silu and mul implementation builder."""
+
+    @staticmethod
+    def build(inplace: bool = False):
+        """build."""
+        return AscendSiluAndMulImpl()

--- a/lmdeploy/pytorch/backends/dlinfer/activation.py
+++ b/lmdeploy/pytorch/backends/dlinfer/activation.py
@@ -4,7 +4,7 @@ from lmdeploy.pytorch.kernels.dlinfer.activation import silu_and_mul
 from ..activation import SiluAndMulBuilder, SiluAndMulImpl
 
 
-class AscendSiluAndMulImpl(SiluAndMulImpl):
+class DlinferSiluAndMulImpl(SiluAndMulImpl):
     """silu + multiple fused implementation."""
 
     def forward(self, x):
@@ -12,10 +12,10 @@ class AscendSiluAndMulImpl(SiluAndMulImpl):
         return silu_and_mul(x)
 
 
-class AscendSiluAndMulBuilder(SiluAndMulBuilder):
+class DlinferSiluAndMulBuilder(SiluAndMulBuilder):
     """silu and mul implementation builder."""
 
     @staticmethod
     def build(inplace: bool = False):
         """build."""
-        return AscendSiluAndMulImpl()
+        return DlinferSiluAndMulImpl()

--- a/lmdeploy/pytorch/backends/dlinfer/ascend/graph_runner.py
+++ b/lmdeploy/pytorch/backends/dlinfer/ascend/graph_runner.py
@@ -1,8 +1,9 @@
 # Copyright (c) OpenMMLab. All rights reserved.
+import warnings
 from importlib import import_module
-from typing import Any, Dict, List, Tuple
 
 import torch
+import torch.distributed
 
 from lmdeploy.pytorch.config import BackendConfig, CacheConfig, ModelConfig
 from lmdeploy.utils import get_logger
@@ -10,6 +11,7 @@ from lmdeploy.utils import get_logger
 from ...graph_runner import GraphRunner
 
 logger = get_logger('lmdeploy')
+
 
 class AscendGraphRunner(GraphRunner):
     """ascend graph runner."""
@@ -22,27 +24,57 @@ class AscendGraphRunner(GraphRunner):
 
         self.enable_graph = self.check_enable_graph()
         if self.enable_graph:
+            import dlinfer.graph
+            dlinfer.graph.config.enable_graph_mode = True
             self.patch_kernels_custom_op()
             self.patch_kvcache_static_shape()
-            self.model = torch.compile(self.model, fullgraph=True, dynamic=True, backend='atbgraph')
+            self.model = torch.compile(self.model,
+                                       fullgraph=True,
+                                       dynamic=True,
+                                       backend='atbgraph')
 
     def check_enable_graph(self):
         """check enable graph."""
-        return not self.backend_config.eager_mode
+        # eager_mode
+        if self.backend_config.eager_mode:
+            return False
+        # tp
+        if torch.distributed.is_initialized():
+            warnings.warn(
+                "Graph mode of device_type 'ascend' only supports tp=1 "
+                'for now, fallback to eager mode', RuntimeWarning)
+            return False
+        # model support
+        self.supported_model = {
+            'Llama2': 'LlamaConfig',
+            'InternLM2': 'InternLM2Config',
+            'Qwen2': 'Qwen2Config',
+        }
+        is_model_support = True
+        model_config_name = str(type(self.model_config.hf_config).__name__)
+        if model_config_name not in self.supported_model.values():
+            is_model_support = False
+        if not is_model_support:
+            warnings.warn(
+                "Graph mode of device_type 'ascend' only supports models: "
+                f"{', '.join(self.supported_model.keys())} when tp=1 for now",
+                RuntimeWarning)
+        return True
 
     def patch_kernels_custom_op(self):
         from dlinfer.graph.custom_op import register_custom_op
-        ascend_kernels_module = import_module("lmdeploy.pytorch.kernels.ascend")
-        ascend_backends_module = import_module("lmdeploy.pytorch.backends.ascend")
+        ascend_kernels_module = import_module(
+            'lmdeploy.pytorch.kernels.ascend')
+        ascend_backends_module = import_module(
+            'lmdeploy.pytorch.backends.ascend')
 
         # prefill_attention
-        module_str = "pagedattention"
+        module_str = 'pagedattention'
         paged_attn_module = getattr(ascend_kernels_module, module_str)
-        func_str = "prefill_attention"
+        func_str = 'prefill_attention'
         prefill_attn_origin = getattr(paged_attn_module, func_str)
         prefill_attn_registered = register_custom_op(
-            f"lmdeploy::{func_str}", ["attn_output"]
-        )(prefill_attn_origin)
+            f'lmdeploy::{func_str}', ['attn_output'])(prefill_attn_origin)
         setattr(paged_attn_module, func_str, prefill_attn_registered)
 
         # apply_rotary_pos_emb
@@ -53,26 +85,32 @@ class AscendGraphRunner(GraphRunner):
             if k_out is not None:
                 result[1] = k_out
             return tuple(result)
-        module_str = "apply_rotary_emb"
+
+        module_str = 'apply_rotary_emb'
         apply_rotary_emb_module = getattr(ascend_backends_module, module_str)
-        func_str = "apply_rotary_pos_emb"
-        apply_rotary_pos_emb_origin = getattr(apply_rotary_emb_module, func_str)
+        func_str = 'apply_rotary_pos_emb'
+        apply_rotary_pos_emb_origin = getattr(apply_rotary_emb_module,
+                                              func_str)
         apply_rotary_pos_emb_registered = register_custom_op(
-            f"lmdeploy::{func_str}",
-            impl_abstract_func=apply_rotary_emb_abstract_impl
-        )(apply_rotary_pos_emb_origin)
-        setattr(apply_rotary_emb_module, func_str, apply_rotary_pos_emb_registered)  
+            f'lmdeploy::{func_str}',
+            impl_abstract_func=apply_rotary_emb_abstract_impl)(
+                apply_rotary_pos_emb_origin)
+        setattr(apply_rotary_emb_module, func_str,
+                apply_rotary_pos_emb_registered)
 
     def patch_kvcache_static_shape(self):
         import torch._dynamo as dynamo
         from torch.utils._pytree import tree_map
-        cache_engine_module = import_module("lmdeploy.pytorch.engine.cache_engine")
-        class_str = "CacheEngine"
+        cache_engine_module = import_module(
+            'lmdeploy.pytorch.engine.cache_engine')
+        class_str = 'CacheEngine'
         cache_engine_class = getattr(cache_engine_module, class_str)
-        func_str = "allocate_gpu_cache"
+        func_str = 'allocate_gpu_cache'
         allocate_gpu_cache_origin = getattr(cache_engine_class, func_str)
+
         def allocate_gpu_cache_mark_static(self):
             gpu_cache = allocate_gpu_cache_origin(self)
             tree_map(lambda x: dynamo.mark_static(x), gpu_cache)
             return gpu_cache
+
         setattr(cache_engine_class, func_str, allocate_gpu_cache_mark_static)

--- a/lmdeploy/pytorch/backends/dlinfer/ascend/graph_runner.py
+++ b/lmdeploy/pytorch/backends/dlinfer/ascend/graph_runner.py
@@ -1,0 +1,78 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+from importlib import import_module
+from typing import Any, Dict, List, Tuple
+
+import torch
+
+from lmdeploy.pytorch.config import BackendConfig, CacheConfig, ModelConfig
+from lmdeploy.utils import get_logger
+
+from ...graph_runner import GraphRunner
+
+logger = get_logger('lmdeploy')
+
+class AscendGraphRunner(GraphRunner):
+    """ascend graph runner."""
+
+    def __init__(self, model: torch.nn.Module, model_config: ModelConfig,
+                 cache_config: CacheConfig, backend_config: BackendConfig,
+                 device: torch.device):
+        super().__init__(model, model_config, cache_config, backend_config,
+                         device)
+
+        self.enable_graph = self.check_enable_graph()
+        if self.enable_graph:
+            self.patch_kernels_custom_op()
+            self.patch_kvcache_static_shape()
+            self.model = torch.compile(self.model, fullgraph=True, dynamic=True, backend='atbgraph')
+
+    def check_enable_graph(self):
+        """check enable graph."""
+        return not self.backend_config.eager_mode
+
+    def patch_kernels_custom_op(self):
+        from dlinfer.graph.custom_op import register_custom_op
+        ascend_kernels_module = import_module("lmdeploy.pytorch.kernels.ascend")
+        ascend_backends_module = import_module("lmdeploy.pytorch.backends.ascend")
+
+        # prefill_attention
+        module_str = "pagedattention"
+        paged_attn_module = getattr(ascend_kernels_module, module_str)
+        func_str = "prefill_attention"
+        prefill_attn_origin = getattr(paged_attn_module, func_str)
+        prefill_attn_registered = register_custom_op(
+            f"lmdeploy::{func_str}", ["attn_output"]
+        )(prefill_attn_origin)
+        setattr(paged_attn_module, func_str, prefill_attn_registered)
+
+        # apply_rotary_pos_emb
+        def apply_rotary_emb_abstract_impl(q, k, cos, sin, q_out, k_out):
+            result = [q, k]
+            if q_out is not None:
+                result[0] = q_out
+            if k_out is not None:
+                result[1] = k_out
+            return tuple(result)
+        module_str = "apply_rotary_emb"
+        apply_rotary_emb_module = getattr(ascend_backends_module, module_str)
+        func_str = "apply_rotary_pos_emb"
+        apply_rotary_pos_emb_origin = getattr(apply_rotary_emb_module, func_str)
+        apply_rotary_pos_emb_registered = register_custom_op(
+            f"lmdeploy::{func_str}",
+            impl_abstract_func=apply_rotary_emb_abstract_impl
+        )(apply_rotary_pos_emb_origin)
+        setattr(apply_rotary_emb_module, func_str, apply_rotary_pos_emb_registered)  
+
+    def patch_kvcache_static_shape(self):
+        import torch._dynamo as dynamo
+        from torch.utils._pytree import tree_map
+        cache_engine_module = import_module("lmdeploy.pytorch.engine.cache_engine")
+        class_str = "CacheEngine"
+        cache_engine_class = getattr(cache_engine_module, class_str)
+        func_str = "allocate_gpu_cache"
+        allocate_gpu_cache_origin = getattr(cache_engine_class, func_str)
+        def allocate_gpu_cache_mark_static(self):
+            gpu_cache = allocate_gpu_cache_origin(self)
+            tree_map(lambda x: dynamo.mark_static(x), gpu_cache)
+            return gpu_cache
+        setattr(cache_engine_class, func_str, allocate_gpu_cache_mark_static)

--- a/lmdeploy/pytorch/backends/dlinfer/ascend/graph_runner.py
+++ b/lmdeploy/pytorch/backends/dlinfer/ascend/graph_runner.py
@@ -63,14 +63,14 @@ class AscendGraphRunner(GraphRunner):
 
     def patch_kernels_custom_op(self):
         from dlinfer.graph.custom_op import register_custom_op
-        ascend_kernels_module = import_module(
-            'lmdeploy.pytorch.kernels.ascend')
-        ascend_backends_module = import_module(
-            'lmdeploy.pytorch.backends.ascend')
+        dlinfer_kernels_module = import_module(
+            'lmdeploy.pytorch.kernels.dlinfer')
+        dlinfer_backends_module = import_module(
+            'lmdeploy.pytorch.backends.dlinfer')
 
         # prefill_attention
         module_str = 'pagedattention'
-        paged_attn_module = getattr(ascend_kernels_module, module_str)
+        paged_attn_module = getattr(dlinfer_kernels_module, module_str)
         func_str = 'prefill_attention'
         prefill_attn_origin = getattr(paged_attn_module, func_str)
         prefill_attn_registered = register_custom_op(
@@ -87,7 +87,7 @@ class AscendGraphRunner(GraphRunner):
             return tuple(result)
 
         module_str = 'apply_rotary_emb'
-        apply_rotary_emb_module = getattr(ascend_backends_module, module_str)
+        apply_rotary_emb_module = getattr(dlinfer_backends_module, module_str)
         func_str = 'apply_rotary_pos_emb'
         apply_rotary_pos_emb_origin = getattr(apply_rotary_emb_module,
                                               func_str)

--- a/lmdeploy/pytorch/backends/dlinfer/ascend/op_backend.py
+++ b/lmdeploy/pytorch/backends/dlinfer/ascend/op_backend.py
@@ -4,6 +4,7 @@ from typing import Tuple
 import torch
 
 from lmdeploy.utils import get_logger
+from lmdeploy.pytorch.config import BackendConfig, CacheConfig, ModelConfig
 
 from ..op_backend import DlinferOpsBackend
 
@@ -12,6 +13,7 @@ logger = get_logger('lmdeploy')
 
 class AscendOpsBackend(DlinferOpsBackend):
     """ascend layer backend."""
+    eager_mode = True
 
     @staticmethod
     def get_name() -> str:
@@ -50,6 +52,11 @@ class AscendOpsBackend(DlinferOpsBackend):
         device = step_context.block_offsets.device
 
         is_unpaged_prefill = False
+        q_start_loc_cpu = step_context.q_start_loc.cpu()
+        q_seqlens_cpu = step_context.q_seqlens.cpu()
+        max_q_seq_len = torch.max(q_seqlens_cpu).item()
+        max_kv_seq_len = torch.max(step_context.kv_seqlens.cpu()).item()
+
         if not step_context.is_decoding:
             is_unpaged_prefill = \
                 all((step_context.q_seqlens ==
@@ -89,6 +96,17 @@ class AscendOpsBackend(DlinferOpsBackend):
                 attention_mask.append(single_attention_mask)
 
         kv_start_indices = torch.cat(kv_start_indices)
+        if not cls.eager_mode:
+            kv_start_indices = kv_start_indices.flatten().to(torch.int32)
+            import torch._dynamo as dynamo
+            step_context.block_offsets = step_context.block_offsets.to(torch.int32).contiguous()
+            dynamo.mark_dynamic(step_context.block_offsets, [0, 1])
+            if not step_context.is_decoding and is_unpaged_prefill:
+                attention_mask = [mask.half() for mask in attention_mask]
+            kv_seqlens = step_context.kv_seqlens.to(torch.int32)
+        else:
+            kv_seqlens = step_context.kv_seqlens.cpu()
+
 
         if step_context.is_decoding:
             # prepare somae params of paged_decode attention stage.
@@ -123,7 +141,7 @@ class AscendOpsBackend(DlinferOpsBackend):
             step_context.block_offsets,
             q_start_loc=q_start_loc_cpu,
             q_seqlens=q_seqlens_cpu,
-            kv_seqlens=kv_seqlens_cpu,
+            kv_seqlens=kv_seqlens,
             kv_start_indices=kv_start_indices,
             block_size=block_size,
             attention_mask=attention_mask,
@@ -134,3 +152,14 @@ class AscendOpsBackend(DlinferOpsBackend):
 
         step_context.attn_metadata = attn_metadata
         return step_context
+
+    @staticmethod
+    def build_graph_runner(model: torch.nn.Module, model_config: ModelConfig,
+                           cache_config: CacheConfig,
+                           backend_config: BackendConfig,
+                           device: torch.device):
+        """build graph runner."""
+        from .graph_runner import AscendGraphRunner
+        AscendOpsBackend.eager_mode = backend_config.eager_mode
+        return AscendGraphRunner(model, model_config, cache_config,
+                                 backend_config, device)

--- a/lmdeploy/pytorch/backends/dlinfer/ascend/op_backend.py
+++ b/lmdeploy/pytorch/backends/dlinfer/ascend/op_backend.py
@@ -3,8 +3,8 @@ from typing import Tuple
 
 import torch
 
-from lmdeploy.utils import get_logger
 from lmdeploy.pytorch.config import BackendConfig, CacheConfig, ModelConfig
+from lmdeploy.utils import get_logger
 
 from ..op_backend import DlinferOpsBackend
 
@@ -13,9 +13,9 @@ logger = get_logger('lmdeploy')
 
 class AscendOpsBackend(DlinferOpsBackend):
     """ascend layer backend."""
-    eager_mode = True
+    enable_graph = False
     half_negative_inf = torch.finfo(torch.float16).min
-    total_slots = None 
+    total_slots = None
 
     @staticmethod
     def get_name() -> str:
@@ -49,42 +49,44 @@ class AscendOpsBackend(DlinferOpsBackend):
     @classmethod
     def update_step_context(cls, step_context):
         """update step context."""
+
         def get_total_slots():
             if cls.total_slots is None:
-                cls.total_slots = torch.arange(block_num * block_size,  
-                               dtype=torch.long,
-                               device=step_context.block_offsets.device)
+                cls.total_slots = torch.arange(
+                    block_num * block_size,
+                    dtype=torch.long,
+                    device=step_context.block_offsets.device)
                 cls.total_slots = cls.total_slots.view(block_num, block_size)
             return cls.total_slots
 
-        kv_start_indices, attention_mask = [], []      
+        kv_start_indices, attention_mask = [], []
         block_num, block_size, _ = step_context.kv_caches[0][0].shape
         is_unpaged_prefill = False
-        if not step_context.is_decoding:                
+        if not step_context.is_decoding:
             is_unpaged_prefill = \
                 all((step_context.q_seqlens ==
-                     step_context.kv_seqlens).tolist())      
+                     step_context.kv_seqlens).tolist())
         q_seqlens_list = step_context.q_seqlens.tolist()
-        kv_seqlens_list = step_context.kv_seqlens.tolist()             
-        max_q_seq_len = max(q_seqlens_list)     
+        kv_seqlens_list = step_context.kv_seqlens.tolist()
+        max_q_seq_len = max(q_seqlens_list)
         max_kv_seq_len = max(kv_seqlens_list)
 
         for i in range(step_context.q_start_loc.size(0)):
             q_seq_len = q_seqlens_list[i]
-            kv_seq_len = kv_seqlens_list[i]                              
-                                       
+            kv_seq_len = kv_seqlens_list[i]
+
             # collect kv start indices.
-            history_length = kv_seq_len - q_seq_len     
+            history_length = kv_seq_len - q_seq_len
             total_slots = get_total_slots()
             slot_tables = total_slots[step_context.block_offsets[i]].view(-1)
-            slots = slot_tables[history_length : kv_seq_len]
+            slots = slot_tables[history_length:kv_seq_len]
             kv_start_indices.append(slots)
-                                       
+
             # collect attention mask of paged_prefill attention stage.
             if not (step_context.is_decoding or is_unpaged_prefill):
                 single_attention_mask = torch.logical_not(
                     torch.tril(
-                        torch.ones(q_seq_len,     
+                        torch.ones(q_seq_len,
                                    step_context.block_offsets.shape[1] *
                                    block_size,
                                    dtype=torch.bool,
@@ -112,18 +114,17 @@ class AscendOpsBackend(DlinferOpsBackend):
         else:
             # prepare some params of paged_prefill attention stage.
             q_start_loc_cpu, q_seqlens_cpu = None, None
-            attention_mask = [
-                torch.cat([mask for mask in attention_mask])
-            ]
+            attention_mask = [torch.cat([mask for mask in attention_mask])]
 
-        if not cls.eager_mode:
+        if cls.enable_graph:
             kv_start_indices = kv_start_indices.view(-1).to(torch.int32)
             import torch._dynamo as dynamo
             if not is_unpaged_prefill:
-                step_context.block_offsets = step_context.block_offsets.to(torch.int32)
+                step_context.block_offsets = step_context.block_offsets.to(
+                    torch.int32)
                 if not step_context.is_decoding:
-                    step_context.block_offsets = step_context.block_offsets.repeat_interleave(
-                        step_context.q_seqlens, 0)
+                    step_context.block_offsets = step_context.block_offsets\
+                        .repeat_interleave(step_context.q_seqlens, 0)
             dynamo.mark_dynamic(step_context.block_offsets, [0, 1])
             kv_seqlens = step_context.kv_seqlens.to(torch.int32)
             if not step_context.is_decoding:
@@ -146,9 +147,10 @@ class AscendOpsBackend(DlinferOpsBackend):
             else:
                 kv_seqlens_cpu = step_context.kv_seqlens.repeat_interleave(
                     step_context.q_seqlens, 0).cpu()
-                block_offsets_int32 = step_context.block_offsets.to(torch.int32)
-                step_context.block_offsets = block_offsets_int32.repeat_interleave( 
-                    step_context.q_seqlens, 0)
+                block_offsets_int32 = step_context.block_offsets.to(
+                    torch.int32)
+                step_context.block_offsets = block_offsets_int32\
+                    .repeat_interleave(step_context.q_seqlens, 0)
             kv_seqlens = kv_seqlens_cpu
 
         attn_meta_cls = cls.get_attention_metadata_cls()
@@ -176,6 +178,8 @@ class AscendOpsBackend(DlinferOpsBackend):
                            device: torch.device):
         """build graph runner."""
         from .graph_runner import AscendGraphRunner
-        AscendOpsBackend.eager_mode = backend_config.eager_mode
-        return AscendGraphRunner(model, model_config, cache_config,
-                                 backend_config, device)
+        ascend_graph_runner = AscendGraphRunner(model, model_config,
+                                                cache_config, backend_config,
+                                                device)
+        AscendOpsBackend.enable_graph = ascend_graph_runner.enable_graph
+        return ascend_graph_runner

--- a/lmdeploy/pytorch/backends/dlinfer/op_backend.py
+++ b/lmdeploy/pytorch/backends/dlinfer/op_backend.py
@@ -28,6 +28,9 @@ class DlinferOpsBackend(DefaultOpsBackend):
         elif layer_type == OpType.ApplyRotaryEmb:
             from .apply_rotary_emb import DlinferApplyRotaryEmbBuilder
             return DlinferApplyRotaryEmbBuilder
+        elif layer_type == OpType.SiluAndMul:
+            from .activation import DlinferSiluAndMulBuilder
+            return DlinferSiluAndMulBuilder
         elif layer_type == OpType.RMSNorm:
             from .norm import DlinferRMSNormBuilder
             return DlinferRMSNormBuilder
@@ -40,6 +43,9 @@ class DlinferOpsBackend(DefaultOpsBackend):
         elif layer_type == OpType.LinearW4A16:
             from .awq_modules import AwqLinearW4A16Builder
             return AwqLinearW4A16Builder
+        elif layer_type == OpType.RotaryEmbedding:
+            from .rotary_embedding import DlinferRotaryEmbeddingBuilder
+            return DlinferRotaryEmbeddingBuilder
         else:
             logger.debug(
                 f'Op {layer_type} fallback to default implementation.')

--- a/lmdeploy/pytorch/backends/dlinfer/rotary_embedding.py
+++ b/lmdeploy/pytorch/backends/dlinfer/rotary_embedding.py
@@ -2,6 +2,8 @@
 import torch
 from torch import nn
 
+from ..default.rotary_embedding import (Llama3RotaryEmbeddingImpl,
+                                        LlamaDynamicNTKScalingRotaryEmbedding)
 from ..rotary_embedding import (Llama3Parameters, LongRoPEScalingParameters,
                                 RopeType, RotaryEmbeddingBuilder,
                                 RotaryEmbeddingImpl, YarnParameters)
@@ -23,11 +25,6 @@ class DlinferRotaryEmbeddingImpl(RotaryEmbeddingImpl, nn.Module):
             self.dim)).float().cuda()
         self.register_buffer('inv_freq', inv_freq, persistent=False)
 
-    def dump_tensor(self, name, t):
-        import pickle
-        with open(f'/tzy/dev_ops/{name}.pkl', 'wb') as f:
-            pickle.dump(t.cpu(), f)
-
     def forward(self, x, position_ids):
         """forward."""
         # x: [bs, num_attention_heads, seq_len, head_size]
@@ -47,7 +44,6 @@ class DlinferRotaryEmbeddingImpl(RotaryEmbeddingImpl, nn.Module):
         device_type = x.device.type
         device_type = device_type if isinstance(
             device_type, str) and device_type != 'mps' else 'cpu'
-        # with torch.autocast(device_type=device_type, enabled=False):
         inv_freq_expanded = inv_freq_expanded
         position_ids_expanded = position_ids_expanded
         tmp = torch.bmm(inv_freq_expanded, position_ids_expanded)
@@ -78,37 +74,11 @@ class DlinferRotaryEmbeddingBuilder(RotaryEmbeddingBuilder):
         elif emb_type == RopeType.DynamicNTKScaling:
             return LlamaDynamicNTKScalingRotaryEmbedding(
                 dim, base, scaling_factor, max_position_embeddings)
+        elif emb_type == RopeType.Llama3:
+            return Llama3RotaryEmbeddingImpl(dim, base, scaling_factor,
+                                             llama3_params.low_freq_factor,
+                                             llama3_params.high_freq_factor,
+                                             max_position_embeddings)
         else:
             raise NotImplementedError(
                 f'Unsupported embedding type: {emb_type}')
-
-
-class LlamaDynamicNTKScalingRotaryEmbedding(RotaryEmbeddingImpl):
-    """LlamaRotaryEmbedding extended with Dynamic NTK scaling.
-
-    Credits to the Reddit users /u/bloc97 and /u/emozilla
-    """
-
-    def __init__(self,
-                 dim: int,
-                 base: int = 10000,
-                 scaling_factor: float = 1.0,
-                 max_position_embeddings: int = 2048):
-        super().__init__(dim, base, scaling_factor)
-        self.max_position_embeddings = max_position_embeddings
-
-    def forward(self, x, position_ids):
-        """forward."""
-        seq_len = torch.max(position_ids) + 1
-        if seq_len > self.max_position_embeddings:
-            base = self.base * ((self.scaling_factor * seq_len /
-                                 self.max_position_embeddings) -
-                                (self.scaling_factor - 1))**(self.dim /
-                                                             (self.dim - 2))
-            inv_freq = 1.0 / (base**(torch.arange(
-                0, self.dim, 2, dtype=torch.int64).float().to(x.device) /
-                                     self.dim))
-            self.register_buffer('inv_freq', inv_freq, persistent=False)
-
-        cos, sin = super().forward(x, position_ids)
-        return cos, sin

--- a/lmdeploy/pytorch/backends/dlinfer/rotary_embedding.py
+++ b/lmdeploy/pytorch/backends/dlinfer/rotary_embedding.py
@@ -7,7 +7,7 @@ from ..rotary_embedding import (Llama3Parameters, LongRoPEScalingParameters,
                                 RotaryEmbeddingImpl, YarnParameters)
 
 
-class AscendRotaryEmbeddingImpl(RotaryEmbeddingImpl, nn.Module):
+class DlinferRotaryEmbeddingImpl(RotaryEmbeddingImpl, nn.Module):
     """base rotary embedding."""
 
     def __init__(self,
@@ -58,7 +58,7 @@ class AscendRotaryEmbeddingImpl(RotaryEmbeddingImpl, nn.Module):
         return cos.to(dtype=x.dtype), sin.to(dtype=x.dtype)
 
 
-class AscendRotaryEmbeddingBuilder(RotaryEmbeddingBuilder):
+class DlinferRotaryEmbeddingBuilder(RotaryEmbeddingBuilder):
     """rotary embedding builder."""
 
     @staticmethod
@@ -74,7 +74,7 @@ class AscendRotaryEmbeddingBuilder(RotaryEmbeddingBuilder):
     ):
         """build."""
         if emb_type in (RopeType.Default, RopeType.LinearScaling):
-            return AscendRotaryEmbeddingImpl(dim, base, scaling_factor)
+            return DlinferRotaryEmbeddingImpl(dim, base, scaling_factor)
         elif emb_type == RopeType.DynamicNTKScaling:
             return LlamaDynamicNTKScalingRotaryEmbedding(
                 dim, base, scaling_factor, max_position_embeddings)

--- a/lmdeploy/pytorch/backends/dlinfer/rotary_embedding.py
+++ b/lmdeploy/pytorch/backends/dlinfer/rotary_embedding.py
@@ -1,0 +1,115 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+import torch
+from torch import nn
+
+from ..rotary_embedding import (Llama3Parameters, LongRoPEScalingParameters,
+                                RopeType, RotaryEmbeddingBuilder,
+                                RotaryEmbeddingImpl, YarnParameters)
+
+
+class AscendRotaryEmbeddingImpl(RotaryEmbeddingImpl, nn.Module):
+    """base rotary embedding."""
+
+    def __init__(self,
+                 dim: int,
+                 base: int = 10000,
+                 scaling_factor: float = 1.0):
+        super().__init__()
+        self.scaling_factor = scaling_factor
+        self.dim = dim
+        self.base = base
+        inv_freq = 1.0 / (self.base**(torch.arange(
+            0, self.dim, 2, dtype=torch.int64).float() / self.dim)).float().cuda()
+        self.register_buffer('inv_freq', inv_freq, persistent=False)
+
+    def dump_tensor(self, name, t):
+        import pickle
+        with open(f'/tzy/dev_ops/{name}.pkl', 'wb') as f:
+            pickle.dump(t.cpu(), f)
+
+
+    def forward(self, x, position_ids):
+        """forward."""
+        # x: [bs, num_attention_heads, seq_len, head_size]
+        if self.inv_freq.device != x.device:
+            self.inv_freq = self.inv_freq.to(x.device)
+
+        if self.scaling_factor != 1.0:
+            position_ids = position_ids.float() / self.scaling_factor
+        else:
+            position_ids = position_ids.float()
+
+        inv_freq_expanded = self.inv_freq.view(1, -1, 1)
+        position_ids_expanded = position_ids.unsqueeze(1)
+
+        # # Force float32 since bfloat16 loses precision on long contexts
+        # See https://github.com/huggingface/transformers/pull/29285
+        device_type = x.device.type
+        device_type = device_type if isinstance(
+            device_type, str) and device_type != 'mps' else 'cpu'
+        # with torch.autocast(device_type=device_type, enabled=False):
+        inv_freq_expanded = inv_freq_expanded
+        position_ids_expanded = position_ids_expanded
+        tmp = torch.bmm(inv_freq_expanded, position_ids_expanded)
+        # tmp = torch.ops.atb.bmm.default(inv_freq_expanded, position_ids_expanded)
+        freqs = tmp.transpose(1, 2)
+        emb = torch.cat((freqs, freqs), dim=-1)
+        cos = emb.cos()
+        sin = emb.sin()
+        return cos.to(dtype=x.dtype), sin.to(dtype=x.dtype)
+
+
+class AscendRotaryEmbeddingBuilder(RotaryEmbeddingBuilder):
+    """rotary embedding builder."""
+
+    @staticmethod
+    def build(
+        dim: int,
+        max_position_embeddings: int = 2048,
+        base: int = 10000,
+        scaling_factor: float = 1.0,
+        yarn_params: YarnParameters = None,
+        longrope_params: LongRoPEScalingParameters = None,
+        llama3_params: Llama3Parameters = None,
+        emb_type: RopeType = RopeType.Default,
+    ):
+        """build."""
+        if emb_type in (RopeType.Default, RopeType.LinearScaling):
+            return AscendRotaryEmbeddingImpl(dim, base, scaling_factor)
+        elif emb_type == RopeType.DynamicNTKScaling:
+            return LlamaDynamicNTKScalingRotaryEmbedding(
+                dim, base, scaling_factor, max_position_embeddings)
+        else:
+            raise NotImplementedError(
+                f'Unsupported embedding type: {emb_type}')
+
+
+class LlamaDynamicNTKScalingRotaryEmbedding(RotaryEmbeddingImpl):
+    """LlamaRotaryEmbedding extended with Dynamic NTK scaling.
+
+    Credits to the Reddit users /u/bloc97 and /u/emozilla
+    """
+
+    def __init__(self,
+                 dim: int,
+                 base: int = 10000,
+                 scaling_factor: float = 1.0,
+                 max_position_embeddings: int = 2048):
+        super().__init__(dim, base, scaling_factor)
+        self.max_position_embeddings = max_position_embeddings
+
+    def forward(self, x, position_ids):
+        """forward."""
+        seq_len = torch.max(position_ids) + 1
+        if seq_len > self.max_position_embeddings:
+            base = self.base * ((self.scaling_factor * seq_len /
+                                 self.max_position_embeddings) -
+                                (self.scaling_factor - 1))**(self.dim /
+                                                             (self.dim - 2))
+            inv_freq = 1.0 / (base**(torch.arange(
+                0, self.dim, 2, dtype=torch.int64).float().to(x.device) /
+                                     self.dim))
+            self.register_buffer('inv_freq', inv_freq, persistent=False)
+
+        cos, sin = super().forward(x, position_ids)
+        return cos, sin

--- a/lmdeploy/pytorch/backends/dlinfer/rotary_embedding.py
+++ b/lmdeploy/pytorch/backends/dlinfer/rotary_embedding.py
@@ -18,15 +18,15 @@ class AscendRotaryEmbeddingImpl(RotaryEmbeddingImpl, nn.Module):
         self.scaling_factor = scaling_factor
         self.dim = dim
         self.base = base
-        inv_freq = 1.0 / (self.base**(torch.arange(
-            0, self.dim, 2, dtype=torch.int64).float() / self.dim)).float().cuda()
+        inv_freq = 1.0 / (self.base**(
+            torch.arange(0, self.dim, 2, dtype=torch.int64).float() /
+            self.dim)).float().cuda()
         self.register_buffer('inv_freq', inv_freq, persistent=False)
 
     def dump_tensor(self, name, t):
         import pickle
         with open(f'/tzy/dev_ops/{name}.pkl', 'wb') as f:
             pickle.dump(t.cpu(), f)
-
 
     def forward(self, x, position_ids):
         """forward."""
@@ -51,7 +51,6 @@ class AscendRotaryEmbeddingImpl(RotaryEmbeddingImpl, nn.Module):
         inv_freq_expanded = inv_freq_expanded
         position_ids_expanded = position_ids_expanded
         tmp = torch.bmm(inv_freq_expanded, position_ids_expanded)
-        # tmp = torch.ops.atb.bmm.default(inv_freq_expanded, position_ids_expanded)
         freqs = tmp.transpose(1, 2)
         emb = torch.cat((freqs, freqs), dim=-1)
         cos = emb.cos()

--- a/lmdeploy/pytorch/engine/logits_process.py
+++ b/lmdeploy/pytorch/engine/logits_process.py
@@ -336,6 +336,7 @@ class FusedLogitsProcessor(LogitsWarper):
                                   guided_input_ids, self.tokenizer)
         return scores
 
+    @torch.inference_mode()
     def sampling(self, logits: torch.Tensor):
         """sampling."""
         sampling_inputs = self.sampling_inputs

--- a/lmdeploy/pytorch/kernels/dlinfer/activation.py
+++ b/lmdeploy/pytorch/kernels/dlinfer/activation.py
@@ -1,0 +1,9 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+import dlinfer.ops as ext_ops
+from torch import Tensor
+
+
+def silu_and_mul(
+    input_tensor: Tensor,
+) -> Tensor:
+    return ext_ops.silu_and_mul(input_tensor)

--- a/lmdeploy/pytorch/kernels/dlinfer/activation.py
+++ b/lmdeploy/pytorch/kernels/dlinfer/activation.py
@@ -3,7 +3,5 @@ import dlinfer.ops as ext_ops
 from torch import Tensor
 
 
-def silu_and_mul(
-    input_tensor: Tensor,
-) -> Tensor:
+def silu_and_mul(input_tensor: Tensor, ) -> Tensor:
     return ext_ops.silu_and_mul(input_tensor)

--- a/lmdeploy/pytorch/kernels/dlinfer/apply_rotary_pos_emb.py
+++ b/lmdeploy/pytorch/kernels/dlinfer/apply_rotary_pos_emb.py
@@ -1,4 +1,6 @@
 # Copyright (c) OpenMMLab. All rights reserved.
+from typing import Optional, Tuple
+
 import dlinfer.ops as ext_ops
 from torch import Tensor
 
@@ -8,9 +10,9 @@ def apply_rotary_pos_emb(
     key_states: Tensor,
     cos: Tensor,
     sin: Tensor,
-    q_embed: Tensor = None,
-    k_embed: Tensor = None,
-):
+    q_embed: Optional[Tensor],
+    k_embed: Optional[Tensor],
+) -> Tuple[Tensor, Tensor]:
     query_states = query_states.contiguous()
     key_states = key_states.contiguous()
     bs = query_states.shape[0]

--- a/lmdeploy/pytorch/kernels/dlinfer/pagedattention.py
+++ b/lmdeploy/pytorch/kernels/dlinfer/pagedattention.py
@@ -19,7 +19,7 @@ def prefill_attention(
     block_size: int,
     attn_mask: Sequence[Optional[Tensor]],
     is_unpaged_prefill: Optional[bool],
-):
+) -> Tensor:
     num_q_heads = query_states.shape[1]
     num_kv_heads = value_states.shape[1]
 

--- a/lmdeploy/pytorch/models/llama.py
+++ b/lmdeploy/pytorch/models/llama.py
@@ -313,7 +313,6 @@ class LlamaModel(nn.Module):
                 residual=residual,
                 attn_metadata=attn_metadata,
             )
-            # break
 
         # norm
         hidden_states, _ = self.norm(hidden_states, residual)

--- a/lmdeploy/pytorch/models/llama.py
+++ b/lmdeploy/pytorch/models/llama.py
@@ -313,6 +313,7 @@ class LlamaModel(nn.Module):
                 residual=residual,
                 attn_metadata=attn_metadata,
             )
+            # break
 
         # norm
         hidden_states, _ = self.norm(hidden_states, residual)


### PR DESCRIPTION
## Motivation

Add ascend's graph mode for following models when tp=1:
Llama2, InternLM2, Qwen2

Other models aren't verified on ascend's graph mode, may or may not be worked, we show warning when using ascend's
graph mode on other models.

## Modification

Add AscendGraphRunner, silu_and_mul ops and rotary_embedding ops on ascend.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
