### PR TITLE
support update params with dp=1 for pytorch engine

### DIFF
--- a/lmdeploy/pytorch/engine/model_agent.py
+++ b/lmdeploy/pytorch/engine/model_agent.py
@@ -707,7 +707,10 @@ class BaseModelAgent(AutoModelAgent):
             return func(*args).clone()
 
         with self.all_context():
-            weights = ForkingPickler.loads(base64.b64decode(request.serialized_named_tensors))
+            serialized_data = request.serialized_named_tensors
+            if isinstance(serialized_data, list):
+                serialized_data = serialized_data[self.dist_ctx.tp_rank]
+            weights = ForkingPickler.loads(base64.b64decode(serialized_data))
             weights = [(k, _construct(v)) for k, v in weights]
             self.patched_model.get_model().load_weights(weights)
 

--- a/lmdeploy/serve/openai/protocol.py
+++ b/lmdeploy/serve/openai/protocol.py
@@ -377,5 +377,5 @@ class GenerateResponse(BaseModel):
 
 class UpdateParamsRequest(BaseModel):
     """Update weights request."""
-    serialized_named_tensors: str
+    serialized_named_tensors: Union[str, List[str]]
     finished: bool = False


### PR DESCRIPTION
## Motivation

Since the serialization and deserialization of tensors need to appear in pairs to avoid memory leak, we need to update the related api to support settings of tp=1 and tp > 1. Under such a model configuration, the data format should be [serialize_tp0_data, serialize_tp1_data, ...]

related demo https://gitee.pjlab.org.cn/L1/_source/L1/chenxin/lmdeploy-rl-demo/-/blob/heads%2Fmain/demo_dp1_proxy.py

