### PR TITLE
Fix inputs split

### DIFF
--- a/lmdeploy/pytorch/model_inputs.py
+++ b/lmdeploy/pytorch/model_inputs.py
@@ -152,7 +152,7 @@ class ModelInputs:
             step_seqlens = self.seq_length
         self.history_lengths += step_seqlens
         self.max_kv_seqlen += self.max_q_seqlen
-        self.sum_kv_seqlen += self.max_kv_seqlen * self.seq_length.numel()
+        self.sum_kv_seqlen += self.max_q_seqlen * self.seq_length.numel()
         if input_ids.dim() == 1:
             input_ids = input_ids[None, :]
         self.input_ids = input_ids


### PR DESCRIPTION
## Motivation

Fix inputs split of too large `max_kv_seqlen`, which leads to output with `nan` value for fa3 
https://github.com/InternLM/lmdeploy/blob/b9ee7596d9681644c76373c055cfd0d1b8802a6d/lmdeploy/pytorch/backends/cuda/attention.py#L520 



## Modification

Please briefly describe what modification is made in this PR.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
