### PR TITLE
fix qwen2.5-vl chat template

### DIFF
--- a/lmdeploy/model.py
+++ b/lmdeploy/model.py
@@ -1050,7 +1050,7 @@ class Qwen2d5Chat(Qwen7BChat):
                             tool_call = tool_call['function']
                         if isinstance(tool_call['arguments'], str):
                             tool_call['arguments'] = json.loads(tool_call['arguments'])
-                        ret += f'{self.separator}<tool_call>{self.separator}{{"name": "{tool_call['name']}", "arguments": {json.dumps(tool_call['arguments'], ensure_ascii=False)}}}{self.separator}</tool_call>'  # noqa
+                        ret += f'{self.separator}<tool_call>{self.separator}{{"name": "{tool_call["name"]}", "arguments": {json.dumps(tool_call["arguments"], ensure_ascii=False)}}}{self.separator}</tool_call>'  # noqa
                 ret += self.eosys
             if message['role'] == 'tool':
                 if index == 0 or messages[index - 1]['role'] != 'tool':

--- a/lmdeploy/model.py
+++ b/lmdeploy/model.py
@@ -1050,7 +1050,7 @@ class Qwen2d5Chat(Qwen7BChat):
                             tool_call = tool_call['function']
                         if isinstance(tool_call['arguments'], str):
                             tool_call['arguments'] = json.loads(tool_call['arguments'])
-                        ret += f'{self.separator}<tool_call>{self.separator}{{"name": "{tool_call["name"]}", "arguments": {json.dumps(tool_call["arguments"], ensure_ascii=False)}}}{self.separator}</tool_call>'  # noqa
+                        ret += f'{self.separator}<tool_call>{self.separator}{{"name": "{tool_call['name']}", "arguments": {json.dumps(tool_call['arguments'], ensure_ascii=False)}}}{self.separator}</tool_call>'  # noqa
                 ret += self.eosys
             if message['role'] == 'tool':
                 if index == 0 or messages[index - 1]['role'] != 'tool':
@@ -1069,8 +1069,26 @@ class Qwen2d5Chat(Qwen7BChat):
             model_path (str): the model path used for matching.
         """
         lower_path = model_path.lower()
-        if 'qwen2.5' in lower_path or 'qwen2_5' in lower_path:
+        if ('qwen2.5' in lower_path or 'qwen2_5' in lower_path) and 'vl' not in lower_path:
             return 'qwen2d5'
+
+
+@MODELS.register_module(name='qwen2d5-vl')
+class Qwen2d5VL(Qwen2d5Chat):
+
+    def __init__(self, meta_instruction='You are a helpful assistant.', **kwargs):
+        super().__init__(meta_instruction=meta_instruction, **kwargs)
+
+    @classmethod
+    def match(cls, model_path: str) -> Optional[str]:
+        """Return the model_name that was registered to MODELS.
+
+        Args:
+            model_path (str): the model path used for matching.
+        """
+        lower_path = model_path.lower()
+        if ('qwen2.5' in lower_path or 'qwen2_5' in lower_path) and 'vl' in lower_path:
+            return 'qwen2d5-vl'
 
 
 @MODELS.register_module(name='qwq_preview')

--- a/tests/test_lmdeploy/test_model.py
+++ b/tests/test_lmdeploy/test_model.py
@@ -9,6 +9,7 @@ from lmdeploy.model import MODELS, best_match_model
     ('models--internlm--internlm-chat-7b/snapshots/1234567', ['internlm']),
     ('Qwen/Qwen-7B-Chat', ['qwen']),
     ('Qwen/Qwen2.5-7B-Instruct', ['qwen2d5']),
+    ('Qwen/Qwen2.5-VL-7B-Instruct', ['qwen2d5-vl']),
     ('codellama/CodeLlama-7b-hf', ['codellama']),
     ('upstage/SOLAR-0-70b', ['solar', 'solar-70b']),
     ('meta-llama/Llama-2-7b-chat-hf', ['llama2']),
@@ -581,6 +582,30 @@ def test_qwen2d5():
                    "'celsius'}\n</tool_response><|im_end|>\n<|im_start"
                    '|>assistant\n')
     assert model.messages2prompt(messages, tools=tools) == tool_prompt
+
+
+def test_qwen2d5_vl():
+    prompt = 'hello, can u introduce yourself'
+    model = MODELS.get('qwen2d5-vl')(capability='completion')
+    assert model.get_prompt(prompt, sequence_start=True) == prompt
+    assert model.get_prompt(prompt, sequence_start=False) == prompt
+
+    model = MODELS.get('qwen2d5-vl')(capability='chat')
+
+    messages = [dict(role='user', content='What\'s the temperature in San Francisco now?')]
+    res = ('<|im_start|>system\nYou are a helpful '
+           "assistant.<|im_end|>\n<|im_start|>user\nWhat's the "
+           'temperature in San Francisco '
+           'now?<|im_end|>\n<|im_start|>assistant\n')
+    assert model.messages2prompt(messages) == res
+
+    messages.append({'role': 'assistant', 'content': 'I don\'t know.'})
+    res = ('<|im_start|>system\nYou are a helpful '
+           "assistant.<|im_end|>\n<|im_start|>user\nWhat's the "
+           'temperature in San Francisco '
+           "now?<|im_end|>\n<|im_start|>assistant\nI don't "
+           'know.<|im_end|>\n<|im_start|>assistant\n')
+    assert model.messages2prompt(messages) == res
 
 
 def test_codellama_completion():


### PR DESCRIPTION
https://github.com/InternLM/lmdeploy/issues/3422

[Qwen2.5 chat template](https://huggingface.co/Qwen/Qwen2.5-7B-Instruct/blob/main/tokenizer_config.json) system prompt is different from that of [Qwen2.5-VL chat template](https://huggingface.co/Qwen/Qwen2.5-VL-7B-Instruct/blob/main/chat_template.json) .

Comparisons of system messages in the previous implementation.

- Prompt A: `You are a helpful assistant.`
- Prompt B: `You are Qwen, created by Alibaba Cloud. You are a helpful assistant.`

|            | Transformers | LMDeploy |
|:----------:|:------------:|:--------:|
| Qwen2.5-VL |       A      |     B    |
|   Qwen2.5  |       B      |     B    |
|  Qwen2-VL  |       A      |     A    |
|    Qwen2   |       A      |     A    |
