### PR TITLE
fix: change debug log from ERROR to DEBUG in RepetitionPenaltyKernel

### DIFF
--- a/src/turbomind/kernels/sampling_penalty_kernels.cu
+++ b/src/turbomind/kernels/sampling_penalty_kernels.cu
@@ -187,7 +187,7 @@ void ApplyRepetitionPenalty(Tensor&               logits,
         if (smem_size > (48 << 10)) {
             TM_CHECK_EQ(cudaFuncSetAttribute(func, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size), 0);
         }
-        TM_LOG_ERROR("smem_size = %d", smem_size);
+        TM_LOG_DEBUG("smem_size = %d", smem_size);
         func<<<bsz, 1024, smem_size, stream>>>(
             logits.data<T>(), penalties.data(), token_ids_ptrs.data(), sequence_length.data(), vocab_size, mask_size);
     };


### PR DESCRIPTION
## Problem

The TM_LOG_ERROR call in ApplyRepetitionPenalty() (line 190 of sampling_penalty_kernels.cu) reports the shared memory allocation size on **every invocation** during inference. This produces excessive console spam:

`
[TM][ERROR] smem_size = 1024
[TM][ERROR] smem_size = 1024
[TM][ERROR] smem_size = 1024
...
`

This message fires once per token generation step and is **not an error condition**  the value (e.g., 1024 bytes for an ~8K vocabulary bitmask) is a perfectly normal shared memory allocation well within GPU limits.

## Impact

- Floods the console during inference, making it difficult to spot real errors
- Confuses users who see [ERROR] and assume something is wrong
- Particularly visible in downstream projects like [Soprano TTS](https://github.com/ekwek/soprano) which use lmdeploy as a backend

## Fix

One-line change: TM_LOG_ERROR  TM_LOG_DEBUG

This preserves the diagnostic information for developers who enable debug logging while keeping the console clean at default log levels.