### PR TITLE
support all2all ep

### DIFF
--- a/lmdeploy/pytorch/backends/cuda/moe.py
+++ b/lmdeploy/pytorch/backends/cuda/moe.py
@@ -369,8 +369,6 @@ class FusedDeepEpMoEBlockedF8Impl(TritonFusedMoEBlockedF8Impl):
         out_states = self.experts.forward(recv_hidden_states, tokens_per_expert, gate_up_weights, gate_up_scale,
                                           down_weights, down_scale)
         out_states = self.token_dispatcher.combine(out_states)
-        # print(f"zcx:out_states:{out_states}")
-        # raise RuntimeError()
         return out_states
 
 

--- a/lmdeploy/pytorch/backends/default/token_dispatcher.py
+++ b/lmdeploy/pytorch/backends/default/token_dispatcher.py
@@ -1,0 +1,130 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+from typing import Tuple
+
+import torch
+
+from ..token_dispatcher import TokenDispatcherImpl
+
+
+class AlltoAllTokenDispatcher(TokenDispatcherImpl):
+
+    def __init__(
+        self,
+        ep_group,
+        num_experts,
+        num_local_experts: int,
+    ) -> None:
+        self.num_local_experts = num_local_experts
+        assert num_experts is not None
+        self.num_experts = num_experts
+        assert self.num_local_experts > 0, 'Expected at least one expert'
+        self.ep_size = num_experts // num_local_experts
+        self.ep_group = ep_group
+        self.tp_size = 1
+        self.input_splits = None
+        self.output_splits = None
+        self.permute_idx_device = torch.device('cuda')
+        input_chunk_idxs = torch.arange(self.num_experts, device=self.permute_idx_device)
+        self.sort_input_by_local_experts = input_chunk_idxs.reshape(-1, self.num_local_experts).T.ravel()
+        self.restore_output_by_local_experts = input_chunk_idxs.reshape(self.num_local_experts, -1).T.ravel()
+
+    def sort_chunks_by_idxs(self,
+                            input: torch.Tensor,
+                            split_sizes: torch.Tensor,
+                            sorted_idxs: torch.Tensor,
+                            fused: bool = False):
+        """Split and sort the input tensor based on the split_sizes and sorted
+        indices."""
+        input = torch.split(input, split_sizes.tolist(), dim=0)
+        output = torch.cat([input[i] for i in sorted_idxs.tolist()], dim=0)
+        return output
+
+    def all_to_all(self, group, input_, output_split_sizes_=None, input_split_sizes=None):
+        output = input_.new_empty(
+            size=[sum(output_split_sizes_)] + list(input_.size()[1:]),
+            dtype=input_.dtype,
+            device=torch.cuda.current_device(),
+        )
+        torch.distributed.all_to_all_single(
+            output,
+            input_,
+            output_split_sizes=output_split_sizes_,
+            input_split_sizes=input_split_sizes,
+            group=group,
+        )
+        return output
+
+    def preprocess(self, routing_map: torch.Tensor, local_expert_indices) -> torch.Tensor:
+        assert (len(local_expert_indices) == self.num_local_experts), 'Invalid local expert indices'
+        for i in range(len(local_expert_indices) - 1):
+            assert (local_expert_indices[i] == local_expert_indices[i + 1] -
+                    1), 'local_expert_indices must be continous'
+
+        num_local_tokens_per_expert = routing_map.sum(dim=0).long()
+        self.input_splits = (num_local_tokens_per_expert.reshape(self.ep_size, self.num_local_experts).sum(axis=1).to(
+            torch.device('cpu'), non_blocking=True).numpy())
+        dim_size = list(num_local_tokens_per_expert.size())
+        dim_size[0] = dim_size[0] * torch.distributed.get_world_size(self.ep_group)
+        output = torch.empty(dim_size,
+                             dtype=num_local_tokens_per_expert.dtype,
+                             device=num_local_tokens_per_expert.device)
+        torch.distributed.all_gather_into_tensor(output, num_local_tokens_per_expert.contiguous(), group=self.ep_group)
+        num_global_tokens_per_expert = (output.reshape(self.ep_size, self.tp_size, self.num_experts).transpose(0, 1))
+        num_global_tokens_per_local_expert = num_global_tokens_per_expert[:, :, local_expert_indices[0]:
+                                                                          local_expert_indices[-1] + 1].contiguous()
+        num_global_tokens_per_rank = num_global_tokens_per_local_expert.sum(axis=2)
+        self.output_splits = (num_global_tokens_per_rank[0].to(torch.device('cpu'), non_blocking=True).numpy())
+        num_tokens_per_local_expert = num_global_tokens_per_local_expert.sum(dim=(0, 1))
+        if self.num_local_experts > 1:
+            self.num_global_tokens_per_local_expert = num_global_tokens_per_local_expert.view(
+                -1, self.num_local_experts)
+
+            self.num_global_tokens_per_local_expert = num_global_tokens_per_local_expert.to(torch.device('cpu'),
+                                                                                            non_blocking=False)
+
+        return num_tokens_per_local_expert
+
+    def dispatch(self, hidden_states: torch.Tensor, topk_ids: torch.Tensor, probs: torch.Tensor,
+                 local_expert_indices) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        self.hidden_shape = hidden_states.shape
+        self.topk_ids = topk_ids
+        self.routing_map, self.topk_weights = super().indices_to_multihot(topk_ids, probs, self.num_experts)
+        assert probs.dim() == 2, 'Expected 2D tensor for probs'
+        assert self.routing_map.dim() == 2, 'Expected 2D tensor for token2expert mask'
+        assert self.routing_map.dtype == torch.bool, 'Expected bool tensor for mask'
+        hidden_states = hidden_states.view(-1, self.hidden_shape[-1])
+        tokens_per_expert = self.preprocess(self.routing_map, local_expert_indices)
+        self.hidden_shape_before_permute = hidden_states.shape
+
+        permutated_local_input_tokens, self.reversed_local_input_permutation_mapping = super().permute(
+            hidden_states,
+            self.routing_map,
+        )
+        global_input_tokens = self.all_to_all(self.ep_group, permutated_local_input_tokens, self.output_splits,
+                                              self.input_splits)
+        if self.num_local_experts > 1:
+            global_input_tokens = self.sort_chunks_by_idxs(
+                global_input_tokens,
+                self.num_global_tokens_per_local_expert.ravel(),
+                self.sort_input_by_local_experts,
+            )
+        return global_input_tokens, None, None, tokens_per_expert
+
+    def combine(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        if self.num_local_experts > 1:
+            hidden_states = self.sort_chunks_by_idxs(
+                hidden_states,
+                self.num_global_tokens_per_local_expert.mT.ravel(),
+                self.restore_output_by_local_experts,
+            )
+        permutated_local_input_tokens = self.all_to_all(self.ep_group, hidden_states, self.input_splits,
+                                                        self.output_splits)
+        output = super().unpermute(
+            permutated_local_input_tokens,
+            self.reversed_local_input_permutation_mapping,
+            restore_shape=self.hidden_shape_before_permute,
+            probs=self.topk_weights,
+            routing_map=self.routing_map,
+        )
+        output = output.view(self.hidden_shape)
+        return output

--- a/lmdeploy/pytorch/backends/token_dispatcher.py
+++ b/lmdeploy/pytorch/backends/token_dispatcher.py
@@ -1,0 +1,73 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+from abc import ABC, abstractmethod
+from typing import Tuple
+
+import torch
+
+
+class TokenDispatcherImpl(ABC):
+    """Token dispatcher implementation api."""
+
+    def permute(
+        self,
+        tokens,
+        routing_map,
+    ):
+        """Copy from Megatron-Core moe for token permutation."""
+        num_tokens, _ = tokens.shape
+        num_experts = routing_map.shape[1]
+        routing_map = routing_map.bool().T.contiguous()
+        token_indices = (torch.arange(num_tokens, device=routing_map.device).unsqueeze(0).expand(num_experts, -1))
+        sorted_indices = token_indices.masked_select(routing_map)
+        permuted_input = tokens.index_select(0, sorted_indices)
+        return permuted_input, sorted_indices
+
+    def unpermute(
+        self,
+        permuted_tokens: torch.Tensor,
+        sorted_indices: torch.Tensor,
+        restore_shape: torch.Size,
+        probs: torch.Tensor = None,
+        routing_map: torch.Tensor = None,
+    ):
+        """Copy from Megatron-Core moe for token unpermutation."""
+        _, hidden = restore_shape
+        if probs is not None:
+            assert routing_map is not None, 'Mask must be provided to permute the probs.'
+            permuted_probs = probs.T.contiguous().masked_select(routing_map.T.contiguous())
+            permuted_tokens = permuted_tokens * permuted_probs.unsqueeze(-1)
+        output_tokens = torch.zeros(restore_shape, device=permuted_tokens.device, dtype=permuted_tokens.dtype)
+        output_tokens.scatter_add_(0, sorted_indices.unsqueeze(1).expand(-1, hidden), permuted_tokens)
+        return output_tokens
+
+    def indices_to_multihot(self, topk_ids, topk_weight, num_experts):
+        tokens = topk_ids.shape[0]
+        multihot_routing_map = torch.zeros(
+            (tokens, num_experts),
+            dtype=torch.bool,
+            device=topk_ids.device,
+        )
+
+        multihot_probs = torch.zeros(
+            (tokens, num_experts),
+            dtype=topk_weight.dtype,
+            device=topk_weight.device,
+        )
+
+        mask = topk_ids != -1
+        valid_indices = topk_ids[mask]
+        row_indices = torch.arange(tokens, device=topk_ids.device).repeat_interleave(mask.sum(dim=1))
+        multihot_routing_map[row_indices, valid_indices] = True
+        multihot_probs[row_indices, valid_indices] = topk_weight[mask]
+        return multihot_routing_map, multihot_probs
+
+    @abstractmethod
+    def dispatch(self, hidden_states: torch.Tensor, probs: torch.Tensor, topk_ids: torch.Tensor,
+                 local_expert_indices) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        """dispatch."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def combine(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        """combine."""
+        raise NotImplementedError


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily receiving feedbacks. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Please describe the motivation of this PR and the goal you want to achieve through this PR.

## Modification

Please briefly describe what modification is made in this PR.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.
```
import datetime
import os
from lmdeploy import pipeline, PytorchEngineConfig
from lmdeploy.messages import GenerationConfig
from lmdeploy.serve.openai.api_server import handle_torchrun
import torch.distributed as dist

def main(rank: int):
    model_path ='path_to_model'
    log_level = 'WARNING'
    prompts = [
        'fast fox jump over the lazy dog.',
        'fast fox jump over the lazy dog.',
        ]
    prompts = prompts[rank:rank+1]

    backend_config = PytorchEngineConfig(
        tp=1,
        dp=2,
        ep=2,
        dp_rank=rank,
        eager_mode=True,
    )
    gen_config = GenerationConfig(
        temperature=1.0,
        top_k=1,
        do_sample=True,
        max_new_tokens=64,
    )

    os.environ['LMDEPLOY_DP_MASTER_ADDR'] = 'localhost'
    os.environ['LMDEPLOY_DP_MASTER_PORT'] = str(port)
    with pipeline(model_path, backend_config=backend_config, log_level=log_level) as pipe:
        outputs = pipe(prompts, gen_config=gen_config)
        print(outputs)

        dist.barrier()

if __name__ == '__main__':
    handle_torchrun()
    rank = int(os.environ['LOCAL_RANK'])
    os.environ['CUDA_VISIBLE_DEVICES'] = str(rank)
    dist.init_process_group(backend='nccl', timeout=datetime.timedelta(90))
    try:
        main(rank)
    finally:
        dist.destroy_process_group()
```
torchrun --nproc-per-node=2   pipline.py
## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
