### PR TITLE
ci(lint): skip flaky deadlink test for python wiki page

### DIFF
--- a/.github/md-link-config.json
+++ b/.github/md-link-config.json
@@ -31,7 +31,7 @@
       "pattern": "^https://kexue.fm"
     },
     {
-      "pattern":"^https://wiki.python.org/moin/DebuggingWithGdb"
+      "pattern": "^https://wiki.python.org/moin/DebuggingWithGdb"
     }
   ],
   "httpHeaders": [

--- a/.github/md-link-config.json
+++ b/.github/md-link-config.json
@@ -29,6 +29,9 @@
     },
     {
       "pattern": "^https://kexue.fm"
+    },
+    {
+      "pattern":"^https://wiki.python.org/moin/DebuggingWithGdb"
     }
   ],
   "httpHeaders": [


### PR DESCRIPTION
## Motivation

The Python wiki page `https://wiki.python.org/moin/DebuggingWithGdb` is randomly returning 503 errors, causing flaky lint tests.

## Modification

Add the URL to the link checker's ignore list.