### PR TITLE
[Fix]: Replace mutable default with default_factory for scheduler_stats

### DIFF
--- a/lmdeploy/metrics/metrics_processor.py
+++ b/lmdeploy/metrics/metrics_processor.py
@@ -1,7 +1,7 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import asyncio
 from contextlib import contextmanager
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 from lmdeploy.utils import get_logger
@@ -17,7 +17,7 @@ logger = get_logger('lmdeploy')
 @dataclass
 class MetricsContext:
     enable_metrics: bool = False
-    scheduler_stats: SchedulerStats = SchedulerStats()
+    scheduler_stats: SchedulerStats = field(default_factory=SchedulerStats)
 
 
 class MetricsManager:


### PR DESCRIPTION


Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily receiving feedbacks. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Use `field(default_factory=SchedulerStats)` to avoid ValueError (Python version==3.11) when using mutable default in dataclass.

## Modification

Replace
```py
@dataclass
class MetricsContext:
    enable_metrics: bool = False
    scheduler_stats: SchedulerStats = SchedulerStats()
```
to:
```py
@dataclass
class MetricsContext:
    enable_metrics: bool = False
    scheduler_stats: SchedulerStats = field(default_factory=SchedulerStats)
```

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
