### PR TITLE
[qwen2]fix build rotary_params

### DIFF
--- a/lmdeploy/pytorch/nn/rotary_embedding.py
+++ b/lmdeploy/pytorch/nn/rotary_embedding.py
@@ -74,7 +74,8 @@ def _get_llama3_parameters(config: PretrainedConfig):
 def build_rotary_params(config: PretrainedConfig):
     """get scaling_factor rotary params, and emb_type."""
     params = dict(emb_type=RopeType.Default)
-    if config.rope_scaling is not None:
+    rope_scaling = getattr(config, 'rope_scaling', None)
+    if rope_scaling is not None:
         rope_type_str = config.rope_scaling.get('rope_type', 'default')
         build_funcs = dict(default=_get_default_rope_parameters,
                            linear=_get_linear_scaling_rope_parameters,


### PR DESCRIPTION
## Motivation
![image](https://github.com/user-attachments/assets/9312872e-c321-4111-b603-615058b87a10)
Qwen2.5 series models config.json don't have  rope_scaling field


