### PR TITLE
Support OpenAI compatible parameter max_completion_tokens

### DIFF
--- a/lmdeploy/serve/openai/api_client.py
+++ b/lmdeploy/serve/openai/api_client.py
@@ -87,30 +87,33 @@ class APIClient:
             return output['input_ids'], output['length']
         return None, None
 
-    def chat_completions_v1(self,
-                            model: str,
-                            messages: Union[str, List[Dict[str, str]]],
-                            temperature: Optional[float] = 0.7,
-                            top_p: Optional[float] = 1.0,
-                            logprobs: Optional[bool] = False,
-                            top_logprobs: Optional[int] = 0,
-                            n: Optional[int] = 1,
-                            max_tokens: Optional[int] = None,
-                            stop: Optional[Union[str, List[str]]] = None,
-                            stream: Optional[bool] = False,
-                            presence_penalty: Optional[float] = 0.0,
-                            frequency_penalty: Optional[float] = 0.0,
-                            user: Optional[str] = None,
-                            repetition_penalty: Optional[float] = 1.0,
-                            ignore_eos: Optional[bool] = False,
-                            skip_special_tokens: Optional[bool] = True,
-                            spaces_between_special_tokens: Optional[bool] = True,
-                            top_k: int = 40,
-                            min_new_tokens: Optional[int] = None,
-                            min_p: float = 0.0,
-                            logit_bias: Optional[Dict[str, float]] = None,
-                            stream_options: Optional[Dict] = None,
-                            **kwargs):
+    def chat_completions_v1(
+        self,
+        model: str,
+        messages: Union[str, List[Dict[str, str]]],
+        temperature: Optional[float] = 0.7,
+        top_p: Optional[float] = 1.0,
+        logprobs: Optional[bool] = False,
+        top_logprobs: Optional[int] = 0,
+        n: Optional[int] = 1,
+        max_completion_tokens: Optional[int] = None,
+        max_tokens: Optional[int] = None,
+        stop: Optional[Union[str, List[str]]] = None,
+        stream: Optional[bool] = False,
+        presence_penalty: Optional[float] = 0.0,
+        frequency_penalty: Optional[float] = 0.0,
+        user: Optional[str] = None,
+        repetition_penalty: Optional[float] = 1.0,
+        ignore_eos: Optional[bool] = False,
+        skip_special_tokens: Optional[bool] = True,
+        spaces_between_special_tokens: Optional[bool] = True,
+        top_k: int = 40,
+        min_new_tokens: Optional[int] = None,
+        min_p: float = 0.0,
+        logit_bias: Optional[Dict[str, float]] = None,
+        stream_options: Optional[Dict] = None,
+        **kwargs,
+    ):
         """Chat completion v1.
 
         Args:
@@ -124,7 +127,9 @@ class APIClient:
             n (int): How many chat completion choices to generate for each
                 input message. Only support one here.
             stream: whether to stream the results or not. Default to false.
+            max_completion_tokens (int | None): output token nums. Default to None.
             max_tokens (int | None): output token nums. Default to None.
+                Deprecated: Use max_completion_tokens instead.
             stop (str | List[str] | None): To stop generating further
               tokens. Only accept stop words that's encoded to one token idex.
             repetition_penalty (float): The parameter for repetition penalty.
@@ -168,25 +173,27 @@ class APIClient:
                     yield output
 
     def completions_v1(
-            self,
-            model: str,
-            prompt: Union[str, List[Any]],
-            suffix: Optional[str] = None,
-            temperature: Optional[float] = 0.7,
-            n: Optional[int] = 1,
-            max_tokens: Optional[int] = 16,
-            stream: Optional[bool] = False,
-            stop: Optional[Union[str, List[str]]] = None,
-            top_p: Optional[float] = 1.0,
-            top_k: Optional[int] = 40,
-            user: Optional[str] = None,
-            # additional argument of lmdeploy
-            repetition_penalty: Optional[float] = 1.0,
-            ignore_eos: Optional[bool] = False,
-            skip_special_tokens: Optional[bool] = True,
-            spaces_between_special_tokens: Optional[bool] = True,
-            stream_options: Optional[Dict] = None,
-            **kwargs):
+        self,
+        model: str,
+        prompt: Union[str, List[Any]],
+        suffix: Optional[str] = None,
+        temperature: Optional[float] = 0.7,
+        n: Optional[int] = 1,
+        max_completion_tokens: Optional[int] = 16,
+        max_tokens: Optional[int] = 16,
+        stream: Optional[bool] = False,
+        stop: Optional[Union[str, List[str]]] = None,
+        top_p: Optional[float] = 1.0,
+        top_k: Optional[int] = 40,
+        user: Optional[str] = None,
+        # additional argument of lmdeploy
+        repetition_penalty: Optional[float] = 1.0,
+        ignore_eos: Optional[bool] = False,
+        skip_special_tokens: Optional[bool] = True,
+        spaces_between_special_tokens: Optional[bool] = True,
+        stream_options: Optional[Dict] = None,
+        **kwargs,
+    ):
         """Chat completion v1.
 
         Args:
@@ -194,7 +201,9 @@ class APIClient:
             prompt (str): the input prompt.
             suffix (str): The suffix that comes after a completion of inserted
                 text.
+            max_completion_tokens (int | None): output token nums. Default to 16.
             max_tokens (int): output token nums
+                Deprecated: Use max_completion_tokens instead.
             temperature (float): to modulate the next token probability
             top_p (float): If set to float < 1, only the smallest set of most
                 probable tokens with probabilities that add up to top_p or

--- a/lmdeploy/serve/openai/api_server.py
+++ b/lmdeploy/serve/openai/api_server.py
@@ -307,7 +307,9 @@ async def chat_completions_v1(request: ChatCompletionRequest, raw_request: Reque
     - stream: whether to stream the results or not. Default to false.
     - stream_options: Options for streaming response. Only set this when you
         set stream: true.
+    - max_completion_tokens (int | None): output token nums. Default to None.
     - max_tokens (int | None): output token nums. Default to None.
+        Deprecated: Use max_completion_tokens instead.
     - repetition_penalty (float): The parameter for repetition penalty.
         1.0 means no penalty
     - stop (str | List[str] | None): To stop generating further
@@ -392,26 +394,29 @@ async def chat_completions_v1(request: ChatCompletionRequest, raw_request: Reque
             return create_error_response(HTTPStatus.BAD_REQUEST, str(e))
 
     random_seed = request.seed if request.seed else None
+    max_new_tokens = (request.max_completion_tokens if request.max_completion_tokens else request.max_tokens)
 
-    gen_config = GenerationConfig(max_new_tokens=request.max_tokens,
-                                  do_sample=True,
-                                  logprobs=gen_logprobs,
-                                  top_k=request.top_k,
-                                  top_p=request.top_p,
-                                  temperature=request.temperature,
-                                  repetition_penalty=request.repetition_penalty,
-                                  ignore_eos=request.ignore_eos,
-                                  stop_words=request.stop,
-                                  skip_special_tokens=request.skip_special_tokens,
-                                  response_format=response_format,
-                                  logits_processors=logits_processors,
-                                  min_new_tokens=request.min_new_tokens,
-                                  min_p=request.min_p,
-                                  random_seed=random_seed,
-                                  spaces_between_special_tokens=request.spaces_between_special_tokens,
-                                  migration_request=migration_request,
-                                  with_cache=with_cache,
-                                  preserve_cache=preserve_cache)
+    gen_config = GenerationConfig(
+        max_new_tokens=max_new_tokens,
+        do_sample=True,
+        logprobs=gen_logprobs,
+        top_k=request.top_k,
+        top_p=request.top_p,
+        temperature=request.temperature,
+        repetition_penalty=request.repetition_penalty,
+        ignore_eos=request.ignore_eos,
+        stop_words=request.stop,
+        skip_special_tokens=request.skip_special_tokens,
+        response_format=response_format,
+        logits_processors=logits_processors,
+        min_new_tokens=request.min_new_tokens,
+        min_p=request.min_p,
+        random_seed=random_seed,
+        spaces_between_special_tokens=request.spaces_between_special_tokens,
+        migration_request=migration_request,
+        with_cache=with_cache,
+        preserve_cache=preserve_cache,
+    )
 
     tools = None
     if request.tools and request.tool_choice != 'none':
@@ -624,7 +629,9 @@ async def completions_v1(request: CompletionRequest, raw_request: Request = None
     - model (str): model name. Available from /v1/models.
     - prompt (str): the input prompt.
     - suffix (str): The suffix that comes after a completion of inserted text.
+    - max_completion_tokens (int): output token nums. Default to None.
     - max_tokens (int): output token nums. Default to 16.
+        Deprecated: Use max_completion_tokens instead.
     - temperature (float): to modulate the next token probability
     - top_p (float): If set to float < 1, only the smallest set of most
         probable tokens with probabilities that add up to top_p or higher
@@ -687,23 +694,31 @@ async def completions_v1(request: CompletionRequest, raw_request: Request = None
     if isinstance(request.stop, str):
         request.stop = [request.stop]
     random_seed = request.seed if request.seed else None
+    if request.max_completion_tokens:
+        max_new_tokens = request.max_completion_tokens
+    elif request.max_tokens:
+        max_new_tokens = request.max_tokens
+    else:
+        max_new_tokens = 16
 
-    gen_config = GenerationConfig(max_new_tokens=request.max_tokens if request.max_tokens else 512,
-                                  do_sample=True,
-                                  logprobs=request.logprobs,
-                                  top_k=request.top_k,
-                                  top_p=request.top_p,
-                                  temperature=request.temperature,
-                                  repetition_penalty=request.repetition_penalty,
-                                  ignore_eos=request.ignore_eos,
-                                  stop_words=request.stop,
-                                  skip_special_tokens=request.skip_special_tokens,
-                                  min_p=request.min_p,
-                                  random_seed=random_seed,
-                                  spaces_between_special_tokens=request.spaces_between_special_tokens,
-                                  migration_request=migration_request,
-                                  with_cache=with_cache,
-                                  preserve_cache=preserve_cache)
+    gen_config = GenerationConfig(
+        max_new_tokens=max_new_tokens,
+        do_sample=True,
+        logprobs=request.logprobs,
+        top_k=request.top_k,
+        top_p=request.top_p,
+        temperature=request.temperature,
+        repetition_penalty=request.repetition_penalty,
+        ignore_eos=request.ignore_eos,
+        stop_words=request.stop,
+        skip_special_tokens=request.skip_special_tokens,
+        min_p=request.min_p,
+        random_seed=random_seed,
+        spaces_between_special_tokens=request.spaces_between_special_tokens,
+        migration_request=migration_request,
+        with_cache=with_cache,
+        preserve_cache=preserve_cache,
+    )
     generators = []
     for i in range(len(request.prompt)):
         result_generator = VariableInterface.async_engine.generate(

--- a/lmdeploy/serve/openai/protocol.py
+++ b/lmdeploy/serve/openai/protocol.py
@@ -117,7 +117,17 @@ class ChatCompletionRequest(BaseModel):
     top_logprobs: Optional[int] = None
     n: Optional[int] = 1
     logit_bias: Optional[Dict[str, float]] = Field(default=None, examples=[None])  # noqa
-    max_tokens: Optional[int] = Field(default=None, examples=[None])
+    max_completion_tokens: Optional[int] = Field(
+        default=None,
+        examples=[None],
+        description=('An upper bound for the number of tokens that can be generated for a completion, '
+                     'including visible output tokens and reasoning tokens'),
+    )
+    max_tokens: Optional[int] = Field(
+        default=None,
+        examples=[None],
+        deprecated='max_tokens is deprecated in favor of the max_completion_tokens field',
+    )
     stop: Optional[Union[str, List[str]]] = Field(default=None, examples=[None])  # noqa
 
     stream: Optional[bool] = False
@@ -261,7 +271,17 @@ class CompletionRequest(BaseModel):
     temperature: Optional[float] = 0.7
     n: Optional[int] = 1
     logprobs: Optional[int] = None
-    max_tokens: Optional[int] = 16
+    max_completion_tokens: Optional[int] = Field(
+        default=16,
+        examples=[16],
+        description=('An upper bound for the number of tokens that can be generated for a completion, '
+                     'including visible output tokens and reasoning tokens'),
+    )
+    max_tokens: Optional[int] = Field(
+        default=16,
+        examples=[16],
+        deprecated='max_tokens is deprecated in favor of the max_completion_tokens field',
+    )
     stop: Optional[Union[str, List[str]]] = Field(default=None, examples=[None])
     stream: Optional[bool] = False
     stream_options: Optional[StreamOptions] = Field(default=None, examples=[None])

--- a/lmdeploy/serve/proxy/proxy.py
+++ b/lmdeploy/serve/proxy/proxy.py
@@ -531,7 +531,9 @@ async def chat_completions_v1(request: ChatCompletionRequest, raw_request: Reque
     - n (int): How many chat completion choices to generate for each input
         message. **Only support one here**.
     - stream: whether to stream the results or not. Default to false.
+    - max_completion_tokens (int | None): output token nums. Default to None.
     - max_tokens (int | None): output token nums. Default to None.
+        Deprecated: Use max_completion_tokens instead.
     - repetition_penalty (float): The parameter for repetition penalty.
         1.0 means no penalty
     - stop (str | List[str] | None): To stop generating further
@@ -671,7 +673,9 @@ async def completions_v1(request: CompletionRequest, raw_request: Request = None
     - model (str): model name. Available from /v1/models.
     - prompt (str): the input prompt.
     - suffix (str): The suffix that comes after a completion of inserted text.
+    - max_completion_tokens (int | None): output token nums. Default to None.
     - max_tokens (int): output token nums. Default to 16.
+        Deprecated: Use max_completion_tokens instead.
     - temperature (float): to modulate the next token probability
     - top_p (float): If set to float < 1, only the smallest set of most
         probable tokens with probabilities that add up to top_p or higher


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily receiving feedbacks. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

In the OpenAI Spec, `max_tokens` is now deprecated in favor of `max_completion_tokens`.

## Modification

- Support `max_completion_tokens` in REST API.
- Still support `max_tokens` but make it deprecated.

## BC-breaking (Optional)

NO

## Use cases (Optional)

NO

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
