### PR TITLE
fix chatting with VLM model via CLI

### DIFF
--- a/lmdeploy/serve/async_engine.py
+++ b/lmdeploy/serve/async_engine.py
@@ -141,7 +141,7 @@ class Session:
                  gen_config: Optional[GenerationConfig] = None,
                  stream_response: bool = True,
                  do_preprocess: bool = True) -> Union[Response, Iterator[Response]]:
-        self._engine.chat(prompt=prompt,
+        self._engine.chat(prompt,
                           gen_config=gen_config or self._gen_config,
                           stream_response=stream_response,
                           do_preprocess=do_preprocess,

--- a/lmdeploy/serve/vl_async_engine.py
+++ b/lmdeploy/serve/vl_async_engine.py
@@ -233,8 +233,9 @@ class VLAsyncEngine(AsyncEngine):
 
         # recover prompts & history
         sess._prompt = prompts
-        last_round = sess.history[-1]
-        sess.history[-1] = (prompts, last_round[-1])
+        if sess.history:
+            last_round = sess.history[-1]
+            sess.history[-1] = (prompts, last_round[-1])
         return sess
 
     @classmethod


### PR DESCRIPTION
## Modification

Use positional args instead of kwargs to resolve the TypeError issue:
```
TypeError: VLAsyncEngine.chat() missing 1 required positional argument: 'prompts'
```

Check `sess.history` before accessing it.

