### PR TITLE
fix: use `is not None` check for seed to prevent seed=0 being silently ignored

### DIFF
--- a/lmdeploy/serve/openai/api_server.py
+++ b/lmdeploy/serve/openai/api_server.py
@@ -460,7 +460,7 @@ async def chat_completions_v1(request: ChatCompletionRequest, raw_request: Reque
         except Exception as e:
             return create_error_response(HTTPStatus.BAD_REQUEST, str(e))
 
-    random_seed = request.seed if request.seed else None
+    random_seed = request.seed if request.seed is not None else None
     max_new_tokens = (request.max_completion_tokens if request.max_completion_tokens else request.max_tokens)
 
     gen_config = GenerationConfig(
@@ -809,7 +809,7 @@ async def completions_v1(request: CompletionRequest, raw_request: Request = None
             sessions.append(VariableInterface.get_session(i + 1))
     if isinstance(request.stop, str):
         request.stop = [request.stop]
-    random_seed = request.seed if request.seed else None
+    random_seed = request.seed if request.seed is not None else None
     max_new_tokens = (request.max_completion_tokens if request.max_completion_tokens else request.max_tokens)
 
     gen_config = GenerationConfig(


### PR DESCRIPTION
## Summary

Fixes seed=0 being silently ignored when calling chat/completions and completions endpoints.

## Problem

In `lmdeploy/serve/openai/api_server.py`, the `random_seed` extraction uses a falsy check:

```python
# Buggy code (two locations: line 463 and 812)
random_seed = request.seed if request.seed else None
```

Since `0` is falsy in Python, passing `seed=0` results in `random_seed = None`. This means the user's request for deterministic generation with seed 0 is **silently discarded**.

## Fix

Changed both occurrences to use an explicit `is not None` check:

```python
# Fixed code
random_seed = request.seed if request.seed is not None else None
```

This correctly handles all valid seed values including `0`, while still passing `None` when no seed is provided.

## Files Changed

- `lmdeploy/serve/openai/api_server.py` — fixed two occurrences (~line 463 in `chat_completions_v1` and ~line 812 in `completions_v1`)

Closes #4525