### PR TITLE
fix build error in ascend dockerfile

### DIFF
--- a/docker/Dockerfile_aarch64_ascend
+++ b/docker/Dockerfile_aarch64_ascend
@@ -73,7 +73,7 @@ $LD_LIBRARY_PATH
 ARG CHIP=all
 ARG TOOLKIT_PKG=Ascend-cann-toolkit_*.run
 ARG KERNELS_PKG=Ascend-cann-kernels-*.run
-ARG NNAL_PKG=Ascend-nnal_*.run
+ARG NNAL_PKG=Ascend-cann-nnal_*.run
 
 RUN --mount=type=cache,target=/tmp,from=build_temp,source=/tmp \
     umask 0022 && \
@@ -87,6 +87,7 @@ RUN --mount=type=cache,target=/tmp,from=build_temp,source=/tmp \
     chmod +x $TOOLKIT_PKG $KERNELS_PKG $NNAL_PKG && \
     ./$TOOLKIT_PKG --quiet --install --install-path=$ASCEND_BASE --install-for-all $CHIPOPTION && \
     ./$KERNELS_PKG --quiet --install --install-path=$ASCEND_BASE --install-for-all && \
+    . /usr/local/Ascend/ascend-toolkit/set_env.sh && \
     ./$NNAL_PKG --quiet --install --install-path=$ASCEND_BASE && \
     rm -f $TOOLKIT_PKG $KERNELS_PKG $NNAL_PKG
 


### PR DESCRIPTION
## Motivation
In  docker/Dockerfile_aarch64_ascend we have two build errors in last updates:
1. incorrect nnal package name
2. not sourcing CANN set_env.sh, nnal build would be failed in installation

## Modification

Add env source and fix package name in docker/Dockerfile_aarch64_ascend

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
