### PR TITLE
[ascend] fix dummy case error

### DIFF
--- a/lmdeploy/pytorch/backends/dlinfer/ascend/op_backend.py
+++ b/lmdeploy/pytorch/backends/dlinfer/ascend/op_backend.py
@@ -154,7 +154,7 @@ class AscendOpsBackend(DlinferOpsBackend):
     def update_step_context(cls, step_context):
         """Update step context."""
 
-        AscendOpsBackend.deal_dummy(step_context)
+        cls.deal_dummy(step_context)
 
         def get_total_slots():
             if cls.total_slots is None:


### PR DESCRIPTION
dummy inputs with kv_seq_len = 0 causes error on ascend backend.
Revert kv_seq_len to 1 to avoid error.