### PR TITLE
fix supported model list in ascend graph mode

### DIFF
--- a/docs/en/get_started/ascend/get_started.md
+++ b/docs/en/get_started/ascend/get_started.md
@@ -49,7 +49,7 @@ For more information about running the Docker client on Ascend devices, please r
 ## Offline batch inference
 
 > \[!TIP\]
-> Graph mode has been supported on Atlas 800T A2. Currently, InternLM2-7B/LLaMa2-7B/Qwen2-7B are tested on graph mode.
+> Graph mode has been supported on Atlas 800T A2. Currently, LLaMa3-8B/LLaMa2-7B/Qwen2-7B are tested on graph mode.
 > Users can set `eager_mode=False` to enable graph mode, or, set `eager_mode=True` to disable graph mode.
 > (Please source `/usr/local/Ascend/nnal/atb/set_env.sh` before enabling graph mode)
 

--- a/docs/zh_cn/get_started/ascend/get_started.md
+++ b/docs/zh_cn/get_started/ascend/get_started.md
@@ -49,7 +49,7 @@ docker run -e ASCEND_VISIBLE_DEVICES=0 --rm --name lmdeploy -t lmdeploy-aarch64-
 ## 离线批处理
 
 > \[!TIP\]
-> 图模式已经支持了Atlas 800T A2。目前，单卡下的InternLM2-7B/LLaMa2-7B/Qwen2-7B已经通过测试。用户可以设定`eager_mode=False`来开启图模式，或者设定`eager_mode=True`来关闭图模式。(启动图模式需要事先source `/usr/local/Ascend/nnal/atb/set_env.sh`)
+> 图模式已经支持了Atlas 800T A2。目前，单卡下的LLaMa3-8B/LLaMa2-7B/Qwen2-7B已经通过测试。用户可以设定`eager_mode=False`来开启图模式，或者设定`eager_mode=True`来关闭图模式。(启动图模式需要事先source `/usr/local/Ascend/nnal/atb/set_env.sh`)
 
 ### LLM 推理
 

--- a/lmdeploy/pytorch/backends/dlinfer/ascend/graph_runner.py
+++ b/lmdeploy/pytorch/backends/dlinfer/ascend/graph_runner.py
@@ -22,6 +22,7 @@ class AscendGraphRunner(GraphRunner):
         super().__init__(model, model_config, cache_config, backend_config,
                          device)
 
+        self.supported_model = ['Llama3-8B', 'Llama2-7B', 'Qwen2-7B']
         self.enable_graph = self.check_enable_graph()
         if self.enable_graph:
             import dlinfer.graph
@@ -44,21 +45,20 @@ class AscendGraphRunner(GraphRunner):
                 "Graph mode of device_type 'ascend' only supports tp=1 "
                 'for now, fallback to eager mode', RuntimeWarning)
             return False
-        # model support
-        self.supported_model = {
-            'Llama2': 'LlamaConfig',
-            'InternLM2': 'InternLM2Config',
-            'Qwen2': 'Qwen2Config',
-        }
-        is_model_support = True
-        model_config_name = str(type(self.model_config.hf_config).__name__)
-        if model_config_name not in self.supported_model.values():
-            is_model_support = False
-        if not is_model_support:
-            warnings.warn(
-                "Graph mode of device_type 'ascend' only supports models: "
-                f"{', '.join(self.supported_model.keys())} when tp=1 for now",
-                RuntimeWarning)
+
+        warnings.warn(
+            '\n\n'
+            '**********************************************************\n'
+            '  The following models were tested in graph mode of\n'
+            "  device_type 'ascend' when tp=1:\n"
+            f"  {', '.join(self.supported_model)}\n"
+            '  Other LLaMa-like models may work in graph mode, please\n'
+            '  check the result yourself!\n'
+            '  If graph mode does not work correctly with your model,\n'
+            '  please use eager mode instead.\n'
+            '**********************************************************\n\n',
+            RuntimeWarning)
+
         return True
 
     def patch_kernels_custom_op(self):


### PR DESCRIPTION
1. Since latest InternLM2 uses NTK in RoPE, graph mode cannot support it for now. llama3-8B is tested in graph mode.
2. Since we cannot distinguish between llama3 and llama3.1, warning message always show in graph mode.
3. Since graph mode is BC-breaking feature, we made the message more noticeable.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
4. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
5. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
6. The documentation has been modified accordingly, like docstring or example tutorials.
