### PR TITLE
fix xcomposer2 when transformers is upgraded greater than 4.46 

### DIFF
--- a/lmdeploy/vl/model/xcomposer2.py
+++ b/lmdeploy/vl/model/xcomposer2.py
@@ -153,6 +153,9 @@ class Xcomposer2VisionModel(VisonModel):
                                                      trust_remote_code=True)
             model.vit.load_model()
             model.vit.resize_pos()
+            if hasattr(self.hf_config, 'img_size'):
+                model.vit.vision_tower.vision_model.embeddings.image_size = \
+                    self.hf_config.img_size
             model.vit.vision_tower.vision_model.post_layernorm.to_empty(
                 device='cpu').half()
             del model.model


### PR DESCRIPTION
## Motivation

fix error when using transformers >= 4.46.0
https://github.com/huggingface/transformers/blob/v4.46.0/src/transformers/models/clip/modeling_clip.py#L244-L245