### PR TITLE
[fix] fix vl gradio, use pipeline api and remove interactive chat

### DIFF
--- a/lmdeploy/pytorch/engine/engine.py
+++ b/lmdeploy/pytorch/engine/engine.py
@@ -235,6 +235,8 @@ class Engine:
 
     def _response(self, resp: Response, resp_type: ResponseType, data: Any = None, err_msg: str = ''):
         """response."""
+        if resp.type == ResponseType.FINISH:
+            return
         resp.type = resp_type
         resp.data = data
         resp.err_msg = err_msg
@@ -273,6 +275,12 @@ class Engine:
             resp_type = ResponseType.SESSION_NOT_EXIST
             if session_id in self.scheduler.sessions:
                 self.scheduler.stop_session(session_id)
+                session = self.scheduler.sessions[session_id]
+                for seq in session.sequences.values():
+                    resp: Response = getattr(seq, 'resp', None)
+                    if resp is not None:
+                        resp.type = ResponseType.FINISH
+                        self.req_manager.response(resp)
                 resp_type = ResponseType.SUCCESS
             if resp:
                 self._response(req.resp, resp_type)


### PR DESCRIPTION
## Motivation

Use pipeline api and remove interactive chat to support vl models like qwen2-vl

Currently with pytoch backend, it seems that the generator cannot be interrupted when sending a stop request. @grimoire 

```python
# reproduction code

import asyncio
from lmdeploy import pipeline, PytorchEngineConfig
pipe = pipeline('/mnt/141/vicuna-7b-v1.5/', backend_config=PytorchEngineConfig())

event = asyncio.Event()
messages = '写一篇高考作文'
session_id = 0

async def inference():
    step = 0
    async for out in pipe.generate(messages=messages, session_id=session_id):
        print(step, out)
        step += 1
        if (step == 5):
            event.set()
    print('inference done')


async def stop():
    await event.wait()
    await pipe.stop_session(session_id=session_id)


async def main():
    await asyncio.gather(inference(), stop())


if __name__ == '__main__':
    asyncio.run(main())
```
