### PR TITLE
fix bug: dp+tp warmup

### DIFF
--- a/lmdeploy/pytorch/engine/model_agent.py
+++ b/lmdeploy/pytorch/engine/model_agent.py
@@ -395,13 +395,15 @@ class BaseModelAgent:
         with self.all_context():
             max_batches = self.cache_config.max_batches
             num_tokens = max_batches
-
+            dist_ctx = get_dist_manager().current_context()
+            dp = dist_ctx.dp
             # warmup prefill
             inputs = self.inputs_strategy.make_dummy(max_batches,
                                                      is_decoding=False,
                                                      device='cuda',
                                                      vocab_size=self.model_config.vocab_size)
-            inputs.build_dp_meta()
+            if dp > 1:
+                inputs.build_dp_meta()
             self._forward_impl(inputs)
 
             # warmup decoding(with cuda graph)
@@ -412,7 +414,8 @@ class BaseModelAgent:
                                                          is_decoding=True,
                                                          device='cuda',
                                                          vocab_size=self.model_config.vocab_size)
-                inputs.build_dp_meta()
+                if dp > 1:
+                    inputs.build_dp_meta()
                 self._forward_impl(inputs)
 
     def _slice_outs(self, inputs: torch.Tensor, seq_length: torch.LongTensor):


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily receiving feedbacks. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation
During the warmup phase of LMDeploy when using Data Parallelism (DP) + Tensor Parallelism (TP), the build_dp_meta() function is not invoked.
### Reproduction:
GPU: H20

Command:
```
lmdeploy serve proxy --server-name 0.0.0.0  --server-port 23333  --routing-strategy "min_expected_latency" --serving-strategy Hybrid
export LMDEPLOY_DP_MASTER_ADDR=0.0.0.0
export LMDEPLOY_DP_MASTER_PORT=23337
lmdeploy serve api_server ../deepseek-v2-lite/ --dp 2 --tp 2 --proxy_url http://0.0.0.0:23333 --backend pytorch
```
Traceback:
<img width="830" height="415" alt="image" src="https://github.com/user-attachments/assets/e056e193-a9b6-4a63-8fa0-291130c54b89" />


## Modification
Call inputs.build_dp_meta() before call _forward_impl

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
