### PR TITLE
fix: add dummy_prefill guard for PD connection operations

### DIFF
--- a/lmdeploy/serve/proxy/proxy.py
+++ b/lmdeploy/serve/proxy/proxy.py
@@ -640,7 +640,8 @@ async def chat_completions_v1(request: ChatCompletionRequest, raw_request: Reque
             is_dummy_prefill=node_manager.dummy_prefill).model_dump(mode='json')
 
         start = node_manager.pre_call(d_url)
-        node_manager.pd_connection_pool.shelf_prefill_session((p_url, d_url), prefill_info['id'])
+        if not node_manager.dummy_prefill:
+            node_manager.pd_connection_pool.shelf_prefill_session((p_url, d_url), prefill_info['id'])
         if request.stream is True:
             response = node_manager.stream_generate(request_dict, d_url, '/v1/chat/completions')
             background_task = node_manager.create_background_tasks(d_url, start)
@@ -781,6 +782,8 @@ async def completions_v1(request: CompletionRequest, raw_request: Request = None
             is_dummy_prefill=node_manager.dummy_prefill).model_dump(mode='json')
 
         start = node_manager.pre_call(d_url)
+        if not node_manager.dummy_prefill:
+            node_manager.pd_connection_pool.shelf_prefill_session((p_url, d_url), prefill_info['id'])
         if request.stream is True:
             response = node_manager.stream_generate(request_dict, d_url, '/v1/completions')
             background_task = node_manager.create_background_tasks(d_url, start)


### PR DESCRIPTION
## Motivation

The current implementation attempts to call `shelf_prefill_session` on the PD (Prefill-Decode) connection pool regardless of whether dummy prefill mode is enabled. However, when `dummy_prefill` is set to True, there is no actual prefill session migration happening, and attempting to shelf a non-existent prefill session can lead to unnecessary operations or potential errors.

```
File "/nvme2/share/root/src/LMDeploy/lmdeploy/serve/proxy/proxy.py", line 643, in chat_completions_v1
    node_manager.pd_connection_pool.shelf_prefill_session((p_url, d_url), prefill_info['id'])
KeyError: 'id'
```

## Modification

Added conditional guards around `node_manager.pd_connection_pool.shelf_prefill_session()` calls in two API endpoints:

- `/v1/chat/completions endpoint` [chat_completions_v1]:
 Added `if not node_manager.dummy_prefill:` guard before calling `shelf_prefill_session`

- `/v1/completions endpoint` [completions_v1]: Added `if not node_manager.dummy_prefill:` guard before calling `shelf_prefill_session`

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
