### PR TITLE
fix pytorch metrics in mp engine

### DIFF
--- a/lmdeploy/pytorch/engine/mp_engine/base.py
+++ b/lmdeploy/pytorch/engine/mp_engine/base.py
@@ -53,6 +53,10 @@ class MPEngine(EngineBase):
         """Update params."""
         return self._collective_rpc('update_params', request)
 
+    def get_schedule_metrics(self):
+        """Get schedule metrics."""
+        return self._collective_rpc('get_schedule_metrics')
+
     def p2p_initialize(self, conn_request: DistServeInitRequest):
         """Init rdma link."""
         return self._collective_rpc('p2p_initialize', conn_request)

--- a/lmdeploy/pytorch/engine/mp_engine/base_worker.py
+++ b/lmdeploy/pytorch/engine/mp_engine/base_worker.py
@@ -79,6 +79,10 @@ class EngineWorkerBase:
         """Get model config."""
         return self.engine.get_model_config()
 
+    def get_schedule_metrics(self):
+        """Get schedule metrics."""
+        return self.engine.get_schedule_metrics()
+
     def p2p_initialize(self, conn_request: DistServeInitRequest):
         """Init rdma link."""
         return self.engine.p2p_initialize(conn_request)


### PR DESCRIPTION
metrics breaks in PyTorch MP Engine mode, since `get_schedule_metrics` doesn't have an RPC call registered.