### PR TITLE
fix lora name and rearange wqkv for internlm2

### DIFF
--- a/lmdeploy/pytorch/models/internvl.py
+++ b/lmdeploy/pytorch/models/internvl.py
@@ -516,6 +516,17 @@ class InternVLChatModel(nn.Module, DeployModelMixin, CudaGraphMixin):
                 inputs_embeds=inputs_embeds,
             )
 
+    def load_lora_weights(self, weights: Iterable[Tuple[str, torch.Tensor]],
+                          adapter_id: int):
+        """load lora weights."""
+
+        if hasattr(self.language_model, 'load_lora_weights'):
+            return self.language_model.load_lora_weights(weights, adapter_id)
+        else:
+            from lmdeploy.pytorch.adapter.adapter import load_lora_weights
+
+            return load_lora_weights(weights, adapter_id)
+
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
         """load weights."""
 

--- a/lmdeploy/pytorch/models/patch.py
+++ b/lmdeploy/pytorch/models/patch.py
@@ -251,6 +251,10 @@ def add_adapters(model: torch.nn.Module,
         ranks, scalings = get_ranks_and_scalings(target_name,
                                                  adapter_cfgs,
                                                  device=device)
+        # split in case target_name has '.' like 'attention.wo'
+        # which cannot be used as name of a module
+        # and it's not aligned with key in model.packed_modules_mapping
+        target_name = target_name.split('.')[-1]
         found_mods, pack_idx = find_all_target(model, target_name)
         sum_rank = ranks.sum().item()
 

--- a/requirements/runtime_ascend.txt
+++ b/requirements/runtime_ascend.txt
@@ -18,6 +18,6 @@ shortuuid
 tiktoken
 torch<=2.4.0,>=2.3.1
 torch-npu==2.3.1
-torchvision<=0.19.0,>=0.15.0
+torchvision<=0.19.0,>=0.18.1
 transformers
 uvicorn

--- a/requirements/runtime_cuda.txt
+++ b/requirements/runtime_cuda.txt
@@ -16,7 +16,7 @@ sentencepiece
 shortuuid
 tiktoken
 torch<=2.5.1,>=2.0.0
-torchvision<=0.19.0,>=0.15.0
+torchvision<=0.20.1,>=0.15.0
 transformers
 triton==3.0.0; sys_platform == "linux"
 uvicorn


### PR DESCRIPTION


## Motivation

fix lora name and rearange lora of wqkv for internlm2

## Modification

- [x]  fix loading lora name with '.' like :
```
  "target_modules": [
    "attention.wo",
    "attention.wqkv",
    "feed_forward.w1",
    "feed_forward.w3",
    "feed_forward.w2"
  ]
```
- [x] rearange lora of wqkv for internlm2



## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
