### PR TITLE
Add flash mla

### DIFF
--- a/lmdeploy/pytorch/backends/attention.py
+++ b/lmdeploy/pytorch/backends/attention.py
@@ -87,6 +87,7 @@ class AttentionBuilder(ABC, Generic[T]):
         sliding_window: int = None,
         logical_softcapping: float = None,
         causal: bool = True,
+        use_flash_mla: bool = False,
         **kwargs,
     ) -> AttentionImpl[T]:
         """build."""

--- a/lmdeploy/pytorch/backends/attention.py
+++ b/lmdeploy/pytorch/backends/attention.py
@@ -35,6 +35,7 @@ class AttentionImpl(ABC, Generic[T]):
         sliding_window: int = None,
         logit_softcapping: float = None,
         causal: bool = True,
+        use_flash_mla: bool = False,
         **kwargs,
     ) -> None:
         if scale is None:
@@ -55,6 +56,14 @@ class AttentionImpl(ABC, Generic[T]):
         self.sliding_window = sliding_window
         self.logit_softcapping = logit_softcapping
         self.causal = causal
+        self.use_flash_mla = use_flash_mla
+        if use_flash_mla is True:
+            assert num_kv_heads == 1, 'MLA requires num kv heads equal to 1'
+            try:
+                import flash_mla_cuda  # noqa
+            except ImportError:
+                raise ImportError(
+                    'To enable flash mla, please install flash_mla through https://github.com/deepseek-ai/FlashMLA')
 
     @abstractmethod
     def forward(

--- a/lmdeploy/pytorch/backends/attention.py
+++ b/lmdeploy/pytorch/backends/attention.py
@@ -57,13 +57,6 @@ class AttentionImpl(ABC, Generic[T]):
         self.logit_softcapping = logit_softcapping
         self.causal = causal
         self.use_flash_mla = use_flash_mla
-        if use_flash_mla is True:
-            assert num_kv_heads == 1, 'MLA requires num kv heads equal to 1'
-            try:
-                import flash_mla_cuda  # noqa
-            except ImportError:
-                raise ImportError(
-                    'To enable flash mla, please install flash_mla through https://github.com/deepseek-ai/FlashMLA')
 
     @abstractmethod
     def forward(

--- a/lmdeploy/pytorch/backends/cuda/attention.py
+++ b/lmdeploy/pytorch/backends/cuda/attention.py
@@ -133,6 +133,7 @@ class TritonAttentionImpl(AttentionImpl[TritonAttentionMetadata]):
         if not self.alibi:
             if is_decoding:
                 if self.use_flash_mla:
+                    # init kv_seqlens and block_offsets with int32 in the future
                     kv_seqlens = kv_seqlens.to(torch.int32)
                     block_offsets = block_offsets.to(torch.int32)
                     query = query.unsqueeze(1)

--- a/lmdeploy/pytorch/backends/cuda/attention.py
+++ b/lmdeploy/pytorch/backends/cuda/attention.py
@@ -46,7 +46,6 @@ class TritonAttentionImpl(AttentionImpl[TritonAttentionMetadata]):
         sliding_window: int = None,
         logit_softcapping: float = None,
         causal: bool = True,
-        use_flash_mla: bool = False,
         **kwargs,
     ):
         super().__init__(
@@ -59,28 +58,18 @@ class TritonAttentionImpl(AttentionImpl[TritonAttentionMetadata]):
             sliding_window=sliding_window,
             logit_softcapping=logit_softcapping,
             causal=causal,
-            use_flash_mla=use_flash_mla,
             **kwargs,
         )
         assert not (alibi and not causal)
 
         from lmdeploy.pytorch.kernels.cuda import (alibi_paged_attention_fwd, fill_kv_cache, flash_attention_fwd,
-                                                   flash_mla_fwd, flatten_kv_cache, paged_attention_fwd)
+                                                   flatten_kv_cache, paged_attention_fwd)
 
         self.fill_kv_cache = fill_kv_cache
         self.paged_attention_fwd = paged_attention_fwd
         self.alibi_paged_attention_fwd = alibi_paged_attention_fwd
         self.flatten_kv_cache = flatten_kv_cache
         self.flash_attention_fwd = flash_attention_fwd
-        # for flash mla
-        self.flash_mla_fwd = flash_mla_fwd
-        if use_flash_mla is True:
-            assert num_kv_heads == 1, 'MLA requires num kv heads equal to 1'
-            try:
-                import flash_mla_cuda  # noqa
-            except ImportError:
-                raise ImportError(
-                    'To enable flash mla, please install flash_mla through https://github.com/deepseek-ai/FlashMLA')
 
         # for alibi attention
         world_size, rank = get_world_rank()
@@ -144,34 +133,20 @@ class TritonAttentionImpl(AttentionImpl[TritonAttentionMetadata]):
         is_decoding = attn_metadata.is_decoding
         if not self.alibi:
             if is_decoding:
-                if self.use_flash_mla:
-                    block_offsets = block_offsets.to(torch.int32)
-                    kv_seqlens = kv_seqlens.to(torch.int32)
-                    query = query.unsqueeze(1)
-                    attn_output = self.flash_mla_fwd(query,
-                                                     k_cache=k_cache,
-                                                     block_table=block_offsets,
-                                                     cache_seqlens=kv_seqlens,
-                                                     head_dim_v=self.v_head_size,
-                                                     softmax_scale=self.scale,
-                                                     tile_scheduler_metadata=attn_metadata.tile_scheduler_metadata,
-                                                     num_splits=attn_metadata.num_splits,
-                                                     causal=True)
-                else:
-                    self.paged_attention_fwd(
-                        query,
-                        k_cache,
-                        v_cache,
-                        attn_output,
-                        block_offsets,
-                        kv_seqlens=kv_seqlens,
-                        k_scales_zeros=k_scales_zeros,
-                        v_scales_zeros=v_scales_zeros,
-                        quant_policy=quant_policy,
-                        window_size=self.sliding_window,
-                        sm_scale=self.scale,
-                        logit_softcapping=self.logit_softcapping,
-                    )
+                self.paged_attention_fwd(
+                    query,
+                    k_cache,
+                    v_cache,
+                    attn_output,
+                    block_offsets,
+                    kv_seqlens=kv_seqlens,
+                    k_scales_zeros=k_scales_zeros,
+                    v_scales_zeros=v_scales_zeros,
+                    quant_policy=quant_policy,
+                    window_size=self.sliding_window,
+                    sm_scale=self.scale,
+                    logit_softcapping=self.logit_softcapping,
+                )
             else:
                 BLOCK_BS = k_cache.size(1)
                 # pad one more block to avoid invalid kv visit
@@ -224,6 +199,144 @@ class TritonAttentionImpl(AttentionImpl[TritonAttentionMetadata]):
         return attn_output
 
 
+class FlashMLAImpl(TritonAttentionImpl):
+
+    def __init__(
+        self,
+        num_heads: int,
+        head_size: int,
+        scale: float = None,
+        num_kv_heads: int = None,
+        v_head_size: int = None,
+        alibi: bool = False,
+        sliding_window: int = None,
+        logit_softcapping: float = None,
+        causal: bool = True,
+        **kwargs,
+    ):
+        assert sliding_window is None, 'sliding window not supported for FlashMLA'
+        assert alibi is False, 'alibi not supported for FlashMLA'
+        assert logit_softcapping is None, 'logit_softcapping not supported for FlashMLA'
+        super().__init__(
+            num_heads=num_heads,
+            head_size=head_size,
+            scale=scale,
+            num_kv_heads=num_kv_heads,
+            v_head_size=v_head_size,
+            alibi=alibi,
+            sliding_window=sliding_window,
+            logit_softcapping=logit_softcapping,
+            causal=causal,
+            **kwargs,
+        )
+
+        from lmdeploy.pytorch.kernels.cuda import flash_mla_fwd
+        self.flash_mla_fwd = flash_mla_fwd
+        assert num_kv_heads == 1, 'MLA requires num kv heads equal to 1'
+
+    def forward(
+        self,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        k_cache: torch.Tensor,
+        v_cache: torch.Tensor,
+        attn_metadata: TritonAttentionMetadata,
+        k_scales_zeros: torch.Tensor = None,
+        v_scales_zeros: torch.Tensor = None,
+        inplace: bool = True,
+    ) -> torch.Tensor:
+        """forward."""
+
+        block_offsets = attn_metadata.block_offsets
+        q_start_loc = attn_metadata.q_start_loc
+        fill_q_start_loc = q_start_loc
+        q_seqlens = attn_metadata.q_seqlens
+        fill_seqlens = q_seqlens
+        kv_start_loc = attn_metadata.kv_start_loc
+        kv_seqlens = attn_metadata.kv_seqlens
+        kv_flatten_size = attn_metadata.kv_flatten_size
+        quant_policy = attn_metadata.quant_policy
+        if attn_metadata.is_decoding:
+            max_q_seqlen = 1
+        else:
+            max_q_seqlen = query.numel() // (query.size(-1) * query.size(-2))
+        fill_max_q_seqlen = max_q_seqlen
+        if attn_metadata.fill_seqlens is not None:
+            fill_seqlens = attn_metadata.fill_seqlens
+            fill_max_q_seqlen = key.numel() // (key.size(-1) * key.size(-2))
+            fill_q_start_loc = fill_seqlens.cumsum(0) - fill_seqlens
+
+        # fill kv cache
+        if key is not None and value is not None:
+            self.fill_kv_cache(
+                key,
+                value,
+                k_cache,
+                v_cache,
+                fill_q_start_loc,
+                fill_seqlens,
+                kv_seq_length=kv_seqlens,
+                max_q_seq_length=fill_max_q_seqlen,
+                block_offsets=block_offsets,
+                k_scales_zeros=k_scales_zeros,
+                v_scales_zeros=v_scales_zeros,
+                quant_policy=quant_policy,
+            )
+
+        q_shape = query.shape
+        o_shape = q_shape[:-1] + (self.v_head_size, )
+        attn_output = query.new_empty(o_shape)
+
+        is_decoding = attn_metadata.is_decoding
+        if is_decoding:
+            query = query.unsqueeze(1)
+            if kv_seqlens.dtype == torch.int64:
+                kv_seqlens = kv_seqlens.to(torch.int32)
+            attn_output = self.flash_mla_fwd(query,
+                                             k_cache=k_cache,
+                                             block_table=block_offsets,
+                                             cache_seqlens=kv_seqlens,
+                                             head_dim_v=self.v_head_size,
+                                             softmax_scale=self.scale,
+                                             tile_scheduler_metadata=attn_metadata.tile_scheduler_metadata,
+                                             num_splits=attn_metadata.num_splits,
+                                             causal=True)
+
+        else:
+            BLOCK_BS = k_cache.size(1)
+            # pad one more block to avoid invalid kv visit
+            out_size = (_cdiv(kv_flatten_size, BLOCK_BS) * BLOCK_BS + BLOCK_BS)
+            flatten_k, flatten_v = self.flatten_kv_cache(
+                k_cache,
+                v_cache,
+                kv_seqlens,
+                block_offsets,
+                start_loc=kv_start_loc,
+                out_size=out_size,
+                out_dtype=query.dtype,
+                k_scales_zeros=k_scales_zeros,
+                v_scales_zeros=v_scales_zeros,
+                quant_policy=quant_policy,
+            )
+            self.flash_attention_fwd(
+                query,
+                flatten_k,
+                flatten_v,
+                attn_output,
+                q_start_loc=q_start_loc,
+                q_seqlens=q_seqlens,
+                kv_start_loc=kv_start_loc,
+                kv_seqlens=kv_seqlens,
+                max_seqlen=max_q_seqlen,
+                window_size=self.sliding_window,
+                sm_scale=self.scale,
+                logit_softcapping=self.logit_softcapping,
+                causal=self.causal,
+            )
+        return attn_output
+
+
 class TritonAttentionBuilder(AttentionBuilder[TritonAttentionMetadata]):
     """triton attention builder."""
 
@@ -242,6 +355,17 @@ class TritonAttentionBuilder(AttentionBuilder[TritonAttentionMetadata]):
         **kwargs,
     ) -> TritonAttentionImpl:
         """build."""
+        if use_flash_mla is True:
+            return FlashMLAImpl(num_heads,
+                                head_size,
+                                scale=scale,
+                                num_kv_heads=num_kv_heads,
+                                v_head_size=v_head_size,
+                                alibi=alibi,
+                                sliding_window=sliding_window,
+                                logical_softcapping=logical_softcapping,
+                                causal=causal,
+                                **kwargs)
         return TritonAttentionImpl(num_heads,
                                    head_size,
                                    scale=scale,
@@ -251,5 +375,4 @@ class TritonAttentionBuilder(AttentionBuilder[TritonAttentionMetadata]):
                                    sliding_window=sliding_window,
                                    logical_softcapping=logical_softcapping,
                                    causal=causal,
-                                   use_flash_mla=use_flash_mla,
                                    **kwargs)

--- a/lmdeploy/pytorch/backends/cuda/op_backend.py
+++ b/lmdeploy/pytorch/backends/cuda/op_backend.py
@@ -125,6 +125,13 @@ class CudaOpsBackend(DefaultOpsBackend):
             kv_flatten_size=kv_flatten_size,
             quant_policy=step_context.kv_quant_policy,
         )
+        if getattr(step_context.model_config, 'use_flash_mla', False) is True:
+            if step_context.is_decoding is True:
+                import flash_mla_cuda
+                tile_scheduler_metadata, num_splits = flash_mla_cuda.get_mla_metadata(
+                    attn_metadata.kv_seqlens.to(torch.int32), step_context.model_config.num_attention_heads, 1)
+                attn_metadata.tile_scheduler_metadata = tile_scheduler_metadata
+                attn_metadata.num_splits = num_splits
 
         cross_seqlens = step_context.cross_seqlens
         cross_kv_seqlens = step_context.cross_kv_seqlens

--- a/lmdeploy/pytorch/config.py
+++ b/lmdeploy/pytorch/config.py
@@ -108,6 +108,7 @@ class ModelConfig:
     hf_config: Any = None
     cogvlm_style: bool = False
     custom_module_map: Dict[str, setattr] = None
+    use_flash_mla: bool = False
 
     def get_head_size(self):
         """get head size."""

--- a/lmdeploy/pytorch/configurations/deepseek_v2.py
+++ b/lmdeploy/pytorch/configurations/deepseek_v2.py
@@ -1,10 +1,8 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 from lmdeploy.pytorch.config import ModelConfig
-from lmdeploy.utils import get_logger
 
 from .builder import AutoModelConfigBuilder
-
-logger = get_logger('lmdeploy')
+from .utils import flash_mla_available
 
 
 class DeepseekV2ModelConfigBuilder(AutoModelConfigBuilder):
@@ -26,14 +24,7 @@ class DeepseekV2ModelConfigBuilder(AutoModelConfigBuilder):
         tp = kwargs.get('tp', 1)
         # update num_kv_heads for tp mode
         num_key_value_heads = cls.update_num_kv_heads(hf_config, tp, num_key_value_heads)
-        # use flash_mla by default if it is installed
-        use_flash_mla = False
-        try:
-            import flash_mla_cuda  # noqa
-            use_flash_mla = True
-        except ImportError:
-            logger.warning('For higher performance, please install flash_mla https://github.com/deepseek-ai/FlashMLA')
-        hf_config.use_flash_mla = use_flash_mla
+        hf_config.use_flash_mla = flash_mla_available()
 
         return ModelConfig(hidden_size=hf_config.hidden_size,
                            num_layers=hf_config.num_hidden_layers,
@@ -45,4 +36,4 @@ class DeepseekV2ModelConfigBuilder(AutoModelConfigBuilder):
                            k_head_dim=k_head_dim,
                            v_head_dim=v_head_dim,
                            vocab_size=hf_config.vocab_size,
-                           use_flash_mla=use_flash_mla)
+                           use_flash_mla=hf_config.use_flash_mla)

--- a/lmdeploy/pytorch/configurations/deepseek_v2.py
+++ b/lmdeploy/pytorch/configurations/deepseek_v2.py
@@ -1,7 +1,10 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 from lmdeploy.pytorch.config import ModelConfig
+from lmdeploy.utils import get_logger
 
 from .builder import AutoModelConfigBuilder
+
+logger = get_logger('lmdeploy')
 
 
 class DeepseekV2ModelConfigBuilder(AutoModelConfigBuilder):
@@ -23,6 +26,14 @@ class DeepseekV2ModelConfigBuilder(AutoModelConfigBuilder):
         tp = kwargs.get('tp', 1)
         # update num_kv_heads for tp mode
         num_key_value_heads = cls.update_num_kv_heads(hf_config, tp, num_key_value_heads)
+        # use flash_mla by default if it is installed
+        use_flash_mla = False
+        try:
+            import flash_mla_cuda  # noqa
+            use_flash_mla = True
+        except ImportError:
+            logger.warning('For higher performance, please install flash_mla https://github.com/deepseek-ai/FlashMLA')
+        hf_config.use_flash_mla = use_flash_mla
 
         return ModelConfig(hidden_size=hf_config.hidden_size,
                            num_layers=hf_config.num_hidden_layers,
@@ -33,4 +44,5 @@ class DeepseekV2ModelConfigBuilder(AutoModelConfigBuilder):
                            head_dim=head_dim,
                            k_head_dim=k_head_dim,
                            v_head_dim=v_head_dim,
-                           vocab_size=hf_config.vocab_size)
+                           vocab_size=hf_config.vocab_size,
+                           use_flash_mla=use_flash_mla)

--- a/lmdeploy/pytorch/configurations/utils.py
+++ b/lmdeploy/pytorch/configurations/utils.py
@@ -1,4 +1,6 @@
 # Copyright (c) OpenMMLab. All rights reserved.
+import torch
+
 from lmdeploy.utils import get_logger
 
 logger = get_logger('lmdeploy')
@@ -10,7 +12,8 @@ def flash_mla_available():
     use_flash_mla = False
     try:
         import flash_mla_cuda  # noqa
-        use_flash_mla = True
+        if torch.cuda.get_device_properties(0).major >= 9:
+            use_flash_mla = True
     except ImportError:
         logger.warning('For higher performance, please install flash_mla https://github.com/deepseek-ai/FlashMLA')
     return use_flash_mla

--- a/lmdeploy/pytorch/configurations/utils.py
+++ b/lmdeploy/pytorch/configurations/utils.py
@@ -1,0 +1,16 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+from lmdeploy.utils import get_logger
+
+logger = get_logger('lmdeploy')
+
+
+def flash_mla_available():
+    """Check if flash mla is available."""
+    # use flash_mla by default if it is installed
+    use_flash_mla = False
+    try:
+        import flash_mla_cuda  # noqa
+        use_flash_mla = True
+    except ImportError:
+        logger.warning('For higher performance, please install flash_mla https://github.com/deepseek-ai/FlashMLA')
+    return use_flash_mla

--- a/lmdeploy/pytorch/engine/engine.py
+++ b/lmdeploy/pytorch/engine/engine.py
@@ -40,10 +40,10 @@ class InferOutput:
     logits: torch.Tensor = None
 
 
-def _tensorlize_block_offsets(block_offsets):
+def _tensorlize_block_offsets(block_offsets, dtype=torch.int32):
     """tensorlize block_offsets."""
     from torch.nn.utils.rnn import pad_sequence
-    block_offsets = [torch.from_numpy(off) for off in block_offsets]
+    block_offsets = [torch.from_numpy(off).to(dtype) for off in block_offsets]
     block_offsets = pad_sequence(block_offsets, batch_first=True)
     return block_offsets
 
@@ -371,6 +371,13 @@ class Engine:
     def gpu_count(self):
         return self.tp * self.dp
 
+    @property
+    def torch_int_dtype(self):
+        """return int32 for cuda, int64 for others."""
+        if self.executor.device_type == 'cuda':
+            return torch.int32
+        return torch.int64
+
     @logging_timer('CreateModelInputs', logger)
     def create_model_inputs(self, messages: SeqList, is_prefill: bool):
         """create model inputs from messages.
@@ -398,7 +405,7 @@ class Engine:
         max_q_seq_length = seq_length.max().item()
 
         block_offsets = self.scheduler.get_block_tables(messages)
-        block_offsets = _tensorlize_block_offsets(block_offsets)
+        block_offsets = _tensorlize_block_offsets(block_offsets, dtype=self.torch_int_dtype)
 
         local_adapter_ids = None
         if self.adapter_manager.num_adapters() > 1:

--- a/lmdeploy/pytorch/engine/executor/base.py
+++ b/lmdeploy/pytorch/engine/executor/base.py
@@ -102,6 +102,8 @@ class ExecutorBase:
     def _adjust_block_size(self):
         """adjust block_size."""
         if self.model_config.use_flash_mla is True:
+            if self.cache_config.block_size != 64:
+                raise ValueError('Please set block_size to 64 for flash_mla.')
             return
         # TODO: support kernel with both large head dim and large block size.
         if self.model_config.k_head_dim >= 512 and self.cache_config.block_size > 32:

--- a/lmdeploy/pytorch/kernels/cuda/__init__.py
+++ b/lmdeploy/pytorch/kernels/cuda/__init__.py
@@ -3,6 +3,7 @@
 from .alibi_pagedattention import alibi_paged_attention_fwd
 from .apply_rotary_pos_emb import apply_rotary_pos_emb
 from .fill_kv_cache import fill_kv_cache
+from .flash_mla import flash_mla_fwd
 from .flashattention import flash_attention_fwd
 from .flatten_kv_cache import flatten_kv_cache
 from .fused_moe import fused_moe
@@ -30,4 +31,5 @@ __all__ = [
     'flash_attention_fwd',
     'flatten_kv_cache',
     'fused_moe_w8a8',
+    'flash_mla_fwd',
 ]

--- a/lmdeploy/pytorch/kernels/cuda/flash_mla.py
+++ b/lmdeploy/pytorch/kernels/cuda/flash_mla.py
@@ -29,6 +29,8 @@ def flash_mla_fwd(
     block_table: torch.Tensor,
     cache_seqlens: torch.Tensor,
     head_dim_v: int,
+    tile_scheduler_metadata: torch.Tensor,
+    num_splits: torch.Tensor,
     softmax_scale: Optional[float] = None,
     causal: bool = False,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
@@ -48,11 +50,6 @@ def flash_mla_fwd(
         out: (batch_size, num_heads_q, head_dim_v).
     """
     import flash_mla_cuda
-    batch_size, seq_len_q, num_heads_q, head_dim = q.shape
-    num_heads_k = k_cache.shape[-2]
-    tile_scheduler_metadata, num_splits = flash_mla_cuda.get_mla_metadata(cache_seqlens,
-                                                                          seq_len_q * num_heads_q // num_heads_k,
-                                                                          num_heads_k)
     if softmax_scale is None:
         softmax_scale = q.shape[-1]**(-0.5)
     out, softmax_lse = flash_mla_cuda.fwd_kvcache_mla(

--- a/lmdeploy/pytorch/kernels/cuda/flash_mla.py
+++ b/lmdeploy/pytorch/kernels/cuda/flash_mla.py
@@ -4,25 +4,6 @@ from typing import Optional, Tuple
 import torch
 
 
-def get_mla_metadata(
-    cache_seqlens: torch.Tensor,
-    num_heads_per_head_k: int,
-    num_heads_k: int,
-) -> Tuple[torch.Tensor, torch.Tensor]:
-    """
-    Arguments:
-        cache_seqlens: (batch_size), dtype torch.int32.
-        num_heads_per_head_k: Equals to seq_len_q * num_heads_q // num_heads_k.
-        num_heads_k: num_heads_k.
-
-    Return:
-        tile_scheduler_metadata: (num_sm_parts, TileSchedulerMetaDataSize), dtype torch.int32.
-        num_splits: (batch_size + 1), dtype torch.int32.
-    """
-    import flash_mla_cuda
-    return flash_mla_cuda.get_mla_metadata(cache_seqlens, num_heads_per_head_k, num_heads_k)
-
-
 def flash_mla_fwd(
     q: torch.Tensor,
     k_cache: torch.Tensor,

--- a/lmdeploy/pytorch/kernels/cuda/flash_mla.py
+++ b/lmdeploy/pytorch/kernels/cuda/flash_mla.py
@@ -1,0 +1,70 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+from typing import Optional, Tuple
+
+import torch
+
+
+def get_mla_metadata(
+    cache_seqlens: torch.Tensor,
+    num_heads_per_head_k: int,
+    num_heads_k: int,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """
+    Arguments:
+        cache_seqlens: (batch_size), dtype torch.int32.
+        num_heads_per_head_k: Equals to seq_len_q * num_heads_q // num_heads_k.
+        num_heads_k: num_heads_k.
+
+    Return:
+        tile_scheduler_metadata: (num_sm_parts, TileSchedulerMetaDataSize), dtype torch.int32.
+        num_splits: (batch_size + 1), dtype torch.int32.
+    """
+    import flash_mla_cuda
+    return flash_mla_cuda.get_mla_metadata(cache_seqlens, num_heads_per_head_k, num_heads_k)
+
+
+def flash_mla_fwd(
+    q: torch.Tensor,
+    k_cache: torch.Tensor,
+    block_table: torch.Tensor,
+    cache_seqlens: torch.Tensor,
+    head_dim_v: int,
+    softmax_scale: Optional[float] = None,
+    causal: bool = False,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """
+    Arguments:
+        q: (batch_size, num_heads_q, head_dim).
+        k_cache: (num_blocks, page_block_size, num_heads_k, head_dim).
+        block_table: (batch_size, max_num_blocks_per_seq), torch.int32.
+        cache_seqlens: (batch_size), torch.int32.
+        head_dim_v: Head_dim of v.
+        tile_scheduler_metadata: (num_sm_parts, TileSchedulerMetaDataSize), torch.int32, return by get_mla_metadata.
+        num_splits: (batch_size + 1), torch.int32, return by get_mla_metadata.
+        softmax_scale: float. The scaling of QK^T before applying softmax. Default to 1 / sqrt(head_dim).
+        causal: bool. Whether to apply causal attention mask.
+
+    Return:
+        out: (batch_size, num_heads_q, head_dim_v).
+    """
+    import flash_mla_cuda
+    batch_size, seq_len_q, num_heads_q, head_dim = q.shape
+    num_heads_k = k_cache.shape[-2]
+    tile_scheduler_metadata, num_splits = flash_mla_cuda.get_mla_metadata(cache_seqlens,
+                                                                          seq_len_q * num_heads_q // num_heads_k,
+                                                                          num_heads_k)
+    if softmax_scale is None:
+        softmax_scale = q.shape[-1]**(-0.5)
+    out, softmax_lse = flash_mla_cuda.fwd_kvcache_mla(
+        q,
+        k_cache,
+        None,
+        head_dim_v,
+        cache_seqlens,
+        block_table,
+        softmax_scale,
+        causal,
+        tile_scheduler_metadata,
+        num_splits,
+    )
+    return out.squeeze(1)

--- a/lmdeploy/pytorch/kernels/flash_mla.py
+++ b/lmdeploy/pytorch/kernels/flash_mla.py
@@ -1,0 +1,4 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+from .dispatcher import FunctionDispatcher
+
+flash_mla_fwd = FunctionDispatcher('flash_mla_fwd').make_caller()

--- a/lmdeploy/pytorch/model_inputs.py
+++ b/lmdeploy/pytorch/model_inputs.py
@@ -262,11 +262,11 @@ class StepContext:
     """
     input_ids: torch.LongTensor
     model_config: ModelConfig
-    block_offsets: torch.LongTensor
+    block_offsets: torch.IntTensor
     position_ids: torch.LongTensor
     attention_mask: torch.LongTensor
     q_seqlens: torch.LongTensor
-    kv_seqlens: torch.LongTensor
+    kv_seqlens: torch.IntTensor
     q_start_loc: torch.LongTensor
     kv_caches: List
     is_decoding: bool

--- a/lmdeploy/pytorch/models/deepseek_v2.py
+++ b/lmdeploy/pytorch/models/deepseek_v2.py
@@ -658,13 +658,6 @@ class DeepseekV2ForCausalLM(nn.Module, CudaGraphMixin):
         input_ids = context.input_ids
         position_ids = context.position_ids
         attn_metadata = context.attn_metadata
-        if context.is_decoding is True:
-            if attn_metadata.tile_scheduler_metadata is None and self.config.use_flash_mla is True:
-                import flash_mla_cuda
-                tile_scheduler_metadata, num_splits = flash_mla_cuda.get_mla_metadata(
-                    attn_metadata.kv_seqlens.to(torch.int32), self.config.num_attention_heads, 1)
-                attn_metadata.tile_scheduler_metadata = tile_scheduler_metadata
-                attn_metadata.num_splits = num_splits
 
         return dict(
             input_ids=input_ids,

--- a/lmdeploy/pytorch/models/deepseek_v2.py
+++ b/lmdeploy/pytorch/models/deepseek_v2.py
@@ -80,6 +80,7 @@ class DeepseekV2Attention(nn.Module):
         self.q_head_dim = config.qk_nope_head_dim + config.qk_rope_head_dim
         num_replicate_kv_heads = getattr(config, 'num_replicate_key_value_heads', 1)
         num_key_value_heads = getattr(config, 'num_key_value_heads', 1)
+        use_flash_mla = getattr(config, 'use_flash_mla', False)
 
         if self.q_lora_rank is None:
             self.q_proj = build_colwise_linear(
@@ -152,7 +153,8 @@ class DeepseekV2Attention(nn.Module):
                                   scale=self.softmax_scale,
                                   num_kv_heads=num_key_value_heads,
                                   v_head_size=config.kv_lora_rank,
-                                  num_replicate_kv_heads=num_replicate_kv_heads)
+                                  num_replicate_kv_heads=num_replicate_kv_heads,
+                                  use_flash_mla=use_flash_mla)
 
         self.vc = DeepseekV2BMM(self.num_heads, config.kv_lora_rank, self.v_head_dim, dtype=dtype, device=device)
         self.o_proj = build_rowwise_linear(

--- a/lmdeploy/pytorch/models/deepseek_v2.py
+++ b/lmdeploy/pytorch/models/deepseek_v2.py
@@ -658,6 +658,13 @@ class DeepseekV2ForCausalLM(nn.Module, CudaGraphMixin):
         input_ids = context.input_ids
         position_ids = context.position_ids
         attn_metadata = context.attn_metadata
+        if context.is_decoding is True:
+            if attn_metadata.tile_scheduler_metadata is None and self.config.use_flash_mla is True:
+                import flash_mla_cuda
+                tile_scheduler_metadata, num_splits = flash_mla_cuda.get_mla_metadata(
+                    attn_metadata.kv_seqlens.to(torch.int32), self.config.num_attention_heads, 1)
+                attn_metadata.tile_scheduler_metadata = tile_scheduler_metadata
+                attn_metadata.num_splits = num_splits
 
         return dict(
             input_ids=input_ids,

--- a/lmdeploy/pytorch/models/utils/cudagraph.py
+++ b/lmdeploy/pytorch/models/utils/cudagraph.py
@@ -121,7 +121,7 @@ class CudaGraphMixin:
             tile_scheduler_metadata, num_splits = flash_mla_cuda.get_mla_metadata(
                 attn_metadata.kv_seqlens.to(torch.int32), self.config.num_attention_heads, 1)
             # here we use copy_ instead of = since to avoid using new allocated mem for cuda graph
-            input_buffers['tile_scheduler_metadata'][:].copy_(tile_scheduler_metadata)
+            input_buffers['tile_scheduler_metadata'].copy_(tile_scheduler_metadata)
             input_buffers['num_splits'][:batch_size + 1].copy_(num_splits[:batch_size + 1])
             attn_metadata.tile_scheduler_metadata = input_buffers['tile_scheduler_metadata']
             attn_metadata.num_splits = input_buffers['num_splits']

--- a/lmdeploy/pytorch/models/utils/cudagraph.py
+++ b/lmdeploy/pytorch/models/utils/cudagraph.py
@@ -120,7 +120,7 @@ class CudaGraphMixin:
             import flash_mla_cuda
             tile_scheduler_metadata, num_splits = flash_mla_cuda.get_mla_metadata(
                 attn_metadata.kv_seqlens.to(torch.int32), self.config.num_attention_heads, 1)
-            # here we use copy_ instead of = since to avoid using new allocated mem for cuda graph
+            # here we use copy_ instead of = to avoid using new allocated mem for cuda graph
             input_buffers['tile_scheduler_metadata'].copy_(tile_scheduler_metadata)
             input_buffers['num_splits'][:batch_size + 1].copy_(num_splits[:batch_size + 1])
             attn_metadata.tile_scheduler_metadata = input_buffers['tile_scheduler_metadata']

--- a/lmdeploy/pytorch/models/utils/cudagraph.py
+++ b/lmdeploy/pytorch/models/utils/cudagraph.py
@@ -60,10 +60,17 @@ class CudaGraphMixin:
         input_buffers: BuffType = dict()
         input_buffers['input_ids'] = torch.zeros(1, max_tokens, dtype=torch.int64, device=device)
         input_buffers['position_ids'] = torch.zeros((1, max_tokens), dtype=torch.int64, device=device)
+        if getattr(self.config, 'use_flash_mla', False) is True:
+            import flash_mla_cuda
 
-        input_buffers['block_offsets'] = torch.zeros((max_batches, num_blocks), dtype=torch.int64, device=device)
+            # create buffers for flash mla
+            input_buffers['tile_scheduler_metadata'], input_buffers['num_splits'] = flash_mla_cuda.get_mla_metadata(
+                torch.ones(max_batches, dtype=torch.int32, device=device), self.config.num_attention_heads, 1)
 
-        input_buffers['qkv_lens'] = torch.zeros(3, max_batches, dtype=torch.int64, device=device)
+        # flash_mla requires block_offsets and kv_lens int32
+        input_buffers['block_offsets'] = torch.zeros((max_batches, num_blocks), dtype=torch.int32, device=device)
+        input_buffers['qkv_lens'] = torch.zeros(3, max_batches, dtype=torch.int32, device=device)
+
         input_buffers['q_start_loc'] = input_buffers['qkv_lens'][0]
         input_buffers['q_seqlens'] = input_buffers['qkv_lens'][1]
         input_buffers['kv_seqlens'] = input_buffers['qkv_lens'][2]
@@ -109,6 +116,15 @@ class CudaGraphMixin:
         attn_metadata.q_start_loc = input_buffers['q_start_loc'][:new_batch_size]
         attn_metadata.q_seqlens = input_buffers['q_seqlens'][:new_batch_size]
         attn_metadata.kv_seqlens = input_buffers['kv_seqlens'][:new_batch_size]
+        if getattr(self.config, 'use_flash_mla', False) is True:
+            import flash_mla_cuda
+            tile_scheduler_metadata, num_splits = flash_mla_cuda.get_mla_metadata(
+                attn_metadata.kv_seqlens.to(torch.int32), self.config.num_attention_heads, 1)
+            # here we use copy_ instead of = since to avoid using new allocated mem for cuda graph
+            input_buffers['tile_scheduler_metadata'][:].copy_(tile_scheduler_metadata)
+            input_buffers['num_splits'][:batch_size + 1].copy_(num_splits[:batch_size + 1])
+            attn_metadata.tile_scheduler_metadata = input_buffers['tile_scheduler_metadata']
+            attn_metadata.num_splits = input_buffers['num_splits']
 
         new_inputs = dict(
             past_key_values=past_key_values,
@@ -149,3 +165,6 @@ class CudaGraphMixin:
         context.q_seqlens = input_buffers['q_seqlens']
         context.kv_seqlens = input_buffers['kv_seqlens']
         context.q_start_loc = input_buffers['q_start_loc']
+        # if getattr(self.config, 'use_flash_mla', False) is True:
+        #     context.tile_scheduler_metadata = input_buffers['tile_scheduler_metadata']
+        #     context.num_splits = input_buffers['num_splits']

--- a/lmdeploy/pytorch/models/utils/cudagraph.py
+++ b/lmdeploy/pytorch/models/utils/cudagraph.py
@@ -165,6 +165,3 @@ class CudaGraphMixin:
         context.q_seqlens = input_buffers['q_seqlens']
         context.kv_seqlens = input_buffers['kv_seqlens']
         context.q_start_loc = input_buffers['q_start_loc']
-        # if getattr(self.config, 'use_flash_mla', False) is True:
-        #     context.tile_scheduler_metadata = input_buffers['tile_scheduler_metadata']
-        #     context.num_splits = input_buffers['num_splits']

--- a/lmdeploy/pytorch/nn/attention.py
+++ b/lmdeploy/pytorch/nn/attention.py
@@ -31,6 +31,7 @@ class Attention(nn.Module):
         sliding_window: int = None,
         logit_softcapping: float = None,
         causal: bool = True,
+        use_flash_mla: bool = False,
         **kwargs,
     ):
         super().__init__()
@@ -53,6 +54,7 @@ class Attention(nn.Module):
             sliding_window=sliding_window,
             logit_softcapping=logit_softcapping,
             causal=causal,
+            use_flash_mla=use_flash_mla,
             **kwargs,
         )
 


### PR DESCRIPTION
Benchmark serving result with `python benchmark/profile_restful_api.py --backend lmdeploy --base-url http://0.0.0.0:23333 --dataset-name random --random-input-len 2048 --random-output-len 2048 --dataset-path ShareGPT_V3_unfiltered_cleaned_split.json --sharegpt-output-len 2048`
```
============ Serving Benchmark Result ============
Backend:                                 lmdeploy  
Traffic request rate:                    inf       
Successful requests:                     1000      
Benchmark duration (s):                  188.84    
Total input tokens:                      1025866   
Total generated tokens:                  1027062   
Total generated tokens (retokenized):    1028569   
Request throughput (req/s):              5.30      
Input token throughput (tok/s):          5432.42   
Output token throughput (tok/s):         5438.75   
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   98695.70  
Median E2E Latency (ms):                 100371.46 
---------------Time to First Token----------------
Mean TTFT (ms):                          77657.46  
Median TTFT (ms):                        76764.84  
P99 TTFT (ms):                           160333.93 
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          22.09     
Median TPOT (ms):                        20.77     
P99 TPOT (ms):                           43.60     
---------------Inter-token Latency----------------
Mean ITL (ms):                           21.05     
Median ITL (ms):                         17.09     
P99 ITL (ms):                            67.49     
==================================================
```

Compared with main:
```
============ Serving Benchmark Result ============
Backend:                                 lmdeploy  
Traffic request rate:                    inf       
Successful requests:                     1000      
Benchmark duration (s):                  214.55    
Total input tokens:                      1025866   
Total generated tokens:                  1027062   
Total generated tokens (retokenized):    1028569   
Request throughput (req/s):              4.66      
Input token throughput (tok/s):          4781.51   
Output token throughput (tok/s):         4787.08   
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   111953.23 
Median E2E Latency (ms):                 114432.68 
---------------Time to First Token----------------
Mean TTFT (ms):                          87930.45  
Median TTFT (ms):                        87668.92  
P99 TTFT (ms):                           182065.02 
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          25.22     
Median TPOT (ms):                        23.65     
P99 TPOT (ms):                           47.83     
---------------Inter-token Latency----------------
Mean ITL (ms):                           23.82     
Median ITL (ms):                         19.80     
P99 ITL (ms):                            72.63     
==================================================
```
About 10%+ improvement.