### PR TITLE
add block_size arg to chat api

### DIFF
--- a/lmdeploy/cli/cli.py
+++ b/lmdeploy/cli/cli.py
@@ -123,6 +123,7 @@ class CLI(object):
         ArgumentHelper.adapters(pt_group)
         ArgumentHelper.device(pt_group)
         ArgumentHelper.eager_mode(pt_group)
+        ArgumentHelper.cache_block_seq_len(pt_group)
         # common engine args
         dtype_act = ArgumentHelper.dtype(pt_group)
         tp_act = ArgumentHelper.tp(pt_group)
@@ -267,7 +268,8 @@ class CLI(object):
                 enable_prefix_caching=args.enable_prefix_caching,
                 device_type=args.device,
                 eager_mode=args.eager_mode,
-                quant_policy=args.quant_policy)
+                quant_policy=args.quant_policy,
+                block_size=args.cache_block_seq_len)
             run_chat(args.model_path,
                      engine_config,
                      chat_template_config=chat_template_config)


### PR DESCRIPTION
## Motivation

Since camb device backend only supports block_size=16 for paged_attention relevant ops, we need to enable control of block_size.

This PR add `cache_block_seq_len` arg parser to lmdeploy chat API.

After this PR, we can use `lmdeploy chat /Shanghai_AI_Laboratory/internlm2_5-7b --backend pytorch --device camb --cache-block-seq-len 16` to chat on camb device


