### PR TITLE
fix side effect brought by #3821

### DIFF
--- a/lmdeploy/serve/async_engine.py
+++ b/lmdeploy/serve/async_engine.py
@@ -273,8 +273,10 @@ class AsyncEngine(LogitsMixin):
         # build backend engine
         if backend == 'turbomind':
             self.engine = self._build_turbomind(model_path=model_path, backend_config=backend_config, **kwargs)
+            self.hf_tm_cfg = self.engine.config
         elif backend == 'pytorch':
             self.engine = self._build_pytorch(model_path=model_path, backend_config=backend_config, **kwargs)
+            self.hf_tm_cfg = getattr(self.engine.model_config, 'hf_config', None)
         else:
             raise ValueError(f'unsupported backend {backend}')
         self.backend_config = self.engine.engine_config


### PR DESCRIPTION
#3821 removed `self.hf_tm_cfg` in AsyncEngine. It causes the following error when `get_ppl` is called
```
 File "/opt/py3/lib/python3.10/site-packages/lmdeploy/serve/utils.py", line 115, in get_ppl
    vocab_size = self.hf_tm_cfg.vocab_size
AttributeError: 'AsyncEngine' object has no attribute 'hf_tm_cfg'. 
```