### PR TITLE
feat: support dynamic/llama3 rotary embedding in ascend graph mode

### DIFF
--- a/lmdeploy/pytorch/backends/dlinfer/rotary_embedding.py
+++ b/lmdeploy/pytorch/backends/dlinfer/rotary_embedding.py
@@ -27,8 +27,6 @@ def _rotary_embedding_fwd(position_ids: torch.Tensor,
     inv_freq_expanded = inv_freq.view(1, -1, 1)
     position_ids_expanded = position_ids.unsqueeze(1)
 
-    inv_freq_expanded = inv_freq_expanded
-    position_ids_expanded = position_ids_expanded
     tmp = torch.bmm(inv_freq_expanded, position_ids_expanded)
     freqs = tmp.transpose(1, 2)
     emb = torch.cat((freqs, freqs), dim=-1)

--- a/lmdeploy/pytorch/backends/dlinfer/rotary_embedding.py
+++ b/lmdeploy/pytorch/backends/dlinfer/rotary_embedding.py
@@ -1,9 +1,10 @@
 # Copyright (c) OpenMMLab. All rights reserved.
+import math
+
 import torch
 from torch import nn
 
-from ..default.rotary_embedding import (Llama3RotaryEmbeddingImpl,
-                                        LlamaDynamicNTKScalingRotaryEmbedding)
+from ..default.rotary_embedding import LlamaDynamicNTKScalingRotaryEmbedding
 from ..rotary_embedding import (Llama3Parameters, LongRoPEScalingParameters,
                                 RopeType, RotaryEmbeddingBuilder,
                                 RotaryEmbeddingImpl, YarnParameters)
@@ -13,8 +14,7 @@ def _rotary_embedding_fwd(position_ids: torch.Tensor,
                           inv_freq: torch.Tensor,
                           scaling_factor: float,
                           mscale: float = None,
-                          dtype: torch.dtype = None,
-                          device_type: torch.device = None):
+                          dtype: torch.dtype = None):
     """rotary embedding forward."""
     if dtype is None:
         dtype = torch.float16
@@ -38,7 +38,6 @@ def _rotary_embedding_fwd(position_ids: torch.Tensor,
     if mscale is not None:
         cos = cos * mscale
         sin = sin * mscale
-
     return cos.to(dtype=dtype), sin.to(dtype=dtype)
 
 
@@ -61,15 +60,13 @@ class DlinferRotaryEmbeddingImpl(RotaryEmbeddingImpl, nn.Module):
     def forward(self, x, position_ids):
         """forward."""
         # x: [bs, num_attention_heads, seq_len, head_size]
-        device_type = x.device.type
         dtype = x.dtype
         if self.inv_freq.device != x.device:
             self.inv_freq = self.inv_freq.to(x.device)
         return _rotary_embedding_fwd(position_ids,
                                      self.inv_freq,
                                      scaling_factor=self.scaling_factor,
-                                     dtype=dtype,
-                                     device_type=device_type)
+                                     dtype=dtype)
 
 
 class DlinferLlamaDynamicNTKScalingRotaryEmbedding(
@@ -85,21 +82,22 @@ class DlinferLlamaDynamicNTKScalingRotaryEmbedding(
                  scaling_factor: float = 1.0,
                  max_position_embeddings: int = 2048):
         super().__init__(dim, base, scaling_factor, max_position_embeddings)
-        self.exponent_1 = self.dim / (self.dim - 2)
-        self.exponent_2 = torch.arange(
+        self.dim_scale_ratio = self.dim / (self.dim - 2)
+        self.pos_freq_scaling = torch.arange(
             0, self.dim, 2, dtype=torch.int64).float().cuda() / self.dim
-        self.sub = self.scaling_factor - 1
-        self.div = self.scaling_factor / self.max_position_embeddings
+        self.scale_offset = self.scaling_factor - 1
+        self.pos_scale_factor = self.scaling_factor / \
+            self.max_position_embeddings
 
     def _ntk_inv_freq(self, seq_len: torch.Tensor):
-        """ntk_inv_freq."""
-        base = self.base * ((self.div * seq_len) - self.sub)**self.exponent_1
-        inv_freq = 1.0 / (base**self.exponent_2)
+        """Calculate inverse frequency with NTK scaling."""
+        base = self.base * ((self.pos_scale_factor * seq_len) -
+                            self.scale_offset)**self.dim_scale_ratio
+        inv_freq = 1.0 / (base**self.pos_freq_scaling)
         return inv_freq
 
     def forward(self, x: torch.Tensor, position_ids: torch.Tensor):
         """forward."""
-        device_type = x.device.type
         dtype = x.dtype
         seq_len = torch.max(position_ids) + 1
         ntk_inv_freq = self._ntk_inv_freq(seq_len)
@@ -111,13 +109,51 @@ class DlinferLlamaDynamicNTKScalingRotaryEmbedding(
         cos, sin = _rotary_embedding_fwd(position_ids,
                                          inv_freq,
                                          scaling_factor=1.0,
-                                         dtype=dtype,
-                                         device_type=device_type)
+                                         dtype=dtype)
         return cos, sin
 
 
+class DlinferLlama3RotaryEmbeddingImpl(DlinferRotaryEmbeddingImpl):
+    """llama3 rotary embedding implementation."""
+
+    def __init__(
+        self,
+        dim: int,
+        base: int = 10000,
+        scaling_factor: float = 1.0,
+        low_freq_factor: float = 1.0,
+        high_freq_factor: float = 4.0,
+        original_max_position_embeddings: int = 8194,
+    ):
+        super().__init__(dim, base, scaling_factor)
+        old_context_len = original_max_position_embeddings
+        low_freq_wavelen = old_context_len / low_freq_factor
+        high_freq_wavelen = old_context_len / high_freq_factor
+
+        inv_freq = self.inv_freq
+        factor = self.scaling_factor
+
+        wavelen = 2 * math.pi / inv_freq
+        # wavelen < high_freq_wavelen: do nothing
+        # wavelen > low_freq_wavelen: divide by factor
+        inv_freq_llama = torch.where(wavelen > low_freq_wavelen,
+                                     inv_freq / factor, inv_freq)
+        # otherwise: interpolate between the two, using a smooth factor
+        smooth_factor = (old_context_len / wavelen - low_freq_factor) / (
+            high_freq_factor - low_freq_factor)
+        smoothed_inv_freq = (
+            1 - smooth_factor
+        ) * inv_freq_llama / factor + smooth_factor * inv_freq_llama
+        is_medium_freq = ~(wavelen < high_freq_wavelen) * ~(wavelen >
+                                                            low_freq_wavelen)
+        inv_freq_llama = torch.where(is_medium_freq, smoothed_inv_freq,
+                                     inv_freq_llama)
+        self.scaling_factor = 1.0
+        self.register_buffer('inv_freq', inv_freq_llama)
+
+
 class DlinferRotaryEmbeddingBuilder(RotaryEmbeddingBuilder):
-    """rotary embedding builder."""
+    """rotary embedding dlinfer builder."""
 
     @staticmethod
     def build(
@@ -137,10 +173,9 @@ class DlinferRotaryEmbeddingBuilder(RotaryEmbeddingBuilder):
             return DlinferLlamaDynamicNTKScalingRotaryEmbedding(
                 dim, base, scaling_factor, max_position_embeddings)
         elif emb_type == RopeType.Llama3:
-            return Llama3RotaryEmbeddingImpl(dim, base, scaling_factor,
-                                             llama3_params.low_freq_factor,
-                                             llama3_params.high_freq_factor,
-                                             max_position_embeddings)
+            return DlinferLlama3RotaryEmbeddingImpl(
+                dim, base, scaling_factor, llama3_params.low_freq_factor,
+                llama3_params.high_freq_factor, max_position_embeddings)
         else:
             raise NotImplementedError(
                 f'Unsupported embedding type: {emb_type}')


### PR DESCRIPTION
## Motivation

support Dynamic NTK scaling and llama3 rotary embedding is supported in ascend graph mode

## Modification

ascend rotary_embedding

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
