### PR TITLE
release state cache

### DIFF
--- a/lmdeploy/pytorch/engine/model_agent/agent.py
+++ b/lmdeploy/pytorch/engine/model_agent/agent.py
@@ -1208,6 +1208,7 @@ class BaseModelAgent:
         if self.dist_config.dp > 1:
             await self.state.to_sleep.wait()
         self.cache_engine = None
+        self.state_cache_engine = None
         self.reset_graph_runner()
         device = 'cpu' if level == 1 else 'meta'
         self.patched_model.get_model().to(device=device, non_blocking=True)
@@ -1245,4 +1246,5 @@ class BaseModelAgent:
         self.reset_graph_runner()
         self.patched_model = None
         self.cache_engine = None
+        self.state_cache_engine = None
         torch.cuda.empty_cache()


### PR DESCRIPTION
## Test

<details>
  <summary>Test script</summary>

```python
import torch
import requests
from time import sleep

BASE_URL = 'http://0.0.0.0:23334'
api_key = 'sk-xxx'

headers = {
    "Content-Type": "application/json",
    "Authorization": f"Bearer {api_key}",
}

def log_memory(msg: str = '') -> None:
    # for rank in range(8):
    for rank in [6, 7]:
        free_mem, total_mem = torch.cuda.mem_get_info(rank)
        used_mem = (total_mem - free_mem) / 1024**3
        print(f'rank {rank}, {msg}, total used mem {used_mem:.2f} GB')

for i in range(3):
    print(f"=== iteration {i} ===")
    log_memory(f"before sleep {i}")
    # offloads weights and kv cache with level=2
    response = requests.post(f"{BASE_URL}/sleep", headers=headers, params=dict(tags=['weights', 'kv_cache'], level=2))
    assert response.status_code == 200, response.status_code
    log_memory(f"after sleep {i}")
    sleep(1)

    # wake up weights, the server is ready for update 
    log_memory(f"before wakeup weight {i}")
    response = requests.post(f"{BASE_URL}/wakeup", headers=headers, params=dict(tags=['weights']))
    assert response.status_code == 200, response.status_code
    log_memory(f"after wakeup weight {i}")
    sleep(1)

    # wake up kv cache, the server is ready for update kv cache
    log_memory(f"before wakeup kv cache {i}")
    response = requests.post(f"{BASE_URL}/wakeup", headers=headers, params=dict(tags=['kv_cache']))
    assert response.status_code == 200, response.status_code
    log_memory(f"after wakeup kv cache {i}")
    sleep(1)
```

</details>



## Compare

Tested with Qwen3.5-35B-A3B with TP=2, GPU mem after sleep then wakeup `70.39 GB -> 68.71 GB`

<details>
  <summary>Before PR</summary>

```text
=== iteration 0 ===
rank 6, before sleep 0, total used mem 68.79 GB
rank 7, before sleep 0, total used mem 68.79 GB
rank 6, after sleep 0, total used mem 4.06 GB
rank 7, after sleep 0, total used mem 4.06 GB
rank 6, before wakeup weight 0, total used mem 4.06 GB
rank 7, before wakeup weight 0, total used mem 4.06 GB
rank 6, after wakeup weight 0, total used mem 37.81 GB
rank 7, after wakeup weight 0, total used mem 37.81 GB
rank 6, before wakeup kv cache 0, total used mem 37.81 GB
rank 7, before wakeup kv cache 0, total used mem 37.81 GB
rank 6, after wakeup kv cache 0, total used mem 70.39 GB
rank 7, after wakeup kv cache 0, total used mem 70.39 GB
=== iteration 1 ===
rank 6, before sleep 1, total used mem 70.39 GB
rank 7, before sleep 1, total used mem 70.39 GB
rank 6, after sleep 1, total used mem 4.06 GB
rank 7, after sleep 1, total used mem 4.06 GB
rank 6, before wakeup weight 1, total used mem 4.06 GB
rank 7, before wakeup weight 1, total used mem 4.06 GB
rank 6, after wakeup weight 1, total used mem 37.81 GB
rank 7, after wakeup weight 1, total used mem 37.81 GB
rank 6, before wakeup kv cache 1, total used mem 37.81 GB
rank 7, before wakeup kv cache 1, total used mem 37.81 GB
rank 6, after wakeup kv cache 1, total used mem 70.39 GB
rank 7, after wakeup kv cache 1, total used mem 70.39 GB
=== iteration 2 ===
rank 6, before sleep 2, total used mem 70.39 GB
rank 7, before sleep 2, total used mem 70.39 GB
rank 6, after sleep 2, total used mem 4.06 GB
rank 7, after sleep 2, total used mem 4.06 GB
rank 6, before wakeup weight 2, total used mem 4.06 GB
rank 7, before wakeup weight 2, total used mem 4.06 GB
rank 6, after wakeup weight 2, total used mem 37.81 GB
rank 7, after wakeup weight 2, total used mem 37.81 GB
rank 6, before wakeup kv cache 2, total used mem 37.81 GB
rank 7, before wakeup kv cache 2, total used mem 37.81 GB
rank 6, after wakeup kv cache 2, total used mem 70.39 GB
rank 7, after wakeup kv cache 2, total used mem 70.39 GB
```
</details>

<details>
  <summary>After PR</summary>

```
=== iteration 0 ===
rank 6, before sleep 0, total used mem 68.79 GB
rank 7, before sleep 0, total used mem 68.79 GB
rank 6, after sleep 0, total used mem 2.37 GB
rank 7, after sleep 0, total used mem 2.37 GB
rank 6, before wakeup weight 0, total used mem 2.37 GB
rank 7, before wakeup weight 0, total used mem 2.37 GB
rank 6, after wakeup weight 0, total used mem 36.13 GB
rank 7, after wakeup weight 0, total used mem 36.13 GB
rank 6, before wakeup kv cache 0, total used mem 36.13 GB
rank 7, before wakeup kv cache 0, total used mem 36.13 GB
rank 6, after wakeup kv cache 0, total used mem 68.71 GB
rank 7, after wakeup kv cache 0, total used mem 68.71 GB
=== iteration 1 ===
rank 6, before sleep 1, total used mem 68.71 GB
rank 7, before sleep 1, total used mem 68.71 GB
rank 6, after sleep 1, total used mem 2.37 GB
rank 7, after sleep 1, total used mem 2.37 GB
rank 6, before wakeup weight 1, total used mem 2.37 GB
rank 7, before wakeup weight 1, total used mem 2.37 GB
rank 6, after wakeup weight 1, total used mem 36.13 GB
rank 7, after wakeup weight 1, total used mem 36.12 GB
rank 6, before wakeup kv cache 1, total used mem 36.13 GB
rank 7, before wakeup kv cache 1, total used mem 36.12 GB
rank 6, after wakeup kv cache 1, total used mem 68.71 GB
rank 7, after wakeup kv cache 1, total used mem 68.71 GB
=== iteration 2 ===
rank 6, before sleep 2, total used mem 68.71 GB
rank 7, before sleep 2, total used mem 68.71 GB
rank 6, after sleep 2, total used mem 2.37 GB
rank 7, after sleep 2, total used mem 2.37 GB
rank 6, before wakeup weight 2, total used mem 2.37 GB
rank 7, before wakeup weight 2, total used mem 2.37 GB
rank 6, after wakeup weight 2, total used mem 36.13 GB
rank 7, after wakeup weight 2, total used mem 36.12 GB
rank 6, before wakeup kv cache 2, total used mem 36.13 GB
rank 7, before wakeup kv cache 2, total used mem 36.12 GB
rank 6, after wakeup kv cache 2, total used mem 68.71 GB
rank 7, after wakeup kv cache 2, total used mem 68.71 GB
```

</details>