### PR TITLE
fix internvl flash long context acc

### DIFF
--- a/lmdeploy/pytorch/models/internvl.py
+++ b/lmdeploy/pytorch/models/internvl.py
@@ -735,7 +735,7 @@ class InternVLChatModel(nn.Module, DeployModelMixin, CudaGraphMixin):
         # create new model inputs and context, to get updated position_ids and attn_metadata
         device = input_ids.device
         total_msgs = len(new_seqlens)
-        kv_seqlens = torch.tensor([meta['new_seqlen'] for meta in context.model_metas], device=device, dtype=torch.long)
+        kv_seqlens = torch.tensor([meta['new_seqlen'] for meta in context.model_metas], dtype=torch.long)
         new_model_inputs = ModelInputs(input_ids=input_ids,
                                        seq_length=torch.tensor(new_seqlens, device=device, dtype=torch.long),
                                        history_lengths=torch.tensor(prev_lens, device=device, dtype=torch.long),


### PR DESCRIPTION
## Motivation

The main branch code was tested with the following script, which uses **large images** that exceed the `max_prefill_token_num` limit, triggering the `is_long_context` condition in lmdeploy. As a result, the response will be repeated and meaningless.

<details>
<summary>Testing script</summary>

```
import os
from lmdeploy import pipeline, PytorchEngineConfig
from lmdeploy.vl import load_image

if __name__ == '__main__':
    os.environ['CUDA_VISIBLE_DEVICES'] = '4'

    # configurations
    tp = 1
    backend_config = PytorchEngineConfig(
        tp=tp,
        # max_prefill_token_num=10240
    )

    # init pipeline
    model_path = 'InternVL3_5-8B-Flash'
    pipe = pipeline(
        model_path,
        backend_config=backend_config,
        log_level='INFO'
    )

    # inference
    messages = [
        dict(role='user', content=[
            dict(type='text', text='<IMAGE_TOKEN>\n<IMAGE_TOKEN>\nDescribe the two images in detail.'),
            dict(type='image_url', image_url=dict(url='img1.jpeg')),
            dict(type='image_url', image_url=dict(url='img2.jpeg')),
        ])
    ]

    response = pipe(messages)
    print(response)
```

</details>

## Performance & Acc

Test with VLMEvalKit, dataset: BLINK

| Model                             | Flash Mode | Time      | Acc |
|---------------------------------|------------------|------------|-------|
| InternVL3.5-8B              | /                    |~3m06s  | 52.66 |
| InternVL3.5-8B-Flash    | false             |~3m06s  | 52.91 |
| InternVL3.5-8B-Flash    | true               |~2m51s  | 51.44 |