### PR TITLE
adding the package install prerequisites section to installation doc

### DIFF
--- a/docs/en/get_started/installation.md
+++ b/docs/en/get_started/installation.md
@@ -10,6 +10,16 @@ It supports LLMs and VLMs deployment on both Linux and Windows platform, with mi
 - Ampere(sm80,sm86): 30 series, A10, A16, A30, A100
 - Ada Lovelace(sm89): 40 series
 
+## Prerequisites
+
+- Your server must have Rust installed, as some dependencies require compiling components with Rust during the package installation.
+
+- Ensure that Rust is properly configured in your system's PATH.
+  You can install Rust using the official installation guide available [here](https://www.rust-lang.org/tools/install). After installing Rust, verify the installation:
+  ```shell
+  rustc --version
+  ```
+
 ## Install with pip (Recommend)
 
 It is recommended installing lmdeploy using pip in a conda environment (python 3.8 - 3.12):

--- a/docs/zh_cn/get_started/installation.md
+++ b/docs/zh_cn/get_started/installation.md
@@ -10,6 +10,15 @@ Turing(sm75): 20 系列，T4
 Ampere(sm80,sm86): 30 系列，A10, A16, A30, A100
 Ada Lovelace(sm89): 40 系列
 
+## 前置条件
+- 请确保服务器已经安装了Rust，因为某些依赖项在安装过程中需要使用Rust来编译组件。
+- 确保Rust已正确配置在系统的PATH中。
+  您可以在[此处](https://www.rust-lang.org/tools/install)找到Rust的官方安装指南。安装后，请通过运行以下命令来验证安装是否成功：
+  ```shell
+  rustc --version
+  ```
+
+
 ## 使用 pip 安装（推荐）
 
 我们推荐在一个干净的conda环境下（python3.8 - 3.12），安装 lmdeploy：


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily receiving feedbacks. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

While setting up a new server, I encountered the following error on a fresh Ubuntu 24.10 server:

```shell
Collecting outlines-core
  Using cached outlines_core-0.1.14.tar.gz (59 kB)
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... done
Collecting interegular (from outlines-core)
  Using cached interegular-0.3.3-py37-none-any.whl.metadata (3.0 kB)
Collecting jsonschema (from outlines-core)
  Using cached jsonschema-4.23.0-py3-none-any.whl.metadata (7.9 kB)
Collecting attrs>=22.2.0 (from jsonschema->outlines-core)
  Using cached attrs-24.2.0-py3-none-any.whl.metadata (11 kB)
Collecting jsonschema-specifications>=2023.03.6 (from jsonschema->outlines-core)
  Using cached jsonschema_specifications-2024.10.1-py3-none-any.whl.metadata (3.0 kB)
Collecting referencing>=0.28.4 (from jsonschema->outlines-core)
  Using cached referencing-0.35.1-py3-none-any.whl.metadata (2.8 kB)
Collecting rpds-py>=0.7.1 (from jsonschema->outlines-core)
  Using cached rpds_py-0.20.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (4.2 kB)
Using cached interegular-0.3.3-py37-none-any.whl (23 kB)
Using cached jsonschema-4.23.0-py3-none-any.whl (88 kB)
Using cached attrs-24.2.0-py3-none-any.whl (63 kB)
Using cached jsonschema_specifications-2024.10.1-py3-none-any.whl (18 kB)
Using cached referencing-0.35.1-py3-none-any.whl (26 kB)
Using cached rpds_py-0.20.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (357 kB)
Building wheels for collected packages: outlines-core
  Building wheel for outlines-core (pyproject.toml) ... error
  error: subprocess-exited-with-error
  
  × Building wheel for outlines-core (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> [76 lines of output]
      running bdist_wheel
      running build
      running build_py
      creating build/lib.linux-x86_64-cpython-312/outlines_core
      copying python/outlines_core/__init__.py -> build/lib.linux-x86_64-cpython-312/outlines_core
      copying python/outlines_core/_version.py -> build/lib.linux-x86_64-cpython-312/outlines_core
      running egg_info
      writing python/outlines_core.egg-info/PKG-INFO
      writing dependency_links to python/outlines_core.egg-info/dependency_links.txt
      writing requirements to python/outlines_core.egg-info/requires.txt
      writing top-level names to python/outlines_core.egg-info/top_level.txt
      ERROR setuptools_scm._file_finders.git listing git files failed - pretending there aren't any
      reading manifest file 'python/outlines_core.egg-info/SOURCES.txt'
      adding license file 'LICENSE'
      writing manifest file 'python/outlines_core.egg-info/SOURCES.txt'
      /tmp/pip-build-env-g5j09e1h/overlay/lib/python3.12/site-packages/setuptools/command/build_py.py:218: _Warning: Package 'outlines_core.fsm' is absent from the packages configuration.
      !!
      
              ********************************************************************************
              ############################
              # Package would be ignored #
              ############################
              Python recognizes 'outlines_core.fsm' as an importable package[^1],
              but it is absent from setuptools' packages configuration.
      
              This leads to an ambiguous overall configuration. If you want to distribute this
              package, please make sure that 'outlines_core.fsm' is explicitly added
              to the packages configuration field.
      
              Alternatively, you can also rely on setuptools' discovery methods
              (for example by using find_namespace_packages(...)/find_namespace:
              instead of find_packages(...)/find:).
      
              You can read more about "package discovery" on setuptools documentation page:
      
              - https://setuptools.pypa.io/en/latest/userguide/package_discovery.html
      
              If you don't want 'outlines_core.fsm' to be distributed and are
              already explicitly excluding 'outlines_core.fsm' via
              find_namespace_packages(...)/find_namespace or find_packages(...)/find,
              you can try to use exclude_package_data, or include-package-data=False in
              combination with a more fine grained package-data configuration.
      
              You can read more about "package data files" on setuptools documentation page:
      
              - https://setuptools.pypa.io/en/latest/userguide/datafiles.html
      
      
              [^1]: For Python, any directory (with suitable naming) can be imported,
                    even if it does not contain any .py files.
                    On the other hand, currently there is no concept of package data
                    directory, all directories are treated like packages.
              ********************************************************************************
      
      !!
        check.warn(importable)
      copying python/outlines_core/py.typed -> build/lib.linux-x86_64-cpython-312/outlines_core
      creating build/lib.linux-x86_64-cpython-312/outlines_core/fsm
      copying python/outlines_core/fsm/__init__.py -> build/lib.linux-x86_64-cpython-312/outlines_core/fsm
      copying python/outlines_core/fsm/guide.py -> build/lib.linux-x86_64-cpython-312/outlines_core/fsm
      copying python/outlines_core/fsm/json_schema.py -> build/lib.linux-x86_64-cpython-312/outlines_core/fsm
      copying python/outlines_core/fsm/outlines_core_rs.pyi -> build/lib.linux-x86_64-cpython-312/outlines_core/fsm
      copying python/outlines_core/fsm/regex.py -> build/lib.linux-x86_64-cpython-312/outlines_core/fsm
      running build_ext
      running build_rust
      error: can't find Rust compiler
      
      If you are using an outdated pip version, it is possible a prebuilt wheel is available for this package but pip is not able to install from it. Installing from the wheel would avoid the need for a Rust compiler.
      
      To update pip, run:
      
          pip install --upgrade pip
      
      and then retry package installation.
      
      If you did intend to build this package from source, try installing a Rust compiler from your system package manager and ensure it is on the PATH during installation. Alternatively, rustup (available at https://rustup.rs) is the recommended way to download and update the Rust compiler toolchain.
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
  ERROR: Failed building wheel for outlines-core
Failed to build outlines-core
ERROR: ERROR: Failed to build installable wheels for some pyproject.toml based projects (outlines-core)
```

## Modification

I suggest adding a "Prerequisites" section to the installation documentation to mention the need for a Rust compiler during setup.

## BC-breaking (Optional)

N/A

## Use cases (Optional)

N/A

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
