### PR TITLE
fix partial rotary factor

### DIFF
--- a/lmdeploy/pytorch/nn/rotary_embedding.py
+++ b/lmdeploy/pytorch/nn/rotary_embedding.py
@@ -107,10 +107,10 @@ def build_rotary_params(config: PretrainedConfig):
                            llama3=_get_llama3_parameters)
         params.update(build_funcs[rope_type_str](config))
 
-        # update partial_rotary_factor
-        partial_rotary_factor = config.partial_rotary_factor if hasattr(config, 'partial_rotary_factor') else None
-        if partial_rotary_factor is not None:
-            params['partial_rotary_factor'] = partial_rotary_factor
+    # update partial_rotary_factor
+    partial_rotary_factor = config.partial_rotary_factor if hasattr(config, 'partial_rotary_factor') else None
+    if partial_rotary_factor is not None:
+        params['partial_rotary_factor'] = partial_rotary_factor
 
     return params
 


### PR DESCRIPTION
Config may have `partial_rotary_factor` attribute without `rope_scaling` attributes.

e.g.

https://huggingface.co/zai-org/GLM-4-9B-0414/blob/main/config.json

https://huggingface.co/zai-org/GLM-4.5-Air/blob/main/config.json

Previous condition checks will miss `partial_rotary_factor` in this case, which leads to incorrect rope calculations.



## Related
This PR is the pre-requisite of GLM4-0414, GLM-4.1V, GLM-4.5 (Air), etc

- https://github.com/InternLM/lmdeploy/pull/3846