### PR TITLE
allow api server terminated through requests from clients

### DIFF
--- a/lmdeploy/cli/serve.py
+++ b/lmdeploy/cli/serve.py
@@ -133,7 +133,7 @@ class SubCliServe:
         ArgumentHelper.model_name(parser)
         ArgumentHelper.max_log_len(parser)
         ArgumentHelper.disable_fastapi_docs(parser)
-
+        ArgumentHelper.allow_terminate_by_client(parser)
         # chat template args
         ArgumentHelper.chat_template(parser)
 
@@ -361,6 +361,7 @@ class SubCliServe:
                        allow_credentials=args.allow_credentials,
                        allow_methods=args.allow_methods,
                        allow_headers=args.allow_headers,
+                       allow_terminate_by_client=args.allow_terminate_by_client,
                        log_level=args.log_level.upper(),
                        api_keys=args.api_keys,
                        ssl=args.ssl,

--- a/lmdeploy/cli/utils.py
+++ b/lmdeploy/cli/utils.py
@@ -407,6 +407,15 @@ class ArgumentHelper:
             help=f'The registered tool parser name {ToolParserManager.module_dict.keys()}. Default to None.')
 
     @staticmethod
+    def allow_terminate_by_client(parser):
+        """Add argument allow_terminate_by_client to parser."""
+
+        return parser.add_argument('--allow-terminate-by-client',
+                                   action='store_true',
+                                   default=False,
+                                   help='Enable server to be terminated by request from client')
+
+    @staticmethod
     def cache_max_entry_count(parser):
         """Add argument cache_max_entry_count to parser."""
 

--- a/lmdeploy/serve/openai/api_server.py
+++ b/lmdeploy/serve/openai/api_server.py
@@ -1070,14 +1070,9 @@ async def startup_event():
     try:
         import requests
         engine_config = VariableInterface.async_engine.engine.engine_config
+        engine_role = engine_config.role.value if hasattr(engine_config, 'role') else 1
         url = f'{VariableInterface.proxy_url}/nodes/add'
-        data = {
-            'url': VariableInterface.api_server_url,
-            'status': {
-                'models': get_model_list(),
-                'role': engine_config.role.value
-            }
-        }
+        data = {'url': VariableInterface.api_server_url, 'status': {'models': get_model_list(), 'role': engine_role}}
         headers = {'accept': 'application/json', 'Content-Type': 'application/json'}
         response = requests.post(url, headers=headers, json=data)
 

--- a/lmdeploy/serve/openai/api_server.py
+++ b/lmdeploy/serve/openai/api_server.py
@@ -54,6 +54,7 @@ class VariableInterface:
     reasoning_parser: Optional[ReasoningParser] = None
     # following is for tool parsers
     tool_parser: Optional[ToolParser] = None
+    allow_terminate_by_client: bool = False
 
 
 router = APIRouter()
@@ -231,6 +232,19 @@ def _create_chat_completion_logprobs(tokenizer: Tokenizer,
 @router.get('/health')
 async def health() -> Response:
     """Health check."""
+    return Response(status_code=200)
+
+
+@router.get('/terminate')
+async def terminate():
+    """terminate server."""
+    import signal
+
+    if not VariableInterface.allow_terminate_by_client:
+        return create_error_response(
+            HTTPStatus.BAD_REQUEST,
+            'The server can not be terminated. Please add --allow-terminate-by-client when start the server.')
+    os.kill(os.getpid(), signal.SIGTERM)
     return Response(status_code=200)
 
 
@@ -1070,7 +1084,7 @@ async def startup_event():
         if response.status_code != 200:
             raise HTTPException(status_code=400, detail='Service registration failed')
     except Exception as e:
-        print(f'Service registration failed: {e}')
+        logger.error(f'Service registration failed: {e}')
 
 
 class ConcurrencyLimitMiddleware(BaseHTTPMiddleware):
@@ -1127,6 +1141,7 @@ def serve(model_path: str,
           max_concurrent_requests: Optional[int] = None,
           reasoning_parser: Optional[str] = None,
           tool_call_parser: Optional[str] = None,
+          allow_terminate_by_client: bool = False,
           **kwargs):
     """An example to perform model inference through the command line
     interface.
@@ -1178,6 +1193,7 @@ def serve(model_path: str,
             clients concurrently during that time. Default to None.
         reasoning_parser (str): The reasoning parser name.
         tool_call_parser (str): The tool call parser name.
+        allow_terminate_by_client (bool): Allow request from client to terminate server.
     """
     if os.getenv('TM_LOG_LEVEL') is None:
         os.environ['TM_LOG_LEVEL'] = log_level
@@ -1207,6 +1223,7 @@ def serve(model_path: str,
     if max_concurrent_requests is not None:
         app.add_middleware(ConcurrencyLimitMiddleware, max_concurrent_requests=max_concurrent_requests)
 
+    VariableInterface.allow_terminate_by_client = allow_terminate_by_client
     if api_keys is not None:
         if isinstance(api_keys, str):
             api_keys = api_keys.split(',')


### PR DESCRIPTION

## Motivation

Allow api server to be terminated through a request from a client.


## Modification

Please briefly describe what modification is made in this PR.

## BC-breaking (Optional)

None

## Use cases (Optional)
1. start server with `--allow-terminate-by-client`
```
lmdeploy serve api_server meta-llama/Meta-Llama-3-8B-Instruct  --allow-terminate-by-client
```
2. terminate with curl
```
curl http://0.0.0.0:23333/terminate
```
## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
4. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
5. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
6. The documentation has been modified accordingly, like docstring or example tutorials.
