### PR TITLE
Update runtime package dependencies

### DIFF
--- a/requirements/runtime_ascend.txt
+++ b/requirements/runtime_ascend.txt
@@ -11,7 +11,6 @@ peft<=0.11.1
 pillow
 protobuf
 pydantic>2.0.0
-pynvml
 safetensors
 sentencepiece
 shortuuid

--- a/requirements/runtime_camb.txt
+++ b/requirements/runtime_camb.txt
@@ -10,7 +10,6 @@ peft<=0.11.1
 pillow
 protobuf
 pydantic>2.0.0
-pynvml
 safetensors
 sentencepiece
 shortuuid

--- a/requirements/runtime_cuda.txt
+++ b/requirements/runtime_cuda.txt
@@ -6,11 +6,10 @@ mmengine-lite
 numpy<2.0.0
 openai
 outlines<0.1.0
-peft<=0.11.1
+peft<=0.14.0
 pillow
 protobuf
 pydantic>2.0.0
-pynvml
 safetensors
 sentencepiece
 shortuuid

--- a/requirements/runtime_maca.txt
+++ b/requirements/runtime_maca.txt
@@ -10,7 +10,6 @@ peft<=0.11.1
 pillow
 protobuf
 pydantic>2.0.0
-pynvml
 safetensors
 sentencepiece
 shortuuid

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,6 +1,6 @@
 allure-pytest
 coverage
-pynvml
+nvidia-ml-py
 pytest
 pytest-assume
 pytest-cov


### PR DESCRIPTION
## Motivation

1. Update `peft` dependency version
2. Update `pynvml` to `nvidia-ml-py` because the former one is deprecated and not compatible with `vllm>=0.7.0`, see [pypi](https://pypi.org/project/pynvml/)

## Modification

See above

## BC-breaking (Optional)

None

## Use cases (Optional)

None
