### PR TITLE
update dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,7 +11,7 @@ FROM ${CUDA_VERSION} AS final
 ARG PYTHON_VERSION=3.10
 
 RUN apt-get update -y && apt-get install -y software-properties-common wget vim git curl openssh-server ssh sudo &&\
-    apt-get install libibverbs1 ibverbs-providers ibverbs-utils librdmacm1 -y &&\
+    apt-get install libibverbs1 ibverbs-providers ibverbs-utils librdmacm1 libibverbs-dev rdma-core -y &&\
     curl https://sh.rustup.rs -sSf | sh -s -- -y &&\
     add-apt-repository ppa:deadsnakes/ppa -y && apt-get update -y && apt-get install -y --no-install-recommends \
     ninja-build rapidjson-dev libgoogle-glog-dev gdb python${PYTHON_VERSION} python${PYTHON_VERSION}-dev python${PYTHON_VERSION}-venv \

--- a/docker/Dockerfile_Hopper
+++ b/docker/Dockerfile_Hopper
@@ -9,10 +9,6 @@ ARG CUDA_HOME=/usr/local/cuda
 ARG GDRCOPY_HOME
 ARG NVSHMEM_PREFIX
 
-# upgrade rdma-core
-RUN sudo apt update -y && \
-    sudo apt install libibverbs-dev rdma-core -y
-
 # GDRCopy
 WORKDIR /tmp
 RUN dpkg -r libgdrapi gdrcopy && \


### PR DESCRIPTION
https://github.com/InternLM/lmdeploy/pull/3304 DistServe `pip install dlslime==0.0.1.post2` requires upgraded ib and rdma-core, otherwise leads to missing header file errors. Move the related logic to the base docker file.