### PR TITLE
[ascend] fix recompile on different rank

### DIFF
--- a/lmdeploy/pytorch/engine/model_agent.py
+++ b/lmdeploy/pytorch/engine/model_agent.py
@@ -444,7 +444,10 @@ class AutoModelAgent:
                 stopped, num_appendable_ids = _batch_stopping_criteria(next_token_ids, sampling_inputs.stop_words,
                                                                        num_appendable_ids)
             else:
-                next_token_ids = torch.empty_like(num_ignore_eos)
+                # Avoid adding the ADInplaceOrView dispatch key to `next_token_ids`,
+                # as it can trigger recompilation on different ranks when using torch.compile.
+                with torch.inference_mode():
+                    next_token_ids = torch.empty_like(num_ignore_eos)
                 stopped = None
 
             if need_broadcast_next:


### PR DESCRIPTION
fix recompile on different rank. This is the root cause of #3354 and https://github.com/DeepLink-org/dlinfer/issues/201
(add `inference_mode` on `async def _async_step_background` as a decorator does not work)