### PR TITLE
Add version restrictions in runtime_ascend.txt to ensure functionality

### DIFF
--- a/requirements/runtime_ascend.txt
+++ b/requirements/runtime_ascend.txt
@@ -1,5 +1,5 @@
 accelerate>=0.29.3
-dlinfer-ascend
+dlinfer-ascend>=0.1.2
 einops
 fastapi
 fire


### PR DESCRIPTION
## Motivation

After testing, some of the required interfaces for `serve` and `chat` are implemented in the `dlinfer-ascend` 0.1.2 version. To ensure that users can smoothly use lmdeploy on Ascend, a version restriction has been added. 

## Modification

Add version restrictions in `runtime_ascend.txt`


Thank you for your approval!!!