### PR TITLE
fix(turbomind): fix dimension mismatch in ApplyTokenBitmaskInplace

### DIFF
--- a/src/turbomind/generation/guided_decoding.cc
+++ b/src/turbomind/generation/guided_decoding.cc
@@ -80,7 +80,11 @@ void GuidedDecoding::ApplyMask(int phase, TensorMap& env)
             comm::Broadcast(tp_group_, bitmask_buf_.data(), numel, 0);
         }
         Copy(bitmask_buf_.buffer(), numel, d.bitmask.buffer());
-        ApplyTokenBitmaskInplace(env.at("logits"), d.bitmask.slice(0, d.matchers.size()));
+        // Use logits shape(0) instead of d.matchers.size() to ensure dimension match.
+        // d.matchers.size() is the total number of requests in batch, but logits may be
+        // sliced to only include requests that are still generating (generation_size).
+        auto logits = env.at("logits");
+        ApplyTokenBitmaskInplace(logits, d.bitmask.slice(0, logits.shape(0)));
     }
 }
 


### PR DESCRIPTION
The bug occurs when batch contains requests that have finished generation but are still waiting in the batch for synchronization. In this case, generation_size (number of requests still generating) is less than matchers.size() (total requests in batch).

Root cause:
- In generation.cc Forward(), logits is sliced to match generation_size: env.produce("logits", logits.slice(0, gs));
- But in guided_decoding.cc ApplyMask(), bitmask was sliced using d.matchers.size() instead of the actual logits batch size.

This causes TM_CHECK(logits_shape.first == bitmask_shape.first) to fail in apply_token_bitmask_inplace_cuda.cu when the dimensions don't match.

fix: #4453 