### PR TITLE
[Fix] all RayEngineWorker actors created at node 0 in RL training

### DIFF
--- a/lmdeploy/pytorch/engine/mp_engine/ray_engine.py
+++ b/lmdeploy/pytorch/engine/mp_engine/ray_engine.py
@@ -111,7 +111,7 @@ class RayMPEngine(MPEngine):
 
     def _create_worker(self, model_path: str, engine_config: PytorchEngineConfig = None, **kwargs):
         """Create a Ray worker."""
-        bundle_id = 0
+        bundle_id = 0 if len(_envs.ray_external_pg_bundles) == 0 else _envs.ray_external_pg_bundles[0]
         scheduling_strategy = PlacementGroupSchedulingStrategy(
             placement_group=self.placement_group,
             placement_group_capture_child_tasks=True,


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily receiving feedbacks. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

When lmdeploy is used in Reinforcement Learning training, ray_engine worker is used to share ray resources. For now, RayEngineWorker is created at the node which contains the bundle_idx 0 in ray placement group. This behaviour leads to a lot of RayEngineWorker would be created at the node. For examples, tp_size=1 and 128 GPUs with 16 nodes cause 128 RayEngineWorker actors are created on the same node.

## Modification

Just use the first bundle index in envs.ray_external_pg_bundles if given, otherwise bundle_idx = 0.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
