### PR TITLE
[Feat] enable ascend update_params

### DIFF
--- a/lmdeploy/utils.py
+++ b/lmdeploy/utils.py
@@ -458,7 +458,6 @@ def serialize_state_dict(state_dict: dict) -> str:
     from multiprocessing.reduction import ForkingPickler
 
     from torch.multiprocessing.reductions import reduce_tensor
-    assert all(v.device.type == 'cuda' for v in state_dict.values())
     data = [(k, reduce_tensor(v)) for k, v in state_dict.items()]
     buf = BytesIO()
     ForkingPickler(buf).dump(data)


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily receiving feedbacks. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

`serialize_state_dict` in lmdeploy/utils.py contains an assert that checking all input values tensor are cuda tensors.
This disable the usage of update_params on ascend platform.

## Modification

Remove the assert to enable the usage of update_params on ascend platform.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
