### PR TITLE
[Fix]: Avoid quantize qk norm for qwen3 dense models

### DIFF
--- a/lmdeploy/pytorch/models/qwen3.py
+++ b/lmdeploy/pytorch/models/qwen3.py
@@ -63,16 +63,13 @@ class Qwen3Attention(nn.Module):
         # q, k norm
         self.q_norm = RMSNorm(head_dim,
                               config.rms_norm_eps,
-                              quant_config=quantization_config,
                               dtype=dtype,
-                              device=device,
-                              qk_norm=True,)
+                              device=device)
+        
         self.k_norm = RMSNorm(head_dim,
                               config.rms_norm_eps,
-                              quant_config=quantization_config,
                               dtype=dtype,
-                              device=device,
-                              qk_norm=True,)
+                              device=device)
 
     def forward(
         self,

--- a/lmdeploy/pytorch/models/qwen3.py
+++ b/lmdeploy/pytorch/models/qwen3.py
@@ -65,12 +65,14 @@ class Qwen3Attention(nn.Module):
                               config.rms_norm_eps,
                               quant_config=quantization_config,
                               dtype=dtype,
-                              device=device)
+                              device=device,
+                              qk_norm=True,)
         self.k_norm = RMSNorm(head_dim,
                               config.rms_norm_eps,
                               quant_config=quantization_config,
                               dtype=dtype,
-                              device=device)
+                              device=device,
+                              qk_norm=True,)
 
     def forward(
         self,

--- a/lmdeploy/pytorch/models/qwen3.py
+++ b/lmdeploy/pytorch/models/qwen3.py
@@ -61,15 +61,8 @@ class Qwen3Attention(nn.Module):
                                    is_tp=True)
 
         # q, k norm
-        self.q_norm = RMSNorm(head_dim,
-                              config.rms_norm_eps,
-                              dtype=dtype,
-                              device=device)
-        
-        self.k_norm = RMSNorm(head_dim,
-                              config.rms_norm_eps,
-                              dtype=dtype,
-                              device=device)
+        self.q_norm = RMSNorm(head_dim, config.rms_norm_eps, dtype=dtype, device=device)
+        self.k_norm = RMSNorm(head_dim, config.rms_norm_eps, dtype=dtype, device=device)
 
     def forward(
         self,

--- a/lmdeploy/pytorch/nn/norm.py
+++ b/lmdeploy/pytorch/nn/norm.py
@@ -33,11 +33,16 @@ class RMSNorm(nn.Module):
                  device: torch.device = None,
                  quant_config: Any = None,
                  tp: bool = False,
-                 align: int = 1):
+                 align: int = 1,
+                 qk_norm: bool = False,):
         super().__init__()
         backend = get_backend()
 
         w8a8_flag, quant_dtype = _is_w8a8(quant_config)
+
+        if qk_norm:
+            w8a8_flag = False
+
         if w8a8_flag:
             builder = backend.get_layer_impl_builder(OpType.RMSNormW8A8)
         else:

--- a/lmdeploy/pytorch/nn/norm.py
+++ b/lmdeploy/pytorch/nn/norm.py
@@ -33,15 +33,11 @@ class RMSNorm(nn.Module):
                  device: torch.device = None,
                  quant_config: Any = None,
                  tp: bool = False,
-                 align: int = 1,
-                 qk_norm: bool = False,):
+                 align: int = 1):
         super().__init__()
         backend = get_backend()
 
         w8a8_flag, quant_dtype = _is_w8a8(quant_config)
-
-        if qk_norm:
-            w8a8_flag = False
 
         if w8a8_flag:
             builder = backend.get_layer_impl_builder(OpType.RMSNormW8A8)


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily receiving feedbacks. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

解决qwen3_w8a8_int8模型推理报错的问题。

## Modification

当使用qwen3模型的w8a8推理时，需要避免对q_norm和k_norm进行量化。

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
