### PR TITLE
[bug fix] fix PD Disaggregation in DSV3

### DIFF
--- a/lmdeploy/pytorch/engine/cache_engine.py
+++ b/lmdeploy/pytorch/engine/cache_engine.py
@@ -364,6 +364,8 @@ class CacheEngine:
                 remote_engine_id].remote_engine_config.num_gpu_blocks * assignment_len
 
             for i, t in enumerate(self.full_gpu_cache):
+                if t.numel() == 0:
+                    continue
                 assignment_batch.extend(
                     get_assignment_batch(str(i), blocks_to_migration, assignment_len, layer_stride,
                                          remote_layer_stride))

--- a/lmdeploy/pytorch/messages.py
+++ b/lmdeploy/pytorch/messages.py
@@ -8,7 +8,6 @@ import numpy as np
 from torch import Tensor
 
 from lmdeploy.messages import GenerationConfig, LogitsProcessor
-from lmdeploy.pytorch.disagg.messages import MigrationExecutionBatch
 from lmdeploy.pytorch.disagg.request import MigrationRequest
 from lmdeploy.pytorch.multimodal.data_type import MultiModalInputs
 from lmdeploy.utils import get_logger
@@ -466,7 +465,6 @@ class SchedulerSequence:
     migration_request: Optional[MigrationRequest] = None
     resp_cache: bool = False
     preserve_cache: bool = False
-    migration_inputs: Optional[MigrationExecutionBatch] = None
 
     def __post_init__(self):
         """post init."""

--- a/lmdeploy/pytorch/model_inputs.py
+++ b/lmdeploy/pytorch/model_inputs.py
@@ -1,7 +1,7 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 from contextlib import contextmanager
 from dataclasses import dataclass, field, fields
-from typing import Any, Dict, List, Literal, Optional
+from typing import Any, Dict, List, Literal
 
 import torch
 
@@ -9,8 +9,6 @@ import torch
 import lmdeploy.pytorch.distributed as dist
 from lmdeploy.pytorch.backends import get_backend
 from lmdeploy.pytorch.config import ModelConfig
-from lmdeploy.pytorch.disagg.messages import MigrationExecutionBatch
-from lmdeploy.pytorch.disagg.request import MigrationRequest
 from lmdeploy.pytorch.multimodal.data_type import MultiModalTensor
 
 
@@ -153,8 +151,6 @@ class ModelInputs:
     history_cross_length: torch.LongTensor = None
     model_metas: List[Dict[str, Any]] = None
     dp_meta: 'DPMeta' = None
-    migration_inputs: Optional[MigrationExecutionBatch] = None
-    migration_requests: Optional[MigrationRequest] = None
 
     def update(self, input_ids: torch.LongTensor):
         """update input ids."""

--- a/lmdeploy/pytorch/paging/scheduler.py
+++ b/lmdeploy/pytorch/paging/scheduler.py
@@ -194,20 +194,6 @@ class Scheduler:
             running.append(seq)
             nonlocal token_count
             token_count += seq.num_token_ids
-            if seq.migration_request:
-                migration_execution_requests: List[Tuple[int, List[Tuple[int, int]]]] = []
-                migration_request = seq.migration_request
-                prefill_block_ids = migration_request.remote_block_ids
-                decode_block_ids = list(self.block_manager.get_block_table(msg=seq))
-
-                assert len(prefill_block_ids) == len(decode_block_ids)
-                migration_execution_requests.append((
-                    migration_request.remote_engine_id,
-                    list(zip(prefill_block_ids, decode_block_ids)),
-                ))
-                migration_inputs = MigrationExecutionBatch(protocol=migration_request.protocol,
-                                                           requests=migration_execution_requests)
-                seq.migration_inputs = migration_inputs
 
         def __evict_for_seq(seq: SchedulerSequence, waiting):
             """evict until can append."""

--- a/lmdeploy/pytorch/paging/scheduler.py
+++ b/lmdeploy/pytorch/paging/scheduler.py
@@ -3,9 +3,8 @@
 
 from collections import OrderedDict
 from dataclasses import dataclass
-from typing import Dict, List, Tuple
+from typing import Dict, List
 
-from lmdeploy.pytorch.disagg.messages import MigrationExecutionBatch
 from lmdeploy.utils import get_logger, logging_timer
 
 from ..config import CacheConfig, SchedulerConfig


### PR DESCRIPTION
1. add `collect_migration_done` before `inputs_maker.prefetch_next_inputs()` because of dummy run.
2. bugfix when preemption in decode engine
3. bypass 0-shape vcache tensor migration.
