### PR TITLE
move releasing resource from async_engine to inference engine

### DIFF
--- a/lmdeploy/pytorch/engine/engine.py
+++ b/lmdeploy/pytorch/engine/engine.py
@@ -1211,6 +1211,11 @@ class Engine(EngineBase):
             self._loop_finally()
 
     def close(self):
+        if self.executor.device_type == 'cuda':
+            # https://discuss.pytorch.org/t/how-to-delete-a-tensor-in-gpu-to-free-up-memory/48879/32
+            # W/O this, repeatedly rebuilding and destroying engines within the same process
+            # will cause more and more reserved CUDA memory.
+            torch._C._cuda_clearCublasWorkspaces()
         if self._loop_main is not None:
             self._loop_main.cancel()
         else:

--- a/lmdeploy/serve/async_engine.py
+++ b/lmdeploy/serve/async_engine.py
@@ -13,7 +13,6 @@ from queue import Queue
 from threading import Thread
 from typing import Any, AsyncIterator, Dict, Iterator, List, Literal, Optional, Tuple, Union
 
-import torch
 import tqdm
 
 from lmdeploy import Tokenizer
@@ -307,7 +306,6 @@ class AsyncEngine(LogitsMixin):
         self.free_insts = None
         self.instances.clear()
         self.engine.close()
-        torch._C._cuda_clearCublasWorkspaces()
 
     def __enter__(self):
         return self


### PR DESCRIPTION

## Motivation

- Fix crash when destroying pipeline on A3 platform
```
E                 File "/opt/lmdeploy/autotest/tools/pipeline/llm_case.py", line 104, in <module>
E                   fire.Fire()
E                 File "/usr/local/python3.10.17/lib/python3.10/site-packages/fire/core.py", line 135, in Fire
E                   component_trace = _Fire(component, args, parsed_flag_args, context, name)
E                 File "/usr/local/python3.10.17/lib/python3.10/site-packages/fire/core.py", line 468, in _Fire
E                   component, remaining_args = _CallAndUpdateTrace(
E                 File "/usr/local/python3.10.17/lib/python3.10/site-packages/fire/core.py", line 684, in _CallAndUpdateTrace
E                   component = fn(*varargs, **kwargs)
E                 File "/opt/lmdeploy/autotest/tools/pipeline/llm_case.py", line 96, in run_pipeline_chat_test
E                   pipe.close()
E                 File "/opt/lmdeploy/lmdeploy/serve/async_engine.py", line 310, in close
E                   torch._C._cuda_clearCublasWorkspaces()
E               AttributeError: module 'torch._C' has no attribute '_cuda_clearCublasWorkspaces'
```

- Follow the allocate-and-free ownership principle. Inference engine instead of async_engine is supposed to manage the device resources 
