### PR TITLE
fix bug: leaves empty

### DIFF
--- a/lmdeploy/pytorch/paging/block_trie.py
+++ b/lmdeploy/pytorch/paging/block_trie.py
@@ -176,6 +176,9 @@ class BlockTrie:
                 access_time = self.allocator.get_access_time(parent.block)
                 heapq.heappush(leaves, (access_time, parent))
 
+        if len(self.leaves) == 0:
+            return 0
+
         evicted_blocks = []
         leaves = list(self.leaves)
 


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily receiving feedbacks. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation
In scenarios with extreme memory pressure where all leaf nodes are evicted, leave_blocks becomes an empty array. This causes self.allocator.get_ref_count(leave_blocks)to throw an unhandled exception when processing eviction candidates. I think this is a corner case caused by GPU memory exhaustion.

### Reproduction:
GPU: H20

Command:
Simulate the situation of gpu  memory limitation
```
lmdeploy serve api_server ../qwen_06B --backend pytorch --max-batch-size 256 --enable-prefix-caching --cache-max-entry-count 0.005  
```
```
python /opt/maoruihan/lmdeploy/benchmark/profile_restful_api.py --backend lmdeploy  --dataset-path ./ShareGPT_V3_unfiltered_cleaned_split.json
```

Traceback:
<img width="1278" height="416" alt="image" src="https://github.com/user-attachments/assets/0774a74e-2230-40e0-8621-f6a1b4272b7c" />




## Modification
Check whether self.leaves is empty before calling self.allocator.get_ref_count
@grimoire 


## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
