### PR TITLE
[Fix]: kernel meta retrieval for SM7X does not work

### DIFF
--- a/lmdeploy/pytorch/kernels/cuda/flashattention.py
+++ b/lmdeploy/pytorch/kernels/cuda/flashattention.py
@@ -459,7 +459,7 @@ def flash_attention_fwd(
     num_warps = 4
     if _nv_cap[0] < 8:
         BLOCK_M, BLOCK_N, num_warps, num_stages = _kernel_meta_sm7x(BLOCK_DK)
-    if _nv_cap[0] < 9:
+    elif _nv_cap[0] < 9:
         if _nv_cap[1] in [6, 9]:
             BLOCK_M, BLOCK_N, num_warps, num_stages = _kernel_meta_sm86(BLOCK_DK, shared_kv)
         else:


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily receiving feedbacks. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

kernel meta retrieval in attention module does not wrok on SM7X GPUs

## Modification

fix the bug

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
No

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
