### PR TITLE
fix: add safe.directory for git in docker workflows

### DIFF
--- a/.github/workflows/linux_x64_gpu.yml
+++ b/.github/workflows/linux_x64_gpu.yml
@@ -54,6 +54,7 @@ jobs:
             -w /work \
             openmmlab/lmdeploy-builder:cuda${{ matrix.cudaver }} \
             bash -c "
+              git config --global --add safe.directory /work && \
               source /opt/conda/bin/activate && \
               conda activate py310 && \
               pip install build && \

--- a/builder/manywheel/entrypoint_build.sh
+++ b/builder/manywheel/entrypoint_build.sh
@@ -8,6 +8,9 @@ export GROUPID=${GROUPID}
 export NCCL_INCLUDE_DIR=/usr/local/cuda/include
 export NCCL_LIB_DIR=/usr/local/cuda/lib64
 
+# Fix git dubious ownership issue when building inside docker
+git config --global --add safe.directory /lmdeploy
+
 source /opt/conda/bin/activate
 conda activate $PYTHON_VERSION
 


### PR DESCRIPTION
Fix 'dubious ownership' error when building inside docker containers.

## Background

Since Git 2.35.2 (April 2022), Git added a security check that prevents operations on repositories owned by a different user. This is documented in [CVE-2022-24765](https://github.com/git/git/security/advisories/GHSA-8h2j-crm9-x5wg).

When running in GitHub Actions with Docker, the repository is checked out by the runner (typically as root or a specific user), but the Docker container may run as a different user. This causes the error:



## Changes

- Add `git config --global --add safe.directory /work` in linux_x64_gpu.yml
- Add `git config --global --add safe.directory /lmdeploy` in entrypoint_build.sh

This tells Git to trust the mounted directory inside the Docker container, resolving the build failures in CI.