### PR TITLE
feature: enable tool_call and reasoning_content parsing for qwen3 #3412

### DIFF
--- a/lmdeploy/serve/openai/api_server.py
+++ b/lmdeploy/serve/openai/api_server.py
@@ -489,12 +489,15 @@ async def chat_completions_v1(raw_request: Request = None):
                 if tool_delta is not None:
                     delta_message.tool_calls = tool_delta.tool_calls
                     delta_message.content = tool_delta.content
+                    delta_message.reasoning_content = tool_delta.reasoning_content
                     if isinstance(tool_delta.tool_calls, List) and len(tool_delta.tool_calls):
                         streaming_tools = True
+                else:
+                    continue
                 previous_text = current_text
                 previous_token_ids = current_token_ids
             elif request.tool_choice != 'none' and request.tools is not None and VariableInterface.tool_parser is None:
-                logger.error('Please lanuch the api_server with --tool-call-parser if you want to use tool.')
+                logger.error('Please launch the api_server with --tool-call-parser if you want to use tool.')
             if VariableInterface.reasoning_parser is not None:
                 current_text = current_text + res.response
                 delta_token_ids = res.token_ids if res.token_ids is not None else []
@@ -556,12 +559,14 @@ async def chat_completions_v1(raw_request: Request = None):
             if isinstance(tool_calls, List) and len(tool_calls):
                 if final_res.finish_reason == 'stop':
                     final_res.finish_reason = 'tool_calls'
+            if tool_call_info.reasoning_content is not None:
+                reasoning_content = tool_call_info.reasoning_content
 
         except Exception as e:
             logger.error(f'Failed to parse {text}. Exception: {e}.')
             return create_error_response(HTTPStatus.BAD_REQUEST, 'Failed to parse fc related info to json format!')
     elif request.tool_choice != 'none' and request.tools is not None and VariableInterface.tool_parser is None:
-        logger.error('Please lanuch the api_server with --tool-call-parser if you want to use tool.')
+        logger.error('Please launch the api_server with --tool-call-parser if you want to use tool.')
 
     if VariableInterface.reasoning_parser is not None:
         reasoning_content, text = VariableInterface.reasoning_parser.extract_reasoning_content(text, request)

--- a/lmdeploy/serve/openai/protocol.py
+++ b/lmdeploy/serve/openai/protocol.py
@@ -161,6 +161,7 @@ class ExtractedToolCallInformation(BaseModel):
     # content - per OpenAI spec, content AND tool calls can be returned rarely
     # But some models will do this intentionally
     content: Optional[str] = None
+    reasoning_content: Optional[str] = None
 
 
 class ChatMessage(BaseModel):

--- a/lmdeploy/serve/openai/tool_parser/__init__.py
+++ b/lmdeploy/serve/openai/tool_parser/__init__.py
@@ -2,6 +2,14 @@
 from .internlm2_parser import Internlm2ToolParser
 from .llama3_parser import Llama3JsonToolParser
 from .qwen2d5_parser import Qwen2d5ToolParser
+from .qwen3_parser import Qwen3ToolParser
 from .tool_parser import ToolParser, ToolParserManager
 
-__all__ = ['Internlm2ToolParser', 'Qwen2d5ToolParser', 'ToolParser', 'ToolParserManager', 'Llama3JsonToolParser']
+__all__ = [
+    'Internlm2ToolParser',
+    'Qwen2d5ToolParser',
+    'Qwen3ToolParser',
+    'ToolParser',
+    'ToolParserManager',
+    'Llama3JsonToolParser',
+]

--- a/lmdeploy/serve/openai/tool_parser/qwen3_parser.py
+++ b/lmdeploy/serve/openai/tool_parser/qwen3_parser.py
@@ -1,0 +1,256 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+import json
+import re
+from dataclasses import dataclass
+from typing import Dict, Optional, Sequence, Union
+
+import partial_json_parser
+import shortuuid
+from partial_json_parser.core.exceptions import MalformedJSON, PartialJSON
+from partial_json_parser.core.options import Allow
+
+from lmdeploy.serve.openai.protocol import (ChatCompletionRequest, DeltaFunctionCall, DeltaMessage, DeltaToolCall,
+                                            ExtractedToolCallInformation, FunctionCall, ToolCall)
+from lmdeploy.utils import get_logger
+
+from .tool_parser import ToolParser, ToolParserManager
+
+logger = get_logger('lmdeploy')
+
+
+@dataclass
+class ParserState(object):
+    """Maintains the state of parsing during tool call extraction.
+
+    Tracks position in text, tool call index, parsing flags, and what parts of the tool call have been sent to the
+    client.
+    """
+    position: int = 0  # Current position in the text being parsed
+    current_index: int = -1  # Index of the current tool call
+
+    id: str = ''  # ID of the current tool call
+    parse_arg_as_object: bool = False  # Whether to parse arguments as an object
+    parsing_reasoning: bool = False  # Whether currently parsing reasoning content
+    name_sent: bool = False  # Whether the tool name has been sent
+    args_sent: bool = False  # Whether the tool arguments have been sent
+
+
+@ToolParserManager.register_module(['qwen3'])
+class Qwen3ToolParser(ToolParser):
+    """Parser for Qwen3 model's tool call format.
+
+    Handles the extraction of tool calls from Qwen3's output format, which uses XML-like tags for tool calls and
+    reasoning.
+    """
+
+    def __init__(self, tokenizer: object):
+        super().__init__(tokenizer)
+        self.think_start_token = '<think>'
+        self.think_end_token = '</think>'
+        self.tool_start_token = '<tool_call>'
+        self.tool_end_token = '</tool_call>'
+        self.tool_call_pat = re.compile(r'<tool_call>(.*?)</tool_call>', re.DOTALL)
+        self.think_pat = re.compile(r'<think>(.*?)</think>', re.DOTALL)
+
+    def get_argments(self, obj):
+        """Extract arguments from tool call object, handling different formats.
+
+        Supports both 'parameters' and 'arguments' keys in the tool call object.
+        """
+        if 'parameters' in obj:
+            return obj.get('parameters')
+        elif 'arguments' in obj:
+            return obj.get('arguments')
+        return None
+
+    def _split(self, parser_state: ParserState, parsing_content: str):
+        """Split content into tuple: (text_content, reasoning_content, tool_content)
+
+        This method parses the model output and separates it into regular text,
+        reasoning content (inside <think> tags), and tool call content.
+        """
+        # reasoning content
+        if parser_state.parsing_reasoning:
+            if self.think_end_token in parsing_content:
+                parser_state.parsing_reasoning = False
+                end_pos = parsing_content.index(self.think_end_token)
+                parser_state.position += end_pos + len(self.think_end_token)
+                return '', parsing_content[:end_pos], ''
+            parser_state.position += len(parsing_content)
+            return '', parsing_content, ''
+        if self.think_start_token in parsing_content:
+            start_pos = parsing_content.index(self.think_start_token)
+            if self.think_end_token not in parsing_content:
+                # parse content: <think> ... (incomplete)
+                parser_state.parsing_reasoning = True
+                parser_state.position += len(parsing_content)
+                return parsing_content[:start_pos], parsing_content[start_pos + len(self.think_start_token):], ''
+            # parse content: <think> ... </think>
+            end_pos = parsing_content.index(self.think_end_token)
+            parser_state.parsing_reasoning = False
+            parser_state.position += end_pos + len(self.think_end_token)
+            return parsing_content[:start_pos], parsing_content[start_pos + len(self.think_start_token):end_pos], ''
+
+        # tool call
+        try:
+            start_idx = parsing_content.index(self.tool_start_token)
+        except ValueError:
+            parser_state.position += len(parsing_content)
+            return parsing_content, '', ''
+        try:
+            end_idx = parsing_content.index(self.tool_end_token)
+        except ValueError:
+            parser_state.position += start_idx
+            return parsing_content[:start_idx], '', parsing_content[start_idx + len(self.tool_start_token):]
+        parser_state.position += start_idx
+        return parsing_content[:start_idx], '', parsing_content[start_idx + len(self.tool_start_token):end_idx]
+
+    def _parse_delta_tool_call(self, parser_state: ParserState, tool_content: str) -> Optional[DeltaToolCall]:
+        """Parse tool content into a DeltaToolCall object.
+
+        This method handles the incremental parsing of tool calls from partial JSON content.
+        """
+        # bit mask flags for partial JSON parsing. If the name hasn't been
+        # sent yet, don't allow sending an incomplete string since OpenAI only ever
+        # allows sending the entire tool/function name at once.
+        flags = Allow.ALL & ~Allow.STR & ~Allow.NUM & ~Allow.BOOL & ~Allow.NULL
+        if parser_state.parse_arg_as_object:
+            flags &= ~Allow.OBJ
+
+        try:
+            parsable_arr = tool_content.strip()
+
+            # Tool calls are generated in an object format,
+            # Attempt to parse the JSON content incrementally.
+            # Parallel tool calls is not supported yet.
+            try:
+                tool_call_arr: Dict = partial_json_parser.loads(parsable_arr, flags)
+            except (MalformedJSON, PartialJSON):
+                logger.debug('not enough tokens to parse into JSON yet')
+                return None
+
+            fcall = DeltaFunctionCall()
+            # Extract and set function name if not already sent
+            if not parser_state.name_sent:
+                func_name = tool_call_arr.get('name')
+                if func_name:
+                    fcall.name = func_name
+                    parser_state.name_sent = True
+            # Extract and set function arguments if not already sent
+            if not parser_state.args_sent:
+                args = self.get_argments(tool_call_arr)
+                if isinstance(args, dict) and not parser_state.parse_arg_as_object:
+                    # Reparse with new flags to handle object arguments properly
+                    parser_state.parse_arg_as_object = True
+                    flags &= ~Allow.OBJ
+                    try:
+                        tool_call_arr: Dict = partial_json_parser.loads(parsable_arr, flags)
+                        args = self.get_argments(tool_call_arr)
+                    except (MalformedJSON, PartialJSON):
+                        logger.debug('not enough tokens to parse into JSON yet')
+                        args = None
+                if args and isinstance(args, dict):
+                    fcall.arguments = json.dumps(args, ensure_ascii=False)
+                    parser_state.args_sent = True
+
+            # Return None if no new information to send
+            if not fcall.name and not fcall.arguments:
+                return None
+            if not parser_state.id:
+                # A new tool call parsed, allocate a new id & index
+                parser_state.id = f'chatcmpl-tool-{shortuuid.random()}'
+                parser_state.current_index += 1
+            # Create and return the DeltaToolCall object
+            return DeltaToolCall(
+                id=parser_state.id,
+                index=parser_state.current_index,
+                function=fcall.model_dump(exclude_none=True),
+            )
+        except Exception:
+            logger.exception('Error trying to handle streaming tool call.')
+            logger.debug('Skipping chunk as a result of tool streaming extraction error')
+            return None
+
+    def extract_tool_calls_streaming(
+        self,
+        previous_text: str,
+        current_text: str,
+        delta_text: str,
+        previous_token_ids: Sequence[int],
+        current_token_ids: Sequence[int],
+        delta_token_ids: Sequence[int],
+        request: ChatCompletionRequest,
+    ) -> Union[DeltaMessage, None]:
+        """Extract tool calls from streaming model output.
+
+        This method processes incremental model output to extract tool calls, reasoning content, and regular text
+        content in a streaming fashion. It maintains parser state between calls to handle partial outputs.
+        """
+        parser_state = getattr(request, '_tool_parser_state', None)
+        if parser_state is None:
+            parser_state = ParserState()
+            setattr(request, '_tool_parser_state', parser_state)
+
+        # Split the new content into text, reasoning, and tool content
+        text_content, reasoning_content, tool_content = self._split(parser_state, current_text[parser_state.position:])
+        delta = DeltaMessage()
+
+        # Add each type of content to the delta message if present
+        if text_content:
+            delta.content = text_content
+        if reasoning_content:
+            delta.reasoning_content = reasoning_content
+        if tool_content:
+            # Parse tool content into a DeltaToolCall object
+            delta_tool_call = self._parse_delta_tool_call(parser_state, tool_content)
+            if delta_tool_call is not None:
+                delta.tool_calls = [delta_tool_call]
+
+        if delta.content or delta.reasoning_content or delta.tool_calls:
+            return delta
+        return None
+
+    def extract_tool_calls(
+        self,
+        model_output: str,
+        request: ChatCompletionRequest,
+    ) -> ExtractedToolCallInformation:
+        """Extract tool calls from complete model output.
+
+        This method processes the full model output to extract tool calls, reasoning content, and regular text content.
+        Unlike the streaming version, this processes the entire output at once.
+        """
+        text = model_output
+        reasoning_content = []
+
+        # Extract reasoning content (content inside <think> tags)
+        buf = []
+        scan_pos = 0
+        for match in self.think_pat.finditer(text):
+            buf.append(text[:match.start()])  # Add text before the <think> tag
+            scan_pos = match.end()
+            reasoning_content.append(match.group(1))  # Extract content inside <think> tags
+        if scan_pos < len(text):
+            buf.append(text[scan_pos:])  # Add remaining text
+        text = ''.join(buf)  # Reconstruct text without <think> tags
+
+        # Extract tool calls (content inside <tool_call> tags)
+        buf = []
+        scan_pos = 0
+        tool_calls = []
+        for match in self.tool_call_pat.finditer(text):
+            buf.append(text[:match.start()])  # Add text before the <tool_call> tag
+            scan_pos = match.end()
+            action = json.loads(match.group(1))  # Parse the tool call JSON
+            name, arguments = action['name'], json.dumps(action['arguments'], ensure_ascii=False)
+            tool_calls.append(ToolCall(function=FunctionCall(name=name, arguments=arguments)))
+        if scan_pos < len(text):
+            buf.append(text[scan_pos:])  # Add remaining text
+        text = ''.join(buf)  # Reconstruct text without <tool_call> tags
+
+        return ExtractedToolCallInformation(
+            content=text,
+            reasoning_content=''.join(reasoning_content),
+            tool_calls=tool_calls,
+            tools_called=bool(tool_calls),
+        )

--- a/tests/test_lmdeploy/test_qwen3_parser.py
+++ b/tests/test_lmdeploy/test_qwen3_parser.py
@@ -1,0 +1,221 @@
+import json
+from typing import List, Tuple
+
+import pytest
+
+from lmdeploy.serve.openai.protocol import ChatCompletionRequest, DeltaToolCall
+from lmdeploy.serve.openai.tool_parser.qwen3_parser import Qwen3ToolParser
+from lmdeploy.serve.openai.tool_parser.tool_parser import ToolParser
+
+
+class DummyTokenizer:
+
+    def decode(self, token_ids: List[int]) -> str:
+        return ' '.join(map(str, token_ids))
+
+    def encode(self, text: str) -> List[int]:
+        return [ord(c) for c in text]
+
+
+delta_text_sequence = [
+    '<think>',
+    '\n',
+    '好的',
+    '，',
+    '用户',
+    '问',
+    '的是',
+    '北京',
+    '的',
+    '天气',
+    '怎么样',
+    '。',
+    '我',
+    '需要',
+    '调',
+    '用',
+    'get',
+    '_weather',
+    '这个',
+    '工具',
+    '来',
+    '获取',
+    '信息',
+    '。',
+    '首先',
+    '，',
+    '确认',
+    '用户',
+    '提供的',
+    '地点',
+    '是',
+    '北京',
+    '，',
+    '参数',
+    '正确',
+    '。',
+    '然后',
+    '检查',
+    '工具',
+    '的',
+    '参数',
+    '要求',
+    '，',
+    '只需要',
+    'location',
+    '，',
+    '类型',
+    '是',
+    '字符串',
+    '。',
+    '于是',
+    '构造',
+    '参数',
+    '对象',
+    '，',
+    '调',
+    '用',
+    '函数',
+    '，',
+    '返回',
+    '结果',
+    '。',
+    '确保',
+    '没有',
+    '遗漏',
+    '必要',
+    '参数',
+    '，',
+    '比如',
+    'location',
+    '是',
+    '必须',
+    '的',
+    '，',
+    '这里',
+    '已经',
+    '提供',
+    '，',
+    '所以',
+    '没问题',
+    '。',
+    '最后',
+    '将',
+    '结果',
+    '以',
+    '自然',
+    '语言',
+    '回复',
+    '用户',
+    '。\n',
+    '</think>',
+    '\n\n',
+    '<tool_call>',
+    '\n',
+    '{"',
+    'name',
+    '":',
+    ' "',
+    'get',
+    '_weather',
+    '",',
+    ' "',
+    'arguments',
+    '":',
+    ' {"',
+    'location',
+    '":',
+    ' "',
+    '北京',
+    '"}}\n',
+    '</tool_call>',
+]
+
+EXPECTED_CONTENT = ''
+EXPECTED_REASONING_CONTENT = ''.join((
+    '好的，用户问的是北京的天气怎么样。我需要调用get_weather这个工具来获取信息。',
+    '首先，确认用户提供的地点是北京，参数正确。然后检查工具的参数要求，',
+    '只需要location，类型是字符串。于是构造参数对象，调用函数，返回结果。',
+    '确保没有遗漏必要参数，比如location是必须的，这里已经提供，所以没问题。',
+    '最后将结果以自然语言回复用户。',
+))
+
+
+@pytest.mark.parametrize(
+    "parser",
+    [
+        # Qwen2d5ToolParser(tokenizer=DummyTokenizer()), # not pass
+        Qwen3ToolParser(tokenizer=DummyTokenizer()),
+    ])
+def test_parser_stream(parser: ToolParser):
+    request = ChatCompletionRequest(model='qwen', messages=[])
+    content, reasoning_content, tool_calls = _stream_parse(parser, request)
+    assert len(tool_calls) == 1
+    assert tool_calls[0].function.name == 'get_weather'
+    args = json.loads(tool_calls[0].function.arguments)
+    assert args['location'] == '北京'
+    assert content.strip() == EXPECTED_CONTENT
+    assert reasoning_content.strip() == EXPECTED_REASONING_CONTENT
+
+
+def _stream_parse(parser: ToolParser, request: ChatCompletionRequest) -> Tuple[str, str, List[DeltaToolCall]]:
+    # Call parser.extract_tool_calls_streaming with delta_text specified in `delta_text_sequence`.
+    # `current_text` and `previous_text` init values and update logic
+    # can be found in lmdeploy/serve/openai/api_server.py:455-523.
+    content = ''
+    reasoning_content = ''
+    tool_calls = {}
+
+    previous_text = ''
+    current_text = ''
+    for delta_text in delta_text_sequence:
+        current_text += delta_text
+        tool_delta = parser.extract_tool_calls_streaming(previous_text=previous_text,
+                                                         current_text=current_text,
+                                                         delta_text=delta_text,
+                                                         previous_token_ids=[],
+                                                         current_token_ids=[],
+                                                         delta_token_ids=[],
+                                                         request=request)
+        previous_text = current_text
+        if not tool_delta:
+            continue
+        if tool_delta.content:
+            content += tool_delta.content
+        if tool_delta.reasoning_content:
+            reasoning_content += tool_delta.reasoning_content
+        if tool_delta.tool_calls:
+            for c in tool_delta.tool_calls:
+                existing_call = tool_calls.get(c.id, None)
+                if not existing_call:
+                    tool_calls[c.id] = c
+                    continue
+                # merge with existing
+                if c.function.name:
+                    existing_call.function.name = c.function.name
+                if c.function.arguments:
+                    existing_call.function.arguments = existing_call.function.arguments or ''
+                    existing_call.function.arguments += c.function.arguments
+    return content, reasoning_content, list(sorted(tool_calls.values(), key=lambda x: x.index))
+
+
+@pytest.mark.parametrize("parser", [
+    Qwen3ToolParser(tokenizer=DummyTokenizer()),
+])
+def test_parser_nonstream(parser: ToolParser):
+    request = ChatCompletionRequest(model='qwen', messages=[])
+    full_text = ''
+    for delta_text in delta_text_sequence:
+        full_text += delta_text
+
+    extracted_info = parser.extract_tool_calls(full_text, request)
+    content = extracted_info.content
+    reasoning_content = extracted_info.reasoning_content
+    tool_calls = extracted_info.tool_calls
+
+    assert len(tool_calls) == 1
+    assert tool_calls[0].function.name == 'get_weather'
+    args = json.loads(tool_calls[0].function.arguments)
+    assert args['location'] == '北京'
+    assert content.strip() == EXPECTED_CONTENT
+    assert reasoning_content.strip() == EXPECTED_REASONING_CONTENT


### PR DESCRIPTION
# Qwen3 Tool Parser Implementation

## Motivation

This PR adds support for the Qwen3 model's tool call format in LMDeploy. The Qwen3 model uses a specific XML-like format for both **tool calls** and **reasoning content**. By implementing a dedicated parser for Qwen3, we enable LMDeploy to correctly extract and process tool calls and think content from Qwen3 model outputs (stream & non-stream), enhancing compatibility and providing a better user experience when deploying Qwen3 models.

## Modification

- Implements `class Qwen3ToolParser` to handle format for tool calls (`<tool_call>...</tool_call>`) and reasoning content (`<think>...</think>`). Both stream and non-stream modes are supported.
    - modified `lmdeploy/serve/openai/tool_parser/__init__.py`
    - added `lmdeploy/serve/openai/tool_parser/qwen3_parser.py`
    - added `tests/test_lmdeploy/test_qwen3_parser.py`
- As tool parser and reasoning parser are mutually exclusive, allow the tool parser extract reasoning_content and pass to `delta_message`
    - modified `lmdeploy/serve/openai/api_server.py`
    - modified `lmdeploy/serve/openai/protocol.py`
- Fix log message typos (`lanuch` -> `launch`)
    - modified `lmdeploy/serve/openai/api_server.py`


## Checklist

1. Pre-commit and linting tools have been used to ensure code quality and consistency.
2. The implementation is covered by comprehensive unit tests in `test_qwen3_parser.py`.
3. The implementation has been tested with the Qwen3 model to ensure compatibility.
4. Documentation has been added with detailed docstrings explaining the purpose and functionality of the parser.
