### PR TITLE
[Fix] fix `image_token_id` error of qwen2-vl and deepseek

### DIFF
--- a/lmdeploy/vl/model/deepseek.py
+++ b/lmdeploy/vl/model/deepseek.py
@@ -31,7 +31,10 @@ class DeepSeekVisionModel(VisonModel):
     def build_preprocessor(self):
         check_deepseek_vl_install()
         from deepseek_vl.models import VLChatProcessor
-        self.image_processor = VLChatProcessor.from_pretrained(self.model_path).image_processor
+        vl_chat_processor = VLChatProcessor.from_pretrained(self.model_path)
+        tokenizer = vl_chat_processor.tokenizer
+        self.image_token_id = tokenizer.vocab.get(vl_chat_processor.image_tag)
+        self.image_processor = vl_chat_processor.image_processor
 
     def build_model(self):
         """build the vision part of a VLM model when backend is turbomind, or

--- a/lmdeploy/vl/model/qwen2.py
+++ b/lmdeploy/vl/model/qwen2.py
@@ -30,6 +30,9 @@ class Qwen2VLModel(VisonModel):
         check_qwen_vl_deps_install()
         from transformers import AutoProcessor
         self.processor = AutoProcessor.from_pretrained(self.model_path)
+        tokenizer = self.processor.tokenizer
+        image_token = self.processor.image_token
+        self.image_token_id = tokenizer.encode(image_token)[-1]
 
     def preprocess(self, messages: List[Dict]) -> List[Dict]:
         """refer to `super().preprocess()` for spec."""


### PR DESCRIPTION
## Motivation
Fix issue #3285 

## Modification
It could be confirmed that `image_token_id` of `Qwen2-VL` and `DeepSeek-VL` is not same as `pad_token_id`, so this PR add codes reloading `image_token_id` in `build_preprocessor()` of them.

## Reference
For modification of `Qwen2-VL`: https://github.com/huggingface/transformers/blob/fb8e6c50e4a3a4bb1011e286d9bd26d79cd6334d/src/transformers/models/qwen2_vl/processing_qwen2_vl.py#L72-L75

For modification of `DeepSeek-VL`:
https://github.com/deepseek-ai/DeepSeek-VL/blob/681bffb4519856ad27cc17531aacde31ddf6f1a7/deepseek_vl/models/processing_vlm.py#L99
