### PR TITLE
cancel request and block new inputs when sleeping

### DIFF
--- a/lmdeploy/pytorch/engine/engine.py
+++ b/lmdeploy/pytorch/engine/engine.py
@@ -32,6 +32,8 @@ from .request import Request, RequestManager, RequestType, Response
 logger = get_logger('lmdeploy')
 
 SeqList = list[SchedulerSequence]
+_INPUT_REQUEST_TYPES = {RequestType.ADD_SESSION, RequestType.ADD_MESSAGE}
+_SLEEPING_TAGS = {'weights', 'kv_cache'}
 
 
 @dataclass
@@ -181,10 +183,15 @@ class Engine(EngineBase):
         self.engine_config.num_gpu_blocks = self.cache_config.num_gpu_blocks
 
         self.req_manager = self._bind_request_manager()
+        # This state tracks only explicit Engine.sleep()/wakeup() calls. Do not
+        # infer sleeping from empty_init: empty_init still builds runtime
+        # resources and has its own weight-update workflow.
+        self._sleeping_tags = set()
 
         # create main thread
         self.req_manager.set_main_loop_func(self.async_loop)
         self._loop_main = None
+        self._engine_loop = None
 
         # for PD Disaggregation
         # For migrating prefill request to decode engine
@@ -305,9 +312,7 @@ class Engine(EngineBase):
                 for seq in session.sequences.values():
                     _resp: Response = getattr(seq, 'resp', None)
                     if _resp is not None:
-                        _resp.type = ResponseType.CANCEL
-                        _resp.is_done = True
-                        self.req_manager.response(_resp)
+                        self.req_manager.reject_request(_resp)
                 resp_type = ResponseType.SUCCESS
             if resp:
                 self._response(req.resp, resp_type)
@@ -443,13 +448,70 @@ class Engine(EngineBase):
         """Update params."""
         self.executor.update_params(request)
 
+    def _block_new_inputs(self):
+        """Block new inference work from engine instances."""
+        logger.info('PyTorch engine is blocking new inference requests.')
+        self.req_manager.block_request_types(_INPUT_REQUEST_TYPES)
+
+    def _unblock_new_inputs(self):
+        """Allow inference work from engine instances."""
+        logger.info('PyTorch engine is allowing new inference requests.')
+        self.req_manager.unblock_request_types(_INPUT_REQUEST_TYPES)
+
+    def _cancel_and_end_all_sessions(self):
+        """Cancel active responses and remove all scheduler sessions."""
+        num_cancelled = 0
+        session_ids = list(self.scheduler.sessions.keys())
+        for session in list(self.scheduler.sessions.values()):
+            for seq in list(session.sequences.values()):
+                resp: Response = getattr(seq, 'resp', None)
+                if resp is None or resp.is_done:
+                    continue
+                self.req_manager.reject_request(resp, reason='engine sleep')
+                num_cancelled += 1
+
+        # Sleep releases KV cache, so every existing scheduler session becomes
+        # invalid even when the original request asked to preserve cache.
+        for session_id in session_ids:
+            self.end_session(session_id)
+        logger.info('PyTorch engine sleep cleanup cancelled %s active responses and ended %s sessions.',
+                    num_cancelled, len(session_ids))
+
     async def sleep(self, level: int = 1):
         """Sleep."""
+        logger.info('PyTorch engine sleep requested: level=%s.', level)
+        # log sleep tags so we can resume at the right condition in wakeup.
+        self._sleeping_tags = _SLEEPING_TAGS.copy()
+        # block ADD_MESSAGE and ADD_SESSION
+        self._block_new_inputs()
+        if self._engine_loop is not None:
+            await self._engine_loop.drain_for_sleep()
+            logger.info('PyTorch engine loop drained for sleep.')
+        # cancel all remain sessions
+        self._cancel_and_end_all_sessions()
         await self.executor.sleep(level)
+        logger.info('PyTorch engine entered sleep: level=%s, sleeping_tags=%s.', level, sorted(self._sleeping_tags))
 
     def wakeup(self, tags: list[str] | None = None):
         """Wakeup."""
-        self.executor.wakeup(tags)
+        wakeup_tags = tags
+        logger.info('PyTorch engine wakeup requested: tags=%s, sleeping_tags=%s.',
+                    wakeup_tags, sorted(self._sleeping_tags))
+        self.executor.wakeup(wakeup_tags)
+        if wakeup_tags is None:
+            self._sleeping_tags.clear()
+        else:
+            self._sleeping_tags.difference_update(wakeup_tags)
+        # The engine would resume only when all sleep tags has been cleared.
+        if not self._sleeping_tags:
+            # enable ADD_MESSAGE and ADD_SESSION
+            self._unblock_new_inputs()
+            if self._engine_loop is not None:
+                self._engine_loop.resume_from_sleep()
+            logger.info('PyTorch engine wakeup complete; inference requests are enabled.')
+        else:
+            logger.info('PyTorch engine partial wakeup; blocked tags=%s.',
+                        sorted(self._sleeping_tags))
 
     async def async_loop(self):
         engine_loop = None
@@ -460,6 +522,7 @@ class Engine(EngineBase):
 
             # create engine loop
             engine_loop = build_engine_loop(self)
+            self._engine_loop = engine_loop
             self.migration_event = engine_loop.migration_event
 
             # start engine loop
@@ -477,6 +540,7 @@ class Engine(EngineBase):
             logger.debug('Engine main loop finally cleanup.')
             if engine_loop is not None:
                 engine_loop.stop()
+            self._engine_loop = None
             self._loop_finally()
 
     def close(self):

--- a/lmdeploy/pytorch/engine/engine.py
+++ b/lmdeploy/pytorch/engine/engine.py
@@ -502,7 +502,7 @@ class Engine(EngineBase):
             self._sleeping_tags.clear()
         else:
             self._sleeping_tags.difference_update(wakeup_tags)
-        # The engine would resume only when all sleep tags has been cleared.
+        # The engine would resume only when all sleep tags have been cleared.
         if not self._sleeping_tags:
             # enable ADD_MESSAGE and ADD_SESSION
             self._unblock_new_inputs()

--- a/lmdeploy/pytorch/engine/engine_loop.py
+++ b/lmdeploy/pytorch/engine/engine_loop.py
@@ -129,6 +129,18 @@ class EngineLoop:
         self.forward_event = CounterEvent()
         self.migration_event = asyncio.Event()
         self.has_runable_event = RunableEventAsync(self.scheduler)
+        # Sleep uses a small handshake with the scheduling loops:
+        # 1. sleep() sets _sleep_requested and waits for main/migration drain events.
+        # 2. main_loop and migration_loop reach safe boundaries, acknowledge
+        #    drain, then wait on _sleep_resume_event.
+        # 3. wakeup() sets _sleep_resume_event so scheduling can continue.
+        self._sleep_requested = False
+        self._main_sleep_drain_event = asyncio.Event()
+        self._main_sleep_drain_event.set()
+        self._migration_sleep_drain_event = asyncio.Event()
+        self._migration_sleep_drain_event.set()
+        self._sleep_resume_event = asyncio.Event()
+        self._sleep_resume_event.set()
 
         # check init
         if self.config.role != EngineRole.Hybrid:
@@ -139,6 +151,39 @@ class EngineLoop:
         while not self.stop_event.is_set():
             await self.req_manager.step()
             self.has_runable_event.set()
+
+    async def drain_for_sleep(self):
+        """Pause scheduling after the current forward step drains."""
+        if self._sleep_requested:
+            logger.info('EngineLoop sleep drain already requested; waiting for drain point.')
+            await self._main_sleep_drain_event.wait()
+            return
+        logger.info('EngineLoop sleep drain requested.')
+        self._sleep_requested = True
+        self._main_sleep_drain_event.clear()
+        if self.config.role != EngineRole.Hybrid:
+            self._migration_sleep_drain_event.clear()
+        self._sleep_resume_event.clear()
+        # Wake main_loop if it is idle waiting for runnable work, so it can
+        # observe _sleep_requested and acknowledge the drain.
+        self.has_runable_event.event.set()
+        # Wake migration_loop if it is idle on migration_event; it has its own
+        # drain acknowledgement because migration can also touch KV resources.
+        if self.config.role != EngineRole.Hybrid:
+            self.migration_event.set()
+        await self._main_sleep_drain_event.wait()
+        if self.config.role != EngineRole.Hybrid:
+            await self._migration_sleep_drain_event.wait()
+        logger.info('EngineLoop reached sleep drain point.')
+
+    def resume_from_sleep(self):
+        """Resume scheduling after wakeup restores engine resources."""
+        logger.info('EngineLoop resumes scheduling after wakeup.')
+        self._sleep_requested = False
+        self._sleep_resume_event.set()
+        # On resume, respect scheduler state instead of forcing the runnable
+        # event. If sleep ended every session, this should remain cleared.
+        self.has_runable_event.set()
 
     @staticmethod
     def _log_resps(outputs: list[InferOutput]):
@@ -323,6 +368,8 @@ class EngineLoop:
         scheduler = self.scheduler
         if not scheduler.has_unfinished():
             await self.has_runable_event.wait()
+        if self._sleep_requested:
+            return None, None
 
         scheduler.collect_migration_done()
         return await self.inputs_maker.send_next_inputs()
@@ -370,9 +417,23 @@ class EngineLoop:
             await asyncio.sleep(0.1)
 
         while not self.stop_event.is_set():
+            if self._sleep_requested:
+                # Drop prefetched work from before sleep. Sleep ends scheduler
+                # sessions and releases KV cache, so any saved next batch is
+                # stale after the drain point.
+                forward_inputs = None
+                next_running = None
+                # Acknowledge that no new forward input will be scheduled until
+                # wakeup resumes this loop.
+                self._main_sleep_drain_event.set()
+                await self._sleep_resume_event.wait()
+                continue
+
             if next_running is None:
                 forward_inputs, next_running = await self._main_loop_try_send_next_inputs()
                 if next_running is None:
+                    if self._sleep_requested:
+                        continue
                     await __no_running_warning()
                     continue
 
@@ -462,6 +523,12 @@ class EngineLoop:
     async def migration_loop(self):
         """Async loop migration."""
         while not self.stop_event.is_set():
+            if self._sleep_requested:
+                self.migration_event.clear()
+                self._migration_sleep_drain_event.set()
+                await self._sleep_resume_event.wait()
+                continue
+
             migration_ready = self.scheduler._schedule_migration()
             if not migration_ready and not self.scheduler.has_migration_waiting():
                 await self.migration_event.wait()

--- a/lmdeploy/pytorch/engine/engine_loop.py
+++ b/lmdeploy/pytorch/engine/engine_loop.py
@@ -157,6 +157,8 @@ class EngineLoop:
         if self._sleep_requested:
             logger.info('EngineLoop sleep drain already requested; waiting for drain point.')
             await self._main_sleep_drain_event.wait()
+            if self.config.role != EngineRole.Hybrid:
+                await self._migration_sleep_drain_event.wait()
             return
         logger.info('EngineLoop sleep drain requested.')
         self._sleep_requested = True

--- a/lmdeploy/pytorch/engine/request.py
+++ b/lmdeploy/pytorch/engine/request.py
@@ -102,7 +102,8 @@ class RequestSender:
 
     def _gather_request(self, req_types: list[RequestType], data: list[Any]):
         """Gather requests."""
-        if self.manager._loop_task is None:
+        should_enqueue = any(not self.manager.is_request_blocked(rtype) for rtype in req_types)
+        if should_enqueue and self.manager._loop_task is None:
             self.manager.create_loop_task()
         assert len(req_types) == len(data)
 
@@ -115,6 +116,10 @@ class RequestSender:
                             event=event,
                             data=None,
                             err_msg=None)
+            if self.manager.is_request_blocked(rtype):
+                self.manager.reject_request(resp, rtype, 'request type is blocked')
+                resps.append(resp)
+                continue
             req = Request(type=rtype, sender_id=self.sender_id, data=rdata, resp=resp)
             resps.append(resp)
             reqs.append(req)
@@ -123,7 +128,8 @@ class RequestSender:
     def batched_send_async(self, req_types: list[RequestType], data: list[Any]):
         """Batched send request asynchronize."""
         resps, reqs = self._gather_request(req_types, data)
-        self._req_put(reqs)
+        if len(reqs) > 0:
+            self._req_put(reqs)
         return resps
 
     def send_async(self, req_type: RequestType, data: Any):
@@ -183,6 +189,9 @@ class RequestManager:
         self._sender_wait_task: asyncio.Task = None
         self._send_count = 0
         self._send_event = None
+        # Sleep uses this admission gate to reject new inference work while
+        # still allowing cleanup requests such as STOP_SESSION/END_SESSION.
+        self._blocked_request_types: set[RequestType] = set()
 
     async def prepare_send(self):
         if self._condition is None:
@@ -288,6 +297,39 @@ class RequestManager:
         self.senders[sender_id] = new_sender
         return new_sender
 
+    def block_request_types(self, req_types: set[RequestType] | list[RequestType]):
+        """Block request types from entering the engine."""
+        req_types = set(req_types)
+        newly_blocked = req_types - self._blocked_request_types
+        self._blocked_request_types.update(req_types)
+        if newly_blocked:
+            names = ', '.join(sorted(req_type.name for req_type in newly_blocked))
+            logger.info(f'Blocking engine request types: {names}')
+
+    def unblock_request_types(self, req_types: set[RequestType] | list[RequestType]):
+        """Allow request types to enter the engine."""
+        req_types = set(req_types)
+        newly_unblocked = req_types & self._blocked_request_types
+        self._blocked_request_types.difference_update(req_types)
+        if newly_unblocked:
+            names = ', '.join(sorted(req_type.name for req_type in newly_unblocked))
+            logger.info(f'Unblocking engine request types: {names}')
+
+    def is_request_blocked(self, req_type: RequestType):
+        """Check whether a request type is blocked."""
+        return req_type in self._blocked_request_types
+
+    def reject_request(self, resp: Response, req_type: RequestType | None = None, reason: str = ''):
+        """Reject request and wake sender."""
+        if req_type is not None:
+            reason = reason or 'request rejected'
+            logger.info(f'Reject {req_type.name} request from sender {resp.sender_id}: {reason}')
+        elif reason:
+            logger.debug(f'Reject response from sender {resp.sender_id}: {reason}')
+        resp.type = ResponseType.CANCEL
+        resp.is_done = True
+        self.response(resp)
+
     def has_requests(self):
         """Has unprocessed request."""
         if self.requests is None:
@@ -335,6 +377,11 @@ class RequestManager:
 
     def process_request(self, req_type: RequestType, reqs: ReqList, **kwargs):
         """Process reqs with given req type."""
+        if self.is_request_blocked(req_type):
+            for req in reqs:
+                self.reject_request(req.resp, req_type, 'queued request type is blocked')
+            return
+
         # get callback
         func = self.callbacks.get(req_type, None)
         if func is not None:

--- a/lmdeploy/pytorch/engine/request.py
+++ b/lmdeploy/pytorch/engine/request.py
@@ -323,7 +323,7 @@ class RequestManager:
         """Reject request and wake sender."""
         if req_type is not None:
             reason = reason or 'request rejected'
-            logger.info(f'Reject {req_type.name} request from sender {resp.sender_id}: {reason}')
+            logger.debug(f'Reject {req_type.name} request from sender {resp.sender_id}: {reason}')
         elif reason:
             logger.debug(f'Reject response from sender {resp.sender_id}: {reason}')
         resp.type = ResponseType.CANCEL

--- a/tests/pytorch/engine/test_engine_sleep.py
+++ b/tests/pytorch/engine/test_engine_sleep.py
@@ -1,0 +1,148 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from lmdeploy.messages import EngineOutput, ResponseType
+from lmdeploy.pytorch.engine.engine import Engine
+from lmdeploy.pytorch.engine.engine_instance import EngineInstance
+from lmdeploy.pytorch.engine.request import RequestManager, RequestType, Response
+
+
+class _FakeSequence:
+
+    def __init__(self, resp):
+        self.resp = resp
+
+
+class _FakeSession:
+
+    def __init__(self, seq):
+        self.sequences = {0: seq}
+
+
+class _FakeScheduler:
+
+    def __init__(self, session):
+        self.sessions = {1: session}
+        self.ended_sessions = []
+
+    def end_session(self, session_id):
+        self.ended_sessions.append(session_id)
+        self.sessions.pop(session_id)
+
+
+class _FakeEngineLoop:
+
+    def __init__(self, engine):
+        self.engine = engine
+        self.drained = False
+        self.resumed = False
+
+    async def drain_for_sleep(self):
+        assert self.engine.req_manager.is_request_blocked(RequestType.ADD_SESSION)
+        assert self.engine.req_manager.is_request_blocked(RequestType.ADD_MESSAGE)
+        self.drained = True
+
+    def resume_from_sleep(self):
+        self.resumed = True
+
+
+
+
+class _FakeExecutor:
+
+    def __init__(self, engine):
+        self.engine = engine
+        self.sleep_calls = []
+        self.wakeup_calls = []
+
+    async def sleep(self, level=1):
+        assert self.engine.req_manager.is_request_blocked(RequestType.ADD_SESSION)
+        assert self.engine.scheduler.sessions == {}
+        self.sleep_calls.append(level)
+
+    def wakeup(self, tags=None):
+        self.wakeup_calls.append(tags)
+
+
+@pytest.fixture
+def event_loop():
+    old_loop = asyncio.get_event_loop()
+    new_loop = asyncio.new_event_loop()
+    try:
+        asyncio.set_event_loop(new_loop)
+        yield new_loop
+    finally:
+        new_loop.stop()
+        asyncio.set_event_loop(old_loop)
+
+
+def _build_sleeping_test_engine(event_loop):
+    engine = Engine.__new__(Engine)
+    engine.req_manager = RequestManager()
+    resp = Response(type=ResponseType.INTERNAL_ENGINE_ERROR, sender_id=0, event=asyncio.Event())
+    seq = _FakeSequence(resp)
+    session = _FakeSession(seq)
+    engine.scheduler = _FakeScheduler(session)
+    engine._sleeping_tags = set()
+    engine._engine_loop = _FakeEngineLoop(engine)
+    engine.executor = _FakeExecutor(engine)
+    return engine, resp
+
+
+def test_engine_sleep_blocks_inputs_cancels_sessions_then_sleeps(event_loop):
+    engine, resp = _build_sleeping_test_engine(event_loop)
+
+    event_loop.run_until_complete(engine.sleep(level=1))
+
+    assert engine.req_manager.is_request_blocked(RequestType.ADD_SESSION)
+    assert engine.req_manager.is_request_blocked(RequestType.ADD_MESSAGE)
+    assert engine._engine_loop.drained
+    assert resp.type == ResponseType.CANCEL
+    assert resp.is_done
+    assert resp.event.is_set()
+    assert engine.scheduler.ended_sessions == [1]
+    assert engine.executor.sleep_calls == [1]
+
+
+def test_engine_wakeup_reenables_inputs_only_after_all_tags(event_loop):
+    engine, _ = _build_sleeping_test_engine(event_loop)
+    engine.req_manager.block_request_types({RequestType.ADD_SESSION, RequestType.ADD_MESSAGE})
+    engine._sleeping_tags = {'weights', 'kv_cache'}
+
+    engine.wakeup(['weights'])
+
+    assert engine.req_manager.is_request_blocked(RequestType.ADD_SESSION)
+    assert engine.req_manager.is_request_blocked(RequestType.ADD_MESSAGE)
+    assert not engine._engine_loop.resumed
+
+    engine.wakeup(['kv_cache'])
+
+    assert not engine.req_manager.is_request_blocked(RequestType.ADD_SESSION)
+    assert not engine.req_manager.is_request_blocked(RequestType.ADD_MESSAGE)
+    assert engine._engine_loop.resumed
+    assert engine.executor.wakeup_calls == [['weights'], ['kv_cache']]
+
+
+def test_engine_instance_new_request_after_sleep_returns_cancel(event_loop):
+    engine = SimpleNamespace(
+        req_manager=RequestManager(),
+        max_session_len=8,
+        engine_config=SimpleNamespace(enable_transfer_obj_ref=False, distributed_executor_backend='uni'),
+    )
+    engine.req_manager.block_request_types({RequestType.ADD_SESSION, RequestType.ADD_MESSAGE})
+    inst = EngineInstance(engine)
+
+    async def __collect():
+        outputs: list[EngineOutput] = []
+        async for out in inst.async_stream_infer(1, [1, 2, 3]):
+            outputs.append(out)
+        return outputs
+
+    outputs = event_loop.run_until_complete(__collect())
+
+    assert len(outputs) == 1
+    assert outputs[0].status == ResponseType.CANCEL
+    assert engine.req_manager._loop_task is None

--- a/tests/pytorch/engine/test_engine_sleep.py
+++ b/tests/pytorch/engine/test_engine_sleep.py
@@ -75,7 +75,15 @@ def event_loop():
         asyncio.set_event_loop(new_loop)
         yield new_loop
     finally:
+        pending = asyncio.all_tasks(new_loop)
+        for task in pending:
+            task.cancel()
+        if pending:
+            new_loop.run_until_complete(
+                asyncio.gather(*pending, return_exceptions=True))
+        new_loop.run_until_complete(new_loop.shutdown_asyncgens())
         new_loop.stop()
+        new_loop.close()
         asyncio.set_event_loop(old_loop)
 
 

--- a/tests/pytorch/engine/test_request.py
+++ b/tests/pytorch/engine/test_request.py
@@ -61,7 +61,6 @@ class TestRequestHander:
         # cleanup, cancel main task
         task_to_cancel = manager._loop_task
         manager.stop_loop()
-        asyncio.run
         event_loop.run_until_complete(asyncio.gather(task_to_cancel, return_exceptions=True))
 
     def test_blocked_add_requests_are_cancelled_immediately(self, manager):

--- a/tests/pytorch/engine/test_request.py
+++ b/tests/pytorch/engine/test_request.py
@@ -63,3 +63,98 @@ class TestRequestHander:
         manager.stop_loop()
         asyncio.run
         event_loop.run_until_complete(asyncio.gather(task_to_cancel, return_exceptions=True))
+
+    def test_blocked_add_requests_are_cancelled_immediately(self, manager):
+        sender = manager.build_sender()
+        manager.block_request_types({RequestType.ADD_SESSION, RequestType.ADD_MESSAGE})
+
+        add_session_resp = sender.send_async(RequestType.ADD_SESSION, dict(session_id=1))
+        add_message_resp = sender.send_async(RequestType.ADD_MESSAGE, dict(session_id=1))
+
+        assert add_session_resp.type == ResponseType.CANCEL
+        assert add_session_resp.is_done
+        assert add_session_resp.event.is_set()
+        assert add_message_resp.type == ResponseType.CANCEL
+        assert add_message_resp.is_done
+        assert add_message_resp.event.is_set()
+        assert manager._loop_task is None
+
+    def test_cleanup_requests_are_allowed_while_add_requests_blocked(self, manager, event_loop):
+
+        def __success_callback(reqs, **kwargs):
+            for req in reqs:
+                req.resp.type = ResponseType.SUCCESS
+                manager.response(req.resp)
+
+        async def __dummy_loop():
+            while True:
+                try:
+                    await manager.step()
+                except Exception:
+                    return
+
+        sender = manager.build_sender()
+        manager.set_main_loop_func(__dummy_loop)
+        manager.bind_func(RequestType.STOP_SESSION, __success_callback)
+        manager.bind_func(RequestType.END_SESSION, __success_callback)
+        manager.block_request_types({RequestType.ADD_SESSION, RequestType.ADD_MESSAGE})
+
+        stop_resp = sender.send(RequestType.STOP_SESSION, dict(session_id=1))
+        end_resp = sender.send(RequestType.END_SESSION, dict(session_id=1))
+
+        assert stop_resp.type == ResponseType.SUCCESS
+        assert end_resp.type == ResponseType.SUCCESS
+
+        task_to_cancel = manager._loop_task
+        manager.stop_loop()
+        event_loop.run_until_complete(asyncio.gather(task_to_cancel, return_exceptions=True))
+
+    def test_queued_add_request_is_cancelled_when_blocked_before_processing(self, manager, event_loop):
+
+        async def __idle_loop():
+            await asyncio.Event().wait()
+
+        sender = manager.build_sender()
+        manager.set_main_loop_func(__idle_loop)
+        resp = sender.send_async(RequestType.ADD_SESSION, dict(session_id=1))
+
+        manager.block_request_types({RequestType.ADD_SESSION})
+        event_loop.run_until_complete(manager.step())
+
+        assert resp.type == ResponseType.CANCEL
+        assert resp.is_done
+        assert resp.event.is_set()
+
+        task_to_cancel = manager._loop_task
+        manager.stop_loop()
+        event_loop.run_until_complete(asyncio.gather(task_to_cancel, return_exceptions=True))
+
+    def test_unblock_request_types_restores_normal_processing(self, manager, event_loop):
+
+        def __success_callback(reqs, **kwargs):
+            for req in reqs:
+                req.resp.type = ResponseType.SUCCESS
+                manager.response(req.resp)
+
+        async def __dummy_loop():
+            while True:
+                try:
+                    await manager.step()
+                except Exception:
+                    return
+
+        sender = manager.build_sender()
+        manager.block_request_types({RequestType.ADD_SESSION})
+        blocked_resp = sender.send_async(RequestType.ADD_SESSION, dict(session_id=1))
+        assert blocked_resp.type == ResponseType.CANCEL
+
+        manager.unblock_request_types({RequestType.ADD_SESSION})
+        manager.set_main_loop_func(__dummy_loop)
+        manager.bind_func(RequestType.ADD_SESSION, __success_callback)
+        resp = sender.send(RequestType.ADD_SESSION, dict(session_id=1))
+
+        assert resp.type == ResponseType.SUCCESS
+
+        task_to_cancel = manager._loop_task
+        manager.stop_loop()
+        event_loop.run_until_complete(asyncio.gather(task_to_cancel, return_exceptions=True))


### PR DESCRIPTION
# PR: Guard PyTorch Engine Sleep Against In-flight and New Requests

## Summary

This PR fixes a PyTorch engine sleep race where `sleep()` can release model/KV-cache resources while requests are still active or while new `EngineInstance` inputs are accepted. After sleep, those requests can resume or enter inference against invalid resources and break generation.

The fix is scoped to `lmdeploy/pytorch/engine`.

## Problem

Before this change, PyTorch engine sleep only delegated to executor/model-agent sleep. Direct PyTorch engine instances could still enqueue new inference work around the sleep transition, and existing scheduler sessions could remain alive even though sleep may release KV cache.

This creates unsafe cases:

- A new request arrives after sleep starts but before resources are restored.
- An active request is still attached to scheduler state while KV cache is released.
- A prefetched next batch from before sleep survives the drain point and may be used after wakeup.

## Changes

- Add a request-admission gate in the PyTorch request manager.
  - Blocks only `ADD_SESSION` and `ADD_MESSAGE` during explicit PyTorch engine sleep.
  - Keeps cleanup requests such as `STOP_SESSION` and `END_SESSION` enabled.
  - Rejects blocked requests immediately with `ResponseType.CANCEL` and wakes the sender.
  - Also rejects already-queued add requests if the gate is enabled before processing.

- Make `Engine.sleep()` perform PyTorch-engine cleanup before resource release.
  - Blocks new inference inputs before awaiting anything.
  - Drains the engine loop to a safe scheduling boundary.
  - Cancels active request responses.
  - Ends all remaining scheduler sessions because sleep invalidates KV cache, including sessions that requested cache preservation.
  - Calls executor sleep only after the engine loop is drained and sessions are removed.

- Make `Engine.wakeup()` re-enable inference only after all sleeping tags are restored.
  - Partial wakeup, such as weights-only, keeps inference blocked while KV cache is still sleeping.
  - Full wakeup unblocks `ADD_SESSION` and `ADD_MESSAGE` and resumes scheduling.

- Add sleep-drain coordination in `EngineLoop`.
  - `Engine.sleep()` requests a drain and waits for the main loop to acknowledge a safe boundary.
  - The main loop drops prefetched work from before sleep because those batches are stale after sessions are ended and KV cache is released.
  - Resume uses scheduler-aware runnable-event logic rather than forcing runnable state.

- Add logs and comments for the sleep lifecycle.
  - Logs request blocking/unblocking, blocked request rejection, sleep start, drain, cleanup counts, wakeup progress, and partial-wakeup blocking.
  - Comments document the event handshake and why all scheduler sessions are ended during sleep.

## Tests

Focused unit tests were added/updated for:

- Blocked `ADD_SESSION` and `ADD_MESSAGE` returning `ResponseType.CANCEL` immediately.
- Cleanup requests staying allowed while add requests are blocked.
- Already-queued add requests being cancelled after the gate is enabled.
- Request admission being restored after unblock/wakeup.
- `Engine.sleep()` blocking input before executor sleep.
- Active responses being cancelled and scheduler sessions being ended before executor sleep.
- Direct `EngineInstance` requests returning `CANCEL` while sleeping.
- Partial wakeup keeping requests blocked until all sleeping tags are restored.

A real Qwen3-8B corner-case smoke test was also run and passed. It covers:

- Baseline request before sleep.
- Sleep while a streaming request is active.
- New request while sleeping.
- Direct PyTorch `EngineInstance` request while sleeping.
- Weights-only partial wakeup.
- Full wakeup recovery.
- A second sleep/wakeup cycle.

## Notes / Scope

- This PR intentionally does not change `lmdeploy/serve`, `AsyncEngine`, Turbomind, public response enums, or HTTP middleware behavior.
- `empty_init` is not treated as PyTorch engine sleep. The sleep guard is driven only by explicit `Engine.sleep()` / `Engine.wakeup()` calls.
- Migration/disaggregated serving sleep behavior is not covered by the smoke test in this PR. The tested runtime path is PyTorch Hybrid role with MP-engine wrapper.
