### PR TITLE
fix error in interactive api

### DIFF
--- a/lmdeploy/serve/openai/api_server.py
+++ b/lmdeploy/serve/openai/api_server.py
@@ -798,11 +798,10 @@ async def chat_interactive_v1(request: GenerateRequest, raw_request: Request = N
     if isinstance(request.stop, str):
         request.stop = [request.stop]
 
-    end_session = sequence_end and not sequence_start \
-        and request.prompt == '' and request.request_output_len == 0
+    end_session = sequence_end and request.prompt == '' and request.request_output_len == 0
     if end_session:
         await async_engine.end_session(request.session_id)
-        return JSONResponse(dict(text='', tokens=0, input_tokens=0, history_tokens=0, finish_reason=None))
+        return JSONResponse(dict(text='', tokens=0, input_tokens=0, history_tokens=0, finish_reason='stop'))
 
     random_seed = request.seed if request.seed else None
 


### PR DESCRIPTION
Due to historical reason, `finish_reason` is expected to be set to 'stop' when a session ends
