### PR TITLE
assert PytorchEngineConfig block size

### DIFF
--- a/lmdeploy/messages.py
+++ b/lmdeploy/messages.py
@@ -379,6 +379,8 @@ class PytorchEngineConfig:
         assert self.num_gpu_blocks >= 0, 'invalid num_gpu_blocks'
         assert self.quant_policy in (0, 4, 8), 'invalid quant_policy'
         assert self.device_type in ['cuda', 'ascend', 'maca', 'camb'], (f'invalid device_type: {self.device_type}')
+        assert self.block_size >= 16 and (self.block_size & (self.block_size - 1)) == 0, \
+            f'block_size must be >= 16 and a power of 2, but got {self.block_size}'
         if self.quant_policy > 0 and self.device_type not in ['cuda', 'ascend']:
             assert False, \
                    'kv cache quantization only works for CUDA and ASCEND.'


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily receiving feedbacks. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation
If block_size=8:
<img width="836" height="306" alt="image" src="https://github.com/user-attachments/assets/1f23ac8a-f758-443e-8c85-7ce5fc9c42ab" />
if block_size is not power of 2
<img width="745" height="158" alt="image" src="https://github.com/user-attachments/assets/e57e572e-31dc-4be4-b314-178ce20c6b43" />


## Modification

Assert Block size in lmdeploy/messages.py.
