### PR TITLE
fix bug in qwen2

### DIFF
--- a/lmdeploy/pytorch/models/qwen2.py
+++ b/lmdeploy/pytorch/models/qwen2.py
@@ -47,7 +47,7 @@ class Qwen2Attention(nn.Module):
             head_dim,
             num_kv_heads=num_key_value_heads,
             v_head_size=head_dim,
-            sliding_window=config.sliding_window,
+            sliding_window=config.sliding_window if config.use_sliding_window else None,
         )
 
         # o_proj


### PR DESCRIPTION
## Motivation

Resolve the issue where Qwen2 does not adhere to the use_sliding_window setting specified in the configuration file.

