### PR TITLE
fix mllm testcase fail

### DIFF
--- a/lmdeploy/pytorch/models/internvl.py
+++ b/lmdeploy/pytorch/models/internvl.py
@@ -335,7 +335,7 @@ class InternVLChatModel(nn.Module, DeployModelMixin, CudaGraphMixin):
                                                                 'inputs_embeds',
                                                                 index=0)
 
-        self.extract_feature = torch.compile(self.extract_feature, mode='max-autotune')
+        self.extract_feature = torch.compile(self.extract_feature, mode='max-autotune-no-cudagraphs')
         self.compile_vit = True
         self.has_compiled_vit = False
 


### PR DESCRIPTION
When running the mllm test, the following error will appear in the code modified by [#3433](https://github.com/InternLM/lmdeploy/pull/3433)

```
root@f0d4b9e50158:/__w/lmdeploy/lmdeploy#  python3 autotest/tools/pipeline/mllm_case.py run_pipeline_mllm_test /nvme/qa_test_models/OpenGVLab/Mini-InternVL-Chat-2B-V1-5 /nvme/qa_test_models/resource 1 pytorch False None
backend_config config: PytorchEngineConfig(dtype='auto', tp=1, session_len=32576, max_batch_size=None, cache_max_entry_count=0.6, prefill_interval=16, block_size=64, num_cpu_blocks=0, num_gpu_blocks=0, adapters=None, max_prefill_token_num=4096, thread_safe=False, enable_prefix_caching=False, device_type='cuda', eager_mode=False, custom_module_map=None, download_dir=None, revision=None, quant_policy=0, distributed_executor_backend=None)
2025-04-18 20:22:08,329 - lmdeploy - WARNING - transformers.py:22 - LMDeploy requires transformers version: [4.33.0 ~ 4.46.1], but found version: 4.49.0
Loading weights from safetensors: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████��█████████████████████████████████| 1/1 [00:01<00:00,  1.92s/it]
2025-04-18 20:22:11,045 - lmdeploy - WARNING - async_engine.py:645 - GenerationConfig: GenerationConfig(n=1, max_new_tokens=512, do_sample=False, top_p=1.0, top_k=50, min_p=0.0, temperature=0.8, repetition_penalty=1.0, ignore_eos=False, random_seed=None, stop_words=None, bad_words=None, stop_token_ids=[2, 92540, 92542], bad_token_ids=None, min_new_tokens=None, skip_special_tokens=True, spaces_between_special_tokens=True, logprobs=None, response_format=None, logits_processors=None, output_logits=None, output_last_hidden_state=None)
2025-04-18 20:22:11,046 - lmdeploy - WARNING - async_engine.py:646 - Since v0.6.0, lmdeploy add `do_sample` in GenerationConfig. It defaults to False, meaning greedy decoding. Please set `do_sample=True` if sampling  decoding is needed
AUTOTUNE mm(7175x1024, 1024x4096)
  triton_mm_62 0.2601 ms 100.0% ACC_TYPE='tl.float32', ALLOW_TF32=False, BLOCK_K=64, BLOCK_M=128, BLOCK_N=128, B_PROLOGUE_。。。。
  triton_mm_1864 0.1116 ms 78.9% ACC_TYPE='tl.float32', ALLOW_TF32=False, BLOCK_K=32, BLOCK_M=128, BLOCK_N=64, B_PROLOGUE_CAST_TYPE=None, EVEN_K=True, GROUP_M=8, num_stages=4, num_warps=8
SingleProcess AUTOTUNE benchmarking takes 2.4743 seconds and 0.0026 seconds precompiling
loc("/opt/py3/lib/python3.10/site-packages/lmdeploy/pytorch/kernels/cuda/pagedattention.py":207:11): error: operation scheduled before its operands
loc("/opt/py3/lib/python3.10/site-packages/lmdeploy/pytorch/kernels/cuda/pagedattention.py":207:11): error: operation scheduled before its operands
loc("/opt/py3/lib/python3.10/site-packages/lmdeploy/pytorch/kernels/cuda/pagedattention.py":207:11): error: operation scheduled before its operands
[caseresult single1 start]"The image features a majestic tiger lying on a grassy field. The tiger is positioned in the center of the frame, with its body oriented towards the camera. Its fur is predominantly orange with distinctive black stripes, which is characteristic of a tiger. The tiger's eyes are wide open, and it appears to be looking directly at the camera, giving a sense of alertness and curiosity. The grass is lush and green, and the sunlight casts a soft shadow on the tiger's body, highlighting its form and the texture of its fur. The overall scene conveys a sense of tranquility and natural beauty."[caseresult single1 end]
2025-04-18 20:23:43,142 - lmdeploy - WARNING - async_engine.py:645 - GenerationConfig: GenerationConfig(n=1, max_new_tokens=500, do_sample=False, top_p=1.0, top_k=50, min_p=0.0, temperature=0.8, repetition_penalty=1.0, ignore_eos=False, random_seed=None, stop_words=None, bad_words=None, stop_token_ids=[2, 92540, 92542], bad_token_ids=None, min_new_tokens=None, skip_special_tokens=True, spaces_between_special_tokens=True, logprobs=None, response_format=None, logits_processors=None, output_logits=None, output_last_hidden_state=None)
2025-04-18 20:23:44,238 - lmdeploy - ERROR - model_agent.py:391 - Task <ModelAgentLoop> failed
Traceback (most recent call last):
  File "/opt/py3/lib/python3.10/site-packages/lmdeploy/pytorch/engine/model_agent.py", line 386, in _on_finish_callback
    task.result()
  File "/opt/py3/lib/python3.10/site-packages/lmdeploy/pytorch/engine/model_agent.py", line 374, in _async_loop_background
    await self._async_step_background(
  File "/opt/py3/lib/python3.10/site-packages/lmdeploy/pytorch/engine/model_agent.py", line 322, in _async_step_background
    output = await self._async_model_forward(inputs,
  File "/opt/py3/lib/python3.10/site-packages/lmdeploy/pytorch/engine/model_agent.py", line 243, in _async_model_forward
    ret = await __forward(inputs)
  File "/opt/py3/lib/python3.10/site-packages/lmdeploy/pytorch/engine/model_agent.py", line 220, in __forward
    return await self.async_forward(inputs, swap_in_map=swap_in_map, swap_out_map=swap_out_map)
  File "/opt/py3/lib/python3.10/site-packages/lmdeploy/pytorch/engine/model_agent.py", line 538, in async_forward
    output = self._forward_impl(inputs, swap_in_map=swap_in_map, swap_out_map=swap_out_map)
  File "/opt/py3/lib/python3.10/site-packages/lmdeploy/pytorch/engine/model_agent.py", line 521, in _forward_impl
    output = model_forward(
  File "/opt/py3/lib/python3.10/site-packages/torch/utils/_contextlib.py", line 116, in decorate_context
    return func(*args, **kwargs)
  File "/opt/py3/lib/python3.10/site-packages/lmdeploy/pytorch/engine/model_agent.py", line 75, in model_forward
    output = model(**input_dict)
  File "/opt/py3/lib/python3.10/site-packages/lmdeploy/pytorch/backends/cuda/graph_runner.py", line 174, in __call__
    output = runner.forward(**kwargs)
  File "/opt/py3/lib/python3.10/site-packages/lmdeploy/pytorch/backends/cuda/graph_runner.py", line 93, in forward
    self.model.fill_buffers_cudagraph(self.meta, **kwargs)
  File "/opt/py3/lib/python3.10/site-packages/lmdeploy/pytorch/models/utils/cudagraph.py", line 99, in fill_buffers_cudagraph
    input_buffers['input_ids'][:, :num_tokens] = input_ids
RuntimeError: CUDA error: unspecified launch failure
CUDA kernel errors might be asynchronously reported at some other API call, so the stacktrace below might be incorrect.
For debugging consider passing CUDA_LAUNCH_BLOCKING=1
Compile with `TORCH_USE_CUDA_DSA` to enable device-side assertions.
```


Changing the mode parameter of `torch.compile` from `max-autotune` to `max-autotune-no-cudagraphs` can fix this problem while maintaining performance. We also investigated the implementation of some other mainstream inference engines, and the highest mode is also set to `max-autotune-no-cudagraphs`. The performance test results of mode=`max-autotune-no-cudagraphs` are as follows:


```
============ Serving Benchmark Result ============
Backend:                                 lmdeploy
Traffic request rate:                    inf
Successful requests:                     500
Benchmark duration (s):                  310.51
Total input tokens:                      120414
Total generated tokens:                  2000
Total generated tokens (retokenized):    1996
Request throughput (req/s):              1.61
Input token throughput (tok/s):          387.80
Output token throughput (tok/s):         6.44
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   198738.15
Median E2E Latency (ms):                 180732.24
---------------Time to First Token----------------
Mean TTFT (ms):                          162594.79
Median TTFT (ms):                        162552.74
P99 TTFT (ms):                           309730.48
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          12047.79
Median TPOT (ms):                        11216.19
P99 TPOT (ms):                           28455.25
---------------Inter-token Latency----------------
Mean ITL (ms):                           19327.35
Median ITL (ms):                         613.58
P99 ITL (ms):                            82174.57
==================================================
```