### PR TITLE
[ascend]import patch at initiazing time

### DIFF
--- a/lmdeploy/pytorch/backends/dlinfer/ascend/op_backend.py
+++ b/lmdeploy/pytorch/backends/dlinfer/ascend/op_backend.py
@@ -332,10 +332,6 @@ class AscendOpsBackend(DlinferOpsBackend):
         try:
             from torch_npu.contrib import transfer_to_npu  # noqa: F401
             if SocVersion.is_Ascend310P():
-                # Since we only need to convert weight for language parts,
-                # we need to import patch before building ModelAgent (loading weights).
-                import dlinfer.framework.lmdeploy_ext  # noqa: F401
-
                 # NOTE: Ascend310P has a bug with InternVL vision embedding using interpolate.
                 torch.npu.set_compile_mode(jit_compile=False)
         except ImportError:

--- a/lmdeploy/pytorch/backends/dlinfer/ascend/op_backend.py
+++ b/lmdeploy/pytorch/backends/dlinfer/ascend/op_backend.py
@@ -332,6 +332,10 @@ class AscendOpsBackend(DlinferOpsBackend):
         try:
             from torch_npu.contrib import transfer_to_npu  # noqa: F401
             if SocVersion.is_Ascend310P():
+                # Since we only need to convert weight for language parts,
+                # we need to import patch before building ModelAgent (loading weights).
+                import dlinfer.framework.lmdeploy_ext  # noqa: F401
+
                 # NOTE: Ascend310P has a bug with InternVL vision embedding using interpolate.
                 torch.npu.set_compile_mode(jit_compile=False)
         except ImportError:

--- a/lmdeploy/pytorch/engine/executor/ray_executor.py
+++ b/lmdeploy/pytorch/engine/executor/ray_executor.py
@@ -18,7 +18,7 @@ from lmdeploy.pytorch.config import BackendConfig, CacheConfig, DistConfig, Misc
 from lmdeploy.pytorch.devices import DeviceContext, get_device_manager
 from lmdeploy.pytorch.disagg.messages import MigrationExecutionBatch
 from lmdeploy.pytorch.disagg.request import DistServeConnectionRequest, DistServeInitRequest
-from lmdeploy.utils import get_logger
+from lmdeploy.utils import get_logger, try_import_deeplink
 
 from .base import ExecutorBase
 from .base_worker import WorkerWrapperBase
@@ -229,6 +229,7 @@ class RayWorkerWrapper(WorkerWrapperBase):
         log_level: int = 30,
     ):
         init_backend(device_type)
+        try_import_deeplink(device_type)
 
         from lmdeploy.tokenizer import Tokenizer
         tokenizer = Tokenizer(model_path).model.model


### PR DESCRIPTION
## Motivation

Since Ascend 310P device need to convert linear weight from ND to NZ in graph mode. However,  for VL model, we only compile language part in graph mode and leave vision part in eager mode. So we need skip converting weight in vision part, dlinfer.framework.lmdeploy_ext has a patch for the logic that skips vision part, we need to import it at initializing time to make Ray distributed backend for VL model properly.


