### PR TITLE
fix: replace inf with max or min finite value, then do softmax

### DIFF
--- a/lmdeploy/pytorch/engine/logits_process.py
+++ b/lmdeploy/pytorch/engine/logits_process.py
@@ -361,6 +361,28 @@ class FusedLogitsProcessor(LogitsWarper):
     def sampling(self, logits: torch.Tensor):
         """sampling."""
         sampling_inputs = self.sampling_inputs
+        
+        def _softmax_scores(scores: torch.Tensor):
+            """softmax scores."""
+            # if score has inf, replace it with max or min finite value, then do softmax
+            if torch.isinf(scores).any():
+                dtype = scores.dtype
+                
+                if dtype in [torch.float16, torch.float32, torch.float64]:
+                    max_finite_value = torch.finfo(dtype).max
+                    min_finite_value = torch.finfo(dtype).min
+                elif dtype in [torch.int8, torch.int16, torch.int32, torch.int64]:
+                    max_finite_value = torch.iinfo(dtype).max
+                    min_finite_value = torch.iinfo(dtype).min
+                else:
+                    raise TypeError("Unsupported data type")
+
+                device = scores.device
+                
+                scores = torch.where(scores == float('inf'), torch.tensor(max_finite_value, dtype=dtype, device=device), scores)
+                scores = torch.where(scores == float('-inf'), torch.tensor(min_finite_value, dtype=dtype, device=device), scores)
+            softmax_scores = scores.softmax(dim=1)
+            return softmax_scores
 
         def __random_sampling(scores: torch.Tensor, indices: torch.LongTensor):
             """random sampling."""
@@ -383,7 +405,7 @@ class FusedLogitsProcessor(LogitsWarper):
             if min_p is not None:
                 scores = _filter_minp_sorted_(scores, min_p)
 
-            softmax_scores = scores.softmax(1)
+            softmax_scores = _softmax_scores(scores)
 
             seeds = sampling_inputs.random_seeds
             offsets = sampling_inputs.random_offsets


### PR DESCRIPTION
## Motivation
 
When I deploy a large model inference model, there is an inf value in the scores value, and calling the softmax function results in an nan value. This can cause some errors, such as:

```python
import torch
import torch_npu

#inf_tensor = torch.full((1, 10), float('inf'), dtype=torch.float16)
# or
inf_tensor = torch.tensor([[1, 2, 3, 4, float('inf')]], dtype=torch.float16)

inf_tensor = inf_tensor.npu()
print(inf_tensor)

#res_nan = inf_tensor.softmax(1)
#print(res_nan)

# fix buy replacing inf with max value
res = _softmax_scores(nan_tensor)
print(res)

# error occurred
#sampled_index = torch.multinomial(res_nan,
#                                num_samples=1,
#                                replacement=True)
#print(sampled_index)
```

## Modification

I added the _softmax_stores function and wrapped the softmax function, if score has inf, replace it with max or min finite value, then do softmax.

