### PR TITLE
check in lmdeploy-builder on cuda 12.4 platform

### DIFF
--- a/builder/manywheel/Dockerfile_2014
+++ b/builder/manywheel/Dockerfile_2014
@@ -25,7 +25,7 @@ RUN bash ./install_cuda.sh ${BASE_CUDA_VERSION} && rm install_cuda.sh
 FROM base as conda
 ADD manywheel/scripts/install_conda.sh install_conda.sh
 RUN bash ./install_conda.sh && rm install_conda.sh
-RUN
+
 RUN /opt/conda/bin/conda create -n py38 python=3.8 -yq && \
     /opt/conda/envs/py38/bin/pip install pybind11 && \
     /opt/conda/bin/conda create -n py39 python=3.9 -yq && \
@@ -37,15 +37,9 @@ RUN /opt/conda/bin/conda create -n py38 python=3.8 -yq && \
     /opt/conda/bin/conda create -n py312 python=3.12 -yq && \
     /opt/conda/envs/py312/bin/pip install pybind11
 
-FROM base as mpi
-ADD manywheel/scripts/install_openmpi.sh install_openmpi.sh
-RUN bash ./install_openmpi.sh && rm install_openmpi.sh
-
 FROM base as cuda_final
 COPY --from=cuda            /usr/local/cuda-${BASE_CUDA_VERSION}  /usr/local/cuda-${BASE_CUDA_VERSION}
 RUN ln -sf /usr/local/cuda-${BASE_CUDA_VERSION} /usr/local/cuda
 ENV PATH=/usr/local/cuda/bin:$PATH
 COPY --from=conda           /opt/conda                            /opt/conda
 RUN /opt/conda/bin/conda init bash
-COPY --from=mpi             /usr/local/mpi                        /usr/local/mpi
-ENV PATH=/usr/local/mpi/bin:$PATH

--- a/builder/manywheel/build_docker.sh
+++ b/builder/manywheel/build_docker.sh
@@ -8,8 +8,6 @@ WITH_PUSH=${WITH_PUSH:-}
 
 TARGET=cuda_final
 DOCKER_TAG=cuda${GPU_ARCH_VERSION}
-DOCKER_BUILD_ARG="--build-arg BASE_CUDA_VERSION=${GPU_ARCH_VERSION} --build-arg DEVTOOLSET_VERSION=9"
-DOCKER_TAG=cuda${GPU_ARCH_VERSION}
 
 DOCKER_IMAGE=openmmlab/lmdeploy-builder:${DOCKER_TAG}
 if [[ -n ${MANY_LINUX_VERSION} ]]; then
@@ -22,7 +20,10 @@ fi
     set -x
     DOCKER_BUILDKIT=1 docker build \
         -t "${DOCKER_IMAGE}" \
-        ${DOCKER_BUILD_ARG} \
+        --build-arg BASE_CUDA_VERSION=${GPU_ARCH_VERSION} \
+        --build-arg DEVTOOLSET_VERSION=9 \
+        --build-arg HTTPS_PROXY=${HTTPS_PROXY} \
+        --build-arg HTTP_PROXY=${HTTP_PROXY} \
         --target "${TARGET}" \
         -f "${TOPDIR}/manywheel/Dockerfile${DOCKERFILE_SUFFIX}" \
         "${TOPDIR}"

--- a/builder/manywheel/scripts/install_cuda.sh
+++ b/builder/manywheel/scripts/install_cuda.sh
@@ -64,6 +64,37 @@ function install_121 {
     ldconfig
 }
 
+function install_124 {
+    echo "Installing CUDA 12.4 and cuDNN 8.9 and NCCL 2.25.1"
+    rm -rf /usr/local/cuda-12.4 /usr/local/cuda
+    # install CUDA 12.1.0 in the same container
+    wget -q https://developer.download.nvidia.com/compute/cuda/12.4.1/local_installers/cuda_12.4.1_550.54.15_linux.run
+    chmod +x cuda_12.4.1_550.54.15_linux.run
+    ./cuda_12.4.1_550.54.15_linux.run --toolkit --silent
+    rm -f cuda_12.4.1_550.54.15_linux.run
+    rm -f /usr/local/cuda && ln -s /usr/local/cuda-12.4 /usr/local/cuda
+
+    # cuDNN license: https://developer.nvidia.com/cudnn/license_agreement
+    mkdir tmp_cudnn && cd tmp_cudnn
+    wget -q https://developer.download.nvidia.com/compute/cudnn/redist/cudnn/linux-x86_64/cudnn-linux-x86_64-8.9.2.26_cuda12-archive.tar.xz -O cudnn-linux-x86_64-8.9.2.26_cuda12-archive.tar.xz
+    tar xf cudnn-linux-x86_64-8.9.2.26_cuda12-archive.tar.xz
+    cp -a cudnn-linux-x86_64-8.9.2.26_cuda12-archive/include/* /usr/local/cuda/include/
+    cp -a cudnn-linux-x86_64-8.9.2.26_cuda12-archive/lib/* /usr/local/cuda/lib64/
+    cd ..
+    rm -rf tmp_cudnn
+    ldconfig
+
+    # NCCL license: https://docs.nvidia.com/deeplearning/nccl/#licenses
+    mkdir tmp_nccl && cd tmp_nccl
+    wget -q https://developer.download.nvidia.com/compute/redist/nccl/v2.25.1/nccl_2.25.1-1+cuda12.4_x86_64.txz
+    tar xf nccl_2.25.1-1+cuda12.4_x86_64.txz
+    cp -a nccl_2.25.1-1+cuda12.4_x86_64/include/* /usr/local/cuda/include/
+    cp -a nccl_2.25.1-1+cuda12.4_x86_64/lib/* /usr/local/cuda/lib64/
+    cd ..
+    rm -rf tmp_nccl
+    ldconfig
+}
+
 if test $# -eq 0
 then
     echo "doesn't provide cuda version"; exit 1;
@@ -76,6 +107,8 @@ do
     11.8) install_118
 	        ;;
     12.1) install_121
+            ;;
+    12.4) install_124
             ;;
 	*) echo "bad argument $1"; exit 1
 	   ;;

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -19,14 +19,6 @@ RUN apt-get update -y && apt-get install -y software-properties-common wget vim 
 
 ENV PATH=/opt/py3/bin:$PATH
 
-# install openmpi
-RUN wget https://download.open-mpi.org/release/open-mpi/v4.1/openmpi-4.1.5.tar.gz &&\
-    tar xf openmpi-4.1.5.tar.gz && cd openmpi-4.1.5 && ./configure --prefix=/usr/local/openmpi &&\
-    make -j$(nproc) && make install && cd .. && rm -rf openmpi-4.1.5*
-
-ENV PATH=$PATH:/usr/local/openmpi/bin
-ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/openmpi/lib
-
 # install nccl manually for cuda11.8
 RUN if [ "$CUDA_VERSION_SHORT" = "cu118" ]; then \
     git clone --depth=1 --branch v2.22.3-1 https://github.com/NVIDIA/nccl.git &&\

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -37,6 +37,9 @@ RUN if [ "$CUDA_VERSION_SHORT" = "cu118" ]; then \
     cd .. && rm -rf nccl ; \
     fi
 
+RUN if [ "$CUDA_VERSION_SHORT" = "cu121" ]; then \
+    pip install nvidia-nccl-cu12==2.25.1
+
 ENV LD_LIBRARY_PATH=/usr/local/nccl/lib:$LD_LIBRARY_PATH
 
 


### PR DESCRIPTION
- provide openmmlab/lmdeploy-builder:cuda12.4 image requested by #3601 
- Fix nvidia-nccl-cu12 to version 2.25.1. Pytorch 2.7 introduces nvidia-nccl-cu12 2.26.x, which degrades pytorch engine's performance.
