### PR TITLE
support deepgemm new api

### DIFF
--- a/lmdeploy/pytorch/backends/cuda/blockedf8_modules.py
+++ b/lmdeploy/pytorch/backends/cuda/blockedf8_modules.py
@@ -92,7 +92,7 @@ class DeepGemmLinearBlockedF8Impl(LinearBlockedF8Impl):
         """warmup."""
         import random
 
-        from deep_gemm.jit_kernels.utils import get_m_alignment_for_contiguous_layout
+        from lmdeploy.pytorch.third_party.deep_gemm import get_m_alignment_for_contiguous_layout
         device = 'cuda'
         max_num_tokens = warmup_meta.max_num_tokens
         alignment = get_m_alignment_for_contiguous_layout()

--- a/lmdeploy/pytorch/envs.py
+++ b/lmdeploy/pytorch/envs.py
@@ -103,6 +103,10 @@ with set_envs():
     # If Ray is launched from outside, it may fail to access the environment variables.
     os.getenv('DEEPEP_MAX_BATCH_SIZE', None)
 
+    # deepgemm
+    os.getenv('DG_JIT_DEBUG', '0')
+    os.getenv('DG_JIT_PRINT_COMPILER_COMMAND', '0')
+
 
 def get_all_envs():
     """Get all environment variables."""

--- a/lmdeploy/pytorch/third_party/__init__.py
+++ b/lmdeploy/pytorch/third_party/__init__.py
@@ -1,0 +1,1 @@
+# Copyright (c) OpenMMLab. All rights reserved.

--- a/lmdeploy/pytorch/third_party/deep_gemm/__init__.py
+++ b/lmdeploy/pytorch/third_party/deep_gemm/__init__.py
@@ -1,0 +1,44 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+from contextlib import contextmanager
+
+from lmdeploy.utils import get_logger
+
+logger = get_logger('lmdeploy')
+
+try:
+    import deep_gemm  # noqa: F401
+except ImportError:
+    logger.exception('DeepGemm is not installed. Please install https://github.com/deepseek-ai/DeepGEMM.')
+
+from deep_gemm import ceil_div, get_m_alignment_for_contiguous_layout  # noqa: F401, E402
+
+try:
+    from deep_gemm import fp8_gemm_nt
+except Exception:
+    from deep_gemm.jit_kernels.gemm import gemm_fp8_fp8_bf16_nt
+
+    @contextmanager
+    def _log_jit_build(M: int, N: int, K: int):
+        from deep_gemm.jit.runtime import RuntimeCache
+
+        if hasattr(RuntimeCache, 'get'):
+            func_name = 'get'
+        else:
+            func_name = '__getitem__'
+        origin_func = getattr(RuntimeCache, func_name)
+
+        def __patched_func(self, *args, **kwargs):
+            ret = origin_func(self, *args, **kwargs)
+            if ret is None:
+                logger.warning(f'DeepGemm build <gemm_fp8_fp8_bf16_nt>: M={M}, N={N}, K={K}. Please waiting.')
+            return ret
+
+        setattr(RuntimeCache, func_name, __patched_func)
+        yield
+        setattr(RuntimeCache, func_name, origin_func)
+
+    def fp8_gemm_nt(a, b, d, c, recipe=None, compiled_dim='nk', disable_ue8m0_cast=False):
+        M, K = a[0].shape
+        N, _ = b[0].shape
+        with _log_jit_build(M, N, K):
+            gemm_fp8_fp8_bf16_nt(a, b, d)


### PR DESCRIPTION
DeepGemm update it's python api since PR112

This PR add third-party wrap of deep-gemm. Support both 1.0 and 2.0.

Since deepgemm2.0 used cpp wrapped compile tools, logger can not be patched in it. If compile log is required, `DG_JIT_PRINT_COMPILER_COMMAND=1` or `DG_JIT_DEBUG=1` can be used.