### PR TITLE
feat: add json_object support in response_format

### DIFF
--- a/lmdeploy/pytorch/engine/guided_process.py
+++ b/lmdeploy/pytorch/engine/guided_process.py
@@ -26,7 +26,8 @@ class GuidedDecodingMangager:
         processors = {}
         for i, _format in enumerate(response_formats):
             if isinstance(_format, Dict) and _format.get('type', 'text') != 'text':
-                if _format['type'] == 'json_schema':
+                schema_type = _format['type']
+                if schema_type == 'json_schema':
                     schema = _format['json_schema']
                     if isinstance(schema, Dict):
                         for key in ['json_schema', 'schema']:
@@ -37,15 +38,17 @@ class GuidedDecodingMangager:
                         raise ValueError(f'Cannot parse schema {schema}. The schema must be '
                                          'either a dictionary or a string that contains the'
                                          ' JSON Schema specification')
-                elif _format['type'] == 'regex_schema':
+                elif schema_type == 'regex_schema':
                     schema = _format.get('regex_schema', '')
+                elif schema_type == 'json_object':
+                    schema = '{"type" : "object", "additionalProperties": true}'
                 else:
-                    raise ValueError(f"unsupported format type: {_format['type']}")
+                    raise ValueError(f'unsupported format type: {schema_type}')
 
                 session_id = session_ctx[i]['session_id']
                 seq_id = session_ctx[i]['seq_id']
 
-                processors[i] = self.get_processor(session_id, seq_id, schema, _format['type'])
+                processors[i] = self.get_processor(session_id, seq_id, schema, schema_type)
 
         return processors
 
@@ -63,7 +66,9 @@ class GuidedDecodingMangager:
             assert isinstance(schema, dict)
             compiled = self.compiler.compile_json_schema(schema)
         elif type == 'regex_schema':
-            compiled = self.compiler.compile_regex_grammar(schema)
+            compiled = self.compiler.compile_regex(schema)
+        elif type == 'json_object':
+            compiled = self.compiler.compile_json_schema(schema)
         else:
             assert False, f'Do not support schema type {type}'
 

--- a/lmdeploy/serve/openai/api_server.py
+++ b/lmdeploy/serve/openai/api_server.py
@@ -590,7 +590,7 @@ async def chat_completions_v1(request: ChatCompletionRequest, raw_request: Reque
         tool_calls = None
         reasoning_content = None
         if request.tool_choice != 'none' and VariableInterface.tool_parser is not None:
-            try:  # TODO add json_schema guidance to turbomind
+            try:
                 tool_call_info = VariableInterface.tool_parser.extract_tool_calls(text, request=request)
                 text, tool_calls = tool_call_info.content, tool_call_info.tool_calls
                 if isinstance(tool_calls, List) and len(tool_calls):


### PR DESCRIPTION
## Motivation  
OpenAI-compatible `response_format={"type": "json_object"}` is still part of the official spec and is explicitly requested by users.  
lmdeploy currently rejects this value with  
`ValueError: unsupported format type: json_object`.  
We need to accept it and force the model to emit **any valid JSON object** without requiring the caller to supply a schema.

## Modification  
1. **GuidedDecodingManager**  
   - Treat `json_object` as a built-in schema:  
     `'{"type": "object", "additionalProperties": true}'`  
   - Dispatch it to the existing JSON-schema processor.  

2. **TurboMind backend**  
   - Add `json_object` branch when extracting the schema from `response_format`.  
   - Compile the same permissive object schema with the grammar compiler.  

3. **OpenAI-API server**  
   - Remove the outdated TODO comment; no extra logic is needed here after the core change.  

4. **Tests**  
   - Extend the guided-decoding matrix to cover `json_object`, `json_schema`, `regex_schema`, and the un-guided case.  
   - Validate `json_object` responses with the same permissive schema used in the engine.  

With this patch, clients can use  
`response_format={"type": "json_object"}` and receive guaranteed valid JSON objects.