### PR TITLE
move partial_json_parser from ’serve.txt‘ to ‘runtime.txt‘

### DIFF
--- a/requirements/runtime_ascend.txt
+++ b/requirements/runtime_ascend.txt
@@ -7,6 +7,7 @@ mmengine-lite
 numpy<2.0.0
 openai
 outlines<0.1.0
+partial_json_parser
 peft<=0.11.1
 pillow
 protobuf

--- a/requirements/runtime_camb.txt
+++ b/requirements/runtime_camb.txt
@@ -6,6 +6,7 @@ mmengine-lite
 numpy<2.0.0
 openai
 outlines<0.1.0
+partial_json_parser
 peft<=0.11.1
 pillow
 protobuf

--- a/requirements/runtime_cuda.txt
+++ b/requirements/runtime_cuda.txt
@@ -6,6 +6,7 @@ mmengine-lite
 numpy<2.0.0
 openai
 outlines
+partial_json_parser
 peft<=0.14.0
 pillow
 protobuf

--- a/requirements/runtime_maca.txt
+++ b/requirements/runtime_maca.txt
@@ -6,6 +6,7 @@ mmengine-lite
 numpy<2.0.0
 openai
 outlines<0.1.0
+partial_json_parser
 peft<=0.11.1
 pillow
 protobuf

--- a/requirements/serve.txt
+++ b/requirements/serve.txt
@@ -1,4 +1,3 @@
 gradio
-partial_json_parser
 protobuf
 tritonclient[grpc]


### PR DESCRIPTION
To fix "import error"
```
ModuleNotFoundError: No module named 'partial_json_parser'
```