### PR TITLE
Fix UT of deepseek chat template

### DIFF
--- a/tests/test_lmdeploy/test_model.py
+++ b/tests/test_lmdeploy/test_model.py
@@ -833,4 +833,6 @@ def test_deepseek_r1(model_path_or_name):
     }]
     ref = tokenizer.apply_chat_template(messages, tokenize=False, add_generation_prompt=True)
     lm_res = chat_template.messages2prompt(messages)
+    if model_path_or_name != 'deepseek-ai/DeepSeek-V3':
+        lm_res += '<think>\n'
     assert ref == lm_res


### PR DESCRIPTION
For deepseek-r1 model, the chat template add "<think>\n" after "<|Assistant|>"
```
 AssertionError: assert '<｜begin▁of▁s...nt｜><think>\n' == '<｜begin▁of▁s...<｜Assistant｜>'
```
Since LMDeploy allows users to add assistant content in prompt message, I think we'd better not change "deepseek-r1" in model.py but modifying the UT.
