### PR TITLE
fix flashmla build for cuda12.4

### DIFF
--- a/docker/prepare_wheel.sh
+++ b/docker/prepare_wheel.sh
@@ -21,12 +21,13 @@ if [[ ${PYTHON_VERSION} = "3.13" ]]; then
 fi
 
 if [[ "${CUDA_VERSION_SHORT}" != "cu118" ]]; then
-    FLASH_MLA_VERSION=9edee0c
 
     if [[ "${CUDA_VERSION_SHORT}" = "cu124" ]]; then
         DEEP_GEMM_VERSION=03d0be3
+        FLASH_MLA_VERSION=9edee0c
     else
         DEEP_GEMM_VERSION=1876566
+        FLASH_MLA_VERSION=c759027
     fi
 
     DEEP_EP_VERSION=26cf250


### PR DESCRIPTION
## Fix

Error in https://github.com/InternLM/lmdeploy/actions/runs/17065840339/job/48556288085

FlashMLA has a large refactor after

- https://github.com/deepseek-ai/FlashMLA/pull/76

CUDA12.4 build does not support 100a, therefore we switch to an older version before the above commit.

## Related

- https://github.com/deepseek-ai/FlashMLA/issues/79