### PR TITLE
[Fix]: Split routed experts with query lens

### DIFF
--- a/lmdeploy/pytorch/engine/model_agent.py
+++ b/lmdeploy/pytorch/engine/model_agent.py
@@ -870,16 +870,17 @@ class BaseModelAgent:
         keys = ['inputs', 'sampling_inputs', 'stopping_criteria', 'extra_inputs']
         while True:
             forward_inputs = await self._pre_in_que.get()
-
+            forward_inputs_cuda = {}
+            forward_inputs_cuda.update(forward_inputs)
             logger.debug('preprocessing forward inputs.')
             with torch.cuda.stream(self.out_stream), torch.inference_mode(), record_function('inputs_H2D'):
                 for k in keys:
-                    if k not in forward_inputs:
+                    if k not in forward_inputs_cuda:
                         continue
-                    forward_inputs[k] = _try_to_cuda(forward_inputs[k], non_blocking=non_blocking)
+                    forward_inputs_cuda[k] = _try_to_cuda(forward_inputs_cuda[k], non_blocking=non_blocking)
                 self.out_stream.synchronize()
             logger.debug('preprocessing forward inputs done.')
-            self._in_que.put_nowait(forward_inputs)
+            self._in_que.put_nowait(forward_inputs_cuda)
             if forward_event is not None:
                 forward_event.clear()
 

--- a/lmdeploy/pytorch/strategies/ar/sequence.py
+++ b/lmdeploy/pytorch/strategies/ar/sequence.py
@@ -10,6 +10,7 @@ from lmdeploy.pytorch.disagg.conn.protocol import MigrationRequest
 from lmdeploy.pytorch.engine.model_agent import BatchedOutputs
 from lmdeploy.pytorch.messages import (InputEmbeddings, MessageStatus, MultiModalInputs, SamplingParam,
                                        SchedulerSequence, SchedulerSession, UpdateTokenMode, _to_ndarray)
+from lmdeploy.pytorch.model_inputs import ModelInputs
 
 from ..base.sequence import SequenceStrategy
 
@@ -103,7 +104,7 @@ class ARSequenceStrategy(SequenceStrategy):
             preserve_cache=preserve_cache,
         )
 
-    def update_running(self, running: SeqList, batched_outputs: BatchedOutputs, is_decoding: bool) -> None:
+    def update_running(self, running: SeqList, batched_outputs: BatchedOutputs, model_inputs: 'ModelInputs') -> None:
         """Update running sequences."""
         next_token_ids = batched_outputs.next_token_ids
         stopped = batched_outputs.stopped
@@ -113,16 +114,12 @@ class ARSequenceStrategy(SequenceStrategy):
             model_metas = [None] * len(running)
 
         next_token_ids = next_token_ids.numpy()
-        all_routed_experts = [None] * len(running)
-        if is_decoding:
-            num_tokens = [1] * len(running)
-        else:
-            num_tokens = [msg.num_token_ids for msg in running]
-
+        num_tokens = model_inputs.seq_length.tolist()
+        all_routed_experts = [None] * len(num_tokens)
         if batched_outputs.all_routed_experts is not None:
             all_routed_experts = batched_outputs.all_routed_experts.split(num_tokens, dim=0)
             all_routed_experts = [experts.numpy() for experts in all_routed_experts]
-        update_mode = UpdateTokenMode.DECODE if is_decoding else UpdateTokenMode.PREFILL
+        update_mode = UpdateTokenMode.DECODE if model_inputs.is_decoding else UpdateTokenMode.PREFILL
         for token, msg, stop, model_meta, routed_experts in zip(next_token_ids, running, stopped, model_metas,
                                                                 all_routed_experts):
             if msg.status != MessageStatus.LOCKED:

--- a/lmdeploy/pytorch/strategies/ar_spec/sequence.py
+++ b/lmdeploy/pytorch/strategies/ar_spec/sequence.py
@@ -10,6 +10,7 @@ from lmdeploy.pytorch.disagg.conn.protocol import MigrationRequest
 from lmdeploy.pytorch.engine.model_agent import BatchedOutputs
 from lmdeploy.pytorch.messages import (InputEmbeddings, MessageStatus, MultiModalInputs, SamplingParam,
                                        SchedulerSession, UpdateTokenMode, _to_ndarray)
+from lmdeploy.pytorch.model_inputs import ModelInputs
 
 from ..ar.sequence import ARSequenceStrategy, SchedulerSequenceDefault
 
@@ -155,7 +156,7 @@ class ARSpecSequenceStrategy(ARSequenceStrategy):
                                        resp_cache=resp_cache,
                                        preserve_cache=preserve_cache)
 
-    def update_running(self, running: SeqList, batched_outputs: BatchedOutputs, is_decoding: bool) -> None:
+    def update_running(self, running: SeqList, batched_outputs: BatchedOutputs, model_inputs: 'ModelInputs') -> None:
         """Update running sequences."""
         next_token_ids = batched_outputs.next_token_ids
         extra_outputs = batched_outputs.extra_outputs
@@ -173,7 +174,7 @@ class ARSpecSequenceStrategy(ARSequenceStrategy):
         else:
             draft_token_ids = extra_outputs.draft_token_ids.numpy()
         stop_pos = stop_pos.tolist()
-        update_mode = UpdateTokenMode.DECODE if is_decoding else UpdateTokenMode.PREFILL
+        update_mode = UpdateTokenMode.DECODE if model_inputs.is_decoding else UpdateTokenMode.PREFILL
 
         for idx, token in enumerate(next_token_ids):
             msg = running[idx]

--- a/lmdeploy/pytorch/strategies/base/sequence.py
+++ b/lmdeploy/pytorch/strategies/base/sequence.py
@@ -7,6 +7,7 @@ from lmdeploy.pytorch.disagg.conn.protocol import MigrationRequest
 if TYPE_CHECKING:
     from lmdeploy.pytorch.engine.model_agent import BatchedOutputs
     from lmdeploy.pytorch.messages import SamplingParam, SchedulerSequence, SchedulerSession
+    from lmdeploy.pytorch.model_inputs import ModelInputs
     SeqList = List[SchedulerSequence]
 
 
@@ -25,6 +26,7 @@ class SequenceStrategy(ABC):
         pass
 
     @abstractmethod
-    def update_running(self, running: 'SeqList', batched_outputs: 'BatchedOutputs', is_decoding: bool) -> None:
+    def update_running(self, running: 'SeqList', batched_outputs: 'BatchedOutputs',
+                       model_inputs: 'ModelInputs') -> None:
         """Update running sequences."""
         pass

--- a/lmdeploy/pytorch/strategies/dllm/sequence.py
+++ b/lmdeploy/pytorch/strategies/dllm/sequence.py
@@ -11,6 +11,7 @@ from lmdeploy.pytorch.disagg.conn.protocol import MigrationRequest
 from lmdeploy.pytorch.engine.model_agent import BatchedOutputs
 from lmdeploy.pytorch.messages import (HistoryTokenIds, InputEmbeddings, MessageStatus, MultiModalInputs, SamplingParam,
                                        SchedulerSession, UpdateTokenMode, _to_ndarray)
+from lmdeploy.pytorch.model_inputs import ModelInputs
 
 from ..ar.sequence import SchedulerSequenceDefault
 from ..base.sequence import SequenceStrategy
@@ -217,7 +218,7 @@ class DLLMSequenceStrategy(SequenceStrategy):
                                      resp_cache=resp_cache,
                                      preserve_cache=preserve_cache)
 
-    def update_running(self, running: SeqList, batched_outputs: BatchedOutputs, is_decoding: bool) -> None:
+    def update_running(self, running: SeqList, batched_outputs: BatchedOutputs, model_inputs: 'ModelInputs') -> None:
         """Update running sequences."""
         next_token_ids = batched_outputs.next_token_ids
         stopped = batched_outputs.stopped
@@ -232,7 +233,7 @@ class DLLMSequenceStrategy(SequenceStrategy):
         next_token_ids = next_token_ids.view(batch_size, -1).numpy()
         dllm_mask = dllm_mask.view(batch_size, -1).numpy()
         stop_pos = stop_pos.tolist()
-        update_mode = UpdateTokenMode.DECODE if is_decoding else UpdateTokenMode.PREFILL
+        update_mode = UpdateTokenMode.DECODE if model_inputs.is_decoding else UpdateTokenMode.PREFILL
         for idx, token in enumerate(next_token_ids):
             msg = running[idx]
             stop = stopped[idx]


### PR DESCRIPTION

## Motivation

Pass model inputs to update_running and split experts with query lens.

## Modification

Please briefly describe what modification is made in this PR.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
