### PR TITLE
Fix include_stop_str_in_output with output_logits Exception

### DIFF
--- a/lmdeploy/serve/async_engine.py
+++ b/lmdeploy/serve/async_engine.py
@@ -984,7 +984,7 @@ class AsyncEngine(LogitsMixin):
                         # return the eos token id (MUST be in a list), eos string, eos token's logits and so on
                         token_ids = outputs.token_ids[-1:]
                         response = self.tokenizer.decode(token_ids, skip_special_tokens=False)
-                        logits = outputs.logits[-1:] if outputs.logits else None
+                        logits = outputs.logits[-1:] if outputs.logits is not None else None
                         last_hidden_state = outputs.last_hidden_state[-1:] if outputs.last_hidden_state else None
                         logprobs = outputs.logprobs[-1:] if outputs.logprobs else None
                         gen_len += 1


### PR DESCRIPTION
## Motivation

When using `GenerationConfig` with both `include_stop_str_in_output=True` and `output_logits='generation'`, LMDeploy crashes with:

```
RuntimeError: Boolean value of Tensor with more than one value is ambiguous
```

This occurs because the code evaluates `if outputs.logits:` directly on a PyTorch tensor. When the tensor contains multiple values, PyTorch raises this error to prevent ambiguous boolean conversion. This prevents users from obtaining logits for stop tokens, which is essential for classification tasks (e.g., generating "yes/no" responses and analyzing their probabilities).

## Modification

Changed the ambiguous boolean check to an explicit `None` comparison.

Closing #4241 