### PR TITLE
fix pt engine stop & cancel

### DIFF
--- a/lmdeploy/pytorch/engine/engine.py
+++ b/lmdeploy/pytorch/engine/engine.py
@@ -494,10 +494,10 @@ class Engine:
                 self.scheduler.stop_session(session_id)
                 session = self.scheduler.sessions[session_id]
                 for seq in session.sequences.values():
-                    resp: Response = getattr(seq, 'resp', None)
-                    if resp is not None:
-                        resp.type = ResponseType.FINISH
-                        self.req_manager.response(resp)
+                    _resp: Response = getattr(seq, 'resp', None)
+                    if _resp is not None:
+                        _resp.type = ResponseType.FINISH
+                        self.req_manager.response(_resp)
                 resp_type = ResponseType.SUCCESS
             if resp:
                 self._response(req.resp, resp_type)
@@ -509,9 +509,9 @@ class Engine:
             resp = req.data.get('response', True)
             resp_type = ResponseType.SESSION_NOT_EXIST
             if session_id in self.scheduler.sessions:
-                msg = list(self.scheduler.sessions[session_id].sequences.values())[0]
-                if msg.preserve_cache:
-                    self.scheduler._set_message_status(msg, MessageStatus.TO_BE_MIGRATED)
+                msgs = list(self.scheduler.sessions[session_id].sequences.values())
+                if len(msgs) > 0 and msgs[0].preserve_cache:
+                    self.scheduler._set_message_status(msgs[0], MessageStatus.TO_BE_MIGRATED)
                 else:
                     self.scheduler.end_session(session_id)
                 resp_type = ResponseType.SUCCESS
@@ -520,8 +520,14 @@ class Engine:
 
     def _on_add_message(self, reqs: List[Request], **kwargs):
         """On add message callback."""
+        valid_req = []
         for req in reqs:
             req_data = req.data
+            session_id = req_data['session_id']
+            if self.scheduler and session_id not in self.scheduler.sessions:
+                self._response(req.resp, ResponseType.SESSION_NOT_EXIST)
+                continue
+            valid_req.append(req)
             if req_data.get('input_multimodals', None) is None:
                 continue
             elif self.input_processor is None:
@@ -540,8 +546,8 @@ class Engine:
             req_data['token_ids'] = input_ids
             req_data['input_multimodals'] = input_multimodals
 
-        if len(reqs) > 0:
-            self._add_message(reqs)
+        if len(valid_req) > 0:
+            self._add_message(valid_req)
 
     def _add_message(self, reqs: List[Request]):
 
@@ -1126,7 +1132,7 @@ class Engine:
                                         has_runable_event=has_runable_event,
                                         inputs_maker=inputs_maker)
         except Exception as e:
-            logger.error(f'exception happened: {e}')
+            logger.error(f'exception happened: {type(e)} {e}')
         finally:
             self._loop_finally()
 

--- a/lmdeploy/pytorch/engine/engine.py
+++ b/lmdeploy/pytorch/engine/engine.py
@@ -520,14 +520,14 @@ class Engine:
 
     def _on_add_message(self, reqs: List[Request], **kwargs):
         """On add message callback."""
-        valid_req = []
+        valid_reqs = []
         for req in reqs:
             req_data = req.data
             session_id = req_data['session_id']
             if self.scheduler and session_id not in self.scheduler.sessions:
                 self._response(req.resp, ResponseType.SESSION_NOT_EXIST)
                 continue
-            valid_req.append(req)
+            valid_reqs.append(req)
             if req_data.get('input_multimodals', None) is None:
                 continue
             elif self.input_processor is None:
@@ -546,8 +546,8 @@ class Engine:
             req_data['token_ids'] = input_ids
             req_data['input_multimodals'] = input_multimodals
 
-        if len(valid_req) > 0:
-            self._add_message(valid_req)
+        if len(valid_reqs) > 0:
+            self._add_message(valid_reqs)
 
     def _add_message(self, reqs: List[Request]):
 

--- a/lmdeploy/pytorch/engine/request.py
+++ b/lmdeploy/pytorch/engine/request.py
@@ -164,7 +164,7 @@ class RequestManager:
         self.senders: Dict[int, RequestSender] = dict()
         self.callbacks: Dict[RequestType, Callable] = dict()
         self.request_priority: List[RequestType] = [
-            RequestType.STOP_ENGINE, RequestType.STOP_SESSION, RequestType.END_SESSION, RequestType.ADD_SESSION,
+            RequestType.STOP_ENGINE, RequestType.ADD_SESSION, RequestType.STOP_SESSION, RequestType.END_SESSION,
             RequestType.ADD_MESSAGE
         ]
         self.requests: asyncio.Queue = None

--- a/lmdeploy/pytorch/messages.py
+++ b/lmdeploy/pytorch/messages.py
@@ -207,8 +207,10 @@ class SequenceManager:
         seq_id = seq.seq_id
         old_status_map = self._status_seq_map[old_status]
         new_status_map = self._status_seq_map[new_status]
-        old_status_map.pop(seq_id)
-        new_status_map[seq_id] = seq
+        # may be remove by async_end
+        if seq_id in old_status_map:
+            old_status_map.pop(seq_id)
+            new_status_map[seq_id] = seq
 
 
 class SchedulerSession:

--- a/lmdeploy/serve/async_engine.py
+++ b/lmdeploy/serve/async_engine.py
@@ -586,6 +586,7 @@ class AsyncEngine(LogitsMixin):
         try:
             yield inst
         except (Exception, asyncio.CancelledError, GeneratorExit) as e:
+            logger.error(f'[model_inst] exception caught: {e}')
             if self.backend == 'pytorch':
                 # manually end pytorch session
                 await inst.async_end(session_id)


### PR DESCRIPTION
## Motivation

In dealing with high-frequency requests, there might be two types of errors encountered if the connection disconnected quickly

a) http request disconnected, but the engine is still process the request
b) the engine might crash (asyncio event loop closed)

test-script
```python
import time
import aiohttp
from openai import OpenAI
from threading import Thread
import asyncio

async def work():
  node_url = 'http://0.0.0.0:23333'
  endpoint = '/v1/completions'
  request = dict(model='Qwen/Qwen2.5-7B', prompt='tell me a joke ' * 50, max_tokens=12768, stream=True)
  try:
    async with aiohttp.ClientSession() as session:
      async with session.post(node_url + endpoint, json=request) as response:
        async for _ in response.content:
          pass
  except Exception as e:
    print(e)


async def main():
  loop = asyncio.get_running_loop()
  tasks = []
  for _ in range(1024):
    tasks.append(loop.create_task(work()))
  await asyncio.sleep(15)
  for t in tasks:
    t.cancel()


while True:
  asyncio.run(main())
```