### PR TITLE
remove 'lmdeploy convert' from CLI

### DIFF
--- a/docs/en/inference/load_hf.md
+++ b/docs/en/inference/load_hf.md
@@ -8,7 +8,7 @@ Currently, Turbomind support loading three types of model:
 
 1. A lmdeploy-quantized model hosted on huggingface.co, such as [llama2-70b-4bit](https://huggingface.co/lmdeploy/llama2-chat-70b-4bit), [internlm-chat-20b-4bit](https://huggingface.co/internlm/internlm-chat-20b-4bit), etc.
 2. Other LM models on huggingface.co like Qwen/Qwen-7B-Chat
-3. A model converted by `lmdeploy convert`, legacy format
+
 
 ## Usage
 
@@ -50,22 +50,4 @@ lmdeploy serve gradio $repo_id --model-name $model_name
 
 # Serving with Restful API
 lmdeploy serve api_server $repo_id --model-name $model_name --tp 1
-```
-
-### 3) A model converted by `lmdeploy convert`
-
-The usage is like previous
-
-```
-# Convert a model
-lmdeploy convert $MODEL_NAME /path/to/model --dst-path ./workspace
-
-# Inference by TurboMind
-lmdeploy chat ./workspace --model-name $model_name
-
-# Serving with gradio
-lmdeploy serve gradio ./workspace
-
-# Serving with Restful API
-lmdeploy serve api_server ./workspace --tp 1
 ```

--- a/docs/en/inference/load_hf.md
+++ b/docs/en/inference/load_hf.md
@@ -9,7 +9,6 @@ Currently, Turbomind support loading three types of model:
 1. A lmdeploy-quantized model hosted on huggingface.co, such as [llama2-70b-4bit](https://huggingface.co/lmdeploy/llama2-chat-70b-4bit), [internlm-chat-20b-4bit](https://huggingface.co/internlm/internlm-chat-20b-4bit), etc.
 2. Other LM models on huggingface.co like Qwen/Qwen-7B-Chat
 
-
 ## Usage
 
 ### 1) A lmdeploy-quantized model

--- a/docs/zh_cn/inference/load_hf.md
+++ b/docs/zh_cn/inference/load_hf.md
@@ -8,7 +8,6 @@
 
 1. 在 huggingface.co 上面通过 lmdeploy 量化的模型，如 [llama2-70b-4bit](https://huggingface.co/lmdeploy/llama2-chat-70b-4bit), [internlm-chat-20b-4bit](https://huggingface.co/internlm/internlm-chat-20b-4bit)
 2. huggingface.co 上面其他 LM 模型，如Qwen/Qwen-7B-Chat
-3. 通过 `lmdeploy convert` 命令转换好的模型，兼容旧格式
 
 ## 使用方式
 
@@ -51,22 +50,4 @@ lmdeploy serve gradio $repo_id --model-name $model_name
 
 # Serving with Restful API
 lmdeploy serve api_server $repo_id --model-name $model_name --tp 1
-```
-
-### 3) 通过 `lmdeploy convert` 命令转换好的模型
-
-使用方式与之前相同
-
-```
-# Convert a model
-lmdeploy convert $MODEL_NAME /path/to/model --dst-path ./workspace
-
-# Inference by TurboMind
-lmdeploy chat ./workspace
-
-# Serving with gradio
-lmdeploy serve gradio ./workspace
-
-# Serving with Restful API
-lmdeploy serve api_server ./workspace --tp 1
 ```

--- a/lmdeploy/cli/cli.py
+++ b/lmdeploy/cli/cli.py
@@ -15,49 +15,6 @@ class CLI(object):
     subparsers = parser.add_subparsers(title='Commands', description='lmdeploy has following commands:', dest='command')
 
     @staticmethod
-    def add_parser_convert():
-        """Add parser for convert command."""
-        parser = CLI.subparsers.add_parser('convert',
-                                           formatter_class=DefaultsAndTypesHelpFormatter,
-                                           description=CLI.convert.__doc__,
-                                           help=CLI.convert.__doc__)
-        # define arguments
-        parser.add_argument('model_name',
-                            type=str,
-                            help='deprecated and unused, '
-                            'it will be removed on 2024.12.31. It was originally used to '
-                            'specify the name of the built-in chat template, but now it '
-                            'is substituted with a clearer parameter `--chat-template`')
-        parser.add_argument('model_path', type=str, help='The directory path of the model')
-        ArgumentHelper.model_format(parser)
-        ArgumentHelper.tp(parser)
-        # other args
-        ArgumentHelper.revision(parser)
-        ArgumentHelper.download_dir(parser)
-        parser.add_argument('--tokenizer-path', type=str, default=None, help='The path of tokenizer model')
-        parser.add_argument('--dst-path', type=str, default='workspace', help='The destination path that saves outputs')
-        parser.add_argument('--group-size',
-                            type=int,
-                            default=0,
-                            help='A parameter used in awq to quantize fp16 weights '
-                            'to 4 bits')
-        parser.add_argument('--chat-template',
-                            type=str,
-                            default=None,
-                            help='the name of the built-in chat template, which can be '
-                            'overviewed by `lmdeploy list`')
-        parser.add_argument('--dtype',
-                            type=str,
-                            default='auto',
-                            choices=['auto', 'float16', 'bfloat16'],
-                            help='data type for model weights and activations. '
-                            'The "auto" option will use FP16 precision '
-                            'for FP32 and FP16 models, and BF16 precision '
-                            'for BF16 models. This option will be ignored if '
-                            'the model is a quantized model')
-        parser.set_defaults(run=CLI.convert)
-
-    @staticmethod
     def add_parser_list():
         """Add parser for list command."""
         parser = CLI.subparsers.add_parser('list',
@@ -134,13 +91,6 @@ class CLI(object):
                             help='The file path to save env info. Only '
                             'support file format in `json`, `yml`,'
                             ' `pkl`')
-
-    @staticmethod
-    def convert(args):
-        """Convert LLMs to turbomind format."""
-        from lmdeploy.turbomind.deploy.converter import main
-        kwargs = convert_args(args)
-        main(**kwargs)
 
     @staticmethod
     def list(args):
@@ -255,7 +205,6 @@ class CLI(object):
     @staticmethod
     def add_parsers():
         """Add all parsers."""
-        CLI.add_parser_convert()
         CLI.add_parser_list()
         CLI.add_parser_checkenv()
         CLI.add_parser_chat()

--- a/lmdeploy/serve/turbomind/__init__.py
+++ b/lmdeploy/serve/turbomind/__init__.py
@@ -1,1 +1,0 @@
-# Copyright (c) OpenMMLab. All rights reserved.


### PR DESCRIPTION
Removing the converter and Triton Server Python backend (#3462) left behind some remaining files and code blocks