### PR TITLE
Fix data race for guided decoding in TP mode

### DIFF
--- a/src/turbomind/generation/guided_decoding.cc
+++ b/src/turbomind/generation/guided_decoding.cc
@@ -17,7 +17,8 @@ struct GuidedDecoding::Data {
 };
 
 GuidedDecoding::GuidedDecoding(const BaseGenerationParam& base, const comm::HostComm& tp_group, int phases):
-    BaseGenerationParam{base}, tp_group_{tp_group}
+    BaseGenerationParam{base},        //
+    tp_group_{tp_group->Split(0, 0)}  // duplicate to avoid data race
 {
     const auto bitmask_size = xgrammar::GetBitmaskSize(vocab_size_padded_);
 


### PR DESCRIPTION
Duplicate the communicator so it can be used independently. #4337