### PR TITLE
Pin nvshmem version

### DIFF
--- a/docker/install.sh
+++ b/docker/install.sh
@@ -58,9 +58,9 @@ fi
 pip install -U pip wheel setuptools
 
 if [[ "${CUDA_VERSION_SHORT}" = "cu130" ]]; then
-    pip install nvidia-nvshmem-cu13
+    pip install nvidia-nvshmem-cu13==3.4.5
 elif [[ "${CUDA_VERSION_SHORT}" != "cu118" ]]; then
-    pip install nvidia-nvshmem-cu12
+    pip install nvidia-nvshmem-cu12==3.4.5
 fi
 
 pip install torch${TORCH_VERSION} --extra-index-url https://download.pytorch.org/whl/${CUDA_VERSION_SHORT}

--- a/docker/prepare_wheel.sh
+++ b/docker/prepare_wheel.sh
@@ -31,9 +31,9 @@ if [[ "${CUDA_VERSION_SHORT}" != "cu118" ]]; then
     # DeepEP
     if [[ "${CUDA_VERSION_SHORT}" = "cu130" ]]; then
         export CPLUS_INCLUDE_PATH="/usr/local/cuda/include/cccl":${CPLUS_INCLUDE_PATH}
-        pip install nvidia-nvshmem-cu13
+        pip install nvidia-nvshmem-cu13==3.4.5
     else
-        pip install nvidia-nvshmem-cu12
+        pip install nvidia-nvshmem-cu12==3.4.5
     fi
     pip wheel -v --no-build-isolation --no-deps -w /wheels "git+https://github.com/deepseek-ai/DeepEP.git@${DEEP_EP_VERSION}"
 


### PR DESCRIPTION
nvshmem release a new version on 2026.01.02

https://pypi.org/project/nvidia-nvshmem-cu12/

leads to image build error:

https://github.com/InternLM/lmdeploy/actions/runs/20713992650/job/59535633299?pr=4242

Thus we pin the nvshmem to the previous version now.