### PR TITLE
fix: prevent prefill starvation under high decode load

### DIFF
--- a/lmdeploy/pytorch/engine/inputs_maker.py
+++ b/lmdeploy/pytorch/engine/inputs_maker.py
@@ -55,11 +55,15 @@ class InputsMakerConfig:
     spec_decoding: bool = False
     enable_chunked_prefill: bool = False
     use_mrope: bool = False
+    max_prefill_gap: int = 16
 
     @staticmethod
     def from_engine(engine: 'Engine'):
         cache_config = engine.cache_config
         model_config = engine.model_config
+        max_prefill_gap = engine.engine_config.prefill_interval
+        if max_prefill_gap is None or max_prefill_gap <= 0:
+            max_prefill_gap = 16
         return InputsMakerConfig(
             spec_decoding=engine.specdecode_config is not None,
             max_batches=cache_config.max_batches,
@@ -69,6 +73,7 @@ class InputsMakerConfig:
             dp=engine.dist_config.dp,
             enable_chunked_prefill=engine.misc_config.enable_chunked_prefill,
             use_mrope=model_config.use_mrope,
+            max_prefill_gap=max_prefill_gap,
         )
 
 
@@ -224,6 +229,9 @@ class InputsMakerAsync:
         self.model_agent_strategy = model_agent_strategy
 
         self._init_do_prefill(config)
+
+        # consecutive decode counter for prefill starvation prevention
+        self._decode_count = 0
 
         # record for next forward.
         self.next_is_prefill = True
@@ -693,6 +701,10 @@ class InputsMakerAsync:
                 swap_out_map,
             ) = __create_inputs_prefill()
 
+        # reset decode count only when prefill actually produced inputs
+        if prefill and inputs is not None:
+            self._decode_count = 0
+
         # try decoding
         if inputs is None and len(self.running_seqs) > 0 and self.config.role != EngineRole.Prefill:
             prefill = False
@@ -735,7 +747,12 @@ class InputsMakerAsync:
 
         # do decoding if not waiting
         if not scheduler.has_waiting():
+            self._decode_count = 0
             return False
+
+        # force prefill if too many consecutive decode rounds
+        if self._decode_count >= self.config.max_prefill_gap:
+            return True
 
         # do prefill if too much tokens
         waiting = scheduler.waiting
@@ -753,6 +770,7 @@ class InputsMakerAsync:
             return True
 
         # decoding
+        self._decode_count += 1
         return False
 
     def do_prefill_chunked(self):

--- a/lmdeploy/pytorch/engine/inputs_maker.py
+++ b/lmdeploy/pytorch/engine/inputs_maker.py
@@ -63,7 +63,10 @@ class InputsMakerConfig:
         model_config = engine.model_config
         prefill_interval = engine.engine_config.prefill_interval
         kwargs = dict()
-        if prefill_interval is not None and prefill_interval > 0:
+        if prefill_interval is not None:
+            if not isinstance(prefill_interval, int) or prefill_interval <= 0:
+                raise ValueError('engine.engine_config.prefill_interval must be a positive int '
+                                f'or None, but got {prefill_interval!r}')
             kwargs['prefill_interval'] = prefill_interval
         return InputsMakerConfig(
             spec_decoding=engine.specdecode_config is not None,

--- a/lmdeploy/pytorch/engine/inputs_maker.py
+++ b/lmdeploy/pytorch/engine/inputs_maker.py
@@ -55,15 +55,16 @@ class InputsMakerConfig:
     spec_decoding: bool = False
     enable_chunked_prefill: bool = False
     use_mrope: bool = False
-    max_prefill_gap: int = 16
+    prefill_interval: int = 16
 
     @staticmethod
     def from_engine(engine: 'Engine'):
         cache_config = engine.cache_config
         model_config = engine.model_config
-        max_prefill_gap = engine.engine_config.prefill_interval
-        if max_prefill_gap is None or max_prefill_gap <= 0:
-            max_prefill_gap = 16
+        prefill_interval = engine.engine_config.prefill_interval
+        kwargs = dict()
+        if prefill_interval is not None and prefill_interval > 0:
+            kwargs['prefill_interval'] = prefill_interval
         return InputsMakerConfig(
             spec_decoding=engine.specdecode_config is not None,
             max_batches=cache_config.max_batches,
@@ -73,7 +74,7 @@ class InputsMakerConfig:
             dp=engine.dist_config.dp,
             enable_chunked_prefill=engine.misc_config.enable_chunked_prefill,
             use_mrope=model_config.use_mrope,
-            max_prefill_gap=max_prefill_gap,
+            **kwargs,
         )
 
 
@@ -701,8 +702,8 @@ class InputsMakerAsync:
                 swap_out_map,
             ) = __create_inputs_prefill()
 
-        # reset decode count only when prefill actually produced inputs
-        if prefill and inputs is not None:
+        # reset decode count when non-decoding inputs are produced
+        if inputs is not None and not inputs.is_decoding:
             self._decode_count = 0
 
         # try decoding
@@ -751,7 +752,7 @@ class InputsMakerAsync:
             return False
 
         # force prefill if too many consecutive decode rounds
-        if self._decode_count >= self.config.max_prefill_gap:
+        if self._decode_count >= self.config.prefill_interval:
             return True
 
         # do prefill if too much tokens


### PR DESCRIPTION
## Summary
- Under high utilization (running + ready >= 50% max_batches) with small waiting requests (total tokens < max_prefill_token_num), do_prefill_default would always choose decode, starving waiting requests indefinitely
- Add a consecutive decode counter (_decode_count) that forces a prefill after prefill_interval (default 16) decode rounds when requests are waiting
- The counter resets only when a prefill actually produces inputs (not just when one is attempted), preventing the guard from being "burned" by failed allocation attempts
