### PR TITLE
[dlinfer][ascend]set blcoksize default to 128 for 310P device

### DIFF
--- a/lmdeploy/pytorch/backends/dlinfer/ascend/op_backend.py
+++ b/lmdeploy/pytorch/backends/dlinfer/ascend/op_backend.py
@@ -323,7 +323,10 @@ class AscendOpsBackend(DlinferOpsBackend):
             dlinfer.graph.config.enable_graph_mode = True
             if torch.distributed.is_initialized():
                 torch._inductor.config.compile_threads = 1
-            AscendOpsBackend.transdata_func = torch.compile(transdata, fullgraph=True, dynamic=True, backend='atbgraph')
+            AscendOpsBackend.transdata_func = torch.compile(transdata,
+                                                            fullgraph=True,
+                                                            dynamic=False,
+                                                            backend='atbgraph')
         return AscendOpsBackend.transdata_func
 
     @staticmethod


### PR DESCRIPTION
## Motivation

Dlinfer Ascend 310P device will trigger error when using lmdeploy chat api, since the original default block size is 64.
Set block size to 128 will prevent this error

