### PR TITLE
Update internvl.py to fix InternLM/lmdeploy#3528

### DIFF
--- a/lmdeploy/vl/model/internvl.py
+++ b/lmdeploy/vl/model/internvl.py
@@ -240,6 +240,8 @@ class InternVLVisionModel(VisonModel):
                 continue
             n_images = len([1 for x in message['content'] if x['type'] == 'image'])
             content = [x.get('text', '') for x in message['content'] if x['type'] == 'text']
+            if len(content) == 0:
+                content.append('')
             prompt = content[0]
             if IMAGE_TOKEN in prompt and f'<img>{IMAGE_TOKEN}' not in prompt:
                 prompt = prompt.replace(f'{IMAGE_TOKEN}', f'<img>{IMAGE_TOKEN}</img>')


### PR DESCRIPTION
## Motivation

To fix InternLM/lmdeploy#3528. Similar fixes should probably be introduced to other VLMs.

## Modification

Add a simple check before `prompt = content[0]` to avoid `IndexError` caused by only providing images in user role content.

## BC-breaking (Optional)

N/A

## Use cases (Optional)

N/A. It fixes compatibility with downstream applications like Dify. The fix should be done in lmdeploy since OpenAI API allows use cases like this.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
