### PR TITLE
docs: add cli docs

### DIFF
--- a/docs/en/api/cli.rst
+++ b/docs/en/api/cli.rst
@@ -1,0 +1,8 @@
+Command-line Tools
+===================
+
+.. sphinx_argparse_cli::
+   :module: lmdeploy.cli
+   :func: run
+   :hook:
+   :prog: lmdeploy

--- a/docs/en/conf.py
+++ b/docs/en/conf.py
@@ -85,6 +85,7 @@ with open(spec_dir / 'proxy.yaml', 'w', encoding='utf-8') as f:
 
 extensions = [
     'myst_parser',
+    'sphinx_argparse_cli',
     'sphinx.ext.autodoc',
     'sphinx.ext.autosectionlabel',
     'sphinx.ext.autosummary',

--- a/docs/en/index.rst
+++ b/docs/en/index.rst
@@ -114,6 +114,7 @@ Documentation
 
    api/pipeline.rst
    api/openapi.rst
+   api/cli.rst
 
 Indices and tables
 ==================

--- a/docs/en/llm/api_server_tools.md
+++ b/docs/en/llm/api_server_tools.md
@@ -157,13 +157,11 @@ ChatCompletion(id='2', choices=[Choice(finish_reason='tool_calls', index=0, logp
 
 Meta announces in [Llama3's official user guide](https://llama.meta.com/docs/model-cards-and-prompt-formats/llama3_1) that,
 
-```{note}
-There are three built-in tools (brave_search, wolfram_alpha, and code interpreter) can be turned on using the system prompt:
-
-1. Brave Search: Tool call to perform web searches.
-2. Wolfram Alpha: Tool call to perform complex mathematical calculations.
-3. Code Interpreter: Enables the model to output python code.
-```
+> There are three built-in tools (brave_search, wolfram_alpha, and code interpreter) can be turned on using the system prompt:
+>
+> 1. Brave Search: Tool call to perform web searches.
+> 2. Wolfram Alpha: Tool call to perform complex mathematical calculations.
+> 3. Code Interpreter: Enables the model to output python code.
 
 Additionally, it cautions: "**Note:** We recommend using Llama 70B-instruct or Llama 405B-instruct for applications that combine conversation and tool calling. Llama 8B-Instruct can not reliably maintain a conversation alongside tool calling definitions. It can be used for zero-shot tool calling, but tool instructions should be removed for regular conversations between the model and the user."
 

--- a/docs/zh_cn/api/cli.rst
+++ b/docs/zh_cn/api/cli.rst
@@ -1,0 +1,8 @@
+命令行工具
+===========
+
+.. sphinx_argparse_cli::
+   :module: lmdeploy.cli
+   :func: run
+   :hook:
+   :prog: lmdeploy

--- a/docs/zh_cn/conf.py
+++ b/docs/zh_cn/conf.py
@@ -85,6 +85,7 @@ with open(spec_dir / 'proxy.yaml', 'w', encoding='utf-8') as f:
 
 extensions = [
     'myst_parser',
+    'sphinx_argparse_cli',
     'sphinx.ext.autodoc',
     'sphinx.ext.autosectionlabel',
     'sphinx.ext.autosummary',

--- a/docs/zh_cn/index.rst
+++ b/docs/zh_cn/index.rst
@@ -115,6 +115,7 @@ LMDeploy 工具箱提供以下核心功能：
 
    api/pipeline.rst
    api/openapi.rst
+   api/cli.rst
 
 索引与表格
 ==================

--- a/docs/zh_cn/llm/api_server_tools.md
+++ b/docs/zh_cn/llm/api_server_tools.md
@@ -157,13 +157,11 @@ ChatCompletion(id='2', choices=[Choice(finish_reason='tool_calls', index=0, logp
 
 Meta 在 [Llama3 的官方用户指南](https://llama.meta.com/docs/model-cards-and-prompt-formats/llama3_1)中宣布（注：下文为原文的中文翻译）：
 
-```{text}
-有三个内置工具（brave_search、wolfram_alpha 和 code interpreter）可以使用系统提示词打开：
-
-1. Brave Search：执行网络搜索的工具调用。
-2. Wolfram Alpha：执行复杂数学计算的工具调用。
-3. Code Interpreter：使模型能够输出 Python 代码的功能。
-```
+> 有三个内置工具（brave_search、wolfram_alpha 和 code interpreter）可以使用系统提示词打开：
+>
+> 1. Brave Search：执行网络搜索的工具调用。
+> 2. Wolfram Alpha：执行复杂数学计算的工具调用。
+> 3. Code Interpreter：使模型能够输出 Python 代码的功能。
 
 此外，它还警告说：“注意： 我们建议使用 Llama 70B-instruct 或 Llama 405B-instruct 用于结合对话和工具调用的应用。Llama 8B-Instruct 无法可靠地在工具调用定义的同时维持对话。它可以用于零样本工具调用，但在模型和用户之间的常规对话中，应移除工具指令。”（注：引号中内容为原文的中文翻译）
 

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,6 +1,7 @@
 markdown>=3.4.0
 myst-parser
 sphinx==8.0.2
+sphinx-argparse-cli
 sphinx-autodoc-typehints
 sphinx-book-theme
 sphinx-copybutton


### PR DESCRIPTION
## Motivation 

Add automated documentation for LMDeploy's command-line interface to improve user experience and ensure docs stay synchronized with code changes.

## Modification 

Integrate the [tox-dev/sphinx-argparse-cli](https://github.com/tox-dev/sphinx-argparse-cli) extension to auto-generate CLI reference documentation directly from the argparse definitions in `lmdeploy.cli.run()`. This eliminates manual maintenance and guarantees accuracy.