### PR TITLE
[side-effect] The tool message dump is incomplete

### DIFF
--- a/lmdeploy/serve/openai/protocol.py
+++ b/lmdeploy/serve/openai/protocol.py
@@ -61,7 +61,7 @@ class Function(BaseModel):
     """Function descriptions."""
     description: Optional[str] = Field(default=None, examples=[None])
     name: str
-    parameters: Optional[object] = None
+    parameters: Optional[Dict[str, Any]] = None
 
 
 class Tool(BaseModel):


### PR DESCRIPTION
Fix side effect brought by #4251 

In the following example, the "parameters" part of `tools` is missed from the dump dict.

```python      
from openai import OpenAI
import json

tools = [{
    'type': 'function',
    'function': {
        'name': 'get_current_temperature',
        'description': 'Get current temperature at a location.',
        'parameters': {
            'type': 'object',
            'properties': {
                'location': {
                    'type': 'string',
                    'description': 'The location to get the temperature for, in the format \'City, State, Country\'.'
                },
                'unit': {
                    'type': 'string',
                    'enum': [
                        'celsius',
                        'fahrenheit'
                    ],
                    'description': 'The unit to return the temperature in. Defaults to \'celsius\'.'
                }
            },
            'required': [
                'location'
            ]
        }
    }
},
]



messages = [
    {'role': 'user', 'content': 'Today is 2024-11-14, What\'s the temperature in San Francisco now? How about tomorrow?'}
]

openai_api_key = "EMPTY"
openai_api_base = "http://0.0.0.0:23333/v1"
client = OpenAI(
    api_key=openai_api_key,
    base_url=openai_api_base,
)
model_name = client.models.list().data[0].id
response = client.chat.completions.create(
    model=model_name,
    messages=messages,
    max_tokens=32768,
    temperature=0.8,
    top_p=0.8,
    # stream=False,
    stream=True,
    # extra_body=dict(spaces_between_special_tokens=False, enable_thinking=True),
    extra_body=dict(enable_thinking=True),
    tools=tools
    )
for res in response:
    print(res)
```