### PR TITLE
Fix internvl2.5 error after eviction

### DIFF
--- a/lmdeploy/pytorch/models/internvl.py
+++ b/lmdeploy/pytorch/models/internvl.py
@@ -401,7 +401,8 @@ class InternVLChatModel(nn.Module, DeployModelMixin, CudaGraphMixin):
             pixel_values = [data for im_data in pixel_values for data in im_data]
             if len(pixel_values) > 0:
                 image_token_id = pixel_values[0].meta['image_token_id']
-                image_mask = input_ids == image_token_id
+                image_mask = input_ids == -1
+                input_ids.masked_fill_(image_mask, image_token_id)
                 pixel_values = torch.cat([data.data for data in pixel_values])
             else:
                 pixel_values = None
@@ -510,6 +511,7 @@ class InternVLInputProcessor(BaseModelInputProcessor):
             return input_ids, input_multimodals
 
         input_imgs = []
+        image_token_id = None
         for input_mm in input_multimodals:
             pixel_values = input_mm['pixel_values'].to(self.dtype)
             offset = input_mm['offset']
@@ -523,6 +525,13 @@ class InternVLInputProcessor(BaseModelInputProcessor):
                                        end=offset + num_pad,
                                        meta=dict(image_token_id=image_token_id))
             input_imgs.append(mm_data)
+
+        if image_token_id is not None:
+            import numpy as np
+
+            # replace pad token to -1
+            input_ids = np.array(input_ids)
+            input_ids[input_ids == image_token_id] = -1
 
         result = PreprocessInputResult(
             input_ids=input_ids,

--- a/lmdeploy/vl/model/internvl.py
+++ b/lmdeploy/vl/model/internvl.py
@@ -245,8 +245,18 @@ class InternVLVisionModel(VisonModel):
         prompt = chat_template.messages2prompt(prompt_messages, sequence_start)
         return prompt, IMAGE_TOKEN
 
+    @staticmethod
+    def _update_image_token_id(messages, tokenizer):
+        """update image_token_id."""
+        pad_token_id = getattr(tokenizer.model.model, 'pad_token_id', 0)
+        preps = [x['content'] for x in messages if x['role'] == 'preprocess']
+        for prep in preps:
+            for pp in prep:
+                pp['image_token_id'] = pad_token_id
+
     def to_pytorch(self, messages, chat_template, tokenizer, sequence_start):
         prompt, IMAGE_TOKEN = self.proc_messages(messages, chat_template, sequence_start)
+        self._update_image_token_id(messages, tokenizer)
         return self.to_pytorch_aux(messages, prompt, IMAGE_TOKEN, tokenizer, sequence_start)
 
     def to_turbomind(self, messages, chat_template, tokenizer, sequence_start):


### PR DESCRIPTION
Model generate padded image token could lead to error after eviction.
Note that a better solution is to set a pad token that would never generated.