### PR TITLE
[Misc] fix typos in turbomind.py and model.py

### DIFF
--- a/lmdeploy/model.py
+++ b/lmdeploy/model.py
@@ -682,7 +682,7 @@ class ChatmlDirect(BaseChatTemplate):
 class HFChatTemplate(BaseChatTemplate):
     """Chat template for HuggingFace models with `apply_chat_template` method.
 
-    It MUST be at the end of @MODLES registry
+    It MUST be at the end of @MODELS registry
     """
 
     def __init__(self, model_path: str = '', **kwargs):

--- a/lmdeploy/turbomind/turbomind.py
+++ b/lmdeploy/turbomind/turbomind.py
@@ -823,7 +823,7 @@ class TurboMindInstance:
         if cfg.logprobs:
             if cfg.logprobs > MAX_LOGPROBS:
                 cfg.logprobs = MAX_LOGPROBS
-                logger.warning(f'logprobs shoudd be in range [1, {MAX_LOGPROBS}]'
+                logger.warning(f'logprobs should be in range [1, {MAX_LOGPROBS}]'
                                f'update logprobs={cfg.logprobs}')
             c.output_logprobs = cfg.logprobs
         if cfg.random_seed is not None:


### PR DESCRIPTION
## Motivation

Fix two minor typos found in the codebase to improve code readability and accuracy.

## Modification

- `lmdeploy/turbomind/turbomind.py`: fix typo `shoudd` -> `should` in log warning message
- `lmdeploy/model.py`: fix typo `MODLES` -> `MODELS` in docstring comment

## BC-breaking

No.

## Use cases

N/A

## Checklist

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [ ] The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
- [ ] If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
- [x] The documentation has been modified accordingly, like docstring or example tutorials.
