### PR TITLE
build(docker): skip FA2 when use cu13

### DIFF
--- a/docker/install.sh
+++ b/docker/install.sh
@@ -81,6 +81,7 @@ elif [[ "${CUDA_VERSION_SHORT}" = "cu130" ]]; then
 fi
 
 # install pre-built flash attention wheel
+
 PLATFORM="linux_x86_64"
 PY_VERSION=$(python3 - <<'PY'
 import torch, sys
@@ -94,11 +95,13 @@ PY
 
 read TORCH_VER CUDA_VER CXX11ABI PY_TAG <<< "$PY_VERSION"
 
-WHEEL="flash_attn-${FA_VERSION}+cu${CUDA_VER}torch${TORCH_VER}cxx11abi${CXX11ABI}-${PY_TAG}-${PY_TAG}-${PLATFORM}.whl"
-BASE_URL="https://github.com/Dao-AILab/flash-attention/releases/download/v${FA_VERSION}"
-FULL_URL="${BASE_URL}/${WHEEL}"
+if [[ "${CUDA_VER}" == "12" ]]; then
+    WHEEL="flash_attn-${FA_VERSION}+cu${CUDA_VER}torch${TORCH_VER}cxx11abi${CXX11ABI}-${PY_TAG}-${PY_TAG}-${PLATFORM}.whl"
+    BASE_URL="https://github.com/Dao-AILab/flash-attention/releases/download/v${FA_VERSION}"
+    FULL_URL="${BASE_URL}/${WHEEL}"
 
-pip install "$FULL_URL"
+    pip install "$FULL_URL"
+fi
 
 # install requirements/serve.txt dependencies such as timm
 pip install -r /tmp/requirements/serve.txt


### PR DESCRIPTION
## Motivation
Flash Attention 2 does not provide pre-built wheels for CUDA 13.0. Installing FA2 on cu13 causes build failures, so we skip it for non-cu12 environments.

## Modification
Conditionally install FA2 only when CUDA version matches cu12*, allowing cu13 to bypass the installation while preserving existing behavior for supported versions.