### PR TITLE
[Fix] failed to update the tokenizer's eos_token_id into stop_word list

### DIFF
--- a/lmdeploy/messages.py
+++ b/lmdeploy/messages.py
@@ -131,15 +131,22 @@ class GenerationConfig:
 
     def update_from_hf_gen_cfg(self, generation_config, tokenizer_eos_token_id):
         """update the stop_token_ids."""
-        stop_token_ids = self.stop_token_ids or []
+        stop_token_ids = set(self.stop_token_ids or [])
+
+        # add tokenizer's eos_token_id
         if tokenizer_eos_token_id is not None:
-            stop_token_ids.append(tokenizer_eos_token_id)
+            stop_token_ids.add(tokenizer_eos_token_id)
+
+        # add eos_token_id from model's generation_config.json file if there
+        # is any.
         eos_token_id = generation_config.get('eos_token_id')
         if eos_token_id is not None:
-            eos_token_id = {eos_token_id} if isinstance(eos_token_id, int) else set(eos_token_id)
-            if stop_token_ids:
-                eos_token_id.update(stop_token_ids)
-            self.stop_token_ids = list(eos_token_id)
+            if isinstance(eos_token_id, int):
+                stop_token_ids.add(eos_token_id)
+            else:
+                stop_token_ids.update(eos_token_id)
+
+        self.stop_token_ids = list(stop_token_ids)
 
     def __post_init__(self):
         """Check input validation."""

--- a/lmdeploy/serve/async_engine.py
+++ b/lmdeploy/serve/async_engine.py
@@ -704,8 +704,6 @@ class AsyncEngine(LogitsMixin):
         stop_ids = []
         if skip_stop_tokens and not gen_config.ignore_eos:
             stop_ids = gen_config.stop_token_ids or []
-            if self.tokenizer.eos_token_id not in stop_ids:
-                stop_ids.append(self.tokenizer.eos_token_id)
 
         async with self.model_inst(session_id) as inst:
             token_ids = input_ids.copy()

--- a/tests/test_lmdeploy/test_messages.py
+++ b/tests/test_lmdeploy/test_messages.py
@@ -1,6 +1,9 @@
 from typing import List
 
+import pytest
+
 from lmdeploy import GenerationConfig, Tokenizer
+from lmdeploy.utils import get_hf_gen_cfg
 
 
 def test_engine_generation_config():
@@ -11,3 +14,17 @@ def test_engine_generation_config():
     assert stop_token_ids == config.stop_token_ids
     assert isinstance(config.stop_token_ids, List) and \
         isinstance(config.stop_token_ids[0], int)
+
+
+@pytest.mark.parametrize('model_path', [
+    'deepseek-ai/DeepSeek-V3',
+    'Qwen/Qwen2.5-32B-Instruct',
+    'internlm/internlm3-8b-instruct',
+])
+def test_update_from_hf_gen_cfg(model_path):
+    tokenizer = Tokenizer(model_path)
+    model_cfg = get_hf_gen_cfg(model_path)
+
+    generation_config = GenerationConfig()
+    generation_config.update_from_hf_gen_cfg(model_cfg, tokenizer.eos_token_id)
+    assert generation_config.stop_token_ids is not None


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily receiving feedbacks. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

For some models such as deepseek-v3, which doesn't have `generation_config.json` file, LMDeploy failed to update the tokenizer's eos_token_id into the stop_word list.