### PR TITLE
Support fp8 w8a8 for pt backend

### DIFF
--- a/docs/en/quantization/w8a8.md
+++ b/docs/en/quantization/w8a8.md
@@ -1,55 +1,62 @@
 # SmoothQuant
 
-LMDeploy provides functions for quantization and inference of large language models using 8-bit integers.
+LMDeploy provides functions for quantization and inference of large language models using 8-bit integers(INT8). For GPUs such as Nvidia H100, lmdeploy also supports 8-bit floating point(FP8).
 
-Before starting inference, ensure that lmdeploy and openai/triton are correctly installed. Execute the following commands to install these:
-
-```shell
-pip install lmdeploy
-pip install triton>=2.1.0
-```
-
-## 8-bit Weight Model Inference
-
-For performing 8-bit weight model inference, you can directly download the pre-quantized 8-bit weight models from LMDeploy's [model zoo](https://huggingface.co/lmdeploy). For instance, the 8-bit Internlm-chat-7B model is available for direct download from the model zoo:
+First of all, run the following command to install lmdeploy:
 
 ```shell
-git-lfs install
-git clone https://huggingface.co/lmdeploy/internlm-chat-7b-w8 (coming soon)
+pip install lmdeploy[all]
 ```
 
-Alternatively, you can manually convert original 16-bit weights into 8-bit by referring to the content under the ["8bit Weight Quantization"](#8bit-weight-quantization) section. Save them in the internlm-chat-7b-w8 directory, using the command below:
+## 8-bit Weight Quantization
 
-```shell
-lmdeploy lite smooth_quant internlm/internlm-chat-7b --work-dir ./internlm-chat-7b-w8
-```
-
-Afterwards, use the following command to interact with the model via the terminal:
-
-```shell
-lmdeploy chat ./internlm-chat-7b-w8 --backend pytorch
-```
-
-## Launching gradio service
-
-Coming soon...
-
-## Inference Speed
-
-Coming soon...
-
-## 8bit Weight Quantization
-
-Performing 8bit weight quantization involves three steps:
+Performing 8-bit weight quantization involves three steps:
 
 1. **Smooth Weights**: Start by smoothing the weights of the Language Model (LLM). This process makes the weights more amenable to quantizing.
 2. **Replace Modules**: Locate DecoderLayers and replace the modules RSMNorm and nn.Linear with QRSMNorm and QLinear modules respectively. These 'Q' modules are available in the lmdeploy/pytorch/models/q_modules.py file.
 3. **Save the Quantized Model**: Once you've made the necessary replacements, save the new quantized model.
 
-The script `lmdeploy/lite/apis/smooth_quant.py` accomplishes all three tasks detailed above. For example, you can obtain the model weights of the quantized Internlm-chat-7B model by running the following command:
+lmdeploy provides `lmdeploy lite smooth_quant` command to accomplish all three tasks detailed above. Note that the argument `--quant-dtype` is used to determine if you are doing int8 or fp8 weight quantization. To get more info about usage of the cli, run `lmdeploy lite smooth_quant --help`
 
-```shell
-lmdeploy lite smooth_quant internlm/internlm-chat-7b --work-dir ./internlm-chat-7b-w8
+Here are two examples:
+
+- int8
+
+  ```shell
+  lmdeploy lite smooth_quant internlm/internlm2_5-7b-chat --work-dir ./internlm2_5-7b-chat-int8-w8a8 --quant-dtype int8
+  ```
+
+- fp8
+
+  ```shell
+  lmdeploy lite smooth_quant internlm/internlm2_5-7b-chat --work-dir ./internlm2_5-7b-chat-fp8-w8a8 --quant-dtype fp8
+  ```
+
+## Inference
+
+Trying the following codes, you can perform the batched offline inference with the quantized model:
+
+```python
+from lmdeploy import pipeline, PytorchEngineConfig
+
+engine_config = PytorchEngineConfig(tp=1)
+pipe = pipeline("internlm2_5-7b-chat-int8-w8a8", backend_config=engine_config)
+response = pipe(["Hi, pls intro yourself", "Shanghai is"])
+print(response)
 ```
 
-After saving, you can instantiate your quantized model by calling the from_pretrained interface.
+## Service
+
+LMDeploy's `api_server` enables models to be easily packed into services with a single command. The provided RESTful APIs are compatible with OpenAI's interfaces. Below are an example of service startup:
+
+```shell
+lmdeploy serve api_server ./internlm2_5-7b-chat-int8-w8a8 --backend pytorch
+```
+
+The default port of `api_server` is `23333`. After the server is launched, you can communicate with server on terminal through `api_client`:
+
+```shell
+lmdeploy serve api_client http://0.0.0.0:23333
+```
+
+You can overview and try out `api_server` APIs online by swagger UI at `http://0.0.0.0:23333`, or you can also read the API specification from [here](../llm/api_server.md).

--- a/docs/en/quantization/w8a8.md
+++ b/docs/en/quantization/w8a8.md
@@ -2,6 +2,18 @@
 
 LMDeploy provides functions for quantization and inference of large language models using 8-bit integers(INT8). For GPUs such as Nvidia H100, lmdeploy also supports 8-bit floating point(FP8).
 
+And the following NVIDIA GPUs are available for INT8/FP8 inference respectively:
+
+- INT8
+  - V100(sm70): V100
+  - Turing(sm75): 20 series, T4
+  - Ampere(sm80,sm86): 30 series, A10, A16, A30, A100
+  - Ada Lovelace(sm89): 40 series
+  - Hopper(sm90): H100
+- FP8
+  - Ada Lovelace(sm89): 40 series
+  - Hopper(sm90): H100
+
 First of all, run the following command to install lmdeploy:
 
 ```shell
@@ -23,13 +35,13 @@ Here are two examples:
 - int8
 
   ```shell
-  lmdeploy lite smooth_quant internlm/internlm2_5-7b-chat --work-dir ./internlm2_5-7b-chat-int8-w8a8 --quant-dtype int8
+  lmdeploy lite smooth_quant internlm/internlm2_5-7b-chat --work-dir ./internlm2_5-7b-chat-int8 --quant-dtype int8
   ```
 
 - fp8
 
   ```shell
-  lmdeploy lite smooth_quant internlm/internlm2_5-7b-chat --work-dir ./internlm2_5-7b-chat-fp8-w8a8 --quant-dtype fp8
+  lmdeploy lite smooth_quant internlm/internlm2_5-7b-chat --work-dir ./internlm2_5-7b-chat-fp8 --quant-dtype fp8
   ```
 
 ## Inference
@@ -40,7 +52,7 @@ Trying the following codes, you can perform the batched offline inference with t
 from lmdeploy import pipeline, PytorchEngineConfig
 
 engine_config = PytorchEngineConfig(tp=1)
-pipe = pipeline("internlm2_5-7b-chat-int8-w8a8", backend_config=engine_config)
+pipe = pipeline("internlm2_5-7b-chat-int8", backend_config=engine_config)
 response = pipe(["Hi, pls intro yourself", "Shanghai is"])
 print(response)
 ```
@@ -50,7 +62,7 @@ print(response)
 LMDeploy's `api_server` enables models to be easily packed into services with a single command. The provided RESTful APIs are compatible with OpenAI's interfaces. Below are an example of service startup:
 
 ```shell
-lmdeploy serve api_server ./internlm2_5-7b-chat-int8-w8a8 --backend pytorch
+lmdeploy serve api_server ./internlm2_5-7b-chat-int8 --backend pytorch
 ```
 
 The default port of `api_server` is `23333`. After the server is launched, you can communicate with server on terminal through `api_client`:

--- a/docs/zh_cn/quantization/w8a8.md
+++ b/docs/zh_cn/quantization/w8a8.md
@@ -13,12 +13,12 @@ pip install lmdeploy[all]
 进行 8-bit 权重量化需要经历以下三步：
 
 1. **权重平滑**：首先对语言模型的权重进行平滑处理，以便更好地进行量化。
-2. **模块替换**：使用 `QRSMNorm` 和 `QLinear` 模块替换原模型 `DecoderLayer` 中的 `RSMNorm` 模块和 `nn.Linear` 模块。`lmdeploy/pytorch/models/q_modules.py` 文件中定义了这些量化模块。
+2. **模块替换**：使用 `QRMSNorm` 和 `QLinear` 模块替换原模型 `DecoderLayer` 中的 `RMSNorm` 模块和 `nn.Linear` 模块。`lmdeploy/pytorch/models/q_modules.py` 文件中定义了这些量化模块。
 3. **保存量化模型**：完成上述必要的替换后，我们即可保存新的量化模型。
 
 lmdeploy 提供了命令行工具 `lmdeploy lite smooth_quant` 实现了以上三个步骤。并且其中命令行参数 `--quant-dtype` 可以用来控制是进行8-bit整数还是浮点数类型的量化。更多命令行工具使用方式，请执行 `lmdeploy lite smooth_quant --help` 查看。
 
-以下示例演示了进行in8或fp8的量化命令。
+以下示例演示了进行 int8 或 fp8 的量化命令。
 
 - int8
 

--- a/docs/zh_cn/quantization/w8a8.md
+++ b/docs/zh_cn/quantization/w8a8.md
@@ -2,6 +2,18 @@
 
 LMDeploy 提供了使用 8-bit 整数(INT8)和浮点数(FP8)对神经网络模型进行量化和推理的功能。
 
+可用于 INT8 和 FP8 推理的 NVIDIA GPU 分别为：
+
+- INT8
+  - V100(sm70): V100
+  - Turing(sm75): 20 series, T4
+  - Ampere(sm80,sm86): 30 series, A10, A16, A30, A100
+  - Ada Lovelace(sm89): 40 series
+  - Hopper(sm90): H100
+- FP8
+  - Ada Lovelace(sm89): 40 series
+  - Hopper(sm90): H100
+
 首先，执行如下命令安装lmdeploy：
 
 ```shell
@@ -23,13 +35,13 @@ lmdeploy 提供了命令行工具 `lmdeploy lite smooth_quant` 实现了以上�
 - int8
 
   ```shell
-  lmdeploy lite smooth_quant internlm/internlm2_5-7b-chat --work-dir ./internlm2_5-7b-chat-int8-w8a8 --quant-dtype int8
+  lmdeploy lite smooth_quant internlm/internlm2_5-7b-chat --work-dir ./internlm2_5-7b-chat-int8 --quant-dtype int8
   ```
 
 - fp8
 
   ```shell
-  lmdeploy lite smooth_quant internlm/internlm2_5-7b-chat --work-dir ./internlm2_5-7b-chat-fp8-w8a8 --quant-dtype fp8
+  lmdeploy lite smooth_quant internlm/internlm2_5-7b-chat --work-dir ./internlm2_5-7b-chat-fp8 --quant-dtype fp8
   ```
 
 ## 模型推理
@@ -40,7 +52,7 @@ lmdeploy 提供了命令行工具 `lmdeploy lite smooth_quant` 实现了以上�
 from lmdeploy import pipeline, PytorchEngineConfig
 
 engine_config = PytorchEngineConfig(tp=1)
-pipe = pipeline("internlm2_5-7b-chat-int8-w8a8", backend_config=engine_config)
+pipe = pipeline("internlm2_5-7b-chat-int8", backend_config=engine_config)
 response = pipe(["Hi, pls intro yourself", "Shanghai is"])
 print(response)
 ```
@@ -52,7 +64,7 @@ print(response)
 LMDeploy `api_server` 支持把模型一键封装为服务，对外提供的 RESTful API 兼容 openai 的接口。以下为服务启动的示例：
 
 ```shell
-lmdeploy serve api_server ./internlm2_5-7b-chat-int8-w8a8 --backend pytorch
+lmdeploy serve api_server ./internlm2_5-7b-chat-int8 --backend pytorch
 ```
 
 服务默认端口是23333。在 server 启动后，你可以在终端通过`api_client`与server进行对话：

--- a/docs/zh_cn/quantization/w8a8.md
+++ b/docs/zh_cn/quantization/w8a8.md
@@ -1,56 +1,64 @@
 # W8A8 LLM 模型部署
 
-LMDeploy 提供了使用 8 bit 整数对神经网络模型进行量化和推理的功能。
+LMDeploy 提供了使用 8-bit 整数(INT8)和浮点数(FP8)对神经网络模型进行量化和推理的功能。
 
-在开始推理前，需要确保已经正确安装了 lmdeploy 和 openai/triton。可以通过以下命令进行安装：
-
-```shell
-pip install lmdeploy
-pip install triton>=2.1.0
-```
-
-## 8bit 权重模型推理
-
-如果你需要进行 8 bit 权重模型推理，可以直接从 LMDeploy 的 [model zoo](https://huggingface.co/lmdeploy) 下载已经量化好的 8bit 权重模型。以8bit 的 Internlm-chat-7B 模型为例，可以从 model zoo 直接下载：
+首先，执行如下命令安装lmdeploy：
 
 ```shell
-git-lfs install
-git clone https://huggingface.co/lmdeploy/internlm-chat-7b-w8 (coming soon)
+pip install lmdeploy[all]
 ```
 
-你也可以参考["8bit 权重量化"](#8bit-权重量化)章节的内容手动将原 16bit 权重量化为 8bit，并保存至 `internlm-chat-7b-w8` 目录下，操作命令如下：
+## 8-bit 权重量化
 
-```shell
-lmdeploy lite smooth_quant internlm/internlm-chat-7b --work-dir ./internlm-chat-7b-w8
-```
-
-然后，执行以下命令，即可在终端与模型对话：
-
-```shell
-lmdeploy chat ./internlm-chat-7b-w8 --backend pytorch
-```
-
-## 启动 gradio 服务
-
-Coming soon...
-
-## 推理速度
-
-Coming soon...
-
-## 8bit 权重量化
-
-进行 8bit 权重量化需要经历以下三步：
+进行 8-bit 权重量化需要经历以下三步：
 
 1. **权重平滑**：首先对语言模型的权重进行平滑处理，以便更好地进行量化。
 2. **模块替换**：使用 `QRSMNorm` 和 `QLinear` 模块替换原模型 `DecoderLayer` 中的 `RSMNorm` 模块和 `nn.Linear` 模块。`lmdeploy/pytorch/models/q_modules.py` 文件中定义了这些量化模块。
 3. **保存量化模型**：完成上述必要的替换后，我们即可保存新的量化模型。
 
-我们在`lmdeploy/lite/api/smooth_quantity.py`脚本中已经实现了以上三个步骤。例如，可以通过以下命令得到量化后的 Internlm-chat-7B 模型的模型权重：
+lmdeploy 提供了命令行工具 `lmdeploy lite smooth_quant` 实现了以上三个步骤。并且其中命令行参数 `--quant-dtype` 可以用来控制是进行8-bit整数还是浮点数类型的量化。更多命令行工具使用方式，请执行 `lmdeploy lite smooth_quant --help` 查看。
 
-```shell
+以下示例演示了进行in8或fp8的量化命令。
 
-lmdeploy lite smooth_quant internlm/internlm-chat-7b --work-dir ./internlm-chat-7b-w8
+- int8
+
+  ```shell
+  lmdeploy lite smooth_quant internlm/internlm2_5-7b-chat --work-dir ./internlm2_5-7b-chat-int8-w8a8 --quant-dtype int8
+  ```
+
+- fp8
+
+  ```shell
+  lmdeploy lite smooth_quant internlm/internlm2_5-7b-chat --work-dir ./internlm2_5-7b-chat-fp8-w8a8 --quant-dtype fp8
+  ```
+
+## 模型推理
+
+量化后的模型，通过以下几行简单的代码，可以实现离线推理：
+
+```python
+from lmdeploy import pipeline, PytorchEngineConfig
+
+engine_config = PytorchEngineConfig(tp=1)
+pipe = pipeline("internlm2_5-7b-chat-int8-w8a8", backend_config=engine_config)
+response = pipe(["Hi, pls intro yourself", "Shanghai is"])
+print(response)
 ```
 
-保存之后，你就可以通过调用from_pretrained接口来实例化你的量化模型。
+关于 pipeline 的详细介绍，请参考[这里](../llm/pipeline.md)
+
+## 推理服务
+
+LMDeploy `api_server` 支持把模型一键封装为服务，对外提供的 RESTful API 兼容 openai 的接口。以下为服务启动的示例：
+
+```shell
+lmdeploy serve api_server ./internlm2_5-7b-chat-int8-w8a8 --backend pytorch
+```
+
+服务默认端口是23333。在 server 启动后，你可以在终端通过`api_client`与server进行对话：
+
+```shell
+lmdeploy serve api_client http://0.0.0.0:23333
+```
+
+还可以通过 Swagger UI `http://0.0.0.0:23333` 在线阅读和试用 `api_server` 的各接口，也可直接查阅[文档](../llm/api_server.md)，了解各接口的定义和使用方法。

--- a/lmdeploy/cli/lite.py
+++ b/lmdeploy/cli/lite.py
@@ -126,6 +126,7 @@ class SubCliLite(object):
         ArgumentHelper.calib_batchsize(parser)
         ArgumentHelper.calib_search_scale(parser)
         ArgumentHelper.dtype(parser)
+        ArgumentHelper.quant_dtype(parser)
 
     @staticmethod
     def auto_awq(args):

--- a/lmdeploy/cli/utils.py
+++ b/lmdeploy/cli/utils.py
@@ -114,6 +114,15 @@ class ArgumentHelper:
             'the model is a quantized model')
 
     @staticmethod
+    def quant_dtype(parser, default: str = 'int8'):
+        return parser.add_argument(
+            '--quant-dtype',
+            type=str,
+            default=default,
+            choices=['int8', 'float8_e4m3fn', 'float8_e5m2'],
+            help='data type for the quantized model weights and activations')
+    
+    @staticmethod
     def model_format(parser, default: str = None):
         return parser.add_argument(
             '--model-format',

--- a/lmdeploy/cli/utils.py
+++ b/lmdeploy/cli/utils.py
@@ -119,9 +119,10 @@ class ArgumentHelper:
             '--quant-dtype',
             type=str,
             default=default,
-            choices=['int8', 'float8_e4m3fn', 'float8_e5m2'],
-            help='data type for the quantized model weights and activations')
-    
+            choices=['int8', 'float8_e4m3fn', 'float8_e5m2', 'fp8'],
+            help='data type for the quantized model weights and activations.'
+            'Note "fp8" is the short version of "float8_e4m3fn"')
+
     @staticmethod
     def model_format(parser, default: str = None):
         return parser.add_argument(

--- a/lmdeploy/lite/apis/smooth_quant.py
+++ b/lmdeploy/lite/apis/smooth_quant.py
@@ -24,7 +24,16 @@ def smooth_quant(model: str,
                  batch_size: int = 1,
                  w_bits: int = 8,
                  dtype: Literal['float16', 'bfloat16', 'auto'] = 'auto',
-                 device: str = 'cuda'):
+                 device: str = 'cuda',
+                 quant_dtype: Literal['int8', 'float8_e4m3fn', 'float8_e5m2'] = 'int8'):
+    
+    quant_dtype = getattr(torch, quant_dtype, torch.int8)
+    if quant_dtype.is_floating_point:
+        q_dtype_info = torch.finfo(quant_dtype)
+    else:
+        q_dtype_info = torch.iinfo(quant_dtype)
+
+    assert q_dtype_info.bits == w_bits
     model_path = model
     vl_model, model, tokenizer, work_dir = calibrate(model,
                                                      calib_dataset,
@@ -84,7 +93,7 @@ def smooth_quant(model: str,
         if skipped_module(name):
             continue
         linear.to(device)
-        q_linear = QLinear.from_float(linear)
+        q_linear = QLinear.from_float(linear, quant_dtype=quant_dtype)
         parent_name, _, child_name = name.rpartition('.')
         parent = model.get_submodule(parent_name)
         setattr(parent, child_name, q_linear)
@@ -94,7 +103,7 @@ def smooth_quant(model: str,
         if skipped_module(name):
             continue
         norm.to(device)
-        q_norm = QRMSNorm.from_float(norm)
+        q_norm = QRMSNorm.from_float(norm, quant_dtype=quant_dtype)
         parent_name, _, child_name = name.rpartition('.')
         parent = model.get_submodule(parent_name)
         setattr(parent, child_name, q_norm)
@@ -104,8 +113,10 @@ def smooth_quant(model: str,
         from .auto_awq import save_vl_model
         save_vl_model(vl_model, model_path, work_dir)
     else:
+        quant_dtype_s = str(quant_dtype).split('.')[1]
         model.config.update(
-            dict(quantization_config=dict(quant_method='smooth_quant')))
+            dict(quantization_config=dict(quant_method='smooth_quant',
+                                          quant_dtype=f'{quant_dtype_s}')))
         model.save_pretrained(work_dir,
                               max_shard_size='2GB',
                               safe_serialization=False)

--- a/lmdeploy/lite/apis/smooth_quant.py
+++ b/lmdeploy/lite/apis/smooth_quant.py
@@ -25,8 +25,11 @@ def smooth_quant(model: str,
                  w_bits: int = 8,
                  dtype: Literal['float16', 'bfloat16', 'auto'] = 'auto',
                  device: str = 'cuda',
-                 quant_dtype: Literal['int8', 'float8_e4m3fn', 'float8_e5m2'] = 'int8'):
-    
+                 quant_dtype: Literal['int8', 'fp8', 'float8_e4m3fn',
+                                      'float8_e5m2'] = 'int8'):
+    if quant_dtype == 'fp8':
+        quant_dtype = 'float8_e4m3fn'
+
     quant_dtype = getattr(torch, quant_dtype, torch.int8)
     if quant_dtype.is_floating_point:
         q_dtype_info = torch.finfo(quant_dtype)

--- a/lmdeploy/pytorch/backends/cuda/norm.py
+++ b/lmdeploy/pytorch/backends/cuda/norm.py
@@ -9,7 +9,7 @@ from ..norm import RMSNormBuilder, RMSNormImpl
 class TritonRMSNormImpl(RMSNormImpl):
     """triton RMS norm implementation."""
 
-    def __init__(self, hidden_size: int, eps: float = 1e-6, **kwargs):
+    def __init__(self, hidden_size: int, eps: float = 1e-6):
         self.hidden_size = hidden_size
         self.eps = eps
 
@@ -30,6 +30,6 @@ class TritonRMSNormBuilder(RMSNormBuilder):
     """triton RMS norm implementation builder."""
 
     @staticmethod
-    def build(weight: torch.Tensor, eps: float = 1e-6, **kwargs):
+    def build(weight: torch.Tensor, eps: float = 1e-6):
         """build."""
-        return TritonRMSNormImpl(weight, eps, **kwargs)
+        return TritonRMSNormImpl(weight, eps)

--- a/lmdeploy/pytorch/backends/cuda/norm.py
+++ b/lmdeploy/pytorch/backends/cuda/norm.py
@@ -9,7 +9,7 @@ from ..norm import RMSNormBuilder, RMSNormImpl
 class TritonRMSNormImpl(RMSNormImpl):
     """triton RMS norm implementation."""
 
-    def __init__(self, hidden_size: int, eps: float = 1e-6):
+    def __init__(self, hidden_size: int, eps: float = 1e-6, **kwargs):
         self.hidden_size = hidden_size
         self.eps = eps
 
@@ -30,6 +30,6 @@ class TritonRMSNormBuilder(RMSNormBuilder):
     """triton RMS norm implementation builder."""
 
     @staticmethod
-    def build(weight: torch.Tensor, eps: float = 1e-6):
+    def build(weight: torch.Tensor, eps: float = 1e-6, **kwargs):
         """build."""
-        return TritonRMSNormImpl(weight, eps)
+        return TritonRMSNormImpl(weight, eps, **kwargs)

--- a/lmdeploy/pytorch/backends/norm.py
+++ b/lmdeploy/pytorch/backends/norm.py
@@ -21,7 +21,7 @@ class RMSNormBuilder(ABC):
 
     @staticmethod
     @abstractmethod
-    def build(hidden_size: int, eps: float = 1e-6):
+    def build(hidden_size: int, eps: float = 1e-6, **kwargs):
         """build."""
         raise NotImplementedError
 

--- a/lmdeploy/pytorch/backends/norm.py
+++ b/lmdeploy/pytorch/backends/norm.py
@@ -21,7 +21,7 @@ class RMSNormBuilder(ABC):
 
     @staticmethod
     @abstractmethod
-    def build(hidden_size: int, eps: float = 1e-6, **kwargs):
+    def build(hidden_size: int, eps: float = 1e-6):
         """build."""
         raise NotImplementedError
 

--- a/lmdeploy/pytorch/backends/qmodules.py
+++ b/lmdeploy/pytorch/backends/qmodules.py
@@ -37,7 +37,9 @@ class RMSNormW8A8Builder(ABC):
 
     @staticmethod
     @abstractmethod
-    def build(hidden_size: int, eps: float = 1e-6):
+    def build(hidden_size: int,
+              eps: float = 1e-6,
+              quant_dtype: torch.dtype = torch.int8):
         """build."""
         raise NotImplementedError
 
@@ -71,6 +73,7 @@ class LinearW8A8Builder(ABC):
     def build(in_features: int,
               out_features: int,
               bias: bool = True,
-              dtype: torch.dtype = None):
+              dtype: torch.dtype = None,
+              quant_dtype: torch.dtype = torch.int8):
         """build."""
         raise NotImplementedError

--- a/lmdeploy/pytorch/engine/engine.py
+++ b/lmdeploy/pytorch/engine/engine.py
@@ -1003,9 +1003,29 @@ class Engine:
             for out in step_outputs.values():
                 __send_resp(out)
 
+        def __do_prefill():
+            # decoding if no waiting
+            if not self.scheduler.has_waiting():
+                return False
+
+            num_running = len(self.scheduler.running)
+            num_waiting = len(self.scheduler.waiting)
+            max_batches = self.scheduler_config.max_batches
+
+            # prefill if too much waiting
+            if num_waiting >= 4:
+                return True
+
+            # prefill if no enough running
+            if num_running < max_batches * 0.5:
+                return True
+
+            # decoding
+            return False
+
         async def __step():
             """step decoding."""
-            prefill = self.scheduler.has_waiting()
+            prefill = __do_prefill()
             schedule_output = self.scheduler.schedule(
                 is_prefill=prefill, prealloc_size=prefill_interval)
             # schedule decoding if no valid prefill reqs.

--- a/lmdeploy/pytorch/kernels/cuda/w8a8_triton_kernels.py
+++ b/lmdeploy/pytorch/kernels/cuda/w8a8_triton_kernels.py
@@ -456,7 +456,7 @@ def rms_norm_dynamic_quant(x, w, eps, residual=None, quant_dtype=torch.int8):
 
     The function reshapes the input tensor `x`, creates an empty tensor `y`
     with the same shape as `x`, and calculates RMS normalization on the
-    reshaped `x` using a Triton kernel `_rms_norm_fwd_fused_dynamic_symmetric`.
+    reshaped `x` using a Triton kernel `rms_norm_quant_kernel`.
     """
     qdtype_info = torch.finfo(
         quant_dtype) if quant_dtype.is_floating_point else torch.iinfo(

--- a/lmdeploy/pytorch/kernels/cuda/w8a8_triton_kernels.py
+++ b/lmdeploy/pytorch/kernels/cuda/w8a8_triton_kernels.py
@@ -14,14 +14,13 @@ else:
     tl_round = tl.math.round
 
 
-def per_channel_quant(x: torch.Tensor, n_bits: int, dtype: torch.dtype):
+def per_channel_quant(x: torch.Tensor, dtype: torch.dtype):
     """Quantize the input tensor 'x' channel-wise using the given number of
     bits.
 
     Args:
         x (torch.Tensor): The input tensor to be quantized. Must be a
             2-dimensional tensor.
-        n_bits (int): The number of bits to use for quantization.
         dtype (torch.dtype): The data type to which the quantized tensor should
             be converted.
 
@@ -527,7 +526,7 @@ def test_rms_and_linear(x,
         return F.linear(x, b)
 
     linear_weight_quant, linear_scale = per_channel_quant(
-        linear_weight, 8, quant_dtype)
+        linear_weight, quant_dtype)
 
     rms_out, rms_scale = rms_norm_dynamic_quant(x,
                                                 rms_weight,
@@ -627,7 +626,7 @@ def bench_rms_and_linear(M: int,
             quant_dtype = torch.float8_e5m2
 
         linear_weight_quant, linear_scale = per_channel_quant(
-            linear_weight, 8, quant_dtype)
+            linear_weight, quant_dtype)
 
         alpha = max(x.max().abs(), x.min().abs())
         if quant_dtype.is_floating_point:

--- a/lmdeploy/pytorch/models/baichuan.py
+++ b/lmdeploy/pytorch/models/baichuan.py
@@ -228,7 +228,6 @@ class BaichuanModel(nn.Module):
         super().__init__()
         self.padding_idx = config.pad_token_id
         self.vocab_size = config.vocab_size
-        quantization_config = getattr(config, 'quantization_config', None)
 
         self.embed_tokens = nn.Embedding(config.vocab_size,
                                          config.hidden_size,
@@ -245,7 +244,6 @@ class BaichuanModel(nn.Module):
         # build norm
         self.norm = RMSNorm(config.hidden_size,
                             config.rms_norm_eps,
-                            quant_config=quantization_config,
                             dtype=dtype,
                             device=device)
 

--- a/lmdeploy/pytorch/models/chatglm2.py
+++ b/lmdeploy/pytorch/models/chatglm2.py
@@ -265,7 +265,6 @@ class GLMTransformer(nn.Module):
                  dtype: torch.dtype = None,
                  device: torch.device = None):
         super().__init__()
-        quantization_config = getattr(config, 'quantization_config', None)
         self.num_layers = config.num_layers
         self.post_layer_norm = config.post_layer_norm
 
@@ -280,7 +279,6 @@ class GLMTransformer(nn.Module):
             assert config.rmsnorm
             self.final_layernorm = RMSNorm(config.hidden_size,
                                            config.layernorm_epsilon,
-                                           quant_config=quantization_config,
                                            dtype=dtype,
                                            device=device)
 

--- a/lmdeploy/pytorch/models/cogvlm.py
+++ b/lmdeploy/pytorch/models/cogvlm.py
@@ -617,7 +617,6 @@ class CogVLMModel(nn.Module):
         super().__init__()
         self.padding_idx = config.pad_token_id
         self.vocab_size = config.vocab_size
-        quantization_config = getattr(config, 'quantization_config', None)
 
         self.embed_tokens = nn.Embedding(config.vocab_size,
                                          config.hidden_size,
@@ -634,7 +633,6 @@ class CogVLMModel(nn.Module):
         # build norm
         self.norm = RMSNorm(config.hidden_size,
                             config.rms_norm_eps,
-                            quant_config=quantization_config,
                             dtype=dtype,
                             device=device)
 

--- a/lmdeploy/pytorch/models/deepseek.py
+++ b/lmdeploy/pytorch/models/deepseek.py
@@ -313,7 +313,6 @@ class DeepseekModel(nn.Module):
         super().__init__()
         self.padding_idx = config.pad_token_id
         self.vocab_size = config.vocab_size
-        quantization_config = getattr(config, 'quantization_config', None)
 
         self.embed_tokens = nn.Embedding(config.vocab_size,
                                          config.hidden_size,
@@ -330,7 +329,6 @@ class DeepseekModel(nn.Module):
         # build norm
         self.norm = RMSNorm(config.hidden_size,
                             config.rms_norm_eps,
-                            quant_config=quantization_config,
                             dtype=dtype,
                             device=device)
 

--- a/lmdeploy/pytorch/models/gemma.py
+++ b/lmdeploy/pytorch/models/gemma.py
@@ -263,7 +263,6 @@ class GemmaModel(nn.Module):
         self.config = config
         self.padding_idx = config.pad_token_id
         self.vocab_size = config.vocab_size
-        quantization_config = getattr(config, 'quantization_config', None)
 
         self.embed_tokens = nn.Embedding(config.vocab_size,
                                          config.hidden_size,
@@ -280,7 +279,6 @@ class GemmaModel(nn.Module):
         # build norm
         self.norm = RMSNorm(config.hidden_size,
                             config.rms_norm_eps,
-                            quant_config=quantization_config,
                             dtype=dtype,
                             device=device)
 

--- a/lmdeploy/pytorch/models/internlm2.py
+++ b/lmdeploy/pytorch/models/internlm2.py
@@ -221,7 +221,6 @@ class InternLM2Model(nn.Module):
         super().__init__()
         self.padding_idx = config.pad_token_id
         self.vocab_size = config.vocab_size
-        quantization_config = getattr(config, 'quantization_config', None)
 
         self.tok_embeddings = nn.Embedding(config.vocab_size,
                                            config.hidden_size,
@@ -241,7 +240,6 @@ class InternLM2Model(nn.Module):
         # build norm
         self.norm = RMSNorm(config.hidden_size,
                             config.rms_norm_eps,
-                            quant_config=quantization_config,
                             dtype=dtype,
                             device=device)
 

--- a/lmdeploy/pytorch/models/internlm2_ve.py
+++ b/lmdeploy/pytorch/models/internlm2_ve.py
@@ -105,7 +105,6 @@ class InternLM2VEModel(nn.Module):
         super().__init__()
         self.padding_idx = config.pad_token_id
         self.vocab_size = config.vocab_size
-        quantization_config = getattr(config, 'quantization_config', None)
 
         self.tok_embeddings = nn.Embedding(config.vocab_size,
                                            config.hidden_size,
@@ -125,7 +124,6 @@ class InternLM2VEModel(nn.Module):
         # build norm
         self.norm = RMSNorm(config.hidden_size,
                             config.rms_norm_eps,
-                            quant_config=quantization_config,
                             dtype=dtype,
                             device=device)
 

--- a/lmdeploy/pytorch/models/minicpmv26.py
+++ b/lmdeploy/pytorch/models/minicpmv26.py
@@ -227,7 +227,6 @@ class MiniCPMV26Model(nn.Module):
         super().__init__()
         self.padding_idx = config.pad_token_id
         self.vocab_size = config.vocab_size
-        quantization_config = getattr(config, 'quantization_config', None)
 
         self.embed_tokens = nn.Embedding(config.vocab_size,
                                          config.hidden_size,
@@ -247,7 +246,6 @@ class MiniCPMV26Model(nn.Module):
         # build norm
         self.norm = RMSNorm(config.hidden_size,
                             config.rms_norm_eps,
-                            quant_config=quantization_config,
                             dtype=dtype,
                             device=device)
 

--- a/lmdeploy/pytorch/models/mistral.py
+++ b/lmdeploy/pytorch/models/mistral.py
@@ -223,7 +223,6 @@ class MistralModel(nn.Module):
         super().__init__()
         self.padding_idx = config.pad_token_id
         self.vocab_size = config.vocab_size
-        quantization_config = getattr(config, 'quantization_config', None)
 
         self.embed_tokens = nn.Embedding(config.vocab_size,
                                          config.hidden_size,
@@ -240,7 +239,6 @@ class MistralModel(nn.Module):
         # build norm
         self.norm = RMSNorm(config.hidden_size,
                             config.rms_norm_eps,
-                            quant_config=quantization_config,
                             dtype=dtype,
                             device=device)
 

--- a/lmdeploy/pytorch/models/phi3.py
+++ b/lmdeploy/pytorch/models/phi3.py
@@ -226,7 +226,6 @@ class Phi3Model(nn.Module):
         super().__init__()
         self.padding_idx = config.pad_token_id
         self.vocab_size = config.vocab_size
-        quantization_config = getattr(config, 'quantization_config', None)
 
         self.embed_tokens = nn.Embedding(config.vocab_size,
                                          config.hidden_size,
@@ -243,7 +242,6 @@ class Phi3Model(nn.Module):
         # build norm
         self.norm = RMSNorm(config.hidden_size,
                             config.rms_norm_eps,
-                            quant_config=quantization_config,
                             dtype=dtype,
                             device=device)
 

--- a/lmdeploy/pytorch/models/q_modules.py
+++ b/lmdeploy/pytorch/models/q_modules.py
@@ -130,7 +130,7 @@ class QLinear(nn.Module):
                     quant_dtype=quant_dtype)
 
         if initialization:
-            weight_quant, scale = per_channel_quant(mod.weight.detach(), 8,
+            weight_quant, scale = per_channel_quant(mod.weight.detach(),
                                                     quant_dtype)
             q_mod.weight.data = weight_quant
             q_mod.scale = scale

--- a/lmdeploy/pytorch/models/qwen.py
+++ b/lmdeploy/pytorch/models/qwen.py
@@ -229,7 +229,6 @@ class QWenModel(nn.Module):
                  dtype: torch.dtype = None,
                  device: torch.device = None):
         super().__init__()
-        quantization_config = getattr(config, 'quantization_config', None)
         self.vocab_size = config.vocab_size
         self.embed_dim = config.hidden_size
         self.wte = nn.Embedding(self.vocab_size,
@@ -263,7 +262,6 @@ class QWenModel(nn.Module):
 
         self.ln_f = RMSNorm(self.embed_dim,
                             eps=config.layer_norm_epsilon,
-                            quant_config=quantization_config,
                             dtype=dtype,
                             device=device)
 

--- a/lmdeploy/pytorch/models/qwen2.py
+++ b/lmdeploy/pytorch/models/qwen2.py
@@ -225,7 +225,6 @@ class Qwen2Model(nn.Module):
         super().__init__()
         self.padding_idx = config.pad_token_id
         self.vocab_size = config.vocab_size
-        quantization_config = getattr(config, 'quantization_config', None)
 
         self.embed_tokens = nn.Embedding(config.vocab_size,
                                          config.hidden_size,
@@ -242,7 +241,6 @@ class Qwen2Model(nn.Module):
         # build norm
         self.norm = RMSNorm(config.hidden_size,
                             config.rms_norm_eps,
-                            quant_config=quantization_config,
                             dtype=dtype,
                             device=device)
 

--- a/lmdeploy/pytorch/models/qwen2_moe.py
+++ b/lmdeploy/pytorch/models/qwen2_moe.py
@@ -328,7 +328,6 @@ class Qwen2MoeModel(nn.Module):
         super().__init__()
         self.padding_idx = config.pad_token_id
         self.vocab_size = config.vocab_size
-        quantization_config = getattr(config, 'quantization_config', None)
 
         self.embed_tokens = nn.Embedding(config.vocab_size,
                                          config.hidden_size,
@@ -345,7 +344,6 @@ class Qwen2MoeModel(nn.Module):
         # build norm
         self.norm = RMSNorm(config.hidden_size,
                             config.rms_norm_eps,
-                            quant_config=quantization_config,
                             dtype=dtype,
                             device=device)
 

--- a/lmdeploy/pytorch/models/qwen2_vl.py
+++ b/lmdeploy/pytorch/models/qwen2_vl.py
@@ -260,7 +260,6 @@ class Qwen2Model(nn.Module):
         self.padding_idx = config.pad_token_id
         self.vocab_size = config.vocab_size
         self.mrope_section = config.rope_scaling['mrope_section']
-        quantization_config = getattr(config, 'quantization_config', None)
 
         self.embed_tokens = nn.Embedding(config.vocab_size,
                                          config.hidden_size,
@@ -277,7 +276,6 @@ class Qwen2Model(nn.Module):
         # build norm
         self.norm = RMSNorm(config.hidden_size,
                             config.rms_norm_eps,
-                            quant_config=quantization_config,
                             dtype=dtype,
                             device=device)
 

--- a/lmdeploy/pytorch/nn/linear.py
+++ b/lmdeploy/pytorch/nn/linear.py
@@ -598,17 +598,16 @@ class QKVAwqLinear(MergedAwqLinear, QKVMixin):
 class W8A8Linear(nn.Module):
     """w8a8 linear."""
 
-    def __init__(
-        self,
-        in_features: int,
-        out_features: int,
-        bias: bool,
-        dtype: Optional[torch.dtype] = None,
-        device: Optional[torch.device] = None,
-        colwise: bool = True,
-        is_tp: bool = False,
-        all_reduce: bool = True,
-    ):
+    def __init__(self,
+                 in_features: int,
+                 out_features: int,
+                 bias: bool,
+                 dtype: Optional[torch.dtype] = None,
+                 device: Optional[torch.device] = None,
+                 colwise: bool = True,
+                 is_tp: bool = False,
+                 all_reduce: bool = True,
+                 quant_dtype: Optional[torch.dtype] = torch.int8):
         super().__init__()
         if device is None:
             device = torch.device('cpu')
@@ -618,10 +617,12 @@ class W8A8Linear(nn.Module):
             in_features, out_features = self._get_io_features(
                 in_features, out_features, colwise)
         impl_builder = get_backend().get_layer_impl_builder(OpType.LinearW8A8)
+        self.quant_dtype = quant_dtype
         self.impl = impl_builder.build(in_features,
                                        out_features,
                                        bias is not None,
-                                       dtype=dtype)
+                                       dtype=dtype,
+                                       quant_dtype=quant_dtype)
         weight, scale, bias = self.create_weights(in_features, out_features,
                                                   bias, dtype, device)
         weight = torch.nn.Parameter(weight, requires_grad=False)
@@ -663,7 +664,9 @@ class W8A8Linear(nn.Module):
                                   loaded_weight: torch.Tensor, rank: int,
                                   world_size: int):
         """weight loader for rowwise linear."""
-        if loaded_weight.dim() == 2 and param.dtype == torch.int8:
+        if loaded_weight.dim() == 2 and param.dtype in (torch.float16,
+                                                        torch.float32,
+                                                        torch.bfloat16):
             weight = loaded_weight.chunk(world_size, 1)[rank]
             return default_weight_loader(param, weight)
         elif loaded_weight.dim() == 2 and loaded_weight.size(1) == 1:
@@ -693,7 +696,7 @@ class W8A8Linear(nn.Module):
                        dtype: torch.dtype, device: torch.device):
         """create weights."""
         weight = torch.empty((out_features, in_features),
-                             dtype=torch.int8,
+                             dtype=self.quant_dtype,
                              device=device)
         scale = torch.empty((out_features, 1),
                             dtype=torch.float32,
@@ -745,7 +748,8 @@ class MergedW8A8Linear(W8A8Linear):
                  dtype: Optional[torch.dtype] = None,
                  device: Optional[torch.device] = None,
                  is_tp: bool = True,
-                 out_names: Optional[List[int]] = None):
+                 out_names: Optional[List[int]] = None,
+                 quant_dtype: torch.dtype = torch.int8):
         self.split_section = all_out_features
         all_out_features = self._update_all_out_features(all_out_features)
         self.all_out_features = all_out_features
@@ -761,7 +765,8 @@ class MergedW8A8Linear(W8A8Linear):
                          dtype,
                          device,
                          colwise=True,
-                         is_tp=is_tp)
+                         is_tp=is_tp,
+                         quant_dtype=quant_dtype)
         self.weight.weight_loader = self.weight_loader
         self.scale.weight_loader = self.weight_loader
         self.weight.weight_spliter = self.weight_spliter
@@ -814,7 +819,9 @@ class QKVW8A8Linear(MergedW8A8Linear, QKVMixin):
                  dtype: Optional[torch.dtype] = None,
                  device: Optional[torch.device] = None,
                  is_tp: bool = True,
-                 num_replicate_kv_heads: int = 1):
+                 num_replicate_kv_heads: int = 1,
+                 quant_dtype: torch.dtype = torch.int8):
+        
         self.qkv_split_section = self._get_qkv_out_features(
             num_q_heads, num_kv_heads, head_size, head_size_v,
             num_replicate_kv_heads)
@@ -835,7 +842,8 @@ class QKVW8A8Linear(MergedW8A8Linear, QKVMixin):
                          dtype=dtype,
                          device=device,
                          is_tp=is_tp,
-                         out_names=out_names)
+                         out_names=out_names,
+                         quant_dtype=quant_dtype)
 
     def _update_all_out_features(self, all_out_features: List[int]):
         """update all out features."""
@@ -1200,6 +1208,10 @@ def build_linear(in_features: int,
         )
 
     quant_method = quant_config['quant_method']
+    quant_dtype = torch.int8
+    if 'quant_dtype' in quant_config:
+        quant_dtype = eval('torch.' + quant_config['quant_dtype'])
+
     if quant_method == 'awq':
         w_bit = quant_config.get('bits', 4)
         group_size = quant_config.get('group_size', 128)
@@ -1215,16 +1227,15 @@ def build_linear(in_features: int,
             all_reduce=all_reduce,
         )
     if quant_method == 'smooth_quant':
-        return W8A8Linear(
-            in_features,
-            out_features,
-            bias=bias,
-            dtype=dtype,
-            device=device,
-            colwise=colwise,
-            is_tp=is_tp,
-            all_reduce=all_reduce,
-        )
+        return W8A8Linear(in_features,
+                          out_features,
+                          bias=bias,
+                          dtype=dtype,
+                          device=device,
+                          colwise=colwise,
+                          is_tp=is_tp,
+                          all_reduce=all_reduce,
+                          quant_dtype=quant_dtype)
     else:
         raise RuntimeError(f'Unsupported quant method: {quant_method}')
 
@@ -1299,6 +1310,10 @@ def build_merged_colwise_linear(
         )
 
     quant_method = quant_config['quant_method']
+    quant_dtype = torch.int8
+    if 'quant_dtype' in quant_config:
+        quant_dtype = eval('torch.' + quant_config['quant_dtype'])
+
     if quant_method == 'awq':
         w_bit = quant_config.get('bits', 4)
         group_size = quant_config.get('group_size', 128)
@@ -1312,15 +1327,14 @@ def build_merged_colwise_linear(
             is_tp=is_tp,
         )
     if quant_method == 'smooth_quant':
-        return MergedW8A8Linear(
-            in_features=in_features,
-            all_out_features=all_out_features,
-            bias=bias,
-            dtype=dtype,
-            device=device,
-            is_tp=is_tp,
-            out_names=out_names,
-        )
+        return MergedW8A8Linear(in_features=in_features,
+                                all_out_features=all_out_features,
+                                bias=bias,
+                                dtype=dtype,
+                                device=device,
+                                is_tp=is_tp,
+                                out_names=out_names,
+                                quant_dtype=quant_dtype)
     else:
         raise RuntimeError(f'Unsupported quant method: {quant_method}')
 
@@ -1357,6 +1371,10 @@ def build_qkv_proj(in_features: int,
                              num_replicate_kv_heads=num_replicate_kv_heads)
 
     quant_method = quant_config['quant_method']
+    quant_dtype = torch.int8
+    if 'quant_dtype' in quant_config:
+        quant_dtype = eval('torch.' + quant_config['quant_dtype'])
+
     if quant_method == 'awq':
         w_bit = quant_config.get('bits', 4)
         group_size = quant_config.get('group_size', 128)
@@ -1381,6 +1399,7 @@ def build_qkv_proj(in_features: int,
                              dtype=dtype,
                              device=device,
                              is_tp=is_tp,
-                             num_replicate_kv_heads=num_replicate_kv_heads)
+                             num_replicate_kv_heads=num_replicate_kv_heads,
+                             quant_dtype=quant_dtype)
     else:
         raise RuntimeError(f'Unsupported quant method: {quant_method}')

--- a/lmdeploy/pytorch/nn/linear.py
+++ b/lmdeploy/pytorch/nn/linear.py
@@ -664,9 +664,9 @@ class W8A8Linear(nn.Module):
                                   loaded_weight: torch.Tensor, rank: int,
                                   world_size: int):
         """weight loader for rowwise linear."""
-        if loaded_weight.dim() == 2 and param.dtype in (torch.float16,
-                                                        torch.float32,
-                                                        torch.bfloat16):
+        if loaded_weight.dim() == 2 and param.dtype in (torch.int8,
+                                                        torch.float8_e4m3fn,
+                                                        torch.float8_e5m2):
             weight = loaded_weight.chunk(world_size, 1)[rank]
             return default_weight_loader(param, weight)
         elif loaded_weight.dim() == 2 and loaded_weight.size(1) == 1:
@@ -821,7 +821,7 @@ class QKVW8A8Linear(MergedW8A8Linear, QKVMixin):
                  is_tp: bool = True,
                  num_replicate_kv_heads: int = 1,
                  quant_dtype: torch.dtype = torch.int8):
-        
+
         self.qkv_split_section = self._get_qkv_out_features(
             num_q_heads, num_kv_heads, head_size, head_size_v,
             num_replicate_kv_heads)

--- a/lmdeploy/pytorch/nn/norm.py
+++ b/lmdeploy/pytorch/nn/norm.py
@@ -39,7 +39,12 @@ class RMSNorm(nn.Module):
             builder = backend.get_layer_impl_builder(OpType.RMSNorm)
         self.register_parameter('weight',
                                 self.create_weight(hidden_size, dtype, device))
-        self.impl = builder.build(hidden_size, eps, quant_dtype=quant_dtype)
+        if w8a8_flag:
+            self.impl = builder.build(hidden_size,
+                                      eps,
+                                      quant_dtype=quant_dtype)
+        else:
+            self.impl = builder.build(hidden_size, eps)
 
     @staticmethod
     def create_weight(hidden_size: int,

--- a/tests/pytorch/kernel/test_fused_moe.py
+++ b/tests/pytorch/kernel/test_fused_moe.py
@@ -266,7 +266,7 @@ class TestFusedMoeW8A8(TestFusedMoe):
             per_channel_quant
         num_experts, num_outs, _ = w.shape
         w = w.flatten(0, -2)
-        w_i8, w_scale = per_channel_quant(w, 8, torch.int8)
+        w_i8, w_scale = per_channel_quant(w, torch.int8)
         w_i8 = w_i8.view(num_experts, num_outs, -1)
         w_scale = w_scale.view(num_experts, num_outs, -1)
         return w_i8, w_scale


### PR DESCRIPTION


## Motivation

Support fp8 w8a8 for pt backend



## Modification

Support fp8 w8a8 for pt backend

## BC-breaking (Optional)

None

## Use cases (Optional)

### fp8 quant
```
lmdeploy lite smooth_quant \
  meta-llama/Meta-Llama-3-8B-Instruct \
  --work-dir Meta-Llama-3-8B-Instruct-fp8-w8a8 \
  --quant-dtype fp8
```

### chat
```
lmdeploy  chat Meta-Llama-3-8B-Instruct-fp8-w8a8 --backend pytorch
```
## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
