### PR TITLE
fix: Pin `timm` version to avoid failed tests

### DIFF
--- a/.github/workflows/daily_ete_test.yml
+++ b/.github/workflows/daily_ete_test.yml
@@ -181,7 +181,7 @@ jobs:
           python3 -m pip install -r requirements/test.txt
           rm -rf ${{env.DEEPSEEK_VL}}/build
           pip install ${{env.DEEPSEEK_VL}} --no-deps
-          python3 -m pip install transformers==4.53.1 datasets==3.6.0 timm
+          python3 -m pip install transformers==4.53.1 datasets==3.6.0
       - name: Check env
         run: |
           python3 -m pip list

--- a/.github/workflows/daily_ete_test_3090.yml
+++ b/.github/workflows/daily_ete_test_3090.yml
@@ -172,7 +172,7 @@ jobs:
       - name: Install lmdeploy
         run: |
           python3 -m pip uninstall lmdeploy -y && python3 -m pip install lmdeploy-*.whl --no-deps
-          python3 -m pip install transformers==4.53.1 datasets==3.6.0 timm
+          python3 -m pip install transformers==4.53.1 datasets==3.6.0
           python3 -m pip install -r requirements/test.txt
       - name: Check env
         run: |

--- a/.github/workflows/daily_ete_test_5080.yml
+++ b/.github/workflows/daily_ete_test_5080.yml
@@ -172,7 +172,7 @@ jobs:
       - name: Install lmdeploy
         run: |
           python3 -m pip uninstall lmdeploy -y && python3 -m pip install lmdeploy-*.whl --no-deps
-          python3 -m pip install transformers==4.53.1 datasets==3.6.0 timm
+          python3 -m pip install transformers==4.53.1 datasets==3.6.0
           python3 -m pip install -r requirements/test.txt
       - name: Check env
         run: |

--- a/.github/workflows/pr_ete_test.yml
+++ b/.github/workflows/pr_ete_test.yml
@@ -67,7 +67,7 @@ jobs:
           export PATH=$PATH:/usr/local/openmpi/bin
           export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/openmpi/lib
           # We need to pin transformers version (<4.52.0) to avoid test failures due to breaking changes.
-          python3 -m pip install transformers==4.51.3 timm
+          python3 -m pip install transformers==4.51.3
           python3 -m pip install -r requirements/lite.txt
           python3 -m pip install -r requirements/test.txt
           python3 -m pip install -e .

--- a/docker/InternVL_Dockerfile
+++ b/docker/InternVL_Dockerfile
@@ -8,6 +8,6 @@ ENV CUDA_VERSION_SHORT=cu118
 
 FROM ${CUDA_VERSION} AS final
 
-RUN python3 -m pip install timm
+RUN python3 -m pip install timm==1.0.22
 
 RUN python3 -m pip install https://github.com/Dao-AILab/flash-attention/releases/download/v2.6.3/flash_attn-2.6.3+${CUDA_VERSION_SHORT}torch2.3cxx11abiFALSE-cp310-cp310-linux_x86_64.whl

--- a/requirements/serve.txt
+++ b/requirements/serve.txt
@@ -1,4 +1,4 @@
 aiohttp
 prometheus_client
 protobuf
-timm
+timm<=1.0.22

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -13,4 +13,4 @@ pytest-sugar
 pytest-xdist
 pyyaml
 qwen_vl_utils
-timm
+timm<=1.0.22


### PR DESCRIPTION

## Motivation
Version 1.0.23 of `timm` introduced a breaking change by removing `apply_rot_embed` and `RotaryEmbedding` exports from `timm.layers.pos_embed_sincos` (see upstream commit https://github.com/huggingface/pytorch-image-models/commit/602634f6984ef5ffb81a415f33cb52ba7be760aa ). However, the backward compatibility layer in `timm.models.layers` continues to depend on these imports, causing runtime import errors and CI test failures across all pipeline environments.

## Modification
Lock the `timm` dependency to version `1.0.22` globally across all build and deployment configurations. This version pinning strategy ensures stability and prevents regression while maintaining compatibility with existing code that relies on the deprecated import paths.

The change consistently applies version constraints to CI workflows, Docker images, and package requirements files, guaranteeing uniform behavior from development through production environments until upstream compatibility issues are resolved.