### PR TITLE
Pass num_tokens_per_iter and max_prefill_iters params through in `lmdeploy serve api_server`

### DIFF
--- a/lmdeploy/cli/serve.py
+++ b/lmdeploy/cli/serve.py
@@ -268,6 +268,8 @@ class SubCliServe:
                                                    cache_block_seq_len=args.cache_block_seq_len,
                                                    enable_prefix_caching=args.enable_prefix_caching,
                                                    max_prefill_token_num=args.max_prefill_token_num,
+                                                   num_tokens_per_iter=args.num_tokens_per_iter,
+                                                   max_prefill_iters=args.max_prefill_iters,
                                                    communicator=args.communicator)
         chat_template_config = get_chat_template(args.chat_template)
         run(args.model_path_or_server,


### PR DESCRIPTION
The num_tokens_per_iter and max_prefill_iters params appear in the list when viewing `lmdeploy serve api_server --help`, but they aren't passed through. This change fixes that.