### PR TITLE
Support Mono-InternVL with PyTorch backend

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-## Contributing to InternLM
+## Contributing to LMDeploy
 
-Welcome to the InternLM community, all kinds of contributions are welcomed, including but not limited to
+Welcome to the LMDeploy community, all kinds of contributions are welcomed, including but not limited to
 
 **Fix bug**
 
@@ -56,7 +56,7 @@ upstream	git@github.com:InternLM/lmdeploy.git (push)
 
 #### 2. Configure pre-commit
 
-You should configure [pre-commit](https://pre-commit.com/#intro) in the local development environment to make sure the code style matches that of InternLM. **Note**: The following code should be executed under the lmdeploy directory.
+You should configure [pre-commit](https://pre-commit.com/#intro) in the local development environment to make sure the code style matches that of LMDeploy. **Note**: The following code should be executed under the lmdeploy directory.
 
 ```shell
 pip install -U pre-commit
@@ -96,7 +96,7 @@ git checkout -b yhc/refactor_contributing_doc
 In subsequent development, if the master branch of the local repository is behind the master branch of "upstream", we need to pull the upstream for synchronization, and then execute the above command:
 
 ```shell
-git pull upstream master
+git pull upstream main
 ```
 
 #### 4. Commit the code and pass the unit test
@@ -151,7 +151,7 @@ Find more details about Pull Request description in [pull request guidelines](#p
 
 <img src="https://user-images.githubusercontent.com/57566630/167307490-f9ebf9fa-63c0-4d83-8ba1-081ea169eb3a.png" width="1200">
 
-IternLM will run unit test for the posted Pull Request on different platforms (Linux, Window, Mac), based on different versions of Python, PyTorch, CUDA to make sure the code is correct. We can see the specific test information by clicking `Details` in the above image so that we can modify the code.
+LMDeploy will run unit test for the posted Pull Request on different platforms (Linux, Window, Mac), based on different versions of Python, PyTorch, CUDA to make sure the code is correct. We can see the specific test information by clicking `Details` in the above image so that we can modify the code.
 
 (3) If the Pull Request passes the CI, then you can wait for the review from other developers. You'll modify the code based on the reviewer's comments, and repeat the steps [4](#4-commit-the-code-and-pass-the-unit-test)-[5](#5-push-the-code-to-remote) until all reviewers approve it. Then, we will merge it ASAP.
 
@@ -163,14 +163,14 @@ If your local branch conflicts with the latest master branch of "upstream", you'
 
 ```shell
 git fetch --all --prune
-git rebase upstream/master
+git rebase upstream/main
 ```
 
 or
 
 ```shell
 git fetch --all --prune
-git merge upstream/master
+git merge upstream/main
 ```
 
 If you are very good at handling conflicts, then you can use rebase to resolve conflicts, as this will keep your commit logs tidy. If you are not familiar with `rebase`, then you can use `merge` to resolve conflicts.

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ ______________________________________________________________________
 <details open>
 <summary><b>2024</b></summary>
 
+- \[2024/11\] Support Mono-InternVL-2B with PyTorch engine
 - \[2024/10\] PyTorchEngine supports graph mode on ascend platform, doubling the inference speed
 - \[2024/09\] LMDeploy PyTorchEngine adds support for [Huawei Ascend](./docs/en/get_started/ascend/get_started.md). See supported models [here](docs/en/supported_models/supported_models.md)
 - \[2024/09\] LMDeploy PyTorchEngine achieves 1.3x faster on Llama3-8B inference by introducing CUDA graph
@@ -155,6 +156,7 @@ For detailed inference benchmarks in more devices and more settings, please refe
   <li>DeepSeek-VL (7B)</li>
   <li>InternVL-Chat (v1.1-v1.5)</li>
   <li>InternVL2 (1B-76B)</li>
+  <li>Mono-InternVL (2B)</li>
   <li>MiniGeminiLlama (7B)</li>
   <li>CogVLM-Chat (17B)</li>
   <li>CogVLM2-Chat (19B)</li>

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ ______________________________________________________________________
 <details open>
 <summary><b>2024</b></summary>
 
-- \[2024/11\] Support Mono-InternVL-2B with PyTorch engine
+- \[2024/11\] Support Mono-InternVL with PyTorch engine
 - \[2024/10\] PyTorchEngine supports graph mode on ascend platform, doubling the inference speed
 - \[2024/09\] LMDeploy PyTorchEngine adds support for [Huawei Ascend](./docs/en/get_started/ascend/get_started.md). See supported models [here](docs/en/supported_models/supported_models.md)
 - \[2024/09\] LMDeploy PyTorchEngine achieves 1.3x faster on Llama3-8B inference by introducing CUDA graph

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -26,6 +26,7 @@ ______________________________________________________________________
 <details open>
 <summary><b>2024</b></summary>
 
+- \[2024/11\] PyTorch engine 支持 Mono-InternVL 模型
 - \[2024/10\] PyTorchEngine 在 ascend 平台上支持了图模式，推理性能提高了 1 倍
 - \[2024/09\] LMDeploy PyTorchEngine 增加了对 [华为 Ascend](docs/zh_cn/get_started/ascend/get_started.md) 的支持。支持的模型请见[这里](docs/zh_cn/supported_models/supported_models.md)
 - \[2024/09\] 通过引入 CUDA Graph，LMDeploy PyTorchEngine 在 Llama3-8B 推理上实现了 1.3 倍的加速
@@ -156,6 +157,7 @@ LMDeploy TurboMind 引擎拥有卓越的推理能力，在各种规模的模型�
   <li>DeepSeek-VL (7B)</li>
   <li>InternVL-Chat (v1.1-v1.5)</li>
   <li>InternVL2 (1B-76B)</li>
+  <li>Mono-InternVL (2B)</li>
   <li>MiniGeminiLlama (7B)</li>
   <li>CogVLM-Chat (17B)</li>
   <li>CogVLM2-Chat (19B)</li>

--- a/docs/en/multi_modal/internvl.md
+++ b/docs/en/multi_modal/internvl.md
@@ -2,12 +2,13 @@
 
 LMDeploy supports the following InternVL series of models, which are detailed in the table below:
 
-|    Model    |    Size    | Supported Inference Engine |
-| :---------: | :--------: | :------------------------: |
-|  InternVL   |  13B-19B   |         TurboMind          |
-| InternVL1.5 |   2B-26B   |     TurboMind, PyTorch     |
-|  InternVL2  |   1B, 4B   |          PyTorch           |
-|  InternVL2  | 2B, 8B-76B |     TurboMind, PyTorch     |
+|     Model     |    Size    | Supported Inference Engine |
+| :-----------: | :--------: | :------------------------: |
+|   InternVL    |  13B-19B   |         TurboMind          |
+|  InternVL1.5  |   2B-26B   |     TurboMind, PyTorch     |
+|   InternVL2   |   1B, 4B   |          PyTorch           |
+|   InternVL2   | 2B, 8B-76B |     TurboMind, PyTorch     |
+| Mono-InternVL |     2B     |          PyTorch           |
 
 The next chapter demonstrates how to deploy an InternVL model using LMDeploy, with [InternVL2-8B](https://huggingface.co/OpenGVLab/InternVL2-8B) as an example.
 

--- a/docs/en/multi_modal/vl_pipeline.md
+++ b/docs/en/multi_modal/vl_pipeline.md
@@ -9,6 +9,7 @@ Currently, it supports the following models.
 - [Yi-VL](https://huggingface.co/01-ai/Yi-VL-6B)
 - [DeepSeek-VL](https://huggingface.co/deepseek-ai/deepseek-vl-7b-chat)
 - [InternVL](https://huggingface.co/OpenGVLab/InternVL-Chat-V1-5)
+- [Mono-InternVL](https://huggingface.co/OpenGVLab/Mono-InternVL-2B)
 - [MGM](https://huggingface.co/YanweiLi/MGM-7B)
 - [XComposer](https://huggingface.co/internlm/internlm-xcomposer2-vl-7b)
 - [CogVLM](https://github.com/InternLM/lmdeploy/tree/main/docs/en/multi_modal/cogvlm.md)

--- a/docs/en/supported_models/supported_models.md
+++ b/docs/en/supported_models/supported_models.md
@@ -80,6 +80,7 @@ The TurboMind engine doesn't support window attention. Therefore, for models tha
 | LLaVA(1.5,1.6) |   7B-34B    | MLLM |    Yes    |   Yes   |   Yes   |  No  |   -   |
 | InternVL(v1.5) |   2B-26B    | MLLM |    Yes    |   Yes   |   Yes   |  No  |  Yes  |
 |   InternVL2    |   1B-40B    | MLLM |    Yes    |   Yes   |   Yes   |  No  |   -   |
+| Mono-InternVL  |     2B      | MLLM |    Yes    |   Yes   |   Yes   |  No  |   -   |
 |     Gemma2     |   9B-27B    | LLM  |    Yes    |   Yes   |   Yes   |  No  |   -   |
 |      GLM4      |     9B      | LLM  |    Yes    |   Yes   |   Yes   |  No  |  No   |
 |     GLM-4V     |     9B      | MLLM |    Yes    |   Yes   |   Yes   |  No  |  No   |

--- a/docs/en/supported_models/supported_models.md
+++ b/docs/en/supported_models/supported_models.md
@@ -80,7 +80,7 @@ The TurboMind engine doesn't support window attention. Therefore, for models tha
 | LLaVA(1.5,1.6) |   7B-34B    | MLLM |    Yes    |   Yes   |   Yes   |  No  |   -   |
 | InternVL(v1.5) |   2B-26B    | MLLM |    Yes    |   Yes   |   Yes   |  No  |  Yes  |
 |   InternVL2    |   1B-40B    | MLLM |    Yes    |   Yes   |   Yes   |  No  |   -   |
-| Mono-InternVL  |     2B      | MLLM |    Yes    |   Yes   |   Yes   |  No  |   -   |
+| Mono-InternVL  |     2B      | MLLM |   Yes\*   |   Yes   |   Yes   |  No  |   -   |
 |     Gemma2     |   9B-27B    | LLM  |    Yes    |   Yes   |   Yes   |  No  |   -   |
 |      GLM4      |     9B      | LLM  |    Yes    |   Yes   |   Yes   |  No  |  No   |
 |     GLM-4V     |     9B      | MLLM |    Yes    |   Yes   |   Yes   |  No  |  No   |
@@ -88,6 +88,10 @@ The TurboMind engine doesn't support window attention. Therefore, for models tha
 |  Phi-3.5-mini  |    3.8B     | LLM  |    Yes    |   Yes   |   No    |  No  |   -   |
 |  Phi-3.5-MoE   |   16x3.8B   | LLM  |    Yes    |   Yes   |   No    |  No  |   -   |
 | Phi-3.5-vision |    4.2B     | MLLM |    Yes    |   Yes   |   No    |  No  |   -   |
+
+```{note}
+* Currently Mono-InternVL does not support FP16 due to numerical instability. Please use BF16 instead.
+```
 
 ## PyTorchEngine on Huawei Ascend Platform
 

--- a/docs/zh_cn/multi_modal/internvl.md
+++ b/docs/zh_cn/multi_modal/internvl.md
@@ -2,14 +2,15 @@
 
 LMDeploy 支持 InternVL 系列模型，具体如下：
 
-|    Model    |    Size    | Supported Inference Engine |
-| :---------: | :--------: | :------------------------: |
-|  InternVL   |  13B-19B   |         TurboMind          |
-| InternVL1.5 |   2B-26B   |     TurboMind, PyTorch     |
-|  InternVL2  |   1B, 4B   |          PyTorch           |
-|  InternVL2  | 2B, 8B-76B |     TurboMind, PyTorch     |
+|     Model     |    Size    | Supported Inference Engine |
+| :-----------: | :--------: | :------------------------: |
+|   InternVL    |  13B-19B   |         TurboMind          |
+|  InternVL1.5  |   2B-26B   |     TurboMind, PyTorch     |
+|   InternVL2   |   1B, 4B   |          PyTorch           |
+|   InternVL2   | 2B, 8B-76B |     TurboMind, PyTorch     |
+| Mono-InternVL |     2B     |          PyTorch           |
 
-本文将以[InternVL2-8B](https://huggingface.co/OpenGVLab/InternVL2-8B)为例，演示使用 LMDeploy 部署 InternVL 系列模型的方法
+本文将以[InternVL2-8B](https://huggingface.co/OpenGVLab/InternVL2-8B)为例，演示使用 LMDeploy 部署 InternVL 系列模型的方法。
 
 ## 安装
 

--- a/docs/zh_cn/multi_modal/vl_pipeline.md
+++ b/docs/zh_cn/multi_modal/vl_pipeline.md
@@ -9,6 +9,7 @@ LMDeploy 把视觉-语言模型（VLM）复杂的推理过程，抽象为简单�
 - [Yi-VL](https://huggingface.co/01-ai/Yi-VL-6B)
 - [DeepSeek-VL](https://huggingface.co/deepseek-ai/deepseek-vl-7b-chat)
 - [InternVL](https://huggingface.co/OpenGVLab/InternVL-Chat-V1-5)
+- [Mono-InternVL](https://huggingface.co/OpenGVLab/Mono-InternVL-2B)
 - [MGM](https://huggingface.co/YanweiLi/MGM-7B)
 - [XComposer](https://huggingface.co/internlm/internlm-xcomposer2-vl-7b)
 - [CogVLM](https://github.com/InternLM/lmdeploy/tree/main/docs/zh_cn/multi_modal/cogvlm.md)

--- a/docs/zh_cn/supported_models/supported_models.md
+++ b/docs/zh_cn/supported_models/supported_models.md
@@ -80,6 +80,7 @@ turbomind 引擎不支持 window attention。所以，对于应用了 window att
 | LLaVA(1.5,1.6) |   7B-34B    | MLLM |    Yes    |   Yes   |   Yes   |  No  |   -   |
 | InternVL(v1.5) |   2B-26B    | MLLM |    Yes    |   Yes   |   Yes   |  No  |  Yes  |
 |   InternVL2    |   1B-40B    | MLLM |    Yes    |   Yes   |   Yes   |  No  |   -   |
+| Mono-InternVL  |     2B      | MLLM |    Yes    |   Yes   |   Yes   |  No  |   -   |
 |     Gemma2     |   9B-27B    | LLM  |    Yes    |   Yes   |   Yes   |  No  |   -   |
 |      GLM4      |     9B      | LLM  |    Yes    |   Yes   |   Yes   |  No  |  No   |
 |     GLM-4V     |     9B      | MLLM |    Yes    |   Yes   |   Yes   |  No  |  No   |

--- a/docs/zh_cn/supported_models/supported_models.md
+++ b/docs/zh_cn/supported_models/supported_models.md
@@ -80,7 +80,7 @@ turbomind 引擎不支持 window attention。所以，对于应用了 window att
 | LLaVA(1.5,1.6) |   7B-34B    | MLLM |    Yes    |   Yes   |   Yes   |  No  |   -   |
 | InternVL(v1.5) |   2B-26B    | MLLM |    Yes    |   Yes   |   Yes   |  No  |  Yes  |
 |   InternVL2    |   1B-40B    | MLLM |    Yes    |   Yes   |   Yes   |  No  |   -   |
-| Mono-InternVL  |     2B      | MLLM |    Yes    |   Yes   |   Yes   |  No  |   -   |
+| Mono-InternVL  |     2B      | MLLM |   Yes\*   |   Yes   |   Yes   |  No  |   -   |
 |     Gemma2     |   9B-27B    | LLM  |    Yes    |   Yes   |   Yes   |  No  |   -   |
 |      GLM4      |     9B      | LLM  |    Yes    |   Yes   |   Yes   |  No  |  No   |
 |     GLM-4V     |     9B      | MLLM |    Yes    |   Yes   |   Yes   |  No  |  No   |
@@ -88,6 +88,10 @@ turbomind 引擎不支持 window attention。所以，对于应用了 window att
 |  Phi-3.5-mini  |    3.8B     | LLM  |    Yes    |   Yes   |   No    |  No  |   -   |
 |  Phi-3.5-MoE   |   16x3.8B   | LLM  |    Yes    |   Yes   |   No    |  No  |   -   |
 | Phi-3.5-vision |    4.2B     | MLLM |    Yes    |   Yes   |   No    |  No  |   -   |
+
+```{note}
+* Currently Mono-InternVL does not support FP16 due to numerical instability. Please use BF16 instead.
+```
 
 ## PyTorchEngine 华为昇腾平台
 

--- a/lmdeploy/model.py
+++ b/lmdeploy/model.py
@@ -578,7 +578,8 @@ class InternVL2InternLM2(InternLM2Chat7B):
             model_path (str): the model path used for matching.
         """
         path = model_path.lower()
-        if 'internvl2' in path and 'internvl2-4b' not in path:
+        if ('internvl2' in path
+                and 'internvl2-4b' not in path) or 'mono-internvl' in path:
             return 'internvl2-internlm2'
 
 

--- a/lmdeploy/pytorch/models/baichuan.py
+++ b/lmdeploy/pytorch/models/baichuan.py
@@ -167,7 +167,7 @@ class DecoderLayer(nn.Module):
         # build attention layer
         self.self_attn = BaichuanAttention(config, dtype=dtype, device=device)
 
-        # builf MLP
+        # build MLP
         self.mlp = MLP(config, dtype=dtype, device=device)
 
         # build input layer norm

--- a/lmdeploy/pytorch/models/chatglm2.py
+++ b/lmdeploy/pytorch/models/chatglm2.py
@@ -279,7 +279,7 @@ class GLMBlock(torch.nn.Module):
         # build attention layer
         self.self_attention = SelfAttention(config, dtype=dtype, device=device)
 
-        # builf MLP
+        # build MLP
         self.mlp = MLP(config, dtype=dtype, device=device)
 
         # build input layer norm

--- a/lmdeploy/pytorch/models/cogvlm.py
+++ b/lmdeploy/pytorch/models/cogvlm.py
@@ -263,7 +263,7 @@ class CogVLMDecoderLayer(nn.Module):
                                                dtype=dtype,
                                                device=device)
 
-        # builf MLP
+        # build MLP
         self.mlp = VisionExpertMLP(config, dtype=dtype, device=device)
 
         # build input layer norm

--- a/lmdeploy/pytorch/models/dbrx.py
+++ b/lmdeploy/pytorch/models/dbrx.py
@@ -301,7 +301,7 @@ class DbrxBlock(nn.Module):
                                                     dtype=dtype,
                                                     device=device)
 
-        # builf MLP
+        # build MLP
         self.ffn = DbrxFFN(config, dtype=dtype, device=device)
 
     def forward(

--- a/lmdeploy/pytorch/models/deepseek.py
+++ b/lmdeploy/pytorch/models/deepseek.py
@@ -250,7 +250,7 @@ class DeepseekDecoderLayer(nn.Module):
         # build attention layer
         self.self_attn = DeepseekAttention(config, dtype=dtype, device=device)
 
-        # builf MLP
+        # build MLP
         self.mlp = (DeepseekMoE(config, dtype=dtype, device=device) if
                     (config.n_routed_experts is not None
                      and layer_idx >= config.first_k_dense_replace

--- a/lmdeploy/pytorch/models/falcon.py
+++ b/lmdeploy/pytorch/models/falcon.py
@@ -179,7 +179,7 @@ class FalconDecoderLayer(nn.Module):
                                               dtype=dtype,
                                               device=device)
 
-        # builf MLP
+        # build MLP
         self.mlp = FalconMLP(config, dtype=dtype, device=device)
 
         if not hasattr(config, 'num_ln_in_parallel_attn'):

--- a/lmdeploy/pytorch/models/gemma.py
+++ b/lmdeploy/pytorch/models/gemma.py
@@ -177,7 +177,7 @@ class GemmaDecoderLayer(nn.Module):
                                         dtype=dtype,
                                         device=device)
 
-        # builf MLP
+        # build MLP
         self.mlp = GemmaMLP(config, dtype=dtype, device=device)
 
         # build input layer norm

--- a/lmdeploy/pytorch/models/internlm.py
+++ b/lmdeploy/pytorch/models/internlm.py
@@ -161,7 +161,7 @@ class InternLMDecoderLayer(nn.Module):
         # build attention layer
         self.self_attn = InternLMAttention(config, dtype=dtype, device=device)
 
-        # builf MLP
+        # build MLP
         self.mlp = InternLMMLP(config, dtype=dtype, device=device)
 
         # build input layer norm

--- a/lmdeploy/pytorch/models/internlm2_ve.py
+++ b/lmdeploy/pytorch/models/internlm2_ve.py
@@ -6,147 +6,16 @@ from torch import nn
 from transformers.configuration_utils import PretrainedConfig
 
 from lmdeploy.pytorch.model_inputs import StepContext, StepContextManager
-from lmdeploy.pytorch.nn import (ApplyRotaryEmb, Attention, RMSNorm, RopeType,
-                                 SiluAndMul, build_rotary_embedding)
-from lmdeploy.pytorch.nn.linear import (build_merged_colwise_linear,
-                                        build_qkv_proj, build_rowwise_linear)
+from lmdeploy.pytorch.models.internlm2 import InternLM2Attention, InternLM2MLP
+from lmdeploy.pytorch.nn import RMSNorm, RopeType, build_rotary_embedding
+from lmdeploy.pytorch.nn.linear import build_rowwise_linear
 from lmdeploy.pytorch.weight_loader.model_weight_loader import load_weight
 
 from .utils.cudagraph import CudaGraphMixin
 
 
-class InternLM2Attention(nn.Module):
-    """Rewrite module of InternLM2Attention."""
-
-    def __init__(self,
-                 config: PretrainedConfig,
-                 dtype: torch.dtype = None,
-                 device: torch.device = None):
-        super().__init__()
-        quantization_config = getattr(config, 'quantization_config', None)
-        num_heads = config.num_attention_heads
-        num_key_value_heads = config.num_key_value_heads
-        hidden_size = config.hidden_size
-        head_dim = hidden_size // num_heads
-
-        # packed qkv
-        self.wqkv = build_qkv_proj(
-            hidden_size,
-            num_q_heads=num_heads,
-            num_kv_heads=num_key_value_heads,
-            head_size=head_dim,
-            bias=config.bias,
-            quant_config=quantization_config,
-            dtype=dtype,
-            device=device,
-        )
-
-        # rotary embedding
-        self.apply_rotary_pos_emb = ApplyRotaryEmb()
-
-        # attention
-        self.attn_fwd = Attention(
-            num_heads,
-            head_dim,
-            num_kv_heads=num_key_value_heads,
-        )
-
-        # o_proj
-        self.wo = build_rowwise_linear(num_heads * head_dim,
-                                       hidden_size,
-                                       bias=config.bias,
-                                       quant_config=quantization_config,
-                                       dtype=dtype,
-                                       device=device,
-                                       is_tp=True)
-
-    def forward(
-        self,
-        hidden_states: torch.Tensor,
-        rotary_pos_emb: Tuple[torch.FloatTensor, torch.FloatTensor],
-        past_key_value: Optional[Tuple[torch.Tensor]] = None,
-        attn_metadata: Any = None,
-    ):
-        """Rewrite of InternLM2Attention.forward."""
-        # qkv proj
-        qkv_states = self.wqkv(hidden_states)
-        # (-1, heads, head_dim)
-        qkv_states = qkv_states.flatten(0, -2)
-        query_states, key_states, value_states = self.wqkv.split_qkv(
-            qkv_states)
-
-        # apply rotary embedding
-        cos, sin = rotary_pos_emb
-        query_states, key_states = self.apply_rotary_pos_emb(
-            query_states,
-            key_states,
-            cos,
-            sin,
-            inplace=True,
-        )
-
-        # attention
-        attn_output = self.attn_fwd(
-            query_states,
-            key_states,
-            value_states,
-            past_key_value[0],
-            past_key_value[1],
-            attn_metadata,
-            k_scales_zeros=None
-            if len(past_key_value) == 2 else past_key_value[2],
-            v_scales_zeros=None
-            if len(past_key_value) == 2 else past_key_value[3],
-            inplace=True,
-        )
-        attn_output = attn_output.reshape(*hidden_states.shape[:-1], -1)
-
-        # o proj
-        attn_output = self.wo(attn_output)
-        return attn_output
-
-
-class InternLM2MLP(nn.Module):
-    """mlp."""
-
-    def __init__(self,
-                 config: PretrainedConfig,
-                 dtype: torch.dtype = None,
-                 device: torch.device = None):
-        super().__init__()
-        quantization_config = getattr(config, 'quantization_config', None)
-        # gate up
-        self.gate_up_proj = build_merged_colwise_linear(
-            config.hidden_size,
-            [config.intermediate_size, config.intermediate_size],
-            bias=False,
-            dtype=dtype,
-            device=device,
-            quant_config=quantization_config,
-            is_tp=True,
-        )
-
-        # silu and mul
-        self.act_fn = SiluAndMul(inplace=True)
-
-        # down
-        self.w2 = build_rowwise_linear(config.intermediate_size,
-                                       config.hidden_size,
-                                       bias=False,
-                                       quant_config=quantization_config,
-                                       dtype=dtype,
-                                       device=device,
-                                       is_tp=True)
-
-    def forward(self, x):
-        """forward."""
-        gate_up = self.gate_up_proj(x)
-        act = self.act_fn(gate_up)
-        return self.w2(act)
-
-
-class InternLM2DecoderLayer(nn.Module):
-    """decoder layer."""
+class InternLM2VEDecoderLayer(nn.Module):
+    """decoder layer with visual expert."""
 
     def __init__(self,
                  config: PretrainedConfig,
@@ -155,6 +24,7 @@ class InternLM2DecoderLayer(nn.Module):
                  device: torch.device = None):
         super().__init__()
         self.layer_idx = layer_idx
+        self.hidden_size = config.hidden_size
         quantization_config = getattr(config, 'quantization_config', None)
 
         # build attention layer
@@ -162,6 +32,9 @@ class InternLM2DecoderLayer(nn.Module):
 
         # build MLP
         self.feed_forward = InternLM2MLP(config, dtype=dtype, device=device)
+
+        # build visual expert
+        self.feed_forward_ve = InternLM2MLP(config, dtype=dtype, device=device)
 
         # build input layer norm
         self.attention_norm = RMSNorm(config.hidden_size,
@@ -184,6 +57,8 @@ class InternLM2DecoderLayer(nn.Module):
         past_key_value: Optional[List[torch.FloatTensor]],
         residual: Optional[torch.Tensor] = None,
         attn_metadata: Any = None,
+        vision_embedding_indexing: Optional[torch.Tensor] = None,
+        text_embedding_indexing: Optional[torch.Tensor] = None,
     ):
 
         if residual is None:
@@ -203,14 +78,25 @@ class InternLM2DecoderLayer(nn.Module):
 
         # Fully Connected
         hidden_states, residual = self.ffn_norm(hidden_states, residual)
-        hidden_states = self.feed_forward(hidden_states)
+        if vision_embedding_indexing is not None:
+            hidden_states[:,
+                          vision_embedding_indexing, :] = self.feed_forward_ve(
+                              hidden_states[:, vision_embedding_indexing, :].
+                              reshape(-1, self.hidden_size)).unsqueeze(0)
+            if text_embedding_indexing is not None:
+                hidden_states[:,
+                              text_embedding_indexing, :] = self.feed_forward(
+                                  hidden_states[:, text_embedding_indexing, :].
+                                  reshape(-1, self.hidden_size)).unsqueeze(0)
+        else:
+            hidden_states = self.feed_forward(hidden_states)
 
         outputs = (hidden_states, residual)
         return outputs
 
 
-class InternLM2Model(nn.Module):
-    """internlm2 model."""
+class InternLM2VEModel(nn.Module):
+    """internlm2 model with visual expert."""
 
     def __init__(self,
                  config: PretrainedConfig,
@@ -229,10 +115,10 @@ class InternLM2Model(nn.Module):
 
         # build all decode layers
         self.layers = nn.ModuleList([
-            InternLM2DecoderLayer(config,
-                                  layer_idx,
-                                  dtype=dtype,
-                                  device=device)
+            InternLM2VEDecoderLayer(config,
+                                    layer_idx,
+                                    dtype=dtype,
+                                    device=device)
             for layer_idx in range(config.num_hidden_layers)
         ])
 
@@ -274,6 +160,8 @@ class InternLM2Model(nn.Module):
         past_key_values: Optional[List[torch.FloatTensor]] = None,
         attn_metadata: Any = None,
         inputs_embeds: Optional[torch.FloatTensor] = None,
+        vision_embedding_indexing: Optional[torch.Tensor] = None,
+        text_embedding_indexing: Optional[torch.Tensor] = None,
     ):
         """Rewrite of forward."""
 
@@ -298,6 +186,8 @@ class InternLM2Model(nn.Module):
                 past_key_value=past_key_value,
                 residual=residual,
                 attn_metadata=attn_metadata,
+                vision_embedding_indexing=vision_embedding_indexing,
+                text_embedding_indexing=text_embedding_indexing,
             )
 
         # norm
@@ -310,8 +200,8 @@ class InternLM2Model(nn.Module):
         return self.tok_embeddings
 
 
-class InternLM2ForCausalLM(nn.Module, CudaGraphMixin):
-    """rewrote model of InternLM2ForCausalLM."""
+class InternLM2VEForCausalLM(nn.Module, CudaGraphMixin):
+    """rewrote model of InternLM2ForCausalLM with visual expert."""
 
     packed_modules_mapping = {
         'gate_up_proj': [
@@ -329,7 +219,7 @@ class InternLM2ForCausalLM(nn.Module, CudaGraphMixin):
         self.config = config
         self.ctx_mgr = ctx_mgr
         # build Model
-        self.model = InternLM2Model(config, dtype=dtype, device=device)
+        self.model = InternLM2VEModel(config, dtype=dtype, device=device)
         # build lm_head
         self.output = build_rowwise_linear(config.hidden_size,
                                            config.vocab_size,
@@ -344,6 +234,8 @@ class InternLM2ForCausalLM(nn.Module, CudaGraphMixin):
         past_key_values: List[List[torch.Tensor]],
         attn_metadata: Any = None,
         inputs_embeds: torch.Tensor = None,
+        vision_embedding_indexing: Optional[torch.Tensor] = None,
+        text_embedding_indexing: Optional[torch.Tensor] = None,
         **kwargs,
     ):
         """model forward, return logits."""
@@ -353,6 +245,8 @@ class InternLM2ForCausalLM(nn.Module, CudaGraphMixin):
             past_key_values=past_key_values,
             attn_metadata=attn_metadata,
             inputs_embeds=inputs_embeds,
+            vision_embedding_indexing=vision_embedding_indexing,
+            text_embedding_indexing=text_embedding_indexing,
         )
         return hidden_states
 
@@ -363,9 +257,12 @@ class InternLM2ForCausalLM(nn.Module, CudaGraphMixin):
     def support_cuda_graph(
         self,
         input_ids: torch.Tensor,
+        attn_metadata: Any = None,
         **kwargs,
     ):
         """support cudagraph."""
+        if not attn_metadata.is_decoding:
+            return False
         seq_lens = input_ids.size(1)
         if seq_lens <= 512:
             return True

--- a/lmdeploy/pytorch/models/internvl.py
+++ b/lmdeploy/pytorch/models/internvl.py
@@ -30,6 +30,10 @@ class InternVLChatModel(nn.Module, CudaGraphMixin):
 
         # for Mono-InternVL
         self.is_mono = self.llm_arch_name == 'InternLM2VEForCausalLM'
+        if self.is_mono:
+            assert dtype != torch.float16, (
+                'Currently Mono-InternVL does not support FP16 due to'
+                'numerical instability. Please use BF16 instead.')
 
     def forward(
         self,

--- a/lmdeploy/pytorch/models/llama.py
+++ b/lmdeploy/pytorch/models/llama.py
@@ -163,7 +163,7 @@ class LlamaDecoderLayer(nn.Module):
         # build attention layer
         self.self_attn = LlamaAttention(config, dtype=dtype, device=device)
 
-        # builf MLP
+        # build MLP
         self.mlp = LlamaMLP(config, dtype=dtype, device=device)
 
         # build input layer norm

--- a/lmdeploy/pytorch/models/minicpm3.py
+++ b/lmdeploy/pytorch/models/minicpm3.py
@@ -237,7 +237,7 @@ class MiniCPMDecoderLayer(nn.Module):
         # build attention layer
         self.self_attn = MiniCPMAttention(config, dtype=dtype, device=device)
 
-        # builf MLP
+        # build MLP
         self.mlp = MiniCPMMLP(config, dtype=dtype, device=device)
 
         # build input layer norm

--- a/lmdeploy/pytorch/models/mistral.py
+++ b/lmdeploy/pytorch/models/mistral.py
@@ -162,7 +162,7 @@ class MistralDecoderLayer(nn.Module):
         # build attention layer
         self.self_attn = MistralAttention(config, dtype=dtype, device=device)
 
-        # builf MLP
+        # build MLP
         self.mlp = MistralMLP(config, dtype=dtype, device=device)
 
         # build input layer norm

--- a/lmdeploy/pytorch/models/mllama.py
+++ b/lmdeploy/pytorch/models/mllama.py
@@ -267,7 +267,7 @@ class MllamaSelfAttentionDecoderLayer(nn.Module):
         # build attention layer
         self.self_attn = LlamaAttention(config, dtype=dtype, device=device)
 
-        # builf MLP
+        # build MLP
         self.mlp = LlamaMLP(config, dtype=dtype, device=device)
 
         # build input layer norm
@@ -336,7 +336,7 @@ class MllamaCrossAttentionDecoderLayer(nn.Module):
                                                    dtype=dtype,
                                                    device=device)
 
-        # builf MLP
+        # build MLP
         self.mlp = LlamaMLP(config, dtype=dtype, device=device)
 
         # build input layer norm

--- a/lmdeploy/pytorch/models/module_map.py
+++ b/lmdeploy/pytorch/models/module_map.py
@@ -149,6 +149,12 @@ MODULE_MAP.update({
     f'{LMDEPLOY_PYTORCH_MODEL_PATH}.internvl.InternVLChatModel'
 })
 
+# mono-internvl
+MODULE_MAP.update({
+    'InternLM2VEForCausalLM':
+    f'{LMDEPLOY_PYTORCH_MODEL_PATH}.internlm2_ve.InternLM2VEForCausalLM',
+})
+
 # phi3 vision
 MODULE_MAP.update({
     'Phi3VForCausalLM':

--- a/lmdeploy/pytorch/models/phi3.py
+++ b/lmdeploy/pytorch/models/phi3.py
@@ -165,7 +165,7 @@ class Phi3DecoderLayer(nn.Module):
         # build attention layer
         self.self_attn = Phi3Attention(config, dtype=dtype, device=device)
 
-        # builf MLP
+        # build MLP
         self.mlp = Phi3MLP(config, dtype=dtype, device=device)
 
         # build input layer norm

--- a/lmdeploy/pytorch/models/qwen.py
+++ b/lmdeploy/pytorch/models/qwen.py
@@ -174,7 +174,7 @@ class QWenBlock(torch.nn.Module):
         # build attention layer
         self.attn = QWenAttention(config, dtype=dtype, device=device)
 
-        # builf MLP
+        # build MLP
         self.mlp = QWenMLP(config, dtype=dtype, device=device)
 
         # build input layer norm

--- a/lmdeploy/pytorch/models/qwen2.py
+++ b/lmdeploy/pytorch/models/qwen2.py
@@ -163,7 +163,7 @@ class Qwen2DecoderLayer(nn.Module):
         # build attention layer
         self.self_attn = Qwen2Attention(config, dtype=dtype, device=device)
 
-        # builf MLP
+        # build MLP
         self.mlp = Qwen2MLP(config, dtype=dtype, device=device)
 
         # build input layer norm

--- a/lmdeploy/pytorch/models/qwen2_moe.py
+++ b/lmdeploy/pytorch/models/qwen2_moe.py
@@ -258,7 +258,7 @@ class Qwen2MoeDecoderLayer(nn.Module):
         # build attention layer
         self.self_attn = Qwen2MoeAttention(config, dtype=dtype, device=device)
 
-        # builf MLP
+        # build MLP
         if (layer_idx not in config.mlp_only_layers) and (
                 config.num_experts > 0) and ((layer_idx + 1) %
                                              config.decoder_sparse_step == 0):

--- a/lmdeploy/pytorch/models/qwen2_vl.py
+++ b/lmdeploy/pytorch/models/qwen2_vl.py
@@ -192,7 +192,7 @@ class Qwen2DecoderLayer(nn.Module):
         # build attention layer
         self.self_attn = Qwen2Attention(config, dtype=dtype, device=device)
 
-        # builf MLP
+        # build MLP
         self.mlp = Qwen2MLP(config, dtype=dtype, device=device)
 
         # build input layer norm

--- a/lmdeploy/pytorch/models/starcoder2.py
+++ b/lmdeploy/pytorch/models/starcoder2.py
@@ -168,7 +168,7 @@ class Starcoder2DecoderLayer(nn.Module):
                                              dtype=dtype,
                                              device=device)
 
-        # builf MLP
+        # build MLP
         self.mlp = Starcoder2MLP(config, dtype=dtype, device=device)
 
         # build input layer norm

--- a/lmdeploy/pytorch/supported_models.py
+++ b/lmdeploy/pytorch/supported_models.py
@@ -62,6 +62,8 @@ _SUPPORTED_ARCHS = dict(
     DeepseekV2ForCausalLM=True,
     # internvl
     InternVLChatModel=True,
+    # mono-internvl
+    InternLM2VEForCausalLM=True,
     # gemma2
     Gemma2ForCausalLM=True,
     # phi3.5-moe


### PR DESCRIPTION
Support [Mono-InternVL](https://huggingface.co/OpenGVLab/Mono-InternVL-2B) with Pytorch backend by creating `internlm2_ve.py` and adding `is_mono` in `internvl.py`. The MoE structure is implemented with `vision_embedding_indexing` and `text_embedding_indexing`. Also fix some typos.