### PR TITLE
add Qwen3-8B accuracy evaluation in llm_compressor.md

### DIFF
--- a/docs/en/quantization/llm_compressor.md
+++ b/docs/en/quantization/llm_compressor.md
@@ -83,15 +83,16 @@ The default service port is 23333. After the server starts, you can access the s
 
 ## Accuracy Evaluation
 
-After deploying the AWQ symmetric and AWQ asymmetric quantized Qwen3-30B-A3B models as services via LMDeploy, we evaluated their accuracy on several academic datasets using [opencompass](https://github.com/open-compass/opencompass). AWQ symmetric and asymmetric quantization show no significant difference in accuracy. Compared with BF16, accuracy drops significantly on long-output datasets such as aime2025 (avg 17,635 tokens) and LCB (avg 14,157 tokens), while on medium/short-output datasets like ifeval (avg 1,885 tokens) and mmlu_pro (avg 2,826 tokens), the accuracy is as expected.
+Aftering deploying AWQ symmetric/asymmetric quantized models of Qwen3-8B (Dense) and Qwen3-30B-A3B (MoE) as services via LMDeploy, we evaluated their accuracy on several academic datasets using [opencompass](https://github.com/open-compass/opencompass). Results indicate that, for Qwen3-8B, asymmetric quantization generally outperforms symmetric quantization, while Qwen3-30B-A3B shows no substantial difference between symmetric and asymmetric quantization. Compared with BF16, Qwen3-8B shows a smaller accuracy gap under both symmetric and asymmetric quantization than Qwen3-30B-A3B. Compared with BF16, accuracy drops significantly on long-output datasets such as aime2025 (avg 17,635 tokens) and LCB (avg 14,157 tokens), while on medium/short-output datasets like ifeval (avg 1,885 tokens) and mmlu_pro (avg 2,826 tokens), the accuracy is as expected.
 
-| dataset           | bf16  | awq sym | awq asym |
-| ----------------- | ----- | ------- | -------- |
-| ifeval            | 86.32 | 84.10   | 84.29    |
-| hle               | 7.00  | 5.47    | 5.65     |
-| gpqa              | 61.74 | 57.95   | 57.07    |
-| aime2025          | 73.44 | 64.79   | 66.67    |
-| mmlu_pro          | 77.85 | 75.77   | 75.69    |
-| LCBCodeGeneration | 56.67 | 50.86   | 49.24    |
+| dataset           | Qwen3-8B |         |          | Qwen3-30B-A3B |         |          |
+| ----------------- | -------- | ------- | -------- | ------------- | ------- | -------- |
+|                   | bf16     | awq sym | awq asym | bf16          | awq sym | awq asym |
+| ifeval            | 85.58    | 83.73   | 85.77    | 86.32         | 84.10   | 84.29    |
+| hle               | 5.05     | 5.05    | 5.24     | 7.00          | 5.47    | 5.65     |
+| gpqa              | 59.97    | 56.57   | 59.47    | 61.74         | 57.95   | 57.07    |
+| aime2025          | 69.48    | 64.38   | 63.96    | 73.44         | 64.79   | 66.67    |
+| mmlu_pro          | 73.69    | 71.73   | 72.34    | 77.85         | 75.77   | 75.69    |
+| LCBCodeGeneration | 50.86    | 44.10   | 46.95    | 56.67         | 50.86   | 49.24    |
 
 For reproduction methods, please refer to [this](https://lmdeploy.readthedocs.io/en/latest/benchmark/evaluate_with_opencompass.html) document.

--- a/docs/zh_cn/quantization/llm_compressor.md
+++ b/docs/zh_cn/quantization/llm_compressor.md
@@ -81,15 +81,16 @@ lmdeploy serve api_server ./qwen3_30b_a3b_4bit --backend turbomind
 
 ## 精度评测
 
-我们把 Qwen3-30B-A3B 的 AWQ 对称量化模型和 AWQ 非对称量化模型通过 LMDeploy 部署为服务后，使用 [opencompass](https://github.com/open-compass/opencompass) 评测了其在若干学术数据集上的精度。AWQ 对称量化和非对称量化的精度表现没有显著差异。与 BF16 相比，在长输出数据集，比如 aime2025（平均 17,635 tokens）、LCB（平均 14,157 tokens），精度下降明显。而在中短输出数据集，比如 ifeval（平均 1,885 tokens）, mmlu_pro（平均 2,826 tokens），精度符合预期。
+我们将 Qwen3-8B (Dense) 与 Qwen3-30B-A3B (MoE) 的 AWQ 对称/非对称量化模型通过 LMDeploy 部署为服务，并使用 [opencompass](https://github.com/open-compass/opencompass) 在多个学术数据集上评测。结果显示：Qwen3-8B 的非对称量化整体优于对称量化，而 Qwen3-30B-A3B 在两种量化方式间差异不显著；Qwen3-8B 在对称/非对称量化下与 BF16 模型的精度差异小于 Qwen3-30B-A3B。与 BF16 相比，量化模型在长输出数据集，比如 aime2025 (平均 17,635 tokens)、LCB (平均 14,157 tokens)，精度下降更明显；在中短输出数据集，比如 ifeval (平均 1,885 tokens)，mmlu_pro (平均 2,826)，精度符合预期。
 
-| dataset           | bf16  | awq sym | awq asym |
-| ----------------- | ----- | ------- | -------- |
-| ifeval            | 86.32 | 84.10   | 84.29    |
-| hle               | 7.00  | 5.47    | 5.65     |
-| gpqa              | 61.74 | 57.95   | 57.07    |
-| aime2025          | 73.44 | 64.79   | 66.67    |
-| mmlu_pro          | 77.85 | 75.77   | 75.69    |
-| LCBCodeGeneration | 56.67 | 50.86   | 49.24    |
+| dataset           | Qwen3-8B |         |          | Qwen3-30B-A3B |         |          |
+| ----------------- | -------- | ------- | -------- | ------------- | ------- | -------- |
+|                   | bf16     | awq sym | awq asym | bf16          | awq sym | awq asym |
+| ifeval            | 85.58    | 83.73   | 85.77    | 86.32         | 84.10   | 84.29    |
+| hle               | 5.05     | 5.05    | 5.24     | 7.00          | 5.47    | 5.65     |
+| gpqa              | 59.97    | 56.57   | 59.47    | 61.74         | 57.95   | 57.07    |
+| aime2025          | 69.48    | 64.38   | 63.96    | 73.44         | 64.79   | 66.67    |
+| mmlu_pro          | 73.69    | 71.73   | 72.34    | 77.85         | 75.77   | 75.69    |
+| LCBCodeGeneration | 50.86    | 44.10   | 46.95    | 56.67         | 50.86   | 49.24    |
 
 复现方式可以参考[这份](https://lmdeploy.readthedocs.io/zh-cn/latest/benchmark/evaluate_with_opencompass.html)文档


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily receiving feedbacks. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

This PR extends the “Accuracy Evaluation” section in llm_compressor.md and llm_compressor.md by adding AWQ (symmetric/asymmetric) results for Qwen3-8B (Dense). The Dense model serves as a baseline under the same quantization settings and evaluation pipeline as Qwen3-30B-A3B (MoE), enabling a clearer comparison to assess whether int4 quantization leads to larger accuracy degradation for MoE models than for Dense models.

## Modification

lmdeploy/docs/en/quantization/llm_compressor.md: add  AWQ (symmetric/asymmetric) accuracy evaluation for Qwen3-8B (Dense).
lmdeploy/docs/zh_cn/quantization/llm_compressor.md: add  AWQ (symmetric/asymmetric) accuracy evaluation for Qwen3-8B (Dense).

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
