### PR TITLE
[Misc] fix mutable default arguments

### DIFF
--- a/lmdeploy/lite/quantization/calibration.py
+++ b/lmdeploy/lite/quantization/calibration.py
@@ -265,7 +265,9 @@ def auto_scale_block(module, module_kwargs, w_bit, w_group_size, input_feat, mod
         module_kwargs.pop('use_cache')
 
     # find the best scale ratio
-    def _search_module_scale(block, linears2scale: list, x, kwargs={}):
+    def _search_module_scale(block, linears2scale: list, x, kwargs=None):
+        if kwargs is None:
+            kwargs = {}
         x = x.to(next(block.parameters()).device)
         with torch.no_grad():
             org_out = block(x, **kwargs)
@@ -313,7 +315,9 @@ def auto_scale_block(module, module_kwargs, w_bit, w_group_size, input_feat, mod
             raise Exception
         return best_ratio
 
-    def _auto_get_scale(layers, inp, module2inspect=None, kwargs={}):
+    def _auto_get_scale(layers, inp, module2inspect=None, kwargs=None):
+        if kwargs is None:
+            kwargs = {}
         # module2inspect: if given, we will check the output diff of
         #  this module instead of layers
         if module2inspect is None:

--- a/lmdeploy/turbomind/deploy/config.py
+++ b/lmdeploy/turbomind/deploy/config.py
@@ -206,8 +206,10 @@ class TurbomindModelConfig:
                 '`--rope-scaling-factor` will be removed in a future release. Please instead use `--hf-overrides`.')
 
     @classmethod
-    def from_dict(cls, config: dict = {}):
+    def from_dict(cls, config: dict | None = None):
         """Construct TurbomindModelConfig instance from config in a dict."""
+        if config is None:
+            config = {}
         _cfg = {field.name: config.get(field.name, {}) for field in fields(TurbomindModelConfig)}
 
         return TurbomindModelConfig(model_config=config_from_dict(ModelConfig, _cfg['model_config']),

--- a/lmdeploy/turbomind/deploy/module.py
+++ b/lmdeploy/turbomind/deploy/module.py
@@ -146,7 +146,9 @@ class Ffn(Module):
         self.inter_size = model.model_config.inter_size
         self.group_size = max(1, model.model_config.group_size)
 
-    def _export(self, inter_size: int, fmt: str, idx: int, w123, kind: str, pack_fn, apply_gs=[], **kwargs):
+    def _export(self, inter_size: int, fmt: str, idx: int, w123, kind: str, pack_fn, apply_gs=None, **kwargs):
+        if apply_gs is None:
+            apply_gs = []
         is_lora_a, is_lora_b = get_lora_flags(kind)
         w1, w2, w3 = map(transpose, w123)
 
@@ -317,7 +319,9 @@ class Attn(Module):
 
         return (q, k, v, o)
 
-    def _export(self, idx: int, qkvo, kind: str, pack_fn, apply_gs=[], **kwargs):
+    def _export(self, idx: int, qkvo, kind: str, pack_fn, apply_gs=None, **kwargs):
+        if apply_gs is None:
+            apply_gs = []
         if all(x is None for x in qkvo):
             return
         is_lora_a, is_lora_b = get_lora_flags(kind)


### PR DESCRIPTION
## Motivation

Fix 5 instances of mutable default arguments (`=[]` and `={}`) in function signatures. This is a classic Python anti-pattern where the default object is shared across all calls — if ever mutated, state leaks to subsequent calls. While the current code doesn't mutate these defaults, it's a latent bug and violates best practice.

## Modification

- `lmdeploy/turbomind/deploy/module.py`: `apply_gs=[]` → `apply_gs=None` (2 places in `Ffn._export` and `Attention._export`)
- `lmdeploy/turbomind/deploy/config.py`: `config: dict = {}` → `None` in `TurbomindModelConfig.from_dict()`
- `lmdeploy/lite/quantization/calibration.py`: `kwargs={}` → `None` (2 places in `_search_module_scale` and `_auto_get_scale`)

All changes initialize the default inside the function body with `if x is None: x = []/{}`, preserving identical runtime behavior.

## BC-breaking

No. Behavior is identical.

## Use cases

N/A

## Checklist

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [ ] The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
- [ ] If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
- [x] The documentation has been modified accordingly, like docstring or example tutorials.
