### PR TITLE
[ascend] remove t().contiguous() in updating moe weights

### DIFF
--- a/lmdeploy/pytorch/backends/dlinfer/moe.py
+++ b/lmdeploy/pytorch/backends/dlinfer/moe.py
@@ -65,11 +65,6 @@ class DlinferFusedMoEImpl(FusedMoEImpl):
 
     def update_weights(self, gate_up_weights: torch.Tensor, down_weights: torch.Tensor):
         """Update weights."""
-        device_type = gate_up_weights.device.type
-        if device_type in ['npu']:
-            if os.getenv('DLINFER_RESET_MOE_UPDATE_WEIGHTS', '0') == '1':
-                return gate_up_weights, down_weights
-            return gate_up_weights.transpose(-1, -2).contiguous(), down_weights.transpose(-1, -2).contiguous()
         return gate_up_weights, down_weights
 
     def ep_expert_list(self, world_size: int, rank: int):


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily receiving feedbacks. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Removed the 'transpose' and 'contiguous' operations during MoE weight loading to ensure the weight layout remains consistent throughout the RL process. This shift implies that the MoE kernel must now handle these operations internally. However, after reviewing the vllm-ascend implementation, it was found that MoE weights can be transposed without requiring a contiguous memory layout. Consequently, we only need to incorporate the transposition logic within the kernel, resulting in negligible performance loss.

## Modification

Please briefly describe what modification is made in this PR.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
