### PR TITLE
Update block_trie.py

### DIFF
--- a/lmdeploy/pytorch/paging/block_trie.py
+++ b/lmdeploy/pytorch/paging/block_trie.py
@@ -84,7 +84,7 @@ class BlockTrie:
         while num_matched + block_size < seq.num_all_ids:
             curr_tokens = seq.history_cache[num_matched:num_matched + block_size]
 
-            key = hash(tuple(curr_tokens))
+            key = hash( ("random",tuple(curr_tokens)) )
             if key not in curr.children:
                 break
 


### PR DESCRIPTION
**问题：** 直接使用 Python 的 hash() 计算整数或元组，结果是固定的，容易被预测和构造冲突。若将此哈希用作缓存键，攻击者可利用冲突恶意覆盖缓存内容。

**解决方案：** 将需要哈希的数据（部分或全部）转换为字符串，或者在哈希输入中加入一个字符串成分。由于 Python 对字符串默认启用了哈希随机化（不同进程使用不同随机种子），使得最终的哈希值在不同进程间变得不可预测，从而有效防御针对缓存的哈希冲突攻击。