### PR TITLE
reduce turbomind compilation time on target attention

### DIFF
--- a/src/turbomind/kernels/attention/CMakeLists.txt
+++ b/src/turbomind/kernels/attention/CMakeLists.txt
@@ -4,9 +4,13 @@ add_library(attention STATIC
             attention.cu
             decoding.cu
             reduce.cu
-            kv_cache_utils_v2.cu
+            # kv_cache_utils_v2.cu
             utils.cc
             cp_utils.cu
+            codegen/kv_cache_v2_process_f16.cu
+            codegen/kv_cache_v2_process_bf16.cu
+            codegen/kv_cache_v2_flatten_f16.cu
+            codegen/kv_cache_v2_flatten_bf16.cu
             codegen/attention_sm70_128_f16.cu
             codegen/attention_sm75_128_f16.cu
             codegen/attention_sm80_128_bf16.cu

--- a/src/turbomind/kernels/attention/codegen/kv_cache_v2_flatten_bf16.cu
+++ b/src/turbomind/kernels/attention/codegen/kv_cache_v2_flatten_bf16.cu
@@ -1,0 +1,30 @@
+// Copyright (c) OpenMMLab. All rights reserved.
+
+#include "../kv_cache_utils_v2_impl.cuh"
+
+namespace turbomind {
+
+#if ENABLE_BF16
+template void invokeFlattenKV_v2(nv_bfloat16*           k,
+                                 nv_bfloat16*           v,
+                                 char**                 blocks,
+                                 const int*             cu_k_len,
+                                 const int*             cu_block_num,
+                                 const RopeKernelParam& rope_param,
+                                 int64_t                stride_b,
+                                 int64_t                stride_c,
+                                 int64_t                stride_h,
+                                 int64_t                stride_s,
+                                 int                    block_seq_len,
+                                 int                    layer_id,
+                                 int                    cp_rank,
+                                 cutlass::FastDivmod    cp_size,
+                                 int                    max_seq_len,
+                                 int                    head_num,
+                                 int                    head_dim,
+                                 int                    batch_size,
+                                 int                    quant_policy,
+                                 cudaStream_t           stream);
+#endif
+
+}  // namespace turbomind

--- a/src/turbomind/kernels/attention/codegen/kv_cache_v2_flatten_f16.cu
+++ b/src/turbomind/kernels/attention/codegen/kv_cache_v2_flatten_f16.cu
@@ -1,0 +1,28 @@
+// Copyright (c) OpenMMLab. All rights reserved.
+
+#include "../kv_cache_utils_v2_impl.cuh"
+
+namespace turbomind {
+
+template void invokeFlattenKV_v2(half*                  k,
+                                 half*                  v,
+                                 char**                 blocks,
+                                 const int*             cu_k_len,
+                                 const int*             cu_block_num,
+                                 const RopeKernelParam& rope_param,
+                                 int64_t                stride_b,
+                                 int64_t                stride_c,
+                                 int64_t                stride_h,
+                                 int64_t                stride_s,
+                                 int                    block_seq_len,
+                                 int                    layer_id,
+                                 int                    cp_rank,
+                                 cutlass::FastDivmod    cp_size,
+                                 int                    max_seq_len,
+                                 int                    head_num,
+                                 int                    head_dim,
+                                 int                    batch_size,
+                                 int                    quant_policy,
+                                 cudaStream_t           stream);
+
+}  // namespace turbomind

--- a/src/turbomind/kernels/attention/codegen/kv_cache_v2_process_bf16.cu
+++ b/src/turbomind/kernels/attention/codegen/kv_cache_v2_process_bf16.cu
@@ -1,0 +1,33 @@
+// Copyright (c) OpenMMLab. All rights reserved.
+
+#include "../kv_cache_utils_v2_impl.cuh"
+
+namespace turbomind {
+
+#if ENABLE_BF16
+template void invokeProcessKV_v2(char**                 blocks,
+                                 const nv_bfloat16*     k,
+                                 const nv_bfloat16*     v,
+                                 const nv_bfloat16*     k_bias,
+                                 const nv_bfloat16*     v_bias,
+                                 const int*             cu_q_len,
+                                 const int*             cu_k_len,
+                                 const int*             cu_block_num,
+                                 const RopeKernelParam& rope_param,
+                                 int64_t                stride_b,
+                                 int64_t                stride_c,
+                                 int64_t                stride_h,
+                                 int64_t                stride_s,
+                                 int                    block_seq_len,
+                                 int                    layer_id,
+                                 int                    cp_rank,
+                                 cutlass::FastDivmod    cp_size,
+                                 int                    max_q_len,
+                                 int                    head_num,
+                                 int                    head_dim,
+                                 int                    batch_size,
+                                 int                    quant_policy,
+                                 cudaStream_t           stream);
+#endif
+
+}  // namespace turbomind

--- a/src/turbomind/kernels/attention/codegen/kv_cache_v2_process_f16.cu
+++ b/src/turbomind/kernels/attention/codegen/kv_cache_v2_process_f16.cu
@@ -1,0 +1,31 @@
+// Copyright (c) OpenMMLab. All rights reserved.
+
+#include "../kv_cache_utils_v2_impl.cuh"
+
+namespace turbomind {
+
+template void invokeProcessKV_v2(char**                 blocks,
+                                 const half*            k,
+                                 const half*            v,
+                                 const half*            k_bias,
+                                 const half*            v_bias,
+                                 const int*             cu_q_len,
+                                 const int*             cu_k_len,
+                                 const int*             cu_block_num,
+                                 const RopeKernelParam& rope_param,
+                                 int64_t                stride_b,
+                                 int64_t                stride_c,
+                                 int64_t                stride_h,
+                                 int64_t                stride_s,
+                                 int                    block_seq_len,
+                                 int                    layer_id,
+                                 int                    cp_rank,
+                                 cutlass::FastDivmod    cp_size,
+                                 int                    max_q_len,
+                                 int                    head_num,
+                                 int                    head_dim,
+                                 int                    batch_size,
+                                 int                    quant_policy,
+                                 cudaStream_t           stream);
+
+}  // namespace turbomind

--- a/src/turbomind/kernels/attention/kv_cache_utils_v2_impl.cuh
+++ b/src/turbomind/kernels/attention/kv_cache_utils_v2_impl.cuh
@@ -1,5 +1,7 @@
 // Copyright (c) OpenMMLab. All rights reserved.
 
+#pragma once
+
 #include <type_traits>
 
 #include "src/turbomind/kernels/attention/block.h"
@@ -274,35 +276,6 @@ void invokeProcessKV_v2(char**                 blocks,
     }
 }
 
-#define INSTANTIATE_invokeProcessKV_v2(type)                                                                           \
-    template void invokeProcessKV_v2(char**                 blocks,                                                    \
-                                     const type*            k,                                                         \
-                                     const type*            v,                                                         \
-                                     const type*            k_bias,                                                    \
-                                     const type*            v_bias,                                                    \
-                                     const int*             cu_q_len,                                                  \
-                                     const int*             cu_k_len,                                                  \
-                                     const int*             cu_block_num,                                              \
-                                     const RopeKernelParam& rope_param,                                                \
-                                     int64_t                stride_b,                                                  \
-                                     int64_t                stride_c,                                                  \
-                                     int64_t                stride_h,                                                  \
-                                     int64_t                stride_s,                                                  \
-                                     int                    block_seq_len,                                             \
-                                     int                    layer_id,                                                  \
-                                     int                    cp_rank,                                                   \
-                                     FastDivmod             cp_size,                                                   \
-                                     int                    max_q_len,                                                 \
-                                     int                    head_num,                                                  \
-                                     int                    head_dim,                                                  \
-                                     int                    batch_size,                                                \
-                                     int                    quant_policy,                                              \
-                                     cudaStream_t           stream);
-
-INSTANTIATE_invokeProcessKV_v2(half);
-#if ENABLE_BF16
-INSTANTIATE_invokeProcessKV_v2(nv_bfloat16);
-#endif
 
 template<int CTA_S, int HeadDim, int WarpCnt, class T, class Tkv, class BlockLayout>
 __global__ void __launch_bounds__(128) flattenKV_v2(T*              k,
@@ -502,32 +475,5 @@ void invokeFlattenKV_v2(T*                     k,
         dispatch(T{});
     }
 }
-
-#define INSTANTIATE_invokeFlattenKV_v2(type)                                                                           \
-    template void invokeFlattenKV_v2(type*                  k,                                                         \
-                                     type*                  v,                                                         \
-                                     char**                 blocks,                                                    \
-                                     const int*             cu_k_len,                                                  \
-                                     const int*             cu_block_num,                                              \
-                                     const RopeKernelParam& rope_param,                                                \
-                                     int64_t                stride_b,                                                  \
-                                     int64_t                stride_c,                                                  \
-                                     int64_t                stride_h,                                                  \
-                                     int64_t                stride_s,                                                  \
-                                     int                    block_seq_len,                                             \
-                                     int                    layer_id,                                                  \
-                                     int                    cp_rank,                                                   \
-                                     FastDivmod             cp_size,                                                   \
-                                     int                    max_seq_len,                                               \
-                                     int                    head_num,                                                  \
-                                     int                    head_dim,                                                  \
-                                     int                    batch_size,                                                \
-                                     int                    quant_policy,                                              \
-                                     cudaStream_t           stream);
-
-INSTANTIATE_invokeFlattenKV_v2(half);
-#if ENABLE_BF16
-INSTANTIATE_invokeFlattenKV_v2(nv_bfloat16);
-#endif
 
 }  // namespace turbomind


### PR DESCRIPTION
before:
Time taken: 674 seconds
646.563s        src/turbomind/kernels/attention/CMakeFiles/attention.dir/kv_cache_utils_v2.cu.o

after:
Time taken: 312 seconds
283.844s        src/turbomind/kernels/attention/CMakeFiles/attention.dir/codegen/kv_cache_v2_process_bf16.cu.o
257.601s        src/turbomind/kernels/attention/CMakeFiles/attention.dir/codegen/kv_cache_v2_flatten_bf16.cu.o
116.851s        src/turbomind/kernels/attention/CMakeFiles/attention.dir/codegen/kv_cache_v2_process_f16.cu.o
78.870s          src/turbomind/kernels/attention/CMakeFiles/attention.dir/codegen/kv_cache_v2_flatten_f16.cu.o