### PR TITLE
quant blocked fp8

### DIFF
--- a/lmdeploy/cli/lite.py
+++ b/lmdeploy/cli/lite.py
@@ -104,6 +104,28 @@ class SubCliLite(object):
         ArgumentHelper.download_dir(parser)
 
     @staticmethod
+    def add_parser_blocked_fp8():
+        """Add parser for blocked_fp8 command."""
+        parser = SubCliLite.subparsers.add_parser('blocked_fp8',
+                                                  formatter_class=DefaultsAndTypesHelpFormatter,
+                                                  description=SubCliLite.blocked_fp8.__doc__,
+                                                  help=SubCliLite.blocked_fp8.__doc__)
+        parser.set_defaults(run=SubCliLite.blocked_fp8)
+        parser.add_argument('model', type=str, help='The name or path of the model to be loaded')
+        parser.add_argument('--work-dir',
+                            type=str,
+                            default='./work_dir',
+                            help='The working directory for outputs. defaults to "./work_dir"')
+        parser.add_argument('--quant-dtype',
+                            type=str,
+                            default='float8_e4m3fn',
+                            choices=['fp8', 'float8_e4m3fn', 'float8_e5m2'],
+                            help='The quantization data type for weight')
+        parser.add_argument('--block-size', type=int, default=128, help='Block size for blocked-fp8 quantization')
+        ArgumentHelper.revision(parser)
+        ArgumentHelper.download_dir(parser)
+
+    @staticmethod
     def auto_awq(args):
         """Perform weight quantization using AWQ algorithm."""
         from lmdeploy.lite.apis.auto_awq import auto_awq
@@ -116,6 +138,13 @@ class SubCliLite(object):
         from lmdeploy.lite.apis.gptq import auto_gptq
         kwargs = convert_args(args)
         auto_gptq(**kwargs)
+
+    @staticmethod
+    def blocked_fp8(args):
+        """Perform weight quantization to blocked fp8 format."""
+        from lmdeploy.lite.apis.blocked_fp8 import blocked_fp8
+        kwargs = convert_args(args)
+        blocked_fp8(**kwargs)
 
     @staticmethod
     def calibrate(args):
@@ -138,3 +167,4 @@ class SubCliLite(object):
         SubCliLite.add_parser_auto_gptq()
         SubCliLite.add_parser_calibrate()
         SubCliLite.add_parser_smooth_quant()
+        SubCliLite.add_parser_blocked_fp8()

--- a/lmdeploy/lite/apis/blocked_fp8.py
+++ b/lmdeploy/lite/apis/blocked_fp8.py
@@ -1,0 +1,94 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+
+import os
+import os.path as osp
+from typing import Literal
+
+import fire
+import torch
+from torch import nn
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+from lmdeploy.lite.quantization.weight.quant_utils import quant_blocked_fp8
+from lmdeploy.lite.utils import collect_target_modules
+from lmdeploy.pytorch.models import QLinear
+
+
+def blocked_fp8(model: str,
+                work_dir: str = './work_dir',
+                quant_dtype: Literal['float8_e4m3fn', 'float8_e5m2'] = 'float8_e4m3fn',
+                block_size: int = 128,
+                revision: str = None,
+                download_dir: str = None):
+    if quant_dtype == 'fp8':
+        quant_dtype = 'float8_e4m3fn'
+
+    q_dtype = getattr(torch, quant_dtype, None)
+    assert q_dtype is not None
+
+    if not osp.exists(model):
+        print(f'can\'t find model from local_path {model}, '
+              'try to download from remote')
+        from lmdeploy.utils import get_model
+        model = get_model(model, revision=revision, download_dir=download_dir)
+
+    model_path = model
+    tokenizer = AutoTokenizer.from_pretrained(model_path, trust_remote_code=True)
+    model = AutoModelForCausalLM.from_pretrained(model_path, trust_remote_code=True, torch_dtype=torch.float16)
+    model = model.eval().cuda()
+
+    # collect all linear layers
+    fcs = collect_target_modules(model, nn.Linear)
+    modules_to_not_convert = [
+        'language_model.lm_head',
+        'language_model.model.embed_tokens',
+        'vision_model',  # don't quantize vision part in internvl3.5
+        'mlp1'  # don't quantize internvl3.5 mlp1
+    ]
+
+    # quantize and replace linear layers
+    for name, linear in fcs.items():
+        # skip not to convert modules
+        if any([x in name for x in modules_to_not_convert]):
+            print(f'skip: {name}')
+            continue
+
+        print(f'quantize: {name}')
+        linear.to('cuda')
+        # quantize weight
+        q_weight, scales = quant_blocked_fp8(linear.weight, q_dtype, block_size=block_size)
+
+        # create and replace with QLinear
+        q_linear = QLinear.from_float(linear, quant_dtype=q_dtype, initialization=False)
+        q_linear.weight.data = q_weight
+        q_linear.weight_scale_inv.data = scales
+        if linear.bias is not None:
+            q_linear.bias.data = linear.bias.detach()
+        parent_name, _, child_name = name.rpartition('.')
+        parent = model.get_submodule(parent_name)
+        setattr(parent, child_name, q_linear)
+
+        # move original layer to CPU to free GPU memory
+        linear.to('cpu')
+        torch.cuda.empty_cache()
+
+    model.to('cpu')
+
+    # update model config
+    quant_config = dict(activation_scheme='dynamic',
+                        modules_to_not_convert=modules_to_not_convert,
+                        fmt='e4m3',
+                        quant_method='fp8',
+                        weight_block_size=[block_size, block_size])
+    model.config.update(dict(quantization_config=quant_config))
+
+    # save model and tokenizer
+    if not osp.exists(work_dir):
+        os.makedirs(work_dir)
+    model.save_pretrained(work_dir, safe_serialization=True)
+    tokenizer.save_pretrained(work_dir)
+    print(f'Blocked FP8 model saved to {work_dir}')
+
+
+if __name__ == '__main__':
+    fire.Fire(blocked_fp8)

--- a/lmdeploy/pytorch/configurations/internvl.py
+++ b/lmdeploy/pytorch/configurations/internvl.py
@@ -12,7 +12,10 @@ class InternVLModelConfigBuilder(AutoModelConfigBuilder):
 
     @classmethod
     def build(cls, hf_config, model_path: str = None, **kwargs):
-        """Build llava hf."""
+        """Build internvl hf."""
+        # hack quantization_config
+        if hasattr(hf_config, 'quantization_config') and not hasattr(hf_config.llm_config, 'quantization_config'):
+            setattr(hf_config.llm_config, 'quantization_config', hf_config.quantization_config)
         cfg = DefaultModelConfigBuilder.build(hf_config.llm_config, model_path, **kwargs)
         cfg.hf_config = hf_config
         return cfg


### PR DESCRIPTION
## Usage

1. quantize

```bash
model_path="InternVL3_5-8b"
quantized_model_path="InternVL3_5-8b-blocked-fp8"

lmdeploy lite blocked_fp8 ${model_path} --work-dir ${quantized_model_path} --quant-dtype fp8
```

2. test
```python
from lmdeploy import pipeline, PytorchEngineConfig
import os

model_path = "InternVL3_5-8b-blocked-fp8"

if __name__ == '__main__':
    os.environ["CUDA_VISIBLE_DEVICES"] = "1"

    engine_config = PytorchEngineConfig(tp=1)
    pipe = pipeline(model_path, backend_config=engine_config)
    response = pipe(["Hi, pls intro yourself", "Shanghai is"])
    print(response)
```

## TODO

- [ ] Add documents for the FP8 model weight conversion
- [ ] Check whether modifications to `weight_scale_inv` affect other quant methods / modules