### PR TITLE
[Fix] move calibrate load dataset location

### DIFF
--- a/lmdeploy/lite/utils/calib_dataloader.py
+++ b/lmdeploy/lite/utils/calib_dataloader.py
@@ -1,7 +1,6 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import numpy as np
 import torch
-from datasets import VerificationMode, load_dataset
 
 NUM_LOADED_SAMPLES = 30000
 
@@ -100,10 +99,11 @@ def process_dataset(ds, tokenizer, max_seq_length):
     return ds
 
 
-def get_wikitext2(tokenizer, nsamples, seed, seqlen):
+def get_wikitext2(dataset, tokenizer, nsamples, seed, seqlen):
     """Load Wikitext-2 train and test datasets and tokenize.
 
     Args:
+        dataset: calib dataset
         tokenizer: Tokenizer to encode text.
         nsamples: Number of samples to take from train set.
         seed: Random seed for sampling.
@@ -112,9 +112,7 @@ def get_wikitext2(tokenizer, nsamples, seed, seqlen):
     Returns:
         List of sampled and tokenized training examples.
     """
-    traindata = load_dataset('wikitext', 'wikitext-2-raw-v1', split='train')
-
-    trainenc = tokenizer('\n\n'.join(traindata['text']), return_tensors='pt')
+    trainenc = tokenizer('\n\n'.join(dataset['text']), return_tensors='pt')
 
     import random
     random.seed(seed)
@@ -127,10 +125,11 @@ def get_wikitext2(tokenizer, nsamples, seed, seqlen):
     return trainloader
 
 
-def get_c4(tokenizer, nsamples, seed, seqlen):
+def get_c4(dataset, tokenizer, nsamples, seed, seqlen):
     """Load C4 train and validation datasets and tokenize.
 
     Args:
+        dataset: calib dataset
         tokenizer: Tokenizer to encode text.
         nsamples: Number of samples to take from train set.
         seed: Random seed for sampling.
@@ -139,19 +138,13 @@ def get_c4(tokenizer, nsamples, seed, seqlen):
     Returns:
         List of sampled and tokenized training examples.
     """
-    traindata = load_dataset('allenai/c4',
-                             'en',
-                             data_files={'train': 'en/c4-train.00000-of-01024.json.gz'},
-                             split='train',
-                             verification_mode=VerificationMode.NO_CHECKS)
-
     import random
     random.seed(seed)
     trainloader = []
     for _ in range(nsamples):
         while True:
-            i = random.randint(0, len(traindata) - 1)
-            trainenc = tokenizer(traindata[i]['text'], return_tensors='pt')
+            i = random.randint(0, len(dataset) - 1)
+            trainenc = tokenizer(dataset[i]['text'], return_tensors='pt')
             if trainenc.input_ids.shape[1] >= seqlen:
                 break
         i = random.randint(0, trainenc.input_ids.shape[1] - seqlen)
@@ -162,10 +155,11 @@ def get_c4(tokenizer, nsamples, seed, seqlen):
     return trainloader
 
 
-def get_pileval(tokenizer, nsamples, seed, seqlen=512):
+def get_pileval(dataset, tokenizer, nsamples, seed, seqlen=512):
     """Load pileval train dataset and tokenize.
 
     Args:
+        dataset: calib dataset
         tokenizer: Tokenizer to encode text.
         nsamples: Number of samples to take from train set.
         seed: Random seed for sampling.
@@ -174,15 +168,6 @@ def get_pileval(tokenizer, nsamples, seed, seqlen=512):
     Returns:
         List of sampled and tokenized training examples.
     """
-    from datasets.builder import DatasetGenerationError
-    try:
-        dataset = load_dataset('mit-han-lab/pile-val-backup', split=f'validation[:{NUM_LOADED_SAMPLES}]')
-    except DatasetGenerationError:
-        raise InterruptedError('There have been some issues when generating '
-                               'the dataset, you could try to download it '
-                               'locally first, and replace the `data_files`'
-                               'with local addresses or use other datasets '
-                               '(c4, wiki, ptb).')
 
     # pileval samples have far fewer tokens than seqlen; recompute how many
     # train items to select so it can still yield enough samples after concatenation.
@@ -223,10 +208,11 @@ def get_pileval(tokenizer, nsamples, seed, seqlen=512):
     return [cat_samples[:, i * seqlen:(i + 1) * seqlen] for i in range(n_split)]
 
 
-def get_gsm8k(tokenizer, nsamples, seed, seqlen):
+def get_gsm8k(dataset, tokenizer, nsamples, seed, seqlen):
     """Load GSM8K train and test datasets and tokenize.
 
     Args:
+        dataset: calib dataset
         tokenizer: Tokenizer to encode text.
         nsamples: Number of samples to take from train set.
         seed: Random seed for sampling.
@@ -235,20 +221,19 @@ def get_gsm8k(tokenizer, nsamples, seed, seqlen):
     Returns:
         List of sampled and tokenized training examples.
     """
-    train_data = load_dataset('openai/gsm8k', 'main', split='train')
-    train_data = train_data.shuffle(seed=seed)
-    train_data = process_dataset(train_data, tokenizer, seqlen)
+    dataset = dataset.shuffle(seed=seed)
+    dataset = process_dataset(dataset, tokenizer, seqlen)
 
     # GSM8K samples have far fewer tokens than seqlen; recompute how many
     # train items to select so it can still yield enough samples after concatenation.
-    lengths = torch.tensor([len(sample['input_ids']) for sample in train_data], dtype=torch.long)
-    avg_tokens = lengths.sum().item() // len(train_data)
+    lengths = torch.tensor([len(sample['input_ids']) for sample in dataset], dtype=torch.long)
+    avg_tokens = lengths.sum().item() // len(dataset)
     needed_samples = max(1, int((seqlen * nsamples) // avg_tokens))
 
     samples = []
     n_run = 0
-    for i in range(len(train_data)):
-        line = train_data[i]['input_ids']
+    for i in range(len(dataset)):
+        line = dataset[i]['input_ids']
         sample = torch.tensor([line])
         if sample.numel() == 0:
             continue
@@ -262,10 +247,11 @@ def get_gsm8k(tokenizer, nsamples, seed, seqlen):
     return [cat_samples[:, i * seqlen:(i + 1) * seqlen] for i in range(n_split)]
 
 
-def get_neuralmagic_calibration(tokenizer, nsamples, seed, seqlen):
+def get_neuralmagic_calibration(dataset, tokenizer, nsamples, seed, seqlen):
     """Load neuralmagic_calibration train and test datasets and tokenize.
 
     Args:
+        dataset: calib dataset
         tokenizer: Tokenizer to encode text.
         nsamples: Number of samples to take from train set.
         seed: Random seed for sampling.
@@ -274,20 +260,19 @@ def get_neuralmagic_calibration(tokenizer, nsamples, seed, seqlen):
     Returns:
         List of sampled and tokenized training examples.
     """
-    train_data = load_dataset('neuralmagic/calibration', 'LLM', split='train')
-    train_data = train_data.shuffle(seed=seed)
-    train_data = process_dataset(train_data, tokenizer, seqlen)
+    dataset = dataset.shuffle(seed=seed)
+    dataset = process_dataset(dataset, tokenizer, seqlen)
 
     # neuralmagic_calibration samples have far fewer tokens than seqlen; recompute how many
     # train items to select so it can still yield enough samples after concatenation.
-    lengths = torch.tensor([len(sample['input_ids']) for sample in train_data], dtype=torch.long)
-    avg_tokens = lengths.sum().item() / len(train_data)
+    lengths = torch.tensor([len(sample['input_ids']) for sample in dataset], dtype=torch.long)
+    avg_tokens = lengths.sum().item() / len(dataset)
     needed_samples = max(1, int((seqlen * nsamples) // avg_tokens))
 
     samples = []
     n_run = 0
-    for i in range(len(train_data)):
-        line = train_data[i]['input_ids']
+    for i in range(len(dataset)):
+        line = dataset[i]['input_ids']
         sample = torch.tensor([line])
         if sample.numel() == 0:
             continue
@@ -301,10 +286,11 @@ def get_neuralmagic_calibration(tokenizer, nsamples, seed, seqlen):
     return [cat_samples[:, i * seqlen:(i + 1) * seqlen] for i in range(n_split)]
 
 
-def get_open_platypus(tokenizer, nsamples, seed, seqlen):
+def get_open_platypus(dataset, tokenizer, nsamples, seed, seqlen):
     """Load open-platypus train and test datasets and tokenize.
 
     Args:
+        dataset: calib dataset
         tokenizer: Tokenizer to encode text.
         nsamples: Number of samples to take from train set.
         seed: Random seed for sampling.
@@ -313,20 +299,19 @@ def get_open_platypus(tokenizer, nsamples, seed, seqlen):
     Returns:
         List of sampled and tokenized training examples.
     """
-    train_data = load_dataset('garage-bAInd/Open-Platypus', split='train')
-    train_data = train_data.shuffle(seed=seed)
-    train_data = process_dataset(train_data, tokenizer, seqlen)
+    dataset = dataset.shuffle(seed=seed)
+    dataset = process_dataset(dataset, tokenizer, seqlen)
 
     # open-platypus samples have far fewer tokens than seqlen; recompute how many
     # train items to select so it can still yield enough samples after concatenation.
-    lengths = torch.tensor([len(sample['input_ids']) for sample in train_data], dtype=torch.long)
-    avg_tokens = lengths.sum().item() / len(train_data)
+    lengths = torch.tensor([len(sample['input_ids']) for sample in dataset], dtype=torch.long)
+    avg_tokens = lengths.sum().item() / len(dataset)
     needed_samples = max(1, int((seqlen * nsamples) // avg_tokens))
 
     samples = []
     n_run = 0
-    for i in range(len(train_data)):
-        line = train_data[i]['input_ids']
+    for i in range(len(dataset)):
+        line = dataset[i]['input_ids']
         sample = torch.tensor([line])
         if sample.numel() == 0:
             continue
@@ -340,10 +325,11 @@ def get_open_platypus(tokenizer, nsamples, seed, seqlen):
     return [cat_samples[:, i * seqlen:(i + 1) * seqlen] for i in range(n_split)]
 
 
-def get_openwebtext(tokenizer, nsamples, seed, seqlen):
+def get_openwebtext(dataset, tokenizer, nsamples, seed, seqlen):
     """Load openwebtext train and test datasets and tokenize.
 
     Args:
+        dataset: calib dataset
         tokenizer: Tokenizer to encode text.
         nsamples: Number of samples to take from train set.
         seed: Random seed for sampling.
@@ -352,20 +338,16 @@ def get_openwebtext(tokenizer, nsamples, seed, seqlen):
     Returns:
         List of sampled and tokenized training examples.
     """
-    train_data = load_dataset('Skylion007/openwebtext',
-                              data_files={'train': 'plain_text/train-00000-of-00080.parquet'},
-                              split=f'train[:{NUM_LOADED_SAMPLES}]',
-                              verification_mode=VerificationMode.NO_CHECKS)
-    train_data = train_data.shuffle(seed=seed)
-    train_data = process_dataset(train_data, tokenizer, seqlen)
+    dataset = dataset.shuffle(seed=seed)
+    dataset = process_dataset(dataset, tokenizer, seqlen)
 
     import random
     random.seed(seed)
     trainloader = []
     for _ in range(nsamples):
         while True:
-            i = random.randint(0, len(train_data) - 1)
-            trainenc = train_data[i]
+            i = random.randint(0, len(dataset) - 1)
+            trainenc = dataset[i]
             if len(trainenc['input_ids']) >= seqlen:
                 break
         i = random.randint(0, len(trainenc['input_ids']) - seqlen)
@@ -391,23 +373,46 @@ def get_calib_loaders(name, tokenizer, nsamples=128, seed=0, seqlen=2048):
     Returns:
         List of sampled and tokenized training examples.
     """
+    from datasets import VerificationMode, load_dataset
     if 'wikitext2' in name:
-        return get_wikitext2(tokenizer, nsamples, seed, seqlen)
+        dataset = load_dataset('wikitext', 'wikitext-2-raw-v1', split='train')
+        return get_wikitext2(dataset, tokenizer, nsamples, seed, seqlen)
 
     if 'c4' in name:
-        return get_c4(tokenizer, nsamples, seed, seqlen)
+        dataset = load_dataset('allenai/c4',
+                               'en',
+                               data_files={'train': 'en/c4-train.00000-of-01024.json.gz'},
+                               split='train',
+                               verification_mode=VerificationMode.NO_CHECKS)
+        return get_c4(dataset, tokenizer, nsamples, seed, seqlen)
 
     if 'pileval' in name:
-        return get_pileval(tokenizer, nsamples, seed, seqlen)
+        from datasets.builder import DatasetGenerationError
+        try:
+            dataset = load_dataset('mit-han-lab/pile-val-backup', split=f'validation[:{NUM_LOADED_SAMPLES}]')
+        except DatasetGenerationError:
+            raise InterruptedError('There have been some issues when generating '
+                                   'the dataset, you could try to download it '
+                                   'locally first, and replace the `data_files`'
+                                   'with local addresses or use other datasets '
+                                   '(c4, wiki, ptb).')
+        return get_pileval(dataset, tokenizer, nsamples, seed, seqlen)
 
     if 'gsm8k' in name:
-        return get_gsm8k(tokenizer, nsamples, seed, seqlen)
+        dataset = load_dataset('openai/gsm8k', 'main', split='train')
+        return get_gsm8k(dataset, tokenizer, nsamples, seed, seqlen)
 
     if 'neuralmagic_calibration' in name:
-        return get_neuralmagic_calibration(tokenizer, nsamples, seed, seqlen)
+        dataset = load_dataset('neuralmagic/calibration', 'LLM', split='train')
+        return get_neuralmagic_calibration(dataset, tokenizer, nsamples, seed, seqlen)
 
     if 'open-platypus' in name:
-        return get_open_platypus(tokenizer, nsamples, seed, seqlen)
+        dataset = load_dataset('garage-bAInd/Open-Platypus', split='train')
+        return get_open_platypus(dataset, tokenizer, nsamples, seed, seqlen)
 
     if 'openwebtext' in name:
-        return get_openwebtext(tokenizer, nsamples, seed, seqlen)
+        dataset = load_dataset('Skylion007/openwebtext',
+                               data_files={'train': 'plain_text/train-00000-of-00080.parquet'},
+                               split=f'train[:{NUM_LOADED_SAMPLES}]',
+                               verification_mode=VerificationMode.NO_CHECKS)
+        return get_openwebtext(dataset, tokenizer, nsamples, seed, seqlen)


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily receiving feedbacks. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Avoiding finding dataset module when not using lite module.

## Modification

Move load_dataset location from outside to the function of get_calib_loaders in lmdeploy/lmdeploy/lite/utils/calib_dataloader.py.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
