### PR TITLE
[Fix] fix a quant scale caculation bug in quant_utils.py

### DIFF
--- a/lmdeploy/lite/quantization/weight/quant_utils.py
+++ b/lmdeploy/lite/quantization/weight/quant_utils.py
@@ -24,7 +24,7 @@ def fast_pow2_torch(x: torch.Tensor, weight_dtype: torch.dtype) -> torch.Tensor:
 
 
 def fast_round_scale_torch(amax: torch.Tensor, fp8_max: torch.Tensor, weight_dtype: torch.dtype) -> torch.Tensor:
-    return fast_pow2_torch(fast_log2_ceil_torch(amax / fp8_max), weight_dtype)         
+    return fast_pow2_torch(fast_log2_ceil_torch(amax / fp8_max), weight_dtype)
 
 
 def _get_quant_scaling(weight: torch.Tensor,
@@ -43,8 +43,9 @@ def _get_quant_scaling(weight: torch.Tensor,
     else:
         # default
         scaling = amax / fmax
-    
-    scaling = torch.where(scaling == 0, 
+
+    scaling = torch.where(
+        scaling == 0,
         torch.tensor(eps, dtype=scaling.dtype, device=scaling.device),
         scaling,
     )


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily receiving feedbacks. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Due to a bug in the scale calculation, the weights of the model converted from bf16 to fp8 in the code differ slightly from the weights of the official fp8 model.

## Modification

The quant_utils.py file under the path lmdeploy/lmdeploy/lite/quantization/weight has been modified. The code to convert weight to fp32 has been removed in the def quant_blocked_fp8 function. In the def _get_quant_scaling function, the eps value under different dtypes is given to limit the amplitude to prevent division by zero.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
