### PR TITLE
fix: turbomind backend config in cli serve

### DIFF
--- a/lmdeploy/cli/serve.py
+++ b/lmdeploy/cli/serve.py
@@ -359,6 +359,8 @@ class SubCliServe:
                                                    cache_block_seq_len=args.cache_block_seq_len,
                                                    enable_prefix_caching=args.enable_prefix_caching,
                                                    max_prefill_token_num=args.max_prefill_token_num,
+                                                   num_tokens_per_iter=args.num_tokens_per_iter,
+                                                   max_prefill_iters=args.max_prefill_iters,
                                                    communicator=args.communicator,
                                                    hf_overrides=args.hf_overrides)
         chat_template_config = get_chat_template(args.chat_template)


### PR DESCRIPTION
## Motivation

When serving with CLI, arguments: max_prefill_token_num and num_tokens_per_iter weren't being set.

## Modification

Added max_prefill_token_num and num_tokens_per_iter as arguments for TurbomindEngineConfig in cli api_serve after being parsed.

## Use cases 

Taking advantage of "Dynamic SplitFuse"-like behavior using CLI. 

## Checklist

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [x] The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
- [x] If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
- [x] The documentation has been modified accordingly, like docstring or example tutorials.
