### PR TITLE
ci: integrate clang-format lint into pre-commit hooks

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,13 +17,6 @@ jobs:
           pre-commit install
       - name: Linting
         run: pre-commit run --all-files
-      - name: Format c/cuda codes with clang-format
-        uses: DoozyX/clang-format-lint-action@v0.13
-        with:
-          source: src
-          extensions: h,c,cpp,hpp,cu,cuh,cc
-          clangFormatVersion: 11
-          style: file
       - name: Check markdown link
         uses: gaurav-nelson/github-action-markdown-link-check@v1
         with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,6 +57,13 @@ repos:
     -   id: check-copyright
         args: ["lmdeploy"]
 
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: v11.1.0
+    hooks:
+      - id: clang-format
+        files: ^src/
+        types_or: [c, c++, cuda]
+
 exclude: |
   (?x)(
     ^cmake/.*\.patch$


### PR DESCRIPTION
## Motivation
It is annoying to fix `clang-format` lint each time without pre-commit hooks.

## Modification

Integrate `clang-format` to pre-commit hooks.