### PR TITLE
convert float16 weight to bfloat16 for FP8 models

### DIFF
--- a/lmdeploy/turbomind/deploy/policy.py
+++ b/lmdeploy/turbomind/deploy/policy.py
@@ -64,10 +64,8 @@ def process_fp8(x: torch.Tensor, kind: str):
         return x.view(dtype=torch.uint8)
     elif kind != 'weight_scale_inv' and x.dtype == torch.float:
         return x.to(dtype=torch.bfloat16)
-    elif x.dtype == torch.float16:
-        return x.to(dtype=torch.bfloat16)
     else:
-        return x
+        return x.to(dtype=torch.bfloat16)
 
 
 def get_input_policy(model_format):


### PR DESCRIPTION
fix #4261 

In the model Qwen/Qwen3-4B-Instruct-2507-FP8, some parameters like "*.weight_scale_inv" are in half precision. However, the turbomind FP8 kernel is only compatible with bfloat16.
This PR implements a temporary workaround by converting Half-precision weights to the bfloat16 format.
