### PR TITLE
Make Intern-S1-Pro compatible with Transformers 5.0+

### DIFF
--- a/lmdeploy/pytorch/models/qwen3_moe.py
+++ b/lmdeploy/pytorch/models/qwen3_moe.py
@@ -354,7 +354,7 @@ class Qwen3MoeModel(nn.Module):
                  device: torch.device = None,
                  prefix: str = ''):
         super().__init__()
-        self.padding_idx = config.pad_token_id
+        self.padding_idx = getattr(config, 'pad_token_id', None)
         self.vocab_size = config.vocab_size
         self.embed_tokens = build_embedding(
             config.vocab_size,


### PR DESCRIPTION
```python
from transformers import AutoConfig

config = AutoConfig.from_pretrained("internlm/Intern-S1-Pro", trust_remote_code=True)
print(config.text_config.pad_token_id)
```

Running the above code with transformers<5, `config.pad_token_id` is None

But with transformers>5, it raises the following error
```
Traceback (most recent call last):
  File "/nvme1/lvhan/lmdeploy/workspace/transformers/config.py", line 7, in <module>
    print(config.pad_token_id)
          ^^^^^^^^^^^^^^^^^^^
  File "/opt/py3/lib/python3.12/site-packages/transformers/configuration_utils.py", line 164, in __getattribute__
    return super().__getattribute__(key)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'InternS1ProTextConfig' object has no attribute 'pad_token_id'. Did you mean: 'bos_token_id'?
```
