### PR TITLE
Make turbomind support embedding inputs on GPU

### DIFF
--- a/lmdeploy/turbomind/turbomind.py
+++ b/lmdeploy/turbomind/turbomind.py
@@ -493,7 +493,7 @@ class TurboMindInstance:
 
         input_embeddings, input_embedding_ranges = self.prepare_embeddings(input_embeddings, input_embedding_ranges)
         if input_embeddings is not None:
-            inputs['input_embeddings'] = input_embeddings
+            inputs['input_embeddings'] = input_embeddings.cpu()
             inputs['input_embedding_ranges'] = input_embedding_ranges
 
         return inputs, input_len


### PR DESCRIPTION
## Motivation

The current implementation of turbomind only supports embedding inputs on the CPU. When embedding inputs are too large, the CPU can become a bottleneck. This PR aims to enable support for embedding inputs on the GPU, thereby alleviating the CPU bottleneck.

## Modification


## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
