### PR TITLE
[hotfix] Fix get_ppl

### DIFF
--- a/lmdeploy/serve/async_engine.py
+++ b/lmdeploy/serve/async_engine.py
@@ -574,7 +574,6 @@ class AsyncEngine(LogitsMixin):
                           **kwargs)
 
     async def _get_prompt_input(self,
-                                session_id: int,
                                 prompt: str,
                                 do_preprocess: bool,
                                 sequence_start: bool,

--- a/tests/test_lmdeploy/test_auto_backend.py
+++ b/tests/test_lmdeploy/test_auto_backend.py
@@ -33,8 +33,6 @@ class TestAutoBackend:
             ('tiiuae/falcon-7b-instruct', True, False),
             ('01-ai/Yi-34B-Chat', True, True),
             ('codellama/CodeLlama-7b-Instruct-hf', True, True),
-            ('mistralai/Mistral-7B-Instruct-v0.1', True, True),
-            ('mistralai/Mixtral-8x7B-Instruct-v0.1', True, True),
             ('Qwen/Qwen-7B-Chat', True, True),
             ('Qwen/Qwen-VL-Chat', False, True),
             ('Qwen/Qwen1.5-4B-Chat', True, True),


### PR DESCRIPTION
OC test with the following config failed
```python
from copy import deepcopy
from mmengine.config import read_base
with read_base():
    # choose a list of datasets
    from opencompass.configs.datasets.ARC_c.ARC_c_few_shot_ppl import \
        ARC_c_datasets  # noqa: F401, E501
    from opencompass.configs.models.hf_internlm.lmdeploy_internlm2_5_7b import \
        models as lmdeploy_internlm2_5_7b  # noqa: F401, E501
turbomind_internlm2_5_7b = deepcopy(*lmdeploy_internlm2_5_7b)
for model in [v for k, v in locals().items() if k.endswith('_4bits')]:
    model['engine_config']['model_format'] = 'awq'
    model['abbr'] = model['abbr'] + '_4bits'
    model['path'] = model['path'] + '-inner-4bits'
for model in [v for k, v in locals().items() if '_batch1' in k]:
    model['abbr'] = model['abbr'] + '_batch1'
    model['engine_config']['max_batch_size'] = 1
    model['batch_size'] = 1
models = [turbomind_internlm2_5_7b]
datasets = [*ARC_c_datasets]
```

```
File "/nvme/envs/vllmtest/lib/python3.10/site-packages/opencompass/tasks/openicl_infer.py", line 161, in <module>
    inferencer.run()
  File "/nvme/envs/vllmtest/lib/python3.10/site-packages/opencompass/tasks/openicl_infer.py", line 89, in run
    self._inference()
  File "/nvme/envs/vllmtest/lib/python3.10/site-packages/opencompass/tasks/openicl_infer.py", line 139, in _inference
    inferencer.inference(retriever,
  File "/nvme/envs/vllmtest/lib/python3.10/site-packages/opencompass/openicl/icl_inferencer/icl_ppl_inferencer.py", line 159, in inference
    sub_res = self.model.get_ppl_from_template(sub_prompt_list).tolist()
  File "/nvme/envs/vllmtest/lib/python3.10/site-packages/opencompass/models/base.py", line 174, in get_ppl_from_template
    return self.get_ppl(inputs, mask_length)
  File "/nvme/envs/vllmtest/lib/python3.10/site-packages/opencompass/models/turbomind.py", line 196, in get_ppl
    results.append(self.pipe.get_ppl(input_ids[i:i + 128]))
  File "/nvme/envs/vllmtest/lib/python3.10/site-packages/lmdeploy/serve/utils.py", line 98, in get_ppl
    res = self._get_ppl(
  File "/nvme/envs/vllmtest/lib/python3.10/site-packages/lmdeploy/serve/utils.py", line 199, in _get_ppl
    _logits = _logits.float()
AttributeError: 'NoneType' object has no attribute 'float'
```