### PR TITLE
fix: Incorrect stats size during inference of throughput benchmark when concurrency > num_prompts

### DIFF
--- a/benchmark/profile_throughput.py
+++ b/benchmark/profile_throughput.py
@@ -349,7 +349,8 @@ def main():
                            temperature=args.temperature,
                            top_p=args.top_p,
                            top_k=args.top_k,
-                           concurrency=args.concurrency,
+                           concurrency=args.concurrency if args.concurrency < \
+                            args.num_prompts else args.num_prompts,
                            stream_output=True)
 
 

--- a/benchmark/profile_throughput.py
+++ b/benchmark/profile_throughput.py
@@ -345,13 +345,14 @@ def main():
     requests = sample_requests(args.dataset, args.num_prompts,
                                engine.tokenizer)
 
-    engine.process_request(requests,
-                           temperature=args.temperature,
-                           top_p=args.top_p,
-                           top_k=args.top_k,
-                           concurrency=args.concurrency if args.concurrency < \
-                            args.num_prompts else args.num_prompts,
-                           stream_output=True)
+    engine.process_request(
+        requests,
+        temperature=args.temperature,
+        top_p=args.top_p,
+        top_k=args.top_k,
+        concurrency=args.concurrency
+        if args.concurrency < args.num_prompts else args.num_prompts,
+        stream_output=True)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Motivation

Resolve #2927 

## Modification

Set concurrency to num of requests when the later is smaller.
