### PR TITLE
ray nsys profile support

### DIFF
--- a/lmdeploy/pytorch/engine/executor/__init__.py
+++ b/lmdeploy/pytorch/engine/executor/__init__.py
@@ -1,8 +1,8 @@
 # Copyright (c) OpenMMLab. All rights reserved.
-import os
 from logging import Logger
 from typing import Any, Dict
 
+from lmdeploy.pytorch import envs
 from lmdeploy.pytorch.config import BackendConfig, CacheConfig, DistConfig, ModelConfig
 from lmdeploy.utils import get_logger
 
@@ -23,7 +23,7 @@ def get_distributed_executor_backend(world_size: int, dp: int, device_type: str,
         _log_info(message)
         return executor_backend
 
-    executor_backend = os.environ.get('LMDEPLOY_EXECUTOR_BACKEND', None)
+    executor_backend = envs.executor_backend
     if executor_backend is not None:
         return _log_and_set_backend('found environment LMDEPLOY_EXECUTOR_BACKEND.', executor_backend)
 

--- a/lmdeploy/pytorch/engine/executor/ray_executor.py
+++ b/lmdeploy/pytorch/engine/executor/ray_executor.py
@@ -406,7 +406,7 @@ class RayExecutor(ExecutorBase):
                 self.collective_rpc('exit')
                 logger.debug('RayExecutor workers exited.')
             except ray.exceptions.RayActorError as e:
-                logger.warning(f'ray actor exit: {e}')
+                logger.debug(f'ray actor exit: {e}')
         else:
             [ray.kill(worker) for worker in self.workers]
 

--- a/lmdeploy/pytorch/envs.py
+++ b/lmdeploy/pytorch/envs.py
@@ -25,7 +25,8 @@ def env_to_bool(
 
 
 # profile
-enable_ray_nsys_profile = env_to_bool('LMDEPLOY_RAY_NSYS_PROFILE', False)
+ray_nsys_enable = env_to_bool('LMDEPLOY_RAY_NSYS_ENABLE', False)
+ray_nsys_output_prefix = os.getenv('LMDEPLOY_RAY_NSYS_OUT_PREFIX', None)
 
 # ascend
 ascend_rank_table_file = os.getenv('ASCEND_RANK_TABLE_FILE_PATH')

--- a/lmdeploy/pytorch/envs.py
+++ b/lmdeploy/pytorch/envs.py
@@ -1,0 +1,38 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+import os
+from typing import Union
+
+
+def env_to_bool(
+    env_var: str,
+    default: bool = False,
+    *,
+    true_values: Union[set, list] = {'true', '1', 'yes', 'on'},
+    false_values: Union[set, list] = {'false', '0', 'no', 'off'},
+):
+    """env to bool."""
+    value = os.getenv(env_var)
+    if value is None:
+        return default
+    value = value.lower().strip()
+    if value in true_values:
+        return True
+    elif value in false_values:
+        return False
+    else:
+        raise ValueError(f"Cannot convert environment variable '{env_var}={value}' to boolean. "
+                         f'Allowed true values: {true_values}, false values: {false_values}')
+
+
+# profile
+enable_ray_nsys_profile = env_to_bool('LMDEPLOY_RAY_NSYS_PROFILE', False)
+
+# ascend
+ascend_rank_table_file = os.getenv('ASCEND_RANK_TABLE_FILE_PATH')
+
+# dp
+dp_master_addr = os.getenv('LMDEPLOY_DP_MASTER_ADDR', None)
+dp_master_port = os.getenv('LMDEPLOY_DP_MASTER_PORT', None)
+
+# executor
+executor_backend = os.getenv('LMDEPLOY_EXECUTOR_BACKEND', None)


### PR DESCRIPTION

> [!NOTE]  
> This PR is used to profile GPU with ray. It has nothing to do with tp=1.


```bash
# Do NOT call this with nsys profile !!!
LMDEPLOY_RAY_NSYS_ENABLE=1 \
LMDEPLOY_RAY_NSYS_OUT_PREFIX=/path/to/save/prefix_ \
python your_script.py
```

If you want to use non-default nsys, please update `PATH` environment before `ray start`

```bash
PATH=/path/to/new/nsys:$PATH ray start --head
```