### PR TITLE
[ci] add testcase for native communicator

### DIFF
--- a/autotest/tools/pipeline/llm_case.py
+++ b/autotest/tools/pipeline/llm_case.py
@@ -31,6 +31,7 @@ def run_pipeline_chat_test(model_path, cases_path, tp, backend_type, is_pr_test,
     if not is_bf16_supported():
         backend_config.dtype = 'float16'
 
+    print('backend_config config: ' + str(backend_config))
     pipe = pipeline(model_path, backend_config=backend_config)
 
     cases_path = os.path.join(cases_path)

--- a/autotest/tools/pipeline/llm_case.py
+++ b/autotest/tools/pipeline/llm_case.py
@@ -21,6 +21,8 @@ def run_pipeline_chat_test(model_path, cases_path, tp, backend_type, is_pr_test,
         backend_config.adapters = extra.get('adapters')
     if 'kvint' in backend_type:
         backend_config.quant_policy = extra.get('quant_policy')
+    if 'turbomind' in backend_type and extra is not None and 'communicator' in extra:
+        backend_config.communicator = extra.get('communicator')
 
     if 'w4' in model_path or ('4bits' in model_path or 'awq' in model_path.lower()):
         backend_config.model_format = 'awq'

--- a/autotest/tools/pipeline/mllm_case.py
+++ b/autotest/tools/pipeline/mllm_case.py
@@ -38,6 +38,7 @@ def run_pipeline_mllm_test(model_path, resource_path, tp, backend_type, is_pr_te
     if not is_bf16_supported():
         backend_config.dtype = 'float16'
 
+    print('backend_config config: ' + str(backend_config))
     pipe = pipeline(model_path, backend_config=backend_config)
 
     image = load_image(f'{resource_path}/{PIC1}')

--- a/autotest/tools/pipeline/mllm_case.py
+++ b/autotest/tools/pipeline/mllm_case.py
@@ -30,6 +30,8 @@ def run_pipeline_mllm_test(model_path, resource_path, tp, backend_type, is_pr_te
 
     if 'kvint' in backend_type:
         backend_config.quant_policy = extra.get('quant_policy')
+    if 'turbomind' in backend_type and extra is not None and 'communicator' in extra:
+        backend_config.communicator = extra.get('communicator')
 
     if 'w4' in model_path or ('4bits' in model_path or 'awq' in model_path.lower()):
         backend_config.model_format = 'awq'

--- a/autotest/tools/pipeline/test_pipeline_chat_turbomind_llm.py
+++ b/autotest/tools/pipeline/test_pipeline_chat_turbomind_llm.py
@@ -1,7 +1,7 @@
 import os
 
 import pytest
-from utils.config_utils import get_all_model_list, get_cuda_id_by_workerid
+from utils.config_utils import get_communicator_list, get_cuda_id_by_workerid, get_turbomind_model_list
 from utils.pipeline_chat import run_pipeline_chat_test
 
 
@@ -10,11 +10,12 @@ from utils.pipeline_chat import run_pipeline_chat_test
 @pytest.mark.pipeline_chat
 @pytest.mark.gpu_num_1
 @pytest.mark.flaky(reruns=0)
-@pytest.mark.parametrize('model', get_all_model_list(tp_num=1))
-def test_pipeline_chat_tp1(config, common_case_config, model, worker_id):
+@pytest.mark.parametrize('model', get_turbomind_model_list(tp_num=1))
+@pytest.mark.parametrize('communicator', get_communicator_list())
+def test_pipeline_chat_tp1(config, common_case_config, model, communicator, worker_id):
     if 'gw' in worker_id:
         os.environ['CUDA_VISIBLE_DEVICES'] = get_cuda_id_by_workerid(worker_id)
-    run_pipeline_chat_test(config, common_case_config, model, 'turbomind', worker_id)
+    run_pipeline_chat_test(config, common_case_config, model, 'turbomind', worker_id, {'communicator': communicator})
 
 
 @pytest.mark.order(6)
@@ -22,12 +23,13 @@ def test_pipeline_chat_tp1(config, common_case_config, model, worker_id):
 @pytest.mark.pipeline_chat
 @pytest.mark.gpu_num_2
 @pytest.mark.flaky(reruns=0)
-@pytest.mark.parametrize('model', get_all_model_list(tp_num=2))
-def test_pipeline_chat_tp2(config, common_case_config, model, worker_id):
+@pytest.mark.parametrize('model', get_turbomind_model_list(tp_num=2))
+@pytest.mark.parametrize('communicator', get_communicator_list())
+def test_pipeline_chat_tp2(config, common_case_config, model, communicator, worker_id):
     if 'gw' in worker_id:
         os.environ['CUDA_VISIBLE_DEVICES'] = get_cuda_id_by_workerid(worker_id, tp_num=2)
         os.environ['MASTER_PORT'] = str(int(worker_id.replace('gw', '')) + 29500)
-    run_pipeline_chat_test(config, common_case_config, model, 'turbomind', worker_id)
+    run_pipeline_chat_test(config, common_case_config, model, 'turbomind', worker_id, {'communicator': communicator})
 
 
 @pytest.mark.order(6)
@@ -35,12 +37,13 @@ def test_pipeline_chat_tp2(config, common_case_config, model, worker_id):
 @pytest.mark.pipeline_chat
 @pytest.mark.gpu_num_4
 @pytest.mark.flaky(reruns=0)
-@pytest.mark.parametrize('model', get_all_model_list(tp_num=4))
-def test_pipeline_chat_tp4(config, common_case_config, model, worker_id):
+@pytest.mark.parametrize('model', get_turbomind_model_list(tp_num=4))
+@pytest.mark.parametrize('communicator', get_communicator_list())
+def test_pipeline_chat_tp4(config, common_case_config, model, communicator, worker_id):
     if 'gw' in worker_id:
         os.environ['CUDA_VISIBLE_DEVICES'] = get_cuda_id_by_workerid(worker_id, tp_num=4)
         os.environ['MASTER_PORT'] = str(int(worker_id.replace('gw', '')) + 29500)
-    run_pipeline_chat_test(config, common_case_config, model, 'turbomind', worker_id)
+    run_pipeline_chat_test(config, common_case_config, model, 'turbomind', worker_id, {'communicator': communicator})
 
 
 @pytest.mark.order(6)
@@ -48,11 +51,15 @@ def test_pipeline_chat_tp4(config, common_case_config, model, worker_id):
 @pytest.mark.pipeline_chat
 @pytest.mark.gpu_num_1
 @pytest.mark.flaky(reruns=0)
-@pytest.mark.parametrize('model', get_all_model_list(tp_num=1, quant_policy=4))
-def test_pipeline_chat_kvint4_tp1(config, common_case_config, model, worker_id):
+@pytest.mark.parametrize('model', get_turbomind_model_list(tp_num=1, quant_policy=4))
+@pytest.mark.parametrize('communicator', get_communicator_list())
+def test_pipeline_chat_kvint4_tp1(config, common_case_config, model, communicator, worker_id):
     if 'gw' in worker_id:
         os.environ['CUDA_VISIBLE_DEVICES'] = get_cuda_id_by_workerid(worker_id)
-    run_pipeline_chat_test(config, common_case_config, model, 'turbomind-kvint', worker_id, {'quant_policy': 4})
+    run_pipeline_chat_test(config, common_case_config, model, 'turbomind-kvint', worker_id, {
+        'quant_policy': 4,
+        'communicator': communicator
+    })
 
 
 @pytest.mark.order(6)
@@ -60,12 +67,16 @@ def test_pipeline_chat_kvint4_tp1(config, common_case_config, model, worker_id):
 @pytest.mark.pipeline_chat
 @pytest.mark.gpu_num_2
 @pytest.mark.flaky(reruns=0)
-@pytest.mark.parametrize('model', get_all_model_list(tp_num=2, quant_policy=4))
-def test_pipeline_chat_kvint4_tp2(config, common_case_config, model, worker_id):
+@pytest.mark.parametrize('model', get_turbomind_model_list(tp_num=2, quant_policy=4))
+@pytest.mark.parametrize('communicator', get_communicator_list())
+def test_pipeline_chat_kvint4_tp2(config, common_case_config, model, communicator, worker_id):
     if 'gw' in worker_id:
         os.environ['CUDA_VISIBLE_DEVICES'] = get_cuda_id_by_workerid(worker_id, tp_num=2)
         os.environ['MASTER_PORT'] = str(int(worker_id.replace('gw', '')) + 29500)
-    run_pipeline_chat_test(config, common_case_config, model, 'turbomind-kvint', worker_id, {'quant_policy': 4})
+    run_pipeline_chat_test(config, common_case_config, model, 'turbomind-kvint', worker_id, {
+        'quant_policy': 4,
+        'communicator': communicator
+    })
 
 
 @pytest.mark.order(6)
@@ -73,12 +84,16 @@ def test_pipeline_chat_kvint4_tp2(config, common_case_config, model, worker_id):
 @pytest.mark.pipeline_chat
 @pytest.mark.gpu_num_4
 @pytest.mark.flaky(reruns=0)
-@pytest.mark.parametrize('model', get_all_model_list(tp_num=4, quant_policy=4))
-def test_pipeline_chat_kvint4_tp4(config, common_case_config, model, worker_id):
+@pytest.mark.parametrize('model', get_turbomind_model_list(tp_num=4, quant_policy=4))
+@pytest.mark.parametrize('communicator', get_communicator_list())
+def test_pipeline_chat_kvint4_tp4(config, common_case_config, model, communicator, worker_id):
     if 'gw' in worker_id:
         os.environ['CUDA_VISIBLE_DEVICES'] = get_cuda_id_by_workerid(worker_id, tp_num=4)
         os.environ['MASTER_PORT'] = str(int(worker_id.replace('gw', '')) + 29500)
-    run_pipeline_chat_test(config, common_case_config, model, 'turbomind-kvint', worker_id, {'quant_policy': 4})
+    run_pipeline_chat_test(config, common_case_config, model, 'turbomind-kvint', worker_id, {
+        'quant_policy': 4,
+        'communicator': communicator
+    })
 
 
 @pytest.mark.order(6)
@@ -86,11 +101,15 @@ def test_pipeline_chat_kvint4_tp4(config, common_case_config, model, worker_id):
 @pytest.mark.pipeline_chat
 @pytest.mark.gpu_num_1
 @pytest.mark.flaky(reruns=0)
-@pytest.mark.parametrize('model', get_all_model_list(tp_num=1, quant_policy=8))
-def test_pipeline_chat_kvint8_tp1(config, common_case_config, model, worker_id):
+@pytest.mark.parametrize('model', get_turbomind_model_list(tp_num=1, quant_policy=8))
+@pytest.mark.parametrize('communicator', get_communicator_list())
+def test_pipeline_chat_kvint8_tp1(config, common_case_config, model, communicator, worker_id):
     if 'gw' in worker_id:
         os.environ['CUDA_VISIBLE_DEVICES'] = get_cuda_id_by_workerid(worker_id)
-    run_pipeline_chat_test(config, common_case_config, model, 'turbomind-kvint', worker_id, {'quant_policy': 8})
+    run_pipeline_chat_test(config, common_case_config, model, 'turbomind-kvint', worker_id, {
+        'quant_policy': 8,
+        'communicator': communicator
+    })
 
 
 @pytest.mark.order(6)
@@ -98,12 +117,16 @@ def test_pipeline_chat_kvint8_tp1(config, common_case_config, model, worker_id):
 @pytest.mark.pipeline_chat
 @pytest.mark.gpu_num_2
 @pytest.mark.flaky(reruns=0)
-@pytest.mark.parametrize('model', get_all_model_list(tp_num=2, quant_policy=8))
-def test_pipeline_chat_kvint8_tp2(config, common_case_config, model, worker_id):
+@pytest.mark.parametrize('model', get_turbomind_model_list(tp_num=2, quant_policy=8))
+@pytest.mark.parametrize('communicator', get_communicator_list())
+def test_pipeline_chat_kvint8_tp2(config, common_case_config, model, communicator, worker_id):
     if 'gw' in worker_id:
         os.environ['CUDA_VISIBLE_DEVICES'] = get_cuda_id_by_workerid(worker_id, tp_num=2)
         os.environ['MASTER_PORT'] = str(int(worker_id.replace('gw', '')) + 29500)
-    run_pipeline_chat_test(config, common_case_config, model, 'turbomind-kvint', worker_id, {'quant_policy': 8})
+    run_pipeline_chat_test(config, common_case_config, model, 'turbomind-kvint', worker_id, {
+        'quant_policy': 8,
+        'communicator': communicator
+    })
 
 
 @pytest.mark.order(6)
@@ -111,12 +134,16 @@ def test_pipeline_chat_kvint8_tp2(config, common_case_config, model, worker_id):
 @pytest.mark.pipeline_chat
 @pytest.mark.gpu_num_4
 @pytest.mark.flaky(reruns=0)
-@pytest.mark.parametrize('model', get_all_model_list(tp_num=4, quant_policy=8))
-def test_pipeline_chat_kvint8_tp4(config, common_case_config, model, worker_id):
+@pytest.mark.parametrize('model', get_turbomind_model_list(tp_num=4, quant_policy=8))
+@pytest.mark.parametrize('communicator', get_communicator_list())
+def test_pipeline_chat_kvint8_tp4(config, common_case_config, model, communicator, worker_id):
     if 'gw' in worker_id:
         os.environ['CUDA_VISIBLE_DEVICES'] = get_cuda_id_by_workerid(worker_id, tp_num=4)
         os.environ['MASTER_PORT'] = str(int(worker_id.replace('gw', '')) + 29500)
-    run_pipeline_chat_test(config, common_case_config, model, 'turbomind-kvint', worker_id, {'quant_policy': 8})
+    run_pipeline_chat_test(config, common_case_config, model, 'turbomind-kvint', worker_id, {
+        'quant_policy': 8,
+        'communicator': communicator
+    })
 
 
 @pytest.mark.order(6)
@@ -128,8 +155,15 @@ def test_pipeline_chat_kvint8_tp4(config, common_case_config, model, worker_id):
 @pytest.mark.parametrize('model', [
     'internlm/internlm2_5-20b-chat', 'internlm/internlm2_5-20b-chat-inner-4bits', 'mistralai/Mixtral-8x7B-Instruct-v0.1'
 ])
-def test_pipeline_chat_pr(config, common_case_config, model, worker_id):
-    run_pipeline_chat_test(config, common_case_config, model, 'turbomind', worker_id, is_pr_test=True)
+@pytest.mark.parametrize('communicator', get_communicator_list())
+def test_pipeline_chat_pr(config, common_case_config, model, communicator, worker_id):
+    run_pipeline_chat_test(config,
+                           common_case_config,
+                           model,
+                           'turbomind',
+                           worker_id,
+                           extra={'communicator': communicator},
+                           is_pr_test=True)
 
 
 @pytest.mark.order(6)

--- a/autotest/tools/pipeline/test_pipeline_chat_turbomind_mllm.py
+++ b/autotest/tools/pipeline/test_pipeline_chat_turbomind_mllm.py
@@ -1,7 +1,7 @@
 import os
 
 import pytest
-from utils.config_utils import get_all_model_list, get_cuda_id_by_workerid
+from utils.config_utils import get_communicator_list, get_cuda_id_by_workerid, get_turbomind_model_list
 from utils.pipeline_chat import run_pipeline_vl_chat_test
 
 BACKEND = 'turbomind'
@@ -11,97 +11,124 @@ BACKEND_KVINT = 'turbomind-kvint'
 @pytest.mark.order(6)
 @pytest.mark.pipeline_chat
 @pytest.mark.gpu_num_1
-@pytest.mark.parametrize('model', get_all_model_list(tp_num=1, model_type='vl_model'))
-def test_pipeline_chat_tp1(config, model, worker_id):
+@pytest.mark.parametrize('model', get_turbomind_model_list(tp_num=1, model_type='vl_model'))
+@pytest.mark.parametrize('communicator', get_communicator_list())
+def test_pipeline_chat_tp1(config, model, communicator, worker_id):
     if 'gw' in worker_id:
         os.environ['CUDA_VISIBLE_DEVICES'] = get_cuda_id_by_workerid(worker_id)
-    run_pipeline_vl_chat_test(config, model, BACKEND, worker_id)
+    run_pipeline_vl_chat_test(config, model, BACKEND, worker_id, {'communicator': communicator})
 
 
 @pytest.mark.order(6)
 @pytest.mark.pipeline_chat
 @pytest.mark.gpu_num_2
-@pytest.mark.parametrize('model', get_all_model_list(tp_num=2, model_type='vl_model'))
-def test_pipeline_chat_tp2(config, model, worker_id):
+@pytest.mark.parametrize('model', get_turbomind_model_list(tp_num=2, model_type='vl_model'))
+@pytest.mark.parametrize('communicator', get_communicator_list())
+def test_pipeline_chat_tp2(config, model, communicator, worker_id):
     if 'gw' in worker_id:
         os.environ['CUDA_VISIBLE_DEVICES'] = get_cuda_id_by_workerid(worker_id, tp_num=2)
         os.environ['MASTER_PORT'] = str(int(worker_id.replace('gw', '')) + 29500)
-    run_pipeline_vl_chat_test(config, model, BACKEND, worker_id)
+    run_pipeline_vl_chat_test(config, model, BACKEND, worker_id, {'communicator': communicator})
 
 
 @pytest.mark.order(6)
 @pytest.mark.pipeline_chat
 @pytest.mark.gpu_num_4
-@pytest.mark.parametrize('model', get_all_model_list(tp_num=4, model_type='vl_model'))
-def test_pipeline_chat_tp4(config, model, worker_id):
+@pytest.mark.parametrize('model', get_turbomind_model_list(tp_num=4, model_type='vl_model'))
+@pytest.mark.parametrize('communicator', get_communicator_list())
+def test_pipeline_chat_tp4(config, model, communicator, worker_id):
     if 'gw' in worker_id:
         os.environ['CUDA_VISIBLE_DEVICES'] = get_cuda_id_by_workerid(worker_id, tp_num=4)
         os.environ['MASTER_PORT'] = str(int(worker_id.replace('gw', '')) + 29500)
-    run_pipeline_vl_chat_test(config, model, BACKEND, worker_id)
+    run_pipeline_vl_chat_test(config, model, BACKEND, worker_id, {'communicator': communicator})
 
 
 @pytest.mark.order(6)
 @pytest.mark.pipeline_chat
 @pytest.mark.gpu_num_1
-@pytest.mark.parametrize('model', get_all_model_list(tp_num=1, quant_policy=4, model_type='vl_model'))
-def test_pipeline_chat_kvint4_tp1(config, model, worker_id):
+@pytest.mark.parametrize('model', get_turbomind_model_list(tp_num=1, quant_policy=4, model_type='vl_model'))
+@pytest.mark.parametrize('communicator', get_communicator_list())
+def test_pipeline_chat_kvint4_tp1(config, model, communicator, worker_id):
     if 'gw' in worker_id:
         os.environ['CUDA_VISIBLE_DEVICES'] = get_cuda_id_by_workerid(worker_id)
-    run_pipeline_vl_chat_test(config, model, BACKEND_KVINT, worker_id, {'quant_policy': 4})
+    run_pipeline_vl_chat_test(config, model, BACKEND_KVINT, worker_id, {
+        'quant_policy': 4,
+        'communicator': communicator
+    })
 
 
 @pytest.mark.order(6)
 @pytest.mark.pipeline_chat
 @pytest.mark.gpu_num_2
-@pytest.mark.parametrize('model', get_all_model_list(tp_num=2, quant_policy=4, model_type='vl_model'))
-def test_pipeline_chat_kvint4_tp2(config, model, worker_id):
+@pytest.mark.parametrize('model', get_turbomind_model_list(tp_num=2, quant_policy=4, model_type='vl_model'))
+@pytest.mark.parametrize('communicator', get_communicator_list())
+def test_pipeline_chat_kvint4_tp2(config, model, communicator, worker_id):
     if 'gw' in worker_id:
         os.environ['CUDA_VISIBLE_DEVICES'] = get_cuda_id_by_workerid(worker_id, tp_num=2)
         os.environ['MASTER_PORT'] = str(int(worker_id.replace('gw', '')) + 29500)
-    run_pipeline_vl_chat_test(config, model, BACKEND_KVINT, worker_id, {'quant_policy': 4})
+    run_pipeline_vl_chat_test(config, model, BACKEND_KVINT, worker_id, {
+        'quant_policy': 4,
+        'communicator': communicator
+    })
 
 
 @pytest.mark.order(6)
 @pytest.mark.pipeline_chat
 @pytest.mark.gpu_num_4
-@pytest.mark.parametrize('model', get_all_model_list(tp_num=4, quant_policy=4, model_type='vl_model'))
-def test_pipeline_chat_kvint4_tp4(config, model, worker_id):
+@pytest.mark.parametrize('model', get_turbomind_model_list(tp_num=4, quant_policy=4, model_type='vl_model'))
+@pytest.mark.parametrize('communicator', get_communicator_list())
+def test_pipeline_chat_kvint4_tp4(config, model, communicator, worker_id):
     if 'gw' in worker_id:
         os.environ['CUDA_VISIBLE_DEVICES'] = get_cuda_id_by_workerid(worker_id, tp_num=4)
         os.environ['MASTER_PORT'] = str(int(worker_id.replace('gw', '')) + 29500)
-    run_pipeline_vl_chat_test(config, model, BACKEND_KVINT, worker_id, {'quant_policy': 4})
+    run_pipeline_vl_chat_test(config, model, BACKEND_KVINT, worker_id, {
+        'quant_policy': 4,
+        'communicator': communicator
+    })
 
 
 @pytest.mark.order(6)
 @pytest.mark.pipeline_chat
 @pytest.mark.gpu_num_1
-@pytest.mark.parametrize('model', get_all_model_list(tp_num=1, quant_policy=8, model_type='vl_model'))
-def test_pipeline_chat_kvint8_tp1(config, model, worker_id):
+@pytest.mark.parametrize('model', get_turbomind_model_list(tp_num=1, quant_policy=8, model_type='vl_model'))
+@pytest.mark.parametrize('communicator', get_communicator_list())
+def test_pipeline_chat_kvint8_tp1(config, model, communicator, worker_id):
     if 'gw' in worker_id:
         os.environ['CUDA_VISIBLE_DEVICES'] = get_cuda_id_by_workerid(worker_id)
-    run_pipeline_vl_chat_test(config, model, BACKEND_KVINT, worker_id, {'quant_policy': 8})
+    run_pipeline_vl_chat_test(config, model, BACKEND_KVINT, worker_id, {
+        'quant_policy': 8,
+        'communicator': communicator
+    })
 
 
 @pytest.mark.order(6)
 @pytest.mark.pipeline_chat
 @pytest.mark.gpu_num_2
-@pytest.mark.parametrize('model', get_all_model_list(tp_num=2, quant_policy=8, model_type='vl_model'))
-def test_pipeline_chat_kvint8_tp2(config, model, worker_id):
+@pytest.mark.parametrize('model', get_turbomind_model_list(tp_num=2, quant_policy=8, model_type='vl_model'))
+@pytest.mark.parametrize('communicator', get_communicator_list())
+def test_pipeline_chat_kvint8_tp2(config, model, communicator, worker_id):
     if 'gw' in worker_id:
         os.environ['CUDA_VISIBLE_DEVICES'] = get_cuda_id_by_workerid(worker_id, tp_num=2)
         os.environ['MASTER_PORT'] = str(int(worker_id.replace('gw', '')) + 29500)
-    run_pipeline_vl_chat_test(config, model, BACKEND_KVINT, worker_id, {'quant_policy': 8})
+    run_pipeline_vl_chat_test(config, model, BACKEND_KVINT, worker_id, {
+        'quant_policy': 8,
+        'communicator': communicator
+    })
 
 
 @pytest.mark.order(6)
 @pytest.mark.pipeline_chat
 @pytest.mark.gpu_num_4
-@pytest.mark.parametrize('model', get_all_model_list(tp_num=4, quant_policy=8, model_type='vl_model'))
-def test_pipeline_chat_kvint8_tp4(config, model, worker_id):
+@pytest.mark.parametrize('model', get_turbomind_model_list(tp_num=4, quant_policy=8, model_type='vl_model'))
+@pytest.mark.parametrize('communicator', get_communicator_list())
+def test_pipeline_chat_kvint8_tp4(config, model, communicator, worker_id):
     if 'gw' in worker_id:
         os.environ['CUDA_VISIBLE_DEVICES'] = get_cuda_id_by_workerid(worker_id, tp_num=4)
         os.environ['MASTER_PORT'] = str(int(worker_id.replace('gw', '')) + 29500)
-    run_pipeline_vl_chat_test(config, model, BACKEND_KVINT, worker_id, {'quant_policy': 8})
+    run_pipeline_vl_chat_test(config, model, BACKEND_KVINT, worker_id, {
+        'quant_policy': 8,
+        'communicator': communicator
+    })
 
 
 @pytest.mark.pipeline_chat
@@ -111,7 +138,8 @@ def test_pipeline_chat_kvint8_tp4(config, model, worker_id):
     'liuhaotian/llava-v1.6-vicuna-7b', 'OpenGVLab/InternVL2-4B', 'OpenGVLab/InternVL2-8B',
     'internlm/internlm-xcomposer2d5-7b'
 ])
-def test_pipeline_pr_test(config, model, worker_id):
+@pytest.mark.parametrize('communicator', get_communicator_list())
+def test_pipeline_pr_test(config, model, communicator, worker_id):
     if 'gw' in worker_id:
         os.environ['CUDA_VISIBLE_DEVICES'] = str(int(get_cuda_id_by_workerid(worker_id)) + 5)
-    run_pipeline_vl_chat_test(config, model, BACKEND, worker_id, is_pr_test=True)
+    run_pipeline_vl_chat_test(config, model, BACKEND, worker_id, {'communicator': communicator}, is_pr_test=True)

--- a/autotest/tools/restful/test_restful_chat_hf_turbomind_llm.py
+++ b/autotest/tools/restful/test_restful_chat_hf_turbomind_llm.py
@@ -1,5 +1,5 @@
 import pytest
-from utils.config_utils import get_all_model_list, get_workerid
+from utils.config_utils import get_communicator_list, get_turbomind_model_list, get_workerid
 from utils.run_restful_chat import run_all_step, start_restful_api, stop_restful_api
 
 DEFAULT_PORT = 23333
@@ -17,7 +17,15 @@ def prepare_environment(request, config, worker_id):
 
 
 def getModelList(tp_num):
-    return [{'model': item, 'cuda_prefix': None, 'tp_num': tp_num} for item in get_all_model_list(tp_num)]
+    model_list = []
+    for communicator in get_communicator_list():
+        model_list += [{
+            'model': item,
+            'cuda_prefix': None,
+            'tp_num': tp_num,
+            'extra': f'--communicator {communicator}'
+        } for item in get_turbomind_model_list(tp_num)]
+    return model_list
 
 
 @pytest.mark.order(7)
@@ -57,12 +65,15 @@ def test_restful_chat_tp4(config, common_case_config, worker_id):
 
 
 def getKvintModelList(tp_num, quant_policy):
-    return [{
-        'model': item,
-        'cuda_prefix': None,
-        'tp_num': tp_num,
-        'extra': f'--quant-policy {quant_policy}'
-    } for item in get_all_model_list(tp_num, quant_policy=quant_policy)]
+    model_list = []
+    for communicator in get_communicator_list():
+        model_list += [{
+            'model': item,
+            'cuda_prefix': None,
+            'tp_num': tp_num,
+            'extra': f'--quant-policy {quant_policy} --communicator {communicator}'
+        } for item in get_turbomind_model_list(tp_num, quant_policy=quant_policy)]
+    return model_list
 
 
 @pytest.mark.order(7)

--- a/autotest/tools/restful/test_restful_chat_hf_turbomind_mllm.py
+++ b/autotest/tools/restful/test_restful_chat_hf_turbomind_mllm.py
@@ -1,5 +1,5 @@
 import pytest
-from utils.config_utils import get_all_model_list, get_workerid
+from utils.config_utils import get_communicator_list, get_turbomind_model_list, get_workerid
 from utils.run_restful_chat import run_vl_testcase, start_restful_api, stop_restful_api
 
 BASE_HTTP_URL = 'http://localhost'
@@ -18,11 +18,14 @@ def prepare_environment(request, config, worker_id):
 
 
 def getModelList(tp_num):
-    return [{
-        'model': item,
-        'cuda_prefix': None,
-        'tp_num': tp_num,
-    } for item in get_all_model_list(tp_num, model_type='vl_model')]
+    model_list = []
+    for communicator in get_communicator_list():
+        model_list += [{
+            'model': item,
+            'cuda_prefix': None,
+            'tp_num': tp_num,
+            'extra': f'--communicator {communicator}'
+        } for item in get_turbomind_model_list(tp_num, model_type='vl_model')]
 
 
 @pytest.mark.order(7)
@@ -59,12 +62,15 @@ def test_restful_chat_tp4(config, worker_id):
 
 
 def getKvintModelList(tp_num, quant_policy: int = None):
-    return [{
-        'model': item,
-        'cuda_prefix': None,
-        'tp_num': tp_num,
-        'extra': f'--quant-policy {quant_policy}'
-    } for item in get_all_model_list(tp_num, quant_policy=quant_policy, model_type='vl_model')]
+    model_list = []
+    for communicator in get_communicator_list():
+        model_list += [{
+            'model': item,
+            'cuda_prefix': None,
+            'tp_num': tp_num,
+            'extra': f'--quant-policy {quant_policy} --communicator {communicator}'
+        } for item in get_turbomind_model_list(tp_num, quant_policy=quant_policy, model_type='vl_model')]
+    return model_list
 
 
 @pytest.mark.order(7)

--- a/autotest/tools/restful/test_restful_chat_hf_turbomind_mllm.py
+++ b/autotest/tools/restful/test_restful_chat_hf_turbomind_mllm.py
@@ -26,6 +26,7 @@ def getModelList(tp_num):
             'tp_num': tp_num,
             'extra': f'--communicator {communicator}'
         } for item in get_turbomind_model_list(tp_num, model_type='vl_model')]
+    return model_list
 
 
 @pytest.mark.order(7)

--- a/autotest/utils/config_utils.py
+++ b/autotest/utils/config_utils.py
@@ -97,6 +97,12 @@ def get_all_model_list(tp_num: int = None, quant_policy: int = None, model_type:
     return case_list
 
 
+def get_communicator_list():
+    if is_bf16_supported():
+        return ['native', 'nccl']
+    return ['nccl']
+
+
 def get_quantization_model_list(type):
     config = get_config()
     if type == 'awq':


### PR DESCRIPTION
1. add testcase for diff communicator backend. currently cover pipeline and restful testcases in turbomind backend. 
    will add --communicator native for chat cli in future pr.
2. remove pytorch models coverage in turbomind testcase for testing backend auto switching. 
    will add backend auto switching in future pr.