### PR TITLE
fix: handle non-tuple decoder outputs during Qwen-2.5 quantization

### DIFF
--- a/lmdeploy/lite/utils/batch_split.py
+++ b/lmdeploy/lite/utils/batch_split.py
@@ -73,7 +73,7 @@ def concat_decoder_layer_outputs(batch_outputs: List[Any]) -> Any:
     output_is_tuple = True
     if not isinstance(batch_outputs[0], tuple):
         output_is_tuple = False
-        batch_outputs = [(output,) for output in batch_outputs]
+        batch_outputs = [(output, ) for output in batch_outputs]
 
     num_returns = len(batch_outputs[0])
 


### PR DESCRIPTION
## Motivation

This PR addresses a quantization failure encountered with the Qwen2.5 model.

The issue arises because [the latest Qwen2 decoder layer output in transformers](https://github.com/huggingface/transformers/blob/v4.57.3/src/transformers/models/qwen2/modeling_qwen2.py#L383) is now a tensor, not a tuple, which conflicts with the current quantization logic's expectation of a tuple.

This change updates the logic to correctly handle the tensor output, enabling successful quantization of Qwen2.5.
