### PR TITLE
fix dsvl2 no attr config error

### DIFF
--- a/lmdeploy/pytorch/models/deepseek_vl2.py
+++ b/lmdeploy/pytorch/models/deepseek_vl2.py
@@ -109,6 +109,7 @@ class DeepseekVLV2ForCausalLM(nn.Module, CudaGraphMixin, DeployModelMixin):
                  dtype: torch.dtype = None,
                  device: torch.device = None):
         super().__init__()
+        self.config = config
         self.ctx_mgr = ctx_mgr
 
         # ----------- vision encoder ------------


### PR DESCRIPTION
https://github.com/InternLM/lmdeploy/issues/3409

The [check condition](https://github.com/InternLM/lmdeploy/blob/main/lmdeploy/pytorch/models/utils/cudagraph.py#L63), which involves `config` is introduced in FlashMLA PR. Previous DeepSeek-VL2 implementations forgot to define the class `config` attribute, which leads to errors.

Tested with latest main after fix:
![dsvl-debug](https://github.com/user-attachments/assets/8e387cac-42da-44e2-a9b7-cc485bcf18b4)


