### PR TITLE
safe ray api

### DIFF
--- a/lmdeploy/pytorch/engine/executor/ray_executor.py
+++ b/lmdeploy/pytorch/engine/executor/ray_executor.py
@@ -489,7 +489,7 @@ class RayExecutor(ExecutorBase):
             finally:
                 # free ray.put inputs
                 try:
-                    ray._private.internal_api.free(self._prev_inputs)
+                    ray.internal.free(self._prev_inputs, local_only=False)
                 except Exception as e:
                     logger.warning(f'Free input ref failed: {e}')
 


### PR DESCRIPTION
Happend to notice the update in xtuner 

- https://github.com/InternLM/xtuner/pull/1595

```
ray._private.internal_api.free() => ray.internal.free()
```

Two functions are the same, referring to
https://github.com/ray-project/ray/blob/master/python/ray/internal/__init__.py

But better to avoid private method function calls, so change it in lmdeploy as well.