### PR TITLE
 Fix XGrammar bitmask initialization and add null check for gen_config in generate method

### DIFF
--- a/.github/workflows/linux-x64-gpu.yml
+++ b/.github/workflows/linux-x64-gpu.yml
@@ -48,13 +48,14 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
       - name: Build
-        uses: addnab/docker-run-action@v3
-        with:
-          image: openmmlab/lmdeploy-builder:cuda${{ matrix.cudaver }}
-          options: -v ${{ github.workspace }}:/work
-          run: |
-            cd /work
-            source /opt/conda/bin/activate
-            conda activate py310
-            pip install build
-            python -m build --wheel
+        run: |
+          docker run --rm \
+            -v ${{ github.workspace }}:/work \
+            -w /work \
+            openmmlab/lmdeploy-builder:cuda${{ matrix.cudaver }} \
+            bash -c "
+              source /opt/conda/bin/activate && \
+              conda activate py310 && \
+              pip install build && \
+              python -m build --wheel
+            "

--- a/lmdeploy/serve/core/async_engine.py
+++ b/lmdeploy/serve/core/async_engine.py
@@ -351,6 +351,10 @@ class AsyncEngine:
             # TODO(lvhan) VLM doesn't support input_ids as an argument.
             # Figure out a graceful way to handle the invalid input
             prompt_input = dict(input_ids=input_ids)
+
+        if gen_config is None:
+            gen_config = GenerationConfig()
+
         if gen_config.max_new_tokens is None:
             max_new_tokens = max(0, self.session_len - session.step - len(input_ids))
             if max_new_tokens == 0:

--- a/src/turbomind/generation/guided_decoding.cc
+++ b/src/turbomind/generation/guided_decoding.cc
@@ -62,7 +62,9 @@ void GuidedDecoding::FillMask(int phase, TensorMap& env)
                     matcher->FillNextTokenBitmask(&dlbitmask, i);
                 }
                 else {
-                    std::fill_n(bitmask_buf_.data() + i * bitmask_buf_.stride(0), bitmask_buf_.stride(0), 0);
+                    std::fill_n(bitmask_buf_.data() + i * bitmask_buf_.stride(0),
+                                bitmask_buf_.stride(0),
+                                static_cast<int32_t>(-1));
                 }
             }
         }

--- a/tests/test_lmdeploy/test_grammar.py
+++ b/tests/test_lmdeploy/test_grammar.py
@@ -95,3 +95,49 @@ def test_guided_matrix(model_id, backend_name, backend_factory, schema_type):
                 assert re.fullmatch(schema, response[0].text)
     finally:
         pipe.close()
+
+
+@pytest.mark.parametrize('model_id', MODEL_IDS)
+@pytest.mark.parametrize('backend_name,backend_factory', BACKEND_FACTORIES)
+def test_mix_guided_matrix(model_id, backend_name, backend_factory):
+    pipe = pipeline(
+        model_id,
+        backend_config=backend_factory(),
+        log_level='INFO',
+    )
+
+    schema_type = 'json_schema'
+    response_format = {'type': schema_type}
+    schema = SCHEMA_MAP[schema_type]
+    response_format[schema_type] = dict(name='test', schema=schema)
+
+    prompts = ['Make a self introduction please.'] * 4
+    try:
+        config = GenerationConfig(response_format=response_format)
+
+        gen_config = [None if idx % 3 else config for idx in range(4)]
+
+        responses = pipe.batch_infer(prompts, gen_config=gen_config)
+
+        for resp, c in zip(responses, gen_config):
+            if c is None:
+                # Unguided generation: ensure we get some text, and that it does not
+                # accidentally produce JSON that conforms to the guided schema.
+                assert resp and resp.text
+                try:
+                    data = json.loads(resp.text)
+                except json.JSONDecodeError:
+                    # Not valid JSON, so it cannot conform to the schema.
+                    continue
+                else:
+                    try:
+                        validate(instance=data, schema=schema)
+                    except Exception:
+                        # JSON is present but does not satisfy the schema.
+                        continue
+                    else:
+                        pytest.fail('Unguided generation unexpectedly produced schema-conformant JSON')
+            else:
+                validate(instance=json.loads(resp.text), schema=schema)
+    finally:
+        pipe.close()


### PR DESCRIPTION
## Motivation
This PR addresses two critical issues in LMDeploy's guided generation and batch inference functionality:

1. **XGrammar Bitmask Initialization Bug**: The guided decoding mechanism initializes token bitmasks to control which tokens are allowed during constrained generation. Previously, the bitmask was initialized with zeros, which incorrectly blocked all tokens instead of allowing all tokens. This caused generation failures when certain sequences in a batch didn't have grammar constraints applied.

2. **Silent Failure on None gen_config**: The `batch_infer` method accepts a list of `GenerationConfig` objects, but when `None` was passed for individual items, the code would silently fail or hang due to unhandled null pointer dereference when accessing `gen_config.max_new_tokens`.

## Modifications

1. **Guided Decoding Bitmask Fix** (`src/turbomind/generation/guided_decoding.cc`):
   - Changed the bitmask initialization value from `0` to `-1` (all bits set to 1 in two's complement representation for `int32_t`).
   - This ensures that when a sequence doesn't have an active grammar matcher, all tokens are permitted by default rather than none.

2. **Null GenerationConfig Guard** (`lmdeploy/serve/core/async_engine.py`):
   - Added an explicit check to instantiate a default `GenerationConfig()` when `gen_config` is `None`.
   - This prevents downstream code from attempting to access attributes on a null object, which was causing the engine to hang silently.

3. **Regression Test** (`tests/test_lmdeploy/test_grammar.py`):
   - Added `test_mix_guided_matrix` to verify that batch inference works correctly when mixing guided and unguided generation in the same batch.
   - The test ensures unguided sequences produce arbitrary text (not necessarily conforming to schema) while guided sequences strictly follow the JSON schema constraints.