### PR TITLE
Fix NVLS init for mixed DP+TP

### DIFF
--- a/src/turbomind/comm/cuda_ipc/cuda_ipc_comm.cu
+++ b/src/turbomind/comm/cuda_ipc/cuda_ipc_comm.cu
@@ -260,7 +260,7 @@ void CudaIpcCommImpl::Register(const Allocation& alloc, int group)
     const int ranks = n_ranks(group);
     const int rank  = this->rank(group);
 
-    if (multicast_capability_) {
+    if (multicast_capability_ && ranks > 1) {  // ! `cuMulticastCreate` fails for `ranks == 1`
 #if __CUDACC_VER_MAJOR__ >= 12
         CUmulticastObjectProp mc_prop{};
         mc_prop.numDevices = ranks;


### PR DESCRIPTION
`cuMulticastCreate` does not like `numDevices == 1`