### PR TITLE
fix(build): fix version parse regex to support post-release versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -138,6 +138,7 @@ if get_target_device() == 'cuda' and not os.getenv('DISABLE_TURBOMIND', '').lowe
                 '-DCALL_FROM_SETUP_PY:BOOL=ON',
                 '-DBUILD_SHARED_LIBS:BOOL=OFF',
                 # Select the bindings implementation
+                '-DCMAKE_BUILD_TYPE=' + os.getenv('CMAKE_BUILD_TYPE', 'RelWithDebInfo'),
                 '-DBUILD_PY_FFI=ON',
                 '-DBUILD_MULTI_GPU=' + ('OFF' if os.name == 'nt' else 'ON'),
                 '-DUSE_NVTX=' + ('OFF' if os.name == 'nt' else 'ON'),


### PR DESCRIPTION
## Motivation

Fix bug due to too strict version regex, to support more version scheme like post-release version.

## Checklist

- [x]  Pre-commit or other linting tools are used to fix the potential lint issues.
- [ ]  The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
- [x]  If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
- [x]  The documentation has been modified accordingly, like docstring or example tutorials.
