### PR TITLE
refactor(turbomind): consolidate CUDA error handling and add manual stacktracing

### DIFF
--- a/src/turbomind/comm/cuda_ipc/allgather.cu
+++ b/src/turbomind/comm/cuda_ipc/allgather.cu
@@ -111,11 +111,11 @@ void CudaIpcCommImpl::AllGather(
 
         for (int i = 1; i < ranks; ++i) {
             const int p = (rank + i) % ranks;
-            check_cuda_error(cudaMemcpyAsync(symm_ptr.uc[p] + rank * bytesize,  //
-                                             (char*)recvbuff + rank * bytesize,
-                                             bytesize,
-                                             cudaMemcpyDefault,
-                                             stream));
+            TM_CUDA_CHECK(cudaMemcpyAsync(symm_ptr.uc[p] + rank * bytesize,  //
+                                          (char*)recvbuff + rank * bytesize,
+                                          bytesize,
+                                          cudaMemcpyDefault,
+                                          stream));
         }
 
         Barrier(group, stream);
@@ -132,7 +132,7 @@ void CudaIpcCommImpl::AllGather(
             invoke(uint{});
         }
         else {
-            TM_CHECK(0) << "not implemented";
+            TM_LOG_FATAL("not implemented");
         }
     }
     else {
@@ -315,14 +315,14 @@ void CudaIpcCommImpl::AllGather2D(const void*  sendbuff,
 
         for (int i = 1; i < ranks; ++i) {
             const int p = (rank + i) % ranks;
-            check_cuda_error(cudaMemcpy2DAsync(symm_ptr.uc[p] + rank * byte_stride,
-                                               byte_pitch,
-                                               (char*)recvbuff + rank * byte_stride,
-                                               byte_pitch,
-                                               byte_width,
-                                               height,
-                                               cudaMemcpyDefault,
-                                               stream));
+            TM_CUDA_CHECK(cudaMemcpy2DAsync(symm_ptr.uc[p] + rank * byte_stride,
+                                            byte_pitch,
+                                            (char*)recvbuff + rank * byte_stride,
+                                            byte_pitch,
+                                            byte_width,
+                                            height,
+                                            cudaMemcpyDefault,
+                                            stream));
         }
 
         Barrier(group, stream);
@@ -339,7 +339,7 @@ void CudaIpcCommImpl::AllGather2D(const void*  sendbuff,
             invoke(uint{});
         }
         else {
-            TM_CHECK(0) << "not implemented";
+            TM_LOG_FATAL("not implemented");
         }
     }
     else {

--- a/src/turbomind/comm/cuda_ipc/allreduce.cu
+++ b/src/turbomind/comm/cuda_ipc/allreduce.cu
@@ -249,7 +249,7 @@ __global__ void Allreduce_NVLS_V2(
 void CudaIpcCommImpl::AllReduceSum(
     const void* sendbuff, void* recvbuff, size_t count, DataType type, int group, cudaStream_t stream)
 {
-    FT_CHECK(sendbuff == recvbuff);
+    TM_CHECK(sendbuff == recvbuff);
 
     void* data = recvbuff;
 

--- a/src/turbomind/comm/cuda_ipc/bootstrap.h
+++ b/src/turbomind/comm/cuda_ipc/bootstrap.h
@@ -8,6 +8,7 @@
 
 #include "src/turbomind/comm/barrier.h"
 #include "src/turbomind/comm/device_comm.h"
+#include "src/turbomind/core/check.h"
 
 namespace turbomind::comm {
 
@@ -76,7 +77,7 @@ public:
             {
                 std::lock_guard lock{state_->mutexes[rank_]};
                 if (!que.empty()) {
-                    FT_CHECK(que.front().size() == (size_t)size);
+                    TM_CHECK(que.front().size() == (size_t)size);
                     std::copy_n(que.front().begin(), size, (uint8_t*)data);
                     que.pop();
                     return;

--- a/src/turbomind/comm/cuda_ipc/broadcast.cu
+++ b/src/turbomind/comm/cuda_ipc/broadcast.cu
@@ -143,7 +143,7 @@ void CudaIpcCommImpl::Broadcast(const void*  sendbuff,  //
         Barrier(group, stream);
         if (rank != root) {
             SymmetricPtr_V2<char> symm_ptr = get_symmetric_v2((char*)recvbuff, group);
-            check_cuda_error(cudaMemcpyAsync((char*)recvbuff, symm_ptr.uc[root], bytesize, cudaMemcpyDefault, stream));
+            TM_CUDA_CHECK(cudaMemcpyAsync((char*)recvbuff, symm_ptr.uc[root], bytesize, cudaMemcpyDefault, stream));
         }
         Barrier(group, stream);
     }
@@ -157,7 +157,7 @@ void CudaIpcCommImpl::Broadcast(const void*  sendbuff,  //
             Barrier(group, stream);
             int s = i - rank;
             if (0 <= s && s < slices && rank != root) {
-                check_cuda_error(cudaMemcpyAsync(
+                TM_CUDA_CHECK(cudaMemcpyAsync(
                     (char*)recvbuff + s * slice, symm_ptr.uc[rank - 1] + s * slice, slice, cudaMemcpyDefault, stream));
             }
         }
@@ -169,18 +169,15 @@ void CudaIpcCommImpl::Broadcast(const void*  sendbuff,  //
         TM_CHECK_EQ(root, 0);
         Barrier(group, stream);
         if (rank == 4) {
-            check_cuda_error(
-                cudaMemcpyAsync((char*)recvbuff, symm_ptr.uc[rank - 4], bytesize, cudaMemcpyDefault, stream));
+            TM_CUDA_CHECK(cudaMemcpyAsync((char*)recvbuff, symm_ptr.uc[rank - 4], bytesize, cudaMemcpyDefault, stream));
         }
         Barrier(group, stream);
         if (rank == 2 || rank == 6) {
-            check_cuda_error(
-                cudaMemcpyAsync((char*)recvbuff, symm_ptr.uc[rank - 2], bytesize, cudaMemcpyDefault, stream));
+            TM_CUDA_CHECK(cudaMemcpyAsync((char*)recvbuff, symm_ptr.uc[rank - 2], bytesize, cudaMemcpyDefault, stream));
         }
         Barrier(group, stream);
         if (rank & 1) {
-            check_cuda_error(
-                cudaMemcpyAsync((char*)recvbuff, symm_ptr.uc[rank - 1], bytesize, cudaMemcpyDefault, stream));
+            TM_CUDA_CHECK(cudaMemcpyAsync((char*)recvbuff, symm_ptr.uc[rank - 1], bytesize, cudaMemcpyDefault, stream));
         }
         Barrier(group, stream);
     }
@@ -227,36 +224,36 @@ void CudaIpcCommImpl::Broadcast(const void*  sendbuff,  //
         // 0->1, 2->3, 4->5, 6->7
         Barrier(group, stream);
         if (rank == 0) {
-            check_cuda_error(cudaMemcpyAsync(symm_ptr.uc[rank + 4] + slice * (rank + 4),
-                                             symm_ptr.uc[rank + 0] + slice * (rank + 4),
-                                             slice * 4,
-                                             cudaMemcpyDefault,
-                                             stream));
+            TM_CUDA_CHECK(cudaMemcpyAsync(symm_ptr.uc[rank + 4] + slice * (rank + 4),
+                                          symm_ptr.uc[rank + 0] + slice * (rank + 4),
+                                          slice * 4,
+                                          cudaMemcpyDefault,
+                                          stream));
         }
         Barrier(group, stream);
         if (rank == 0 || rank == 4) {
-            check_cuda_error(cudaMemcpyAsync(symm_ptr.uc[rank + 2] + slice * (rank + 2),
-                                             symm_ptr.uc[rank + 0] + slice * (rank + 2),
-                                             slice * 2,
-                                             cudaMemcpyDefault,
-                                             stream));
+            TM_CUDA_CHECK(cudaMemcpyAsync(symm_ptr.uc[rank + 2] + slice * (rank + 2),
+                                          symm_ptr.uc[rank + 0] + slice * (rank + 2),
+                                          slice * 2,
+                                          cudaMemcpyDefault,
+                                          stream));
         }
         Barrier(group, stream);
         if (rank % 2 == 0) {
-            check_cuda_error(cudaMemcpyAsync(symm_ptr.uc[rank + 1] + slice * (rank + 1),
-                                             symm_ptr.uc[rank + 0] + slice * (rank + 1),
-                                             slice * 1,
-                                             cudaMemcpyDefault,
-                                             stream));
+            TM_CUDA_CHECK(cudaMemcpyAsync(symm_ptr.uc[rank + 1] + slice * (rank + 1),
+                                          symm_ptr.uc[rank + 0] + slice * (rank + 1),
+                                          slice * 1,
+                                          cudaMemcpyDefault,
+                                          stream));
         }
         Barrier(group, stream);
         for (int i = 1; i < ranks; ++i) {
             const int p = (rank + i) % ranks;
-            check_cuda_error(cudaMemcpyAsync(symm_ptr.uc[p] + rank * slice,  //
-                                             (char*)recvbuff + rank * slice,
-                                             slice,
-                                             cudaMemcpyDefault,
-                                             stream));
+            TM_CUDA_CHECK(cudaMemcpyAsync(symm_ptr.uc[p] + rank * slice,  //
+                                          (char*)recvbuff + rank * slice,
+                                          slice,
+                                          cudaMemcpyDefault,
+                                          stream));
         }
         Barrier(group, stream);
     }

--- a/src/turbomind/comm/cuda_ipc/cuda_ipc_comm.cu
+++ b/src/turbomind/comm/cuda_ipc/cuda_ipc_comm.cu
@@ -29,8 +29,8 @@ TM_ENV_VAR(COMM, COPY_THRESHOLD, INT64_MAX);
 
 int CudaIpcCommImpl::Split(int color, int key, int group)
 {
-    FT_CHECK(color >= 0);
-    FT_CHECK(rank(group) >= 0);
+    TM_CHECK(color >= 0);
+    TM_CHECK(rank(group) >= 0);
 
     auto& parent = groups_.at(group);
 
@@ -64,8 +64,8 @@ int CudaIpcCommImpl::Split(int color, int key, int group)
 
     g.semaphore.Allocate(l2g.size(), g2l[global_rank_], [&](size_t size) {
         auto buf = (uint64_t*)Allocate(size);
-        check_cuda_error(cudaMemsetAsync(buf, 0, size));
-        check_cuda_error(cudaStreamSynchronize(0));
+        TM_CUDA_CHECK(cudaMemsetAsync(buf, 0, size));
+        TM_CUDA_CHECK(cudaStreamSynchronize(0));
         Register(buf, size);
         return get_symmetric_v2(buf, index);
     });
@@ -83,7 +83,7 @@ CudaIpcCommImpl::CudaIpcCommImpl(HostComm h_comm):
 
     // Exchange device ordinals
     ordinals_.resize(n_ranks);
-    check_cuda_error(cudaGetDevice(&ordinals_[rank]));
+    TM_CUDA_CHECK(cudaGetDevice(&ordinals_[rank]));
     comm::AllGather(h_comm_, ordinals_.data(), 1);
 
     max_ctas_ = {std::min(getSMCount(), kMaxChannels)};
@@ -95,7 +95,7 @@ CudaIpcCommImpl::CudaIpcCommImpl(HostComm h_comm):
 
 #if __CUDACC_VER_MAJOR__ >= 12
     if (global_n_ranks_ >= 4 && GetEnv<COMM_NVLS_ENABLE>()) {  // solve 2n-2>n+1 -> n>3
-        CUDRVCHECK(
+        TM_CUDRV_CHECK(
             cuDeviceGetAttribute(&multicast_capability_, CU_DEVICE_ATTRIBUTE_MULTICAST_SUPPORTED, ordinals_[rank]));
         multicast_capability_ = comm::AllReduce(h_comm_, multicast_capability_, RedOp::kMin);
     }
@@ -119,22 +119,22 @@ CudaIpcCommImpl::CudaIpcCommImpl(HostComm h_comm):
 
     // Prepare packet buffer
     packet_buff_ = Allocate(kPacketBuffSize);
-    check_cuda_error(cudaMemsetAsync(packet_buff_, 0, kPacketBuffSize));
+    TM_CUDA_CHECK(cudaMemsetAsync(packet_buff_, 0, kPacketBuffSize));
 
     // Prepare scratch buffer
     scratch_buff_ = Allocate(kScratchBuffSize);
-    check_cuda_error(cudaMemsetAsync(scratch_buff_, 0, kScratchBuffSize));
+    TM_CUDA_CHECK(cudaMemsetAsync(scratch_buff_, 0, kScratchBuffSize));
 
     /// TODO: release
     g.semaphore.Allocate(global_n_ranks_, global_rank_, [this](size_t size) {
         auto buf = (uint64_t*)Allocate(size);
-        check_cuda_error(cudaMemsetAsync(buf, 0, size));
-        check_cuda_error(cudaStreamSynchronize(0));
+        TM_CUDA_CHECK(cudaMemsetAsync(buf, 0, size));
+        TM_CUDA_CHECK(cudaStreamSynchronize(0));
         Register(buf, size);
         return get_symmetric_v2(buf, 0);
     });
 
-    check_cuda_error(cudaStreamSynchronize(0));
+    TM_CUDA_CHECK(cudaStreamSynchronize(0));
 
     Register(packet_buff_, kPacketBuffSize);
     Register(scratch_buff_, kScratchBuffSize);
@@ -176,24 +176,24 @@ void* CudaIpcCommImpl::Allocate(size_t size)
         CUmulticastObjectProp prop{};
         prop.numDevices = alloc_access_descs_.size();
         prop.size       = size;
-        CUDRVCHECK(cuMulticastGetGranularity(&granularity, &prop, CU_MULTICAST_GRANULARITY_MINIMUM));
+        TM_CUDRV_CHECK(cuMulticastGetGranularity(&granularity, &prop, CU_MULTICAST_GRANULARITY_MINIMUM));
 #else
-        TM_CHECK(0);
+        TM_LOG_FATAL("NVLS not supported");
 #endif
     }
     else {
-        CUDRVCHECK(cuMemGetAllocationGranularity(&granularity, &prop, CU_MEM_ALLOC_GRANULARITY_MINIMUM));
+        TM_CUDRV_CHECK(cuMemGetAllocationGranularity(&granularity, &prop, CU_MEM_ALLOC_GRANULARITY_MINIMUM));
     }
 
     size = round_up(size, granularity);
 
     CUmemGenericAllocationHandle handle{};
-    CUDRVCHECK(cuMemCreate(&handle, size, &prop, 0));
+    TM_CUDRV_CHECK(cuMemCreate(&handle, size, &prop, 0));
 
     CUdeviceptr ptr{};
-    CUDRVCHECK(cuMemAddressReserve(&ptr, size, granularity, 0, 0));
-    CUDRVCHECK(cuMemMap(ptr, size, 0, handle, 0));
-    CUDRVCHECK(cuMemSetAccess(ptr, size, alloc_access_descs_.data(), alloc_access_descs_.size()));
+    TM_CUDRV_CHECK(cuMemAddressReserve(&ptr, size, granularity, 0, 0));
+    TM_CUDRV_CHECK(cuMemMap(ptr, size, 0, handle, 0));
+    TM_CUDRV_CHECK(cuMemSetAccess(ptr, size, alloc_access_descs_.data(), alloc_access_descs_.size()));
 
     Allocation a{};
     a.handle    = handle;
@@ -214,9 +214,9 @@ void CudaIpcCommImpl::Free(void* ptr)
     if (auto it = allocation_.find(ptr); it != allocation_.end()) {
         auto& a    = *it;
         auto  dptr = reinterpret_cast<CUdeviceptr>(ptr);
-        CUDRVCHECK(cuMemUnmap(dptr, a.size));
-        CUDRVCHECK(cuMemRelease(a.handle));
-        CUDRVCHECK(cuMemAddressFree(dptr, a.size));
+        TM_CUDRV_CHECK(cuMemUnmap(dptr, a.size));
+        TM_CUDRV_CHECK(cuMemRelease(a.handle));
+        TM_CUDRV_CHECK(cuMemAddressFree(dptr, a.size));
         allocation_.erase(it);
     }
     else {
@@ -266,24 +266,24 @@ void CudaIpcCommImpl::Register(const Allocation& alloc, int group)
         mc_prop.numDevices = ranks;
         mc_prop.size       = size;
         if (rank == 0) {
-            CUDRVCHECK(cuMulticastCreate(&s.mc_handle, &mc_prop));
+            TM_CUDRV_CHECK(cuMulticastCreate(&s.mc_handle, &mc_prop));
         }
         auto handles = comm::AllGather(h_comm_, s.mc_handle);
         s.mc_handle  = handles.at(g.l2g[0]);
-        CUDRVCHECK(cuMulticastAddDevice(s.mc_handle, ordinals_[global_rank_]));
-        CUDRVCHECK(cuMulticastBindMem(s.mc_handle, 0, alloc.handle, 0, size, 0));
+        TM_CUDRV_CHECK(cuMulticastAddDevice(s.mc_handle, ordinals_[global_rank_]));
+        TM_CUDRV_CHECK(cuMulticastBindMem(s.mc_handle, 0, alloc.handle, 0, size, 0));
         CUdeviceptr mc_ptr{};
-        CUDRVCHECK(cuMemAddressReserve(&mc_ptr, size, alloc.alignment, 0, 0));
-        CUDRVCHECK(cuMemMap(mc_ptr, size, 0, s.mc_handle, 0));
-        CUDRVCHECK(cuMemSetAccess(mc_ptr, size, &alloc_access_descs_[global_rank_], 1));
+        TM_CUDRV_CHECK(cuMemAddressReserve(&mc_ptr, size, alloc.alignment, 0, 0));
+        TM_CUDRV_CHECK(cuMemMap(mc_ptr, size, 0, s.mc_handle, 0));
+        TM_CUDRV_CHECK(cuMemSetAccess(mc_ptr, size, &alloc_access_descs_[global_rank_], 1));
         s.mc_ptr = reinterpret_cast<void*>(mc_ptr);
         if (rank != 0) {
             // Increase reference count to the original handle so that all handles can be released
             // without explicit synchronization
-            CUDRVCHECK(cuMemRetainAllocationHandle(&s.mc_handle, s.mc_ptr));
+            TM_CUDRV_CHECK(cuMemRetainAllocationHandle(&s.mc_handle, s.mc_ptr));
         }
 #else
-        TM_CHECK(0);
+        TM_LOG_FATAL("NVLS not supported");
 #endif
     }
 
@@ -295,14 +295,14 @@ void CudaIpcCommImpl::Deregister(Symmetric& s)
     if (s.mc_handle) {
 #if __CUDACC_VER_MAJOR__ >= 12
         auto deviceptr = reinterpret_cast<CUdeviceptr>(s.mc_ptr);
-        CUDRVCHECK(cuMemUnmap(deviceptr, s.size));
-        CUDRVCHECK(cuMemAddressFree(deviceptr, s.size));
-        CUDRVCHECK(cuMulticastUnbind(s.mc_handle, ordinals_.at(global_rank_), 0, s.size));
-        CUDRVCHECK(cuMemRelease(s.mc_handle));
+        TM_CUDRV_CHECK(cuMemUnmap(deviceptr, s.size));
+        TM_CUDRV_CHECK(cuMemAddressFree(deviceptr, s.size));
+        TM_CUDRV_CHECK(cuMulticastUnbind(s.mc_handle, ordinals_.at(global_rank_), 0, s.size));
+        TM_CUDRV_CHECK(cuMemRelease(s.mc_handle));
         s.mc_handle = {};
         s.mc_ptr    = {};
 #else
-        TM_CHECK(0);
+        TM_LOG_FATAL("NVLS not supported");
 #endif
     }
 }

--- a/src/turbomind/comm/cuda_ipc/fused_allreduce.cu
+++ b/src/turbomind/comm/cuda_ipc/fused_allreduce.cu
@@ -532,7 +532,7 @@ void CudaIpcCommImpl::AllreduceResidualBiasRMSnorm(void*        hidden,
 
     // fallback
     AllReduceSum(hidden, hidden, token_num * dim, dtype, group, stream);
-    invokeResidualBiasRMSNorm(hidden, residual, weights, bias, dtype, dim, token_num, eps, stream);
+    TM_SCOPE_CALL(invokeResidualBiasRMSNorm(hidden, residual, weights, bias, dtype, dim, token_num, eps, stream));
 }
 
 }  // namespace turbomind::comm

--- a/src/turbomind/comm/cuda_ipc/fused_allreduce_ex.cu
+++ b/src/turbomind/comm/cuda_ipc/fused_allreduce_ex.cu
@@ -303,7 +303,7 @@ void CudaIpcCommImpl::AllreduceResidualBiasRMSnormEx(void*        hidden,
                                                      const int*   local_token_nums,
                                                      cudaStream_t stream)
 {
-    FT_CHECK(group0 * group1 == 0);
+    TM_CHECK(group0 * group1 == 0);
 
     const auto& g0 = groups_.at(group0);
     const auto& g1 = groups_.at(group1);
@@ -313,7 +313,7 @@ void CudaIpcCommImpl::AllreduceResidualBiasRMSnormEx(void*        hidden,
 
     const int inner_tp = std::min(tp0, tp1);
 
-    FT_CHECK(tp0 % inner_tp == 0 && tp1 % inner_tp == 0);
+    TM_CHECK(tp0 % inner_tp == 0 && tp1 % inner_tp == 0);
 
     Array<int, kMaxRanks> offsets{};
     Array<int, kMaxRanks> firsts{};
@@ -401,8 +401,6 @@ void CudaIpcCommImpl::AllreduceResidualBiasRMSnormEx(void*        hidden,
         }
         return true;
     };
-
-    sync_check_cuda_error();
 
     auto dispatch_D = [&](auto t) {
         using T                = decltype(t);

--- a/src/turbomind/comm/cuda_ipc/semaphore.h
+++ b/src/turbomind/comm/cuda_ipc/semaphore.h
@@ -38,16 +38,16 @@ struct SystemSemaphoreStorage {
             }
         }
 
-        check_cuda_error(cudaMallocAsync(&info_, sizeof(SystemSemaphoreInfo), 0));
-        check_cuda_error(cudaMemcpyAsync(info_, &info, sizeof(SystemSemaphoreInfo), cudaMemcpyDefault, 0));
+        TM_CUDA_CHECK(cudaMallocAsync(&info_, sizeof(SystemSemaphoreInfo), 0));
+        TM_CUDA_CHECK(cudaMemcpyAsync(info_, &info, sizeof(SystemSemaphoreInfo), cudaMemcpyDefault, 0));
 
-        check_cuda_error(cudaStreamSynchronize(0));
+        TM_CUDA_CHECK(cudaStreamSynchronize(0));
     }
 
     template<class DeregFree>
     void Free(DeregFree dereg_free)
     {
-        check_cuda_error(cudaFreeAsync(info_, 0));
+        TM_CUDA_CHECK(cudaFreeAsync(info_, 0));
         info_ = {};
 
         dereg_free(data_);

--- a/src/turbomind/comm/device_comm.cc
+++ b/src/turbomind/comm/device_comm.cc
@@ -25,7 +25,7 @@ DeviceComm CreateDeviceCommunicator(const std::string& backend, int n_ranks, int
     }
 #endif
 
-    TM_CHECK(0) << "Unknown communication backend: " << backend;
+    TM_LOG_FATAL("Unknown communication backend: {}", backend);
     return {};
 }
 

--- a/src/turbomind/comm/nccl/nccl.cu
+++ b/src/turbomind/comm/nccl/nccl.cu
@@ -149,7 +149,7 @@ public:
             NCCLCHECK(alloc_fn(&ptr, size));
         }
         else {
-            check_cuda_error(cudaMalloc(&ptr, size));
+            TM_CUDA_CHECK(cudaMalloc(&ptr, size));
         }
         buffers_.emplace(ptr, size);
         return ptr;
@@ -162,7 +162,7 @@ public:
                 NCCLCHECK(free_fn(ptr));
             }
             else {
-                check_cuda_error(cudaFree(ptr));
+                TM_CUDA_CHECK(cudaFree(ptr));
             }
             buffers_.erase(ptr);
         }
@@ -285,15 +285,15 @@ public:
         const auto elem_size = byte_size(dtype);
 
         auto rms_norm = [&](int64_t first, int64_t count) {
-            invokeResidualBiasRMSNorm((char*)hidden + elem_size * first * dim,
-                                      (char*)residual + elem_size * first * dim,
-                                      weights,
-                                      bias,
-                                      dtype,
-                                      dim,
-                                      count,
-                                      eps,
-                                      stream);
+            TM_SCOPE_CALL(invokeResidualBiasRMSNorm((char*)hidden + elem_size * first * dim,
+                                                    (char*)residual + elem_size * first * dim,
+                                                    weights,
+                                                    bias,
+                                                    dtype,
+                                                    dim,
+                                                    count,
+                                                    eps,
+                                                    stream));
         };
 
         if (1) {
@@ -328,7 +328,7 @@ public:
         const size_t         elem_size = byte_size(type);
         const ncclDataType_t nccl_type = to_nccl_dtype(type);
 
-        FT_CHECK(group0 == 0 || group1 == 0);
+        TM_CHECK(group0 == 0 || group1 == 0);
 
         ncclComm_t comm0 = groups_.at(group0);
         ncclComm_t comm1 = groups_.at(group1);
@@ -339,7 +339,7 @@ public:
 
         const int inner_tp = std::min(tp0, tp1);
 
-        FT_CHECK(tp0 % inner_tp == 0 && tp1 % inner_tp == 0);
+        TM_CHECK(tp0 % inner_tp == 0 && tp1 % inner_tp == 0);
 
         std::vector<std::tuple<int, int, int>> tasks;
         tasks.reserve(global_n_ranks_);
@@ -364,14 +364,12 @@ public:
                 }
             }
             NCCLCHECK(ncclGroupEnd());
-            sync_check_cuda_error();
         }
 
         if (auto& [offset, first, num] = tasks[global_rank_]; num > 0) {
             char* buff = (char*)hidden + elem_size * (offset + first) * dim;
-            invokeResidualBiasRMSNorm(
-                buff, (char*)residual + elem_size * first * dim, weights, bias, type, dim, num, eps, stream);
-            sync_check_cuda_error();
+            TM_SCOPE_CALL(invokeResidualBiasRMSNorm(
+                buff, (char*)residual + elem_size * first * dim, weights, bias, type, dim, num, eps, stream));
         }
 
         if (tp1 > 1) {
@@ -383,7 +381,6 @@ public:
                 }
             }
             NCCLCHECK(ncclGroupEnd());
-            sync_check_cuda_error();
         }
     }
 

--- a/src/turbomind/comm/test_comm.cu
+++ b/src/turbomind/comm/test_comm.cu
@@ -21,8 +21,6 @@
 
 using namespace turbomind::comm;
 using turbomind::data_type_v;
-using turbomind::check;
-using turbomind::myAssert;
 using std::vector;
 
 [[maybe_unused]] static constexpr bool is_ncu = 0;
@@ -39,15 +37,15 @@ struct Context {
     template<class F>
     float exec(F func)
     {
-        check_cuda_error(cudaStreamSynchronize(stream));
-        check_cuda_error(cudaEventRecord(ev_start, stream));
+        TM_CUDA_CHECK(cudaStreamSynchronize(stream));
+        TM_CUDA_CHECK(cudaEventRecord(ev_start, stream));
 
         func(stream);
 
-        check_cuda_error(cudaEventRecord(ev_end, stream));
-        check_cuda_error(cudaEventSynchronize(ev_end));
+        TM_CUDA_CHECK(cudaEventRecord(ev_end, stream));
+        TM_CUDA_CHECK(cudaEventSynchronize(ev_end));
         float ms{};
-        check_cuda_error(cudaEventElapsedTime(&ms, ev_start, ev_end));
+        TM_CUDA_CHECK(cudaEventElapsedTime(&ms, ev_start, ev_end));
         return ms;
     }
 
@@ -55,7 +53,7 @@ struct Context {
     T* malloc(size_t count)
     {
         T* data;
-        check_cuda_error(cudaMallocAsync(&data, sizeof(T) * count, stream));
+        TM_CUDA_CHECK(cudaMallocAsync(&data, sizeof(T) * count, stream));
         buffers.push_back(data);
         return data;
     }
@@ -63,20 +61,20 @@ struct Context {
     template<class T>
     void copy_n(const T* src, size_t count, T* dst)
     {
-        check_cuda_error(cudaMemcpyAsync(dst, src, sizeof(T) * count, cudaMemcpyDefault, stream));
+        TM_CUDA_CHECK(cudaMemcpyAsync(dst, src, sizeof(T) * count, cudaMemcpyDefault, stream));
     }
 
     void sync()
     {
-        check_cuda_error(cudaStreamSynchronize(stream));
+        TM_CUDA_CHECK(cudaStreamSynchronize(stream));
     }
 
     Context(int device_id)
     {
-        check_cuda_error(cudaSetDevice(device_id));
-        check_cuda_error(cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking));
-        check_cuda_error(cudaEventCreate(&ev_start));
-        check_cuda_error(cudaEventCreate(&ev_end));
+        TM_CUDA_CHECK(cudaSetDevice(device_id));
+        TM_CUDA_CHECK(cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking));
+        TM_CUDA_CHECK(cudaEventCreate(&ev_start));
+        TM_CUDA_CHECK(cudaEventCreate(&ev_end));
     }
     ~Context()
     {
@@ -571,7 +569,7 @@ struct TestComm {
                 auto&        delta = deltas.emplace_back();
                 h_comm->Sync();
                 for (int i = 0; i < warmup_ + iters_; ++i) {
-                    check_cuda_error(cudaMemsetAsync(d_tmp, 0, sizeof(T) * count * n_ranks, ctx.stream));
+                    TM_CUDA_CHECK(cudaMemsetAsync(d_tmp, 0, sizeof(T) * count * n_ranks, ctx.stream));
                     ctx.copy_n(d_data, count, d_tmp + rank * count);
                     auto ms = ctx.exec([&](auto stream) {  //
                         if (d_comm->Query(kHasAllGather2D) && 0) {
@@ -686,7 +684,7 @@ struct TestComm {
                 auto&        delta = deltas.emplace_back();
                 h_comm->Sync();
                 for (int i = 0; i < warmup_ + iters_; ++i) {
-                    check_cuda_error(cudaMemsetAsync(d_tmp, 0, sizeof(T) * count, ctx.stream));
+                    TM_CUDA_CHECK(cudaMemsetAsync(d_tmp, 0, sizeof(T) * count, ctx.stream));
                     if (rank == root) {
                         ctx.copy_n(d_data, count, d_tmp);
                     }

--- a/src/turbomind/core/CMakeLists.txt
+++ b/src/turbomind/core/CMakeLists.txt
@@ -20,6 +20,7 @@ add_library(core STATIC
         allocator.cc
         stream.cc
         context.cc
+        scope.cc
         buffer.cc
         layout.cc
         data_format.cc
@@ -40,6 +41,9 @@ target_compile_options(core PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:-Xptxas=-v>)
 if (BUILD_TEST)
     add_executable(test_core test_core.cc)
     target_link_libraries(test_core PRIVATE core Catch2::Catch2WithMain)
+
+    add_executable(test_scope test_scope.cc)
+    target_link_libraries(test_scope PRIVATE core Catch2::Catch2WithMain)
 
     add_executable(test_logger test_logger.cc)
     target_link_libraries(test_logger PRIVATE core Catch2::Catch2WithMain)

--- a/src/turbomind/core/allocator.cc
+++ b/src/turbomind/core/allocator.cc
@@ -19,9 +19,9 @@ public:
     CudaMemPoolAllocator(Stream stream, bool use_default_pool):
         pool_{}, stream_{stream}, device_{kDEVICE}, use_default_pool_{use_default_pool}
     {
-        check_cuda_error(cudaGetDevice(&device_.id));
+        TM_CUDA_CHECK(cudaGetDevice(&device_.id));
         if (use_default_pool_) {
-            check_cuda_error(cudaDeviceGetDefaultMemPool(&pool_, device_.id));
+            TM_CUDA_CHECK(cudaDeviceGetDefaultMemPool(&pool_, device_.id));
         }
         else {
             cudaMemPoolProps props{};
@@ -29,16 +29,16 @@ public:
             props.handleTypes   = cudaMemHandleTypeNone;
             props.location.type = cudaMemLocationTypeDevice;
             props.location.id   = device_.id;
-            check_cuda_error(cudaMemPoolCreate(&pool_, &props));
+            TM_CUDA_CHECK(cudaMemPoolCreate(&pool_, &props));
             cuuint64_t thres = (cuuint64_t)-1;
-            check_cuda_error(cudaMemPoolSetAttribute(pool_, cudaMemPoolAttrReleaseThreshold, &thres));
+            TM_CUDA_CHECK(cudaMemPoolSetAttribute(pool_, cudaMemPoolAttrReleaseThreshold, &thres));
         }
     }
 
     ~CudaMemPoolAllocator() override
     {
         if (!use_default_pool_) {
-            check_cuda_error(cudaMemPoolDestroy(pool_));
+            TM_CUDA_CHECK(cudaMemPoolDestroy(pool_));
         }
         pool_ = {};
     }
@@ -46,13 +46,13 @@ public:
     void* allocate(ssize_t size) override
     {
         void* ptr{};
-        check_cuda_error(cudaMallocFromPoolAsync(&ptr, size, pool_, stream_.handle()));
+        TM_CUDA_CHECK(cudaMallocFromPoolAsync(&ptr, size, pool_, stream_.handle()));
         return ptr;
     }
 
     void deallocate(void* p, ssize_t) override
     {
-        check_cuda_error(cudaFreeAsync(p, stream_.handle()));
+        TM_CUDA_CHECK(cudaFreeAsync(p, stream_.handle()));
     }
 
     Device device() const noexcept override
@@ -67,7 +67,7 @@ public:
 
     void trim(size_t bytes_to_keep)
     {
-        check_cuda_error(cudaMemPoolTrimTo(pool_, bytes_to_keep));
+        TM_CUDA_CHECK(cudaMemPoolTrimTo(pool_, bytes_to_keep));
     }
 
 private:
@@ -82,13 +82,13 @@ public:
     void* allocate(ssize_t size) override
     {
         void* ptr{};
-        check_cuda_error(cudaMalloc(&ptr, size));
+        TM_CUDA_CHECK(cudaMalloc(&ptr, size));
         return ptr;
     }
 
     void deallocate(void* p, ssize_t) override
     {
-        check_cuda_error(cudaFree(p));
+        TM_CUDA_CHECK(cudaFree(p));
     }
 
     Device device() const noexcept override
@@ -102,13 +102,13 @@ public:
     void* allocate(ssize_t size) override
     {
         void* ptr{};
-        check_cuda_error(cudaHostAlloc(&ptr, size, cudaHostAllocDefault));
+        TM_CUDA_CHECK(cudaHostAlloc(&ptr, size, cudaHostAllocDefault));
         return ptr;
     }
 
     void deallocate(void* p, ssize_t) override
     {
-        check_cuda_error(cudaFreeHost(p));
+        TM_CUDA_CHECK(cudaFreeHost(p));
     }
 
     Device device() const noexcept override

--- a/src/turbomind/core/buffer.cc
+++ b/src/turbomind/core/buffer.cc
@@ -50,7 +50,7 @@ void Copy(const Buffer& a, ssize_t n, Ref<Buffer> b_, const Stream& stream)
     TM_CHECK_LE(n, a.size());
     TM_CHECK_LE(n, b.size());
     if (auto size = byte_size(a.dtype(), n)) {
-        check_cuda_error(cudaMemcpyAsync(b.raw_data(), a.raw_data(), size, cudaMemcpyDefault, stream.handle()));
+        TM_CUDA_CHECK(cudaMemcpyAsync(b.raw_data(), a.raw_data(), size, cudaMemcpyDefault, stream.handle()));
     }
 }
 
@@ -75,7 +75,7 @@ namespace detail {
 void* Copy(const void* a, ssize_t n, void* b, const Stream& stream)
 {
     if (n) {
-        check_cuda_error(cudaMemcpyAsync(b, a, n, cudaMemcpyDefault, stream.handle()));
+        TM_CUDA_CHECK(cudaMemcpyAsync(b, a, n, cudaMemcpyDefault, stream.handle()));
     }
     return (uint8_t*)b + n;
 }
@@ -86,7 +86,7 @@ void Clear(Ref<Buffer> b_, const Stream& stream)
 {
     auto& b = b_.get();
     if (auto size = b.byte_size()) {
-        check_cuda_error(cudaMemsetAsync(b.raw_data(), 0, b.byte_size(), stream.handle()));
+        TM_CUDA_CHECK(cudaMemsetAsync(b.raw_data(), 0, b.byte_size(), stream.handle()));
     }
 }
 

--- a/src/turbomind/core/check.cc
+++ b/src/turbomind/core/check.cc
@@ -6,39 +6,9 @@
 
 #include "src/turbomind/core/check.h"
 #include "src/turbomind/core/logger.h"
+#include "src/turbomind/core/scope.h"
 
 namespace turbomind::core {
-
-namespace {
-
-std::string StripSrcPrefix(const char* file)
-{
-    static const char* flag = std::getenv("TM_SRC_FULL_PATH");
-    if (flag) {
-        return file;
-    }
-
-    std::filesystem::path path{file};
-    std::filesystem::path ret{path};  // return the original path if anchor is not found
-
-    constexpr auto anchor = "turbomind";
-
-    bool found = false;
-
-    for (const auto& x : path) {
-        if (x == anchor) {
-            found = true;
-            ret.clear();
-        }
-        else if (found) {
-            ret /= x;
-        }
-    }
-
-    return ret.string();
-}
-
-}  // namespace
 
 CheckOpStringBuilder::CheckOpStringBuilder()
 {
@@ -64,7 +34,8 @@ std::string* CheckOpStringBuilder::NewString()
 CheckErrorStream::CheckErrorStream(const char* file, int line, const char* expr): file_{file}, line_{line}
 {
     oss_ = new std::ostringstream{};
-    *oss_ << StripSrcPrefix(file) << "(" << line << "): Check failed: " << expr << " ";
+    // *oss_ << StripSrcPrefix(file) << "(" << line << "): Check failed: " << expr << " ";
+    *oss_ << "Check failed: " << expr << " ";
 }
 
 CheckErrorStream::CheckErrorStream(const char* file, int line, const char* expr, std::string* str):
@@ -75,12 +46,14 @@ CheckErrorStream::CheckErrorStream(const char* file, int line, const char* expr,
 
 void CheckErrorStream::Report()
 {
-    Logger::Instance().LogFatal(SourceLocation{file_, line_}, "{}", oss_->str());
+    Scope _("TM_CHECK", file_, line_);
+    Logger::Instance().LogFatalImpl(file_, line_, oss_->str());
 }
 
 void ReportNullError(const char* file, int line, const char* expr)
 {
-    Logger::Instance().LogFatal(SourceLocation{file, line}, "{}: '{}' Must be non NULL", StripSrcPrefix(file), expr);
+    Scope _("TM_CHECK_NOTNULL", file, line);
+    Logger::Instance().LogFatalImpl(file, line, fmt::format("'{}' Must be non NULL", expr));
 }
 
 }  // namespace turbomind::core

--- a/src/turbomind/core/context.cc
+++ b/src/turbomind/core/context.cc
@@ -1,12 +1,48 @@
 
+#include <filesystem>
+#include <fmt/format.h>
+#include <ostream>
 #include <stack>
+#include <string>
+#include <string_view>
+#include <thread>
+#include <vector>
 
 #include "src/turbomind/core/allocator.h"
+#include "src/turbomind/core/check.h"
 #include "src/turbomind/core/context.h"
+#include "src/turbomind/core/scope.h"
 
 namespace turbomind::core {
 
 namespace {
+
+std::string StripNamespace(std::string_view name)
+{
+    static constexpr std::string_view ns = "turbomind::";
+    std::string                       result;
+
+    for (auto it = name.find(ns); it != std::string_view::npos; it = name.find(ns)) {
+        result.append(name.substr(0, it));
+        name.remove_prefix(it + ns.size());
+    }
+
+    result.append(name);
+
+    return result;
+}
+
+std::string StripPathPrefix(std::string_view file)
+{
+    static const char* flag = std::getenv("TM_SRC_FULL_PATH");
+    if (flag) {
+        return std::string{file};
+    }
+
+    // Return only the filename (last component of the path)
+    std::filesystem::path path{file};
+    return path.filename().string();
+}
 
 struct ContextStorage {
     enum
@@ -22,6 +58,8 @@ struct ContextStorage {
     std::stack<Allocator> device_alloc_;
     std::stack<Allocator> pinned_alloc_;
     std::stack<int>       mask_;
+
+    std::vector<ScopeEntry> scope_;
 
     ContextStorage()
     {
@@ -76,6 +114,46 @@ struct ContextStorage {
         mask_.pop();
     }
 
+    void push_scope(const ScopeEntry& entry)
+    {
+        scope_.push_back(entry);
+    }
+
+    void pop_scope()
+    {
+        TM_CHECK(!scope_.empty()) << "pop_scope called with empty scope stack";
+        scope_.pop_back();
+    }
+
+    int scope_depth() const
+    {
+        return static_cast<int>(scope_.size());
+    }
+
+    std::string scope_trace() const
+    {
+        if (scope_.empty()) {
+            return {};
+        }
+        std::ostringstream oss;
+        oss << std::hex << std::this_thread::get_id();
+        std::string s = fmt::format("*** stacktrace of thread 0x{} ***\n", oss.str());
+        for (size_t i = 0; i < scope_.size(); ++i) {
+            const int r    = static_cast<int>(scope_.size()) - i - 1;
+            auto      name = StripNamespace(scope_[r].name);
+            if (scope_[r].type == scope_type::function) {
+                name = StripFunctionSignature(name);
+            }
+            else if (scope_[r].type == scope_type::call) {
+                if (auto p = name.find('('); p != std::string::npos) {
+                    name.resize(p);
+                }
+            }
+            s += fmt::format("  [{:>2}] {} @ {}:{}\n", i, name, StripPathPrefix(scope_[r].file), scope_[r].line);
+        }
+        return s;
+    }
+
     static ContextStorage& instance()
     {
         thread_local ContextStorage inst{};
@@ -98,6 +176,26 @@ void Context::push(const Allocator& alloc)
 void Context::pop()
 {
     ContextStorage::instance().pop();
+}
+
+void Context::push_scope(const ScopeEntry& entry)
+{
+    ContextStorage::instance().push_scope(entry);
+}
+
+void Context::pop_scope()
+{
+    ContextStorage::instance().pop_scope();
+}
+
+std::string Context::scope_trace()
+{
+    return ContextStorage::instance().scope_trace();
+}
+
+int Context::scope_depth()
+{
+    return ContextStorage::instance().scope_depth();
 }
 
 Stream& Context::stream()

--- a/src/turbomind/core/context.h
+++ b/src/turbomind/core/context.h
@@ -1,10 +1,26 @@
 #pragma once
 
+#include <string>
+
 #include "src/turbomind/core/allocator.h"
 #include "src/turbomind/core/common.h"
 #include "src/turbomind/core/stream.h"
 
 namespace turbomind::core {
+
+enum class scope_type
+{
+    named,
+    function,
+    call,
+};
+
+struct ScopeEntry {
+    const char* name;
+    const char* file;
+    int         line;
+    scope_type  type = scope_type::named;
+};
 
 class Context {
 public:
@@ -13,6 +29,11 @@ public:
     static Allocator& device_alloc();
     static Allocator& pinned_alloc();
     static Allocator& alloc(Device device);
+
+    static void        push_scope(const ScopeEntry& entry);
+    static void        pop_scope();
+    static std::string scope_trace();
+    static int         scope_depth();
 
 private:
     friend class ContextGuard;

--- a/src/turbomind/core/copy.cc
+++ b/src/turbomind/core/copy.cc
@@ -110,7 +110,11 @@ void BatchCopy::Run()
                                    core::Context::stream().handle());
 
                 if (auto i = fail_idx; i != SIZE_MAX) {
-                    TM_CHECK(0) << (void*)src_[i] << " " << size_[i] << " " << (void*)dst_[i] << " code " << status;
+                    TM_LOG_FATAL("copy failed: src={} size={} dst={} code={}",
+                                 (void*)src_[i],
+                                 size_[i],
+                                 (void*)dst_[i],
+                                 (int)status);
                 }
             }
             else {

--- a/src/turbomind/core/core.h
+++ b/src/turbomind/core/core.h
@@ -8,6 +8,7 @@
 #include "src/turbomind/core/data_type.h"
 #include "src/turbomind/core/layout.h"
 #include "src/turbomind/core/ranges.h"
+#include "src/turbomind/core/scope.h"
 #include "src/turbomind/core/stream.h"
 #include "src/turbomind/core/tensor.h"
 
@@ -25,6 +26,7 @@ using core::Allocator;
 using core::Stream;
 using core::Event;
 using core::BatchCopy;
+using core::Scope;
 
 using core::subrange;
 

--- a/src/turbomind/core/data_format.cc
+++ b/src/turbomind/core/data_format.cc
@@ -2,6 +2,7 @@
 
 #include "src/turbomind/core/data_format.h"
 #include "src/turbomind/core/check.h"
+#include "src/turbomind/core/logger.h"
 
 namespace turbomind {
 
@@ -57,7 +58,7 @@ DataFormat ResolveLinearWeightFormat(DataType data_type, DataType weight_dtype, 
         return fmt;
     }
 
-    TM_CHECK(0) << "Unsupported weight format: " << to_string(weight_dtype);
+    TM_LOG_FATAL("Unsupported weight format: {}", to_string(weight_dtype));
     return fmt;
 }
 

--- a/src/turbomind/core/data_type.h
+++ b/src/turbomind/core/data_type.h
@@ -6,6 +6,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <fmt/format.h>
 #include <type_traits>
 
 // forward declarations for CUDA floating point types
@@ -266,6 +267,17 @@ inline std::ostream& operator<<(std::ostream& os, DataType type) {
     return os;
 }
 
+}  // namespace turbomind
+
+template <>
+struct fmt::formatter<turbomind::DataType>: formatter<string_view> {
+    auto format(turbomind::DataType type, format_context& ctx) const {
+        return formatter<string_view>::format(turbomind::to_string(type), ctx);
+    }
+};
+
+namespace turbomind {
+
 /// TODO: mapping with DLPack
 
 // clang-format on
@@ -317,7 +329,7 @@ inline std::ostream& operator<<(std::ostream& os, DataType type) {
     switch (var) {                                                                                                     \
         TM_PP_DISPATCH_N(TM_PP_INVOKE_, __VA_ARGS__)(TM_DISPATCH_DTYPE_RET_CASE, f, __VA_ARGS__);                      \
         default:                                                                                                       \
-            TM_CHECK(0) << "unsupported type: "  << to_string(var);                                                    \
+            TM_LOG_FATAL("unsupported type: {}", to_string(var));                                                      \
             return {};                                                                                                 \
     }
 
@@ -325,7 +337,7 @@ inline std::ostream& operator<<(std::ostream& os, DataType type) {
     switch (var) {                                                                                                     \
         TM_PP_DISPATCH_N(TM_PP_INVOKE_, __VA_ARGS__)(TM_DISPATCH_DTYPE_CASE, f, __VA_ARGS__);                          \
         default:                                                                                                       \
-            TM_CHECK(0) << "unsupported type: "  << to_string(var);                                                    \
+            TM_LOG_FATAL("unsupported type: {}", to_string(var));                                                      \
     }
 // clang-format on
 

--- a/src/turbomind/core/logger.cc
+++ b/src/turbomind/core/logger.cc
@@ -1,6 +1,8 @@
 // Copyright (c) OpenMMLab. All rights reserved.
 
 #include "src/turbomind/core/logger.h"
+#include "src/turbomind/core/context.h"
+#include "src/turbomind/core/scope.h"
 
 #include <algorithm>
 #include <array>
@@ -272,6 +274,18 @@ void Logger::Enqueue(Level level, std::string message)
     Enqueue(level, nullptr, 0, std::move(message));
 }
 
+void Logger::LogFatalTraced(const char* file, int line, std::string message)
+{
+    core::Scope _("TM_LOG_FATAL", file, line);
+    LogFatalImpl(file, line, std::move(message));
+}
+
+void Logger::LogFatalImpl(const char* file, int line, std::string message)
+{
+    Enqueue(Level::kFatal, file, line, std::move(message));
+    std::abort();
+}
+
 // ---------------------------------------------------------------------------
 // AsyncLogWorker — background I/O thread
 // ---------------------------------------------------------------------------
@@ -284,6 +298,10 @@ AsyncLogWorker& AsyncLogWorker::Instance()
 
 static void OnFatalSignal(int signum)
 {
+    auto trace = Context::scope_trace();
+    if (!trace.empty()) {
+        fmt::print(stderr, "{}", trace);
+    }
     AsyncLogWorker::Instance().OnSignal();
     ::signal(signum, SIG_DFL);
     ::raise(signum);

--- a/src/turbomind/core/logger.h
+++ b/src/turbomind/core/logger.h
@@ -53,9 +53,10 @@ public:
     template<typename... Args>
     [[noreturn]] void LogFatal(SourceLocation loc, fmt::format_string<Args...> fmt_str, Args&&... args)
     {
-        Enqueue(Level::kFatal, loc.file, loc.line, fmt::format(fmt_str, std::forward<Args>(args)...));
-        std::abort();
+        LogFatalTraced(loc.file, loc.line, fmt::format(fmt_str, std::forward<Args>(args)...));
     }
+
+    [[noreturn]] void LogFatalImpl(const char* file, int line, std::string message);
 
     void set_level(Level level);
 
@@ -74,6 +75,8 @@ private:
 
     void Enqueue(Level level, std::string message);
     void Enqueue(Level level, const char* file, int line, std::string message);
+
+    [[noreturn]] void LogFatalTraced(const char* file, int line, std::string message);
 
     static std::string LevelName(Level level);
     static std::string Prefix(Level level, const char* file, int line);

--- a/src/turbomind/core/scope.cc
+++ b/src/turbomind/core/scope.cc
@@ -1,0 +1,104 @@
+#include "src/turbomind/core/scope.h"
+
+#include <cstring>
+
+namespace turbomind::core {
+namespace {
+
+// Position of `close` matching the `open` at `start` (scan forward).
+size_t match_fwd(const std::string& s, size_t start, char open, char close)
+{
+    for (int d = 0; start < s.size(); ++start) {
+        if (s[start] == open)
+            ++d;
+        else if (s[start] == close && --d == 0)
+            return start;
+    }
+    return std::string::npos;
+}
+
+// Position of `open` matching the `close` just before `end` (scan backward).
+size_t match_rev(const std::string& s, size_t end, char close, char open)
+{
+    for (int d = 0; end > 0; --end) {
+        if (s[end - 1] == close)
+            ++d;
+        else if (s[end - 1] == open && --d == 0)
+            return end - 1;
+    }
+    return std::string::npos;
+}
+
+}  // namespace
+
+Scope::Scope(const char* name, const char* file, int line)
+{
+    Context::push_scope({name, file, line});
+}
+
+Scope::Scope(const char* name, const char* file, int line, scope_type type)
+{
+    Context::push_scope({name, file, line, type});
+}
+
+Scope::~Scope()
+{
+    Context::pop_scope();
+}
+
+std::string Scope::trace()
+{
+    return Context::scope_trace();
+}
+
+int Scope::depth()
+{
+    return Context::scope_depth();
+}
+
+std::string StripFunctionSignature(std::string_view name)
+{
+    std::string s{name};
+
+    // 1. Strip trailing " [with <...>]" (GCC/Clang template args)
+    if (auto p = s.rfind(" [with "); p != std::string::npos)
+        if (match_fwd(s, p + 1, '[', ']') != std::string::npos)
+            s.resize(p);
+
+    // 2. Strip trailing member-function qualifiers
+    for (int again = 1; again;) {
+        again = 0;
+        for (auto q : {" const", " volatile"}) {
+            auto n = std::strlen(q);
+            if (s.size() >= n && !s.compare(s.size() - n, n, q))
+                s.resize(s.size() - n), again = 1;
+        }
+    }
+
+    // 3. Replace parameter list with "()"
+    if (!s.empty() && s.back() == ')')
+        if (auto p = match_rev(s, s.size(), ')', '('); p != std::string::npos)
+            s.replace(p, s.size() - p, "()");
+
+    // 4. Strip function template "<...>" immediately before "()"
+    //    (class template params like Container<T>::method are before "::", kept)
+    if (s.size() >= 4 && s[s.size() - 3] == '>')
+        if (auto p = match_rev(s, s.size() - 2, '>', '<'); p != std::string::npos)
+            s.erase(p, s.size() - 2 - p);
+
+    // 5. Strip return type: everything before last top-level space
+    // clang-format off
+    int a = 0, p = 0, b = 0;
+    for (size_t i = s.size(); i > 0; --i) {
+        switch (s[i - 1]) {
+            case '>': ++a; break; case '<': --a; break;
+            case ')': ++p; break; case '(': --p; break;
+            case ']': ++b; break; case '[': --b; break;
+            case ' ': if (!a && !p && !b) { s.erase(0, i); return s; }
+        }
+    }
+    // clang-format on
+    return s;
+}
+
+}  // namespace turbomind::core

--- a/src/turbomind/core/scope.h
+++ b/src/turbomind/core/scope.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <string>
+#include <string_view>
+
+#include "src/turbomind/core/context.h"
+
+namespace turbomind::core {
+
+class Scope {
+public:
+    Scope(const char* name, const char* file, int line);
+    Scope(const char* name, const char* file, int line, scope_type type);
+    ~Scope();
+
+    Scope(const Scope&) = delete;
+    Scope& operator=(const Scope&) = delete;
+
+    static std::string trace();
+    static int         depth();
+};
+
+// Strip return type, parameter list, and template args from __PRETTY_FUNCTION__
+// or __FUNCSIG__, leaving "QualifiedName()". For named scopes this is not called.
+std::string StripFunctionSignature(std::string_view name);
+
+}  // namespace turbomind::core
+
+#define TM_SCOPE(name) ::turbomind::core::Scope _tm_scope_##__LINE__(name, __FILE__, __LINE__)
+
+#define TM_FUNCTION_SCOPE()                                                                                            \
+    ::turbomind::core::Scope _tm_func_scope_##__LINE__(                                                                \
+        __PRETTY_FUNCTION__, __FILE__, __LINE__, ::turbomind::core::scope_type::function)
+
+#define TM_SCOPE_CALL(func_call)                                                                                       \
+    do {                                                                                                               \
+        ::turbomind::core::Scope _tm_scope_##__LINE__(                                                                 \
+            #func_call, __FILE__, __LINE__, ::turbomind::core::scope_type::call);                                      \
+        func_call;                                                                                                     \
+    } while (0)

--- a/src/turbomind/core/stream.cc
+++ b/src/turbomind/core/stream.cc
@@ -13,7 +13,7 @@ Stream Stream::create(int priority)
 
 void StreamImpl::Wait(const Event& event)
 {
-    check_cuda_error(cudaStreamWaitEvent(stream_, event));
+    TM_CUDA_CHECK(cudaStreamWaitEvent(stream_, event));
 }
 
 }  // namespace turbomind::core

--- a/src/turbomind/core/stream.h
+++ b/src/turbomind/core/stream.h
@@ -11,7 +11,7 @@ class StreamImpl {
 public:
     StreamImpl(int priority): stream_{}
     {
-        check_cuda_error(cudaStreamCreateWithPriority(&stream_, cudaStreamNonBlocking, priority));
+        TM_CUDA_CHECK(cudaStreamCreateWithPriority(&stream_, cudaStreamNonBlocking, priority));
     }
 
     ~StreamImpl()
@@ -24,7 +24,7 @@ public:
 
     void Sync()
     {
-        check_cuda_error(cudaStreamSynchronize(stream_));
+        TM_CUDA_CHECK(cudaStreamSynchronize(stream_));
     }
 
     void Wait(const Event& event);
@@ -93,7 +93,7 @@ class EventImpl {
 public:
     explicit EventImpl(unsigned flags)
     {
-        check_cuda_error(cudaEventCreateWithFlags(&event_, flags));
+        TM_CUDA_CHECK(cudaEventCreateWithFlags(&event_, flags));
     }
 
     ~EventImpl()
@@ -105,12 +105,12 @@ public:
 
     void Record(const Stream& stream)
     {
-        check_cuda_error(cudaEventRecord(event_, stream.handle()));
+        TM_CUDA_CHECK(cudaEventRecord(event_, stream.handle()));
     }
 
     void Sync() const
     {
-        check_cuda_error(cudaEventSynchronize(event_));
+        TM_CUDA_CHECK(cudaEventSynchronize(event_));
     }
 
     cudaEvent_t handle() const

--- a/src/turbomind/core/tensor.cc
+++ b/src/turbomind/core/tensor.cc
@@ -48,7 +48,7 @@ void Copy(const Tensor& src, Ref<Tensor> dst_, const Stream& stream)
     TM_CHECK(src.is_contiguous());
     TM_CHECK(dst.is_contiguous());
     if (auto size = src.byte_size()) {
-        check_cuda_error(cudaMemcpyAsync(dst.raw_data(), src.raw_data(), size, cudaMemcpyDefault, stream.handle()));
+        TM_CUDA_CHECK(cudaMemcpyAsync(dst.raw_data(), src.raw_data(), size, cudaMemcpyDefault, stream.handle()));
     }
 }
 
@@ -62,7 +62,7 @@ void Clear(Ref<Tensor> a_, const Stream& stream)
     auto& a = a_.get();
     TM_CHECK(a.is_contiguous());
     if (auto size = a.byte_size()) {
-        check_cuda_error(cudaMemsetAsync(a.raw_data(), 0, size, stream.handle()));
+        TM_CUDA_CHECK(cudaMemsetAsync(a.raw_data(), 0, size, stream.handle()));
     }
 }
 
@@ -82,7 +82,7 @@ void Copy(const Tensor& src, Tensor& dst, Stream& stream)
 
     auto trivial = [&] {
         const ssize_t bytesize = get_byte_size(dtype, src.size());
-        check_cuda_error(cudaMemcpyAsync(dst.raw_data(), src.raw_data(), bytesize, cudaMemcpyDefault, stream.handle()));
+        TM_CUDA_CHECK(cudaMemcpyAsync(dst.raw_data(), src.raw_data(), bytesize, cudaMemcpyDefault, stream.handle()));
     };
 
     if (src.layout().is_contiguous() && dst.layout().is_contiguous()) {
@@ -128,7 +128,7 @@ void Copy(const Tensor& src, Tensor& dst, Stream& stream)
     }
 
     if (rank == 2) {
-        check_cuda_error(cudaMemcpy2DAsync(dst.raw_data(),
+        TM_CUDA_CHECK(cudaMemcpy2DAsync(dst.raw_data(),
                                            get_byte_size(dtype, b.stride(0)),
                                            src.raw_data(),
                                            get_byte_size(dtype, a.stride(0)),
@@ -155,7 +155,7 @@ void Copy(const Tensor& src, Tensor& dst, Stream& stream)
         param.extent = make_cudaExtent(get_byte_size(dtype, a.shape(2)), a.shape(1), a.shape(0));
         param.kind   = cudaMemcpyDefault;
 
-        if (auto ec = cudaMemcpy3DAsync(&param, stream.handle()); ec == cudaSuccess) {
+        if (auto ec = cudaMemcpy3DAsync(&param, stream.handle()); ec != cudaSuccess) {
             TM_LOG_WARN("{}", cudaGetErrorString(ec));
             return;
         }

--- a/src/turbomind/core/tensor.cu
+++ b/src/turbomind/core/tensor.cu
@@ -110,9 +110,9 @@ void GenericCopy(const Tensor& src, Tensor& dst, Stream& stream)
     const auto size = a.size() / vec_size;
 
     int device{};
-    check_cuda_error(cudaGetDevice(&device));
+    TM_CUDA_CHECK(cudaGetDevice(&device));
     int sm_num{};
-    check_cuda_error(cudaDeviceGetAttribute(&sm_num, cudaDevAttrMultiProcessorCount, device));
+    TM_CUDA_CHECK(cudaDeviceGetAttribute(&sm_num, cudaDevAttrMultiProcessorCount, device));
 
     auto invoke = [&](auto vec_t, auto index_t, auto d) {
         using T         = decltype(vec_t);
@@ -145,7 +145,7 @@ void GenericCopy(const Tensor& src, Tensor& dst, Stream& stream)
         for (int threads = 256; threads <= 1024; threads *= 2) {
             int blocks = cdiv<ssize_t>(size, block_size);
             int n_active{};
-            check_cuda_error(cudaOccupancyMaxActiveBlocksPerMultiprocessor(&n_active, func, block_size, 0));
+            TM_CUDA_CHECK(cudaOccupancyMaxActiveBlocksPerMultiprocessor(&n_active, func, block_size, 0));
             int waves = cdiv(blocks, n_active * sm_num);
             if (waves < min_waves) {
                 min_waves  = waves;

--- a/src/turbomind/core/test_scope.cc
+++ b/src/turbomind/core/test_scope.cc
@@ -1,0 +1,314 @@
+#include "src/turbomind/core/core.h"
+
+#include "catch2/catch_test_macros.hpp"
+
+using namespace turbomind;
+
+TEST_CASE("test scope", "[scope]")
+{
+    using core::Context;
+    using core::Scope;
+
+    // Empty trace
+    REQUIRE(Context::scope_depth() == 0);
+    REQUIRE(Context::scope_trace().empty());
+
+    {
+        TM_SCOPE("outer");
+        REQUIRE(Context::scope_depth() == 1);
+
+        {
+            TM_SCOPE("inner");
+            REQUIRE(Context::scope_depth() == 2);
+
+            auto trace = Context::scope_trace();
+            REQUIRE(trace.find("outer") != std::string::npos);
+            REQUIRE(trace.find("inner") != std::string::npos);
+            REQUIRE(trace.find("test_scope.cc") != std::string::npos);
+        }
+
+        REQUIRE(Context::scope_depth() == 1);
+    }
+
+    REQUIRE(Context::scope_depth() == 0);
+    REQUIRE(Context::scope_trace().empty());
+}
+
+namespace {
+
+std::string last_trace;
+
+void free_test_func()
+{
+    TM_FUNCTION_SCOPE();
+    last_trace = core::Context::scope_trace();
+}
+
+struct TestStruct {
+    void method()
+    {
+        TM_FUNCTION_SCOPE();
+        last_trace = core::Context::scope_trace();
+    }
+};
+
+template<typename T>
+int template_test_func(T)
+{
+    TM_FUNCTION_SCOPE();
+    last_trace = core::Context::scope_trace();
+    return 0;
+}
+
+struct OperatorTest {
+    void operator()(int x)
+    {
+        TM_FUNCTION_SCOPE();
+        last_trace = core::Context::scope_trace();
+    }
+};
+
+std::string scope_call_trace;
+int         scope_call_depth;
+int         scope_call_side_effect;
+
+void scope_call_target(int x)
+{
+    scope_call_side_effect = x;
+    scope_call_trace       = core::Context::scope_trace();
+    scope_call_depth       = core::Context::scope_depth();
+}
+
+}  // namespace
+
+TEST_CASE("test scope call", "[scope]")
+{
+    using core::Context;
+
+    REQUIRE(Context::scope_depth() == 0);
+    REQUIRE(Context::scope_trace().empty());
+
+    SECTION("basic call with stringified expression")
+    {
+        scope_call_side_effect = 0;
+        scope_call_trace.clear();
+        scope_call_depth = 0;
+
+        TM_SCOPE_CALL(scope_call_target(42));
+
+        // The function call actually executed within the scope
+        REQUIRE(scope_call_side_effect == 42);
+
+        // The trace shows just the function name, not the full expression
+        REQUIRE(scope_call_trace.find("scope_call_target(42)") == std::string::npos);
+        REQUIRE(scope_call_trace.find("scope_call_target") != std::string::npos);
+        REQUIRE(scope_call_trace.find("test_scope.cc") != std::string::npos);
+
+        // The scope depth was 1 during the call
+        REQUIRE(scope_call_depth == 1);
+
+        // Scope is cleaned up after the call returns
+        REQUIRE(Context::scope_depth() == 0);
+        REQUIRE(Context::scope_trace().empty());
+    }
+
+    SECTION("nested inside TM_SCOPE")
+    {
+        scope_call_side_effect = 0;
+        scope_call_trace.clear();
+        scope_call_depth = 0;
+
+        {
+            TM_SCOPE("outer");
+            REQUIRE(Context::scope_depth() == 1);
+
+            TM_SCOPE_CALL(scope_call_target(99));
+
+            // Function executed
+            REQUIRE(scope_call_side_effect == 99);
+
+            // During the call, depth was 2 (outer + scope_call)
+            REQUIRE(scope_call_depth == 2);
+
+            // Trace captured during the call contained both names
+            REQUIRE(scope_call_trace.find("outer") != std::string::npos);
+            REQUIRE(scope_call_trace.find("scope_call_target(99)") == std::string::npos);
+            REQUIRE(scope_call_trace.find("scope_call_target") != std::string::npos);
+
+            // After TM_SCOPE_CALL, depth returns to 1 (outer still active)
+            REQUIRE(Context::scope_depth() == 1);
+        }
+
+        REQUIRE(Context::scope_depth() == 0);
+        REQUIRE(Context::scope_trace().empty());
+    }
+
+    SECTION("multiple sequential calls")
+    {
+        scope_call_side_effect = 0;
+        scope_call_trace.clear();
+        scope_call_depth = 0;
+
+        TM_SCOPE_CALL(scope_call_target(1));
+        REQUIRE(scope_call_side_effect == 1);
+        REQUIRE(scope_call_depth == 1);
+        REQUIRE(Context::scope_depth() == 0);
+
+        TM_SCOPE_CALL(scope_call_target(2));
+        REQUIRE(scope_call_side_effect == 2);
+        REQUIRE(scope_call_depth == 1);
+        REQUIRE(Context::scope_depth() == 0);
+
+        // Trace from the second call contains the second expression
+        REQUIRE(scope_call_trace.find("scope_call_target(2)") == std::string::npos);
+        REQUIRE(scope_call_trace.find("scope_call_target") != std::string::npos);
+    }
+}
+
+TEST_CASE("test function scope formatting", "[scope]")
+{
+    using core::Context;
+
+    REQUIRE(Context::scope_depth() == 0);
+
+    SECTION("free function")
+    {
+        free_test_func();
+        REQUIRE(last_trace.find("free_test_func()") != std::string::npos);
+        REQUIRE(last_trace.find("void ") == std::string::npos);
+    }
+
+    SECTION("member function")
+    {
+        TestStruct{}.method();
+        REQUIRE(last_trace.find("TestStruct::method()") != std::string::npos);
+        REQUIRE(last_trace.find("void ") == std::string::npos);
+    }
+
+    SECTION("template function")
+    {
+        template_test_func(42);
+        REQUIRE(last_trace.find("template_test_func()") != std::string::npos);
+        REQUIRE(last_trace.find("[with") == std::string::npos);
+        REQUIRE(last_trace.find("(T)") == std::string::npos);
+        REQUIRE(last_trace.find("int ") == std::string::npos);
+    }
+
+    SECTION("operator()")
+    {
+        OperatorTest{}(42);
+        REQUIRE(last_trace.find("OperatorTest::operator()()") != std::string::npos);
+        REQUIRE(last_trace.find("(int") == std::string::npos);
+        REQUIRE(last_trace.find("void ") == std::string::npos);
+    }
+
+    SECTION("MSVC __FUNCSIG__")
+    {
+        using core::Scope;
+        using core::scope_type;
+
+        // Free function template with __cdecl
+        {
+            Scope _(R"(void __cdecl print<char,int,const char*>(char,int,const char *))",
+                    __FILE__,
+                    __LINE__,
+                    scope_type::function);
+            auto  trace = Context::scope_trace();
+            REQUIRE(trace.find("print()") != std::string::npos);
+            REQUIRE(trace.find("<char,int,const char*>") == std::string::npos);
+            REQUIRE(trace.find("void ") == std::string::npos);
+            REQUIRE(trace.find("__cdecl") == std::string::npos);
+        }
+        REQUIRE(Context::scope_depth() == 0);
+
+        // Member function with __thiscall and trailing const
+        {
+            Scope _("void __thiscall MyClass::method(int) const", __FILE__, __LINE__, scope_type::function);
+            auto  trace = Context::scope_trace();
+            REQUIRE(trace.find("MyClass::method()") != std::string::npos);
+            REQUIRE(trace.find("__thiscall") == std::string::npos);
+            REQUIRE(trace.find(" const") == std::string::npos);
+        }
+        REQUIRE(Context::scope_depth() == 0);
+
+        // __stdcall free function
+        {
+            Scope _("int __stdcall FreeFunc(float)", __FILE__, __LINE__, scope_type::function);
+            auto  trace = Context::scope_trace();
+            REQUIRE(trace.find("FreeFunc()") != std::string::npos);
+            REQUIRE(trace.find("int ") == std::string::npos);
+            REQUIRE(trace.find("__stdcall") == std::string::npos);
+        }
+        REQUIRE(Context::scope_depth() == 0);
+    }
+
+    SECTION("template class member (GCC)")
+    {
+        using core::Scope;
+        using core::scope_type;
+
+        // Template class: Container<T>::process(int) [with T = int]
+        {
+            Scope _("void Container<T>::process(int) [with T = int]", __FILE__, __LINE__, scope_type::function);
+            auto  trace = Context::scope_trace();
+            REQUIRE(trace.find("Container<T>::process()") != std::string::npos);
+            REQUIRE(trace.find("[with") == std::string::npos);
+            REQUIRE(trace.find("(int)") == std::string::npos);
+            REQUIRE(trace.find("void ") == std::string::npos);
+        }
+        REQUIRE(Context::scope_depth() == 0);
+
+        // Nested template: Outer<std::vector<T>>::method(int) [with T = int]
+        {
+            Scope _("void Outer<std::vector<T>>::method(int) [with T = int]", __FILE__, __LINE__, scope_type::function);
+            auto  trace = Context::scope_trace();
+            REQUIRE(trace.find("Outer<std::vector<T>>::method()") != std::string::npos);
+            REQUIRE(trace.find("[with") == std::string::npos);
+            REQUIRE(trace.find("(int)") == std::string::npos);
+        }
+        REQUIRE(Context::scope_depth() == 0);
+
+        // Template class with operator(): Foo<U>::operator()(int) [with U = float]
+        {
+            Scope _("void Foo<U>::operator()(int) [with U = float]", __FILE__, __LINE__, scope_type::function);
+            auto  trace = Context::scope_trace();
+            REQUIRE(trace.find("Foo<U>::operator()()") != std::string::npos);
+            REQUIRE(trace.find("[with") == std::string::npos);
+            REQUIRE(trace.find("(int)") == std::string::npos);
+        }
+        REQUIRE(Context::scope_depth() == 0);
+
+        // Class template + function template member (GCC)
+        {
+            Scope _("void Container<T>::method(U) [with T = int; U = float]", __FILE__, __LINE__, scope_type::function);
+            auto  trace = Context::scope_trace();
+            REQUIRE(trace.find("Container<T>::method()") != std::string::npos);
+            REQUIRE(trace.find("[with") == std::string::npos);
+            REQUIRE(trace.find("(U)") == std::string::npos);
+        }
+        REQUIRE(Context::scope_depth() == 0);
+
+        // Class template + function template member (MSVC)
+        {
+            Scope _("void __cdecl Container<T>::method<U>(U) [with T = int; U = float]",
+                    __FILE__,
+                    __LINE__,
+                    scope_type::function);
+            auto  trace = Context::scope_trace();
+            REQUIRE(trace.find("Container<T>::method()") != std::string::npos);
+            REQUIRE(trace.find("<U>") == std::string::npos);
+            REQUIRE(trace.find("[with") == std::string::npos);
+        }
+        REQUIRE(Context::scope_depth() == 0);
+    }
+
+    SECTION("named scope unchanged")
+    {
+        {
+            TM_SCOPE("my_named_scope");
+            auto trace = Context::scope_trace();
+            REQUIRE(trace.find("my_named_scope") != std::string::npos);
+        }
+        REQUIRE(Context::scope_depth() == 0);
+    }
+}

--- a/src/turbomind/engine/engine.cc
+++ b/src/turbomind/engine/engine.cc
@@ -24,6 +24,8 @@
 #include "src/turbomind/models/llama/SequenceManager.h"
 #include "src/turbomind/models/llama/llama_params.h"
 #include "src/turbomind/models/model_weight.h"
+#include "src/turbomind/core/scope.h"
+#include "src/turbomind/utils/cuda_utils.h"
 #include "src/turbomind/utils/metrics.h"
 
 // #include "dbg.h"
@@ -233,12 +235,12 @@ void Engine::Impl::CreateSequenceManager()
     }
 
     if (has_linear_attention && param_.enable_prefix_caching) {
-        TM_CHECK(0) << "Prefix caching is unsupported when linear attention is present";
+        TM_LOG_FATAL("Prefix caching is unsupported when linear attention is present");
     }
 
     const auto get_free_size = [&] {
         size_t free{}, total{};
-        check_cuda_error(cudaMemGetInfo(&free, &total));
+        TM_CUDA_CHECK(cudaMemGetInfo(&free, &total));
         return AllReduce(tp_group_, free, comm::RedOp::kMin);
     };
 
@@ -543,6 +545,7 @@ void Engine::Impl::Accept(const Requests& rs, vector<Signal>& signals)
 
 void Engine::Impl::Schedule()
 {
+    TM_FUNCTION_SCOPE();
     auto& s = states_.at(0);
 
     vector<const Sequence*>  sequences;
@@ -672,6 +675,7 @@ void Engine::Impl::Schedule()
 
 void Engine::Impl::Setup(BatchData& d)
 {
+    TM_FUNCTION_SCOPE();
     auto& st = states_.at(0);
 
     d.rc.resize(st.active);
@@ -718,6 +722,7 @@ void Engine::Impl::Setup(BatchData& d)
 
 void Engine::Impl::Update(BatchData& b, std::vector<Signal>& signals)
 {
+    TM_FUNCTION_SCOPE();
     auto& s = states_.at(0);
 
     BatchCopy copy;
@@ -807,7 +812,8 @@ void Engine::Impl::Update(BatchData& b, std::vector<Signal>& signals)
 
 void Engine::Impl::InternalThreadEntry()
 {
-    check_cuda_error(cudaSetDevice(device_id_));
+    TM_FUNCTION_SCOPE();
+    TM_CUDA_CHECK(cudaSetDevice(device_id_));
 
     auto stream = Stream::create();
 

--- a/src/turbomind/engine/engine.cc
+++ b/src/turbomind/engine/engine.cc
@@ -18,13 +18,13 @@
 
 #include "src/turbomind/core/copy.h"
 #include "src/turbomind/core/logger.h"
+#include "src/turbomind/core/scope.h"
 #include "src/turbomind/models/decoder_layer_weight.h"
 #include "src/turbomind/models/delta_net_weight.h"
 #include "src/turbomind/models/language_model.h"
 #include "src/turbomind/models/llama/SequenceManager.h"
 #include "src/turbomind/models/llama/llama_params.h"
 #include "src/turbomind/models/model_weight.h"
-#include "src/turbomind/core/scope.h"
 #include "src/turbomind/utils/cuda_utils.h"
 #include "src/turbomind/utils/metrics.h"
 

--- a/src/turbomind/engine/model_executor.cc
+++ b/src/turbomind/engine/model_executor.cc
@@ -32,7 +32,8 @@ struct ModelExecutor::Impl {
 
     void InternalThreadEntry()
     {
-        check_cuda_error(cudaSetDevice(device_id_));
+        TM_FUNCTION_SCOPE();
+        TM_CUDA_CHECK(cudaSetDevice(device_id_));
 
         Stream    stream  = Stream::create();
         Allocator h_alloc = Allocator(kCPU);
@@ -55,6 +56,7 @@ struct ModelExecutor::Impl {
 
     void Run(BatchData& d)
     {
+        TM_FUNCTION_SCOPE();
         auto batch = &d;
 
         BatchCopy copy;

--- a/src/turbomind/generation/generation.cc
+++ b/src/turbomind/generation/generation.cc
@@ -19,6 +19,7 @@
 #include "src/turbomind/kernels/sampling_topk_kernels.h"  // InitializeRandomStates
 
 #include "src/turbomind/models/llama/llama_kernels.h"  // invokePadLastTokenIds
+#include "src/turbomind/utils/cuda_utils.h"
 
 // #include "dbg.h"
 
@@ -123,6 +124,7 @@ struct Generation::Impl {
 
     void Setup(int phase, TensorMap& env)
     {
+        TM_FUNCTION_SCOPE();
         auto& d = *data_.at(phase);
 
         auto& b    = *env.at("batch").data<BatchData*>()[0];
@@ -202,6 +204,7 @@ struct Generation::Impl {
 
     void Prepare(int phase, TensorMap& env)
     {
+        TM_FUNCTION_SCOPE();
         auto& d = *data_.at(phase);
 
         auto& b    = *env.at("batch").data<BatchData*>()[0];
@@ -215,6 +218,7 @@ struct Generation::Impl {
 
     void Unprep(int phase, TensorMap& env)
     {
+        TM_FUNCTION_SCOPE();
         auto& d    = *data_.at(phase);
         auto& b    = *env.at("batch").data<BatchData*>()[0];
         auto& copy = *env.at("copy").data<BatchCopy*>()[0];
@@ -226,6 +230,7 @@ struct Generation::Impl {
 
     void Fetch(int phase, TensorMap& env)
     {
+        TM_FUNCTION_SCOPE();
         auto& d    = *data_.at(phase);
         auto& copy = *env.at("copy").data<BatchCopy*>()[0];
 
@@ -240,11 +245,13 @@ struct Generation::Impl {
 
     void Update(int phase, TensorMap& env)
     {
+        TM_FUNCTION_SCOPE();
         sampling_->Update(phase, env);
     }
 
     void Forward(int phase, TensorMap& env)
     {
+        TM_FUNCTION_SCOPE();
         auto& d = *data_.at(phase);
         auto& b = *env.at("batch").data<BatchData*>()[0];
 
@@ -256,7 +263,6 @@ struct Generation::Impl {
                                    d.random_init.data(),
                                    b.bsz,
                                    stream);
-            sync_check_cuda_error();
         }
 
         env.emplace("output_ids", output_ids_);              // out
@@ -270,7 +276,7 @@ struct Generation::Impl {
 
             if (logits.dtype() != kFloat32) {
                 auto tmp = empty_like(logits, kFloat32);
-                invokeCastFloat2D(logits, tmp, stream);
+                TM_SCOPE_CALL(invokeCastFloat2D(logits, tmp, stream));
                 logits = std::move(tmp);
             }
 

--- a/src/turbomind/generation/logits_processor.cc
+++ b/src/turbomind/generation/logits_processor.cc
@@ -22,6 +22,7 @@
 
 #include "src/turbomind/kernels/ban_bad_words.h"
 #include "src/turbomind/kernels/sampling_penalty_kernels.h"
+#include "src/turbomind/utils/cuda_utils.h"
 
 #include "src/turbomind/generation/logits_processor.h"
 #include "src/turbomind/generation/utils.h"
@@ -64,6 +65,7 @@ LogitsProcessor::LogitsProcessor(const BaseGenerationParam& base, int phases): B
 
 void LogitsProcessor::Forward(int phase, TensorMap& env)
 {
+    TM_FUNCTION_SCOPE();
     // apply repetition penalty -> ban bad words -> min length penalty -> temperature penalty
     // the order is same with transformerss
     TM_LOG_DEBUG("{} start", __PRETTY_FUNCTION__);
@@ -81,38 +83,34 @@ void LogitsProcessor::Forward(int phase, TensorMap& env)
     // repetition penalty
     if (d.has_repetition_penalty) {
         ApplyRepetitionPenalty(logits, d.repetition_penalty_buf, token_ids_ptrs, sequence_length, stream);
-        sync_check_cuda_error();
     }
 
     // ban bad words
     if (auto& bad_words = d.bad_words_ten) {
         BanBadWords(logits, token_ids_ptrs, sequence_length, bad_words, stream);
-        sync_check_cuda_error();
     }
 
     // min length
     if (d.has_min_length_penalty) {
-        invokeMinLengthPenalty(logits.data(),
-                               d.min_lengths_buf.data(),
-                               sequence_length.data(),
-                               vocab_size_padded_,
-                               bsz,
-                               d.end_ids_ten.data(),
-                               d.end_ids_ten.shape(1),
-                               stream);
-        sync_check_cuda_error();
+        TM_SCOPE_CALL(invokeMinLengthPenalty(logits.data(),
+                                             d.min_lengths_buf.data(),
+                                             sequence_length.data(),
+                                             vocab_size_padded_,
+                                             bsz,
+                                             d.end_ids_ten.data(),
+                                             d.end_ids_ten.shape(1),
+                                             stream));
     }
 
     // temperature
     if (d.has_temperature_penalty) {
-        invokeBatchApplyTemperaturePenalty_v2(logits.data(),  //
-                                              (float*)nullptr,
-                                              d.temperature_buf.data(),
-                                              bsz,
-                                              vocab_size_,
-                                              vocab_size_padded_,
-                                              stream);
-        sync_check_cuda_error();
+        TM_SCOPE_CALL(invokeBatchApplyTemperaturePenalty_v2(logits.data(),  //
+                                                            (float*)nullptr,
+                                                            d.temperature_buf.data(),
+                                                            bsz,
+                                                            vocab_size_,
+                                                            vocab_size_padded_,
+                                                            stream));
     }
 
     TM_LOG_DEBUG("{} stop", __PRETTY_FUNCTION__);
@@ -120,6 +118,7 @@ void LogitsProcessor::Forward(int phase, TensorMap& env)
 
 void LogitsProcessor::Setup(int phase, TensorMap& env)
 {
+    TM_FUNCTION_SCOPE();
     TM_LOG_DEBUG("{} start", __PRETTY_FUNCTION__);
 
     auto& d = *data_.at(phase);
@@ -171,8 +170,6 @@ void LogitsProcessor::Setup(int phase, TensorMap& env)
     if (d.has_min_length_penalty) {
         copy(min_lengths, bsz, d.min_lengths_buf);
     }
-
-    sync_check_cuda_error();
 
     d.bad_words_ten = {};
     init_stop_bad_words(&GenerationConfig::bad_ids,  //

--- a/src/turbomind/generation/sampling.cc
+++ b/src/turbomind/generation/sampling.cc
@@ -19,6 +19,7 @@
 #include "src/turbomind/kernels/sampling_kernels.h"
 #include "src/turbomind/kernels/sampling_topk_kernels.h"
 #include "src/turbomind/kernels/sampling_topp_kernels.h"
+#include "src/turbomind/utils/cuda_utils.h"
 
 #include "src/turbomind/engine/batch.h"
 #include "src/turbomind/engine/request.h"
@@ -81,6 +82,7 @@ Sampling::Sampling(const BaseGenerationParam& base, int phases): BaseGenerationP
 
 void Sampling::Forward(int phase, TensorMap& args)
 {
+    TM_FUNCTION_SCOPE();
     // step1:
     //  - use topk / topp_minp kernel to sort and filter the scores
     //  - softmax the left score
@@ -112,12 +114,13 @@ void Sampling::Forward(int phase, TensorMap& args)
         params.batch_size        = bsz;
         params.vocab_size        = vocab_size_;
         params.vocab_size_padded = vocab_size_padded_;
-        invokeTopKSortFilter<float>(params, stream);
+        TM_SCOPE_CALL(invokeTopKSortFilter<float>(params, stream));
     }
 
     // use topp sort if some request skip topk filter
     if (d.min_topk == 0) {
-        invokeSoftmax<float>(logits.data(), vocab_size_padded_, vocab_size_, bsz, d.kept_buf.data(), stream);
+        TM_SCOPE_CALL(
+            invokeSoftmax<float>(logits.data(), vocab_size_padded_, vocab_size_, bsz, d.kept_buf.data(), stream));
 
         TopPSortParams params{};
         params.logits            = logits.data();
@@ -129,7 +132,7 @@ void Sampling::Forward(int phase, TensorMap& args)
         params.batch_size        = bsz;
         params.vocab_size        = vocab_size_;
         params.vocab_size_padded = vocab_size_padded_;
-        invokeTopPSort<float>(params, stream);
+        TM_SCOPE_CALL(invokeTopPSort<float>(params, stream));
     }
 
     // apply topp minp filter
@@ -143,7 +146,7 @@ void Sampling::Forward(int phase, TensorMap& args)
         params.batch_size        = bsz;
         params.vocab_size        = vocab_size_;
         params.vocab_size_padded = vocab_size_padded_;
-        invokeTopPMinPFilter<float>(params, stream);
+        TM_SCOPE_CALL(invokeTopPMinPFilter<float>(params, stream));
     }
 
     // sample
@@ -164,8 +167,7 @@ void Sampling::Forward(int phase, TensorMap& args)
             params.sampled_nums     = d.sampled_nums.data();
         }
 
-        invokeSampling<float>(params, stream);
-        sync_check_cuda_error();
+        TM_SCOPE_CALL(invokeSampling<float>(params, stream));
     }
 
     TM_LOG_DEBUG("{} stop", __PRETTY_FUNCTION__);
@@ -173,6 +175,7 @@ void Sampling::Forward(int phase, TensorMap& args)
 
 void Sampling::Setup(int phase, TensorMap& env)
 {
+    TM_FUNCTION_SCOPE();
 
     const auto& rc   = env.at("batch").data<BatchData*>()[0]->rc;
     auto&       copy = *env.at("copy").data<BatchCopy*>()[0];
@@ -203,6 +206,7 @@ void Sampling::Setup(int phase, TensorMap& env)
 
 void Sampling::Fetch(int phase, TensorMap& env)
 {
+    TM_FUNCTION_SCOPE();
     auto& d    = *data_.at(phase);
     auto& b    = *env.at("batch").data<BatchData*>()[0];
     auto& copy = *env.at("copy").data<BatchCopy*>()[0];
@@ -216,6 +220,7 @@ void Sampling::Fetch(int phase, TensorMap& env)
 
 void Sampling::Update(int phase, TensorMap& env)
 {
+    TM_FUNCTION_SCOPE();
     auto& d = *data_.at(phase);
     auto& b = *env.at("batch").data<BatchData*>()[0];
 

--- a/src/turbomind/generation/stop_criteria.cc
+++ b/src/turbomind/generation/stop_criteria.cc
@@ -4,6 +4,7 @@
 #include "src/turbomind/generation/utils.h"
 
 #include "src/turbomind/kernels/stop_criteria_kernels.h"
+#include "src/turbomind/utils/cuda_utils.h"
 
 #include "src/turbomind/engine/batch.h"
 #include "src/turbomind/engine/request.h"
@@ -32,6 +33,7 @@ StopCriteria::StopCriteria(const BaseGenerationParam& base, int phases): BaseGen
 
 void StopCriteria::Setup(int phase, TensorMap& env)
 {
+    TM_FUNCTION_SCOPE();
     auto& d = *data_.at(phase);
 
     const auto& rs   = env.at("batch").data<BatchData*>()[0]->rc;
@@ -54,6 +56,7 @@ void StopCriteria::Setup(int phase, TensorMap& env)
 
 void StopCriteria::Forward(int phase, TensorMap& env)
 {
+    TM_FUNCTION_SCOPE();
     auto& d = *data_.at(phase);
 
     const Buffer_<int*> token_ids_ptrs  = env.at("token_ids_ptrs").buffer();
@@ -68,22 +71,20 @@ void StopCriteria::Forward(int phase, TensorMap& env)
     if (auto& stop_words = d.stop_words_ten) {
         TM_CHECK_EQ(stop_words.ndim(), 3);  // [batch, 2, len]
         size_t stop_words_len = stop_words.shape(2);
-        invokeStopWordsCriterion_v2((const int**)token_ids_ptrs.data(),
-                                    sequence_length.data(),
-                                    stop_words.data(),
-                                    finished.data(),
-                                    stop_words_len,
-                                    batch_size,
-                                    stream);
-        sync_check_cuda_error();
+        TM_SCOPE_CALL(invokeStopWordsCriterion_v2((const int**)token_ids_ptrs.data(),
+                                                  sequence_length.data(),
+                                                  stop_words.data(),
+                                                  finished.data(),
+                                                  stop_words_len,
+                                                  batch_size,
+                                                  stream));
     }
 
-    invokeLengthCriterion_v2(finished.data(),  //
-                             sequence_length.data(),
-                             d.max_seq_len.data(),
-                             batch_size,
-                             stream);
-    sync_check_cuda_error();
+    TM_SCOPE_CALL(invokeLengthCriterion_v2(finished.data(),  //
+                                           sequence_length.data(),
+                                           d.max_seq_len.data(),
+                                           batch_size,
+                                           stream));
 }
 
 }  // namespace turbomind

--- a/src/turbomind/generation/utils.h
+++ b/src/turbomind/generation/utils.h
@@ -24,7 +24,7 @@ void init_stop_bad_words(G getter, const char* key, const Rs& rs, T* h_buf, T* d
         if (offsets.size() == 0 || token_ids.size() == 0) {
             continue;
         }
-        FT_CHECK(offsets.back() == token_ids.size());
+        TM_CHECK(offsets.back() == token_ids.size());
         if (offsets.back() <= kMaxStopBadWordsLen) {
             copy_tokens[i]  = std::make_pair(token_ids.data(), (int)token_ids.size());
             copy_offsets[i] = std::make_pair(offsets.data(), (int)offsets.size());

--- a/src/turbomind/kernels/activation.cu
+++ b/src/turbomind/kernels/activation.cu
@@ -4,6 +4,7 @@
 #include "src/turbomind/kernels/activation.h"
 #include "src/turbomind/kernels/core/array_ops.h"
 #include "src/turbomind/kernels/core/common.h"
+#include "src/turbomind/utils/cuda_utils.h"
 
 namespace turbomind {
 
@@ -93,11 +94,12 @@ void Activation(Ref<Tensor> gate_, const Tensor& up, ActivationType type, cudaSt
             return invoke(t, SiluGptOss<T>{});
         }
         else {
-            TM_CHECK(0) << "unknown activation type: " << (int)type;
+            TM_LOG_FATAL("unknown activation type: {}", (int)type);
         }
     };
 
     TM_DISPATCH_PRIMARY_DTYPES(gate.dtype(), dispatch);
+    TM_CUDA_CHECK(cudaGetLastError());
 }
 
 template<int vec_size, class Activation, class T>
@@ -183,11 +185,12 @@ void Activation(Tensor&             gate_up,  //
             return invoke(t, SiluGptOss<T>{});
         }
         else {
-            TM_CHECK(0) << "unknown activation type: " << (int)type;
+            TM_LOG_FATAL("unknown activation type: {}", (int)type);
         }
     };
 
     TM_DISPATCH_PRIMARY_DTYPES(gate_up.dtype(), dispatch);
+    TM_CUDA_CHECK(cudaGetLastError());
 }
 
 }  // namespace turbomind

--- a/src/turbomind/kernels/activation_kernels.cu
+++ b/src/turbomind/kernels/activation_kernels.cu
@@ -216,6 +216,7 @@ void invokeGenericActivation_v2(
 
     activation_kernel<kVecSize, Activation, T>
         <<<grid, block, 0, stream>>>(inter_buf, gate_buf, stride, token_num, dims);
+    TM_CUDA_CHECK(cudaGetLastError());
 }
 
 template<template<typename T> class Activation>
@@ -243,6 +244,7 @@ void invokeGenericActivation_v3(Ref<Tensor> inter_, const Tensor& gate, cudaStre
     };
 
     TM_DISPATCH_PRIMARY_DTYPES(inter.dtype(), invoke);
+    TM_CUDA_CHECK(cudaGetLastError());
 }
 
 template void invokeGenericActivation_v3<SiluActivation>(Ref<Tensor> inter_, const Tensor& gate, cudaStream_t stream);

--- a/src/turbomind/kernels/apply_token_bitmask_inplace_cuda.cu
+++ b/src/turbomind/kernels/apply_token_bitmask_inplace_cuda.cu
@@ -24,6 +24,7 @@
 
 #include "src/turbomind/core/context.h"
 #include "src/turbomind/kernels/apply_token_bitmask_inplace_cuda.h"
+#include "src/turbomind/utils/cuda_utils.h"
 // clang-format on
 
 using namespace std;
@@ -164,6 +165,7 @@ void ApplyTokenBitmaskInplaceDispatchToBitsPerThread(T* __restrict__ logits,
         LogitsBitmaskKernel<T, PackedT, 32>
             <<<grid, block, 0, stream.handle()>>>(logits, bitmask, indices, vocab_size, logits_stride, bitmask_stride);
     }
+    TM_CUDA_CHECK(cudaGetLastError());
 }
 
 template<typename T>

--- a/src/turbomind/kernels/attention/attention.cu
+++ b/src/turbomind/kernels/attention/attention.cu
@@ -2,6 +2,7 @@
 
 #include "attention.h"
 #include "src/turbomind/core/data_type.h"
+#include "src/turbomind/core/scope.h"
 #include "src/turbomind/kernels/attention/registry.h"
 #include "src/turbomind/utils/cuda_utils.h"
 
@@ -22,7 +23,7 @@ void dispatchAttention(const AttentionParams<T>& params)
 
     TM_CHECK(kernel) << "No attention kernel found: " + to_string(desc);
 
-    kernel->Launch(&params, reg.sm_count());
+    TM_SCOPE_CALL(kernel->Launch(&params, reg.sm_count()));
 }
 
 template void dispatchAttention(const AttentionParams<half>& params);

--- a/src/turbomind/kernels/attention/attention_template.h
+++ b/src/turbomind/kernels/attention/attention_template.h
@@ -5,6 +5,7 @@
 #include "attention_params.h"
 #include "attention_universal.h"
 #include "reduce.h"
+#include "src/turbomind/utils/cuda_utils.h"
 #include "utils.h"
 
 namespace turbomind {
@@ -60,10 +61,7 @@ void invokeAttention(const typename Kernel::ParamType& params, int sm_count, int
                                                            q_group_size  // cta_per_q_group
     );
 
-    if (auto err = cudaGetLastError(); err != cudaSuccess) {
-        std::cout << cudaGetErrorString(err) << "\n";
-        std::abort();
-    }
+    TM_CUDA_CHECK(cudaGetLastError());
 
     if (params.cp_fn) {
         params.cp_fn(params.cp_fn_ctx);

--- a/src/turbomind/kernels/attention/cp_utils.cu
+++ b/src/turbomind/kernels/attention/cp_utils.cu
@@ -14,7 +14,6 @@ void CpPost(void* context)
                            DataType::kFloat,
                            ctx->attn_cp_group,
                            ctx->stream);
-    sync_check_cuda_error();
 }
 
 }  // namespace turbomind

--- a/src/turbomind/kernels/attention/decoding.cu
+++ b/src/turbomind/kernels/attention/decoding.cu
@@ -2,6 +2,7 @@
 
 #include "decoding.h"
 #include "src/turbomind/core/data_type.h"
+#include "src/turbomind/core/scope.h"
 #include "src/turbomind/kernels/attention/registry.h"
 #include "src/turbomind/models/llama/llama_utils.h"
 #include "src/turbomind/utils/cuda_utils.h"
@@ -17,7 +18,7 @@ void dispatchDecoding(const AttentionParams<T>& params)
     const bool is_kv_int4     = params.quant_policy & QuantPolicy::kCacheKVInt4;
     const int  query_group_sz = params.num_heads / params.num_kv_heads;
 
-    FT_CHECK(!(is_kv_int4 && is_kv_int8));
+    TM_CHECK(!(is_kv_int4 && is_kv_int8));
 
     int kv_quant = is_kv_int4 ? 4 : (is_kv_int8 ? 8 : 0);
 
@@ -33,7 +34,7 @@ void dispatchDecoding(const AttentionParams<T>& params)
 
     TM_CHECK(kernel) << "No decoding kernel found: " + to_string(desc);
 
-    kernel->Launch(&params, reg.sm_count());
+    TM_SCOPE_CALL(kernel->Launch(&params, reg.sm_count()));
 }
 
 template void dispatchDecoding(const AttentionParams<half>& params);

--- a/src/turbomind/kernels/attention/decoding_template.h
+++ b/src/turbomind/kernels/attention/decoding_template.h
@@ -6,6 +6,7 @@
 #include "attention_universal.h"
 #include "reduce.h"
 #include "src/turbomind/kernels/core/thread_map.h"
+#include "src/turbomind/utils/cuda_utils.h"
 #include "utils.h"
 namespace turbomind {
 
@@ -59,10 +60,9 @@ bool invokeDecoding(const typename Kernel::ParamType& params, int sm_count, int 
     kernel_func<<<grid, block, kSmemSize, params.stream>>>(
         params, cache_iter_factory, CtaMap{}, q_group_size, q_head_per_cta, cta_per_q_group);
 
-    if (auto err = cudaGetLastError(); err != cudaSuccess) {
-        std::cout << cudaGetErrorString(err) << "\n";
-        std::abort();
-    }
+    // TM_CUDA_CHECK(cudaErrorAssert);
+
+    TM_CUDA_CHECK(cudaGetLastError());
 
     if (params.cp_fn) {
         params.cp_fn(params.cp_fn_ctx);

--- a/src/turbomind/kernels/attention/kv_cache_utils_v2.cu
+++ b/src/turbomind/kernels/attention/kv_cache_utils_v2.cu
@@ -279,7 +279,7 @@ void invokeProcessKV_v2(char**                 blocks,
         else if (head_dim == 576) {
             return invoke(tkv, std::integral_constant<int, 576>{});
         }
-        FT_CHECK(0);
+        TM_UNREACHABLE;
     };
 
     if (quant_policy & QuantPolicy::kCacheKVInt8) {
@@ -291,6 +291,8 @@ void invokeProcessKV_v2(char**                 blocks,
     else {
         dispatch(T{});
     }
+
+    TM_CUDA_CHECK(cudaGetLastError());
 }
 
 #define INSTANTIATE_invokeProcessKV_v2(type)                                                                           \
@@ -525,7 +527,7 @@ void invokeFlattenKV_v2(T*                     k,
         else if (head_dim == 576) {
             return invoke(tkv, std::integral_constant<int, 576>{});
         }
-        FT_CHECK(0);
+        TM_UNREACHABLE;
     };
 
     if (quant_policy & QuantPolicy::kCacheKVInt8) {
@@ -537,6 +539,8 @@ void invokeFlattenKV_v2(T*                     k,
     else {
         dispatch(T{});
     }
+
+    TM_CUDA_CHECK(cudaGetLastError());
 }
 
 #define INSTANTIATE_invokeFlattenKV_v2(type)                                                                           \

--- a/src/turbomind/kernels/attention/reduce.cu
+++ b/src/turbomind/kernels/attention/reduce.cu
@@ -245,8 +245,6 @@ void invokeReduceV3(T*           out,
             cp_rank,
             stride_k,
             stride_k * CTA_K);
-
-        sync_check_cuda_error();
     };
 
     auto dispatch_cp = [&](int stride_k, auto is_first) {
@@ -275,6 +273,8 @@ void invokeReduceV3(T*           out,
         stride_k *= CTA_K;
         dispatch_cp(stride_k, std::false_type{});
     }
+
+    TM_CUDA_CHECK(cudaGetLastError());
 }
 
 #define INSTANTIATE_invokeReduceV3(dim, type)                                                                          \

--- a/src/turbomind/kernels/attention/reference.cu
+++ b/src/turbomind/kernels/attention/reference.cu
@@ -1,9 +1,11 @@
 // Copyright (c) OpenMMLab. All rights reserved.
 
 #include "reference.h"
+#include "src/turbomind/core/scope.h"
 #include "src/turbomind/kernels/attention/rotary_embedding.h"
 #include "src/turbomind/kernels/core/array_ops.h"
 #include "src/turbomind/kernels/unfused_attention_kernels.h"
+#include "src/turbomind/utils/cuda_utils.h"
 
 namespace turbomind {
 
@@ -69,6 +71,7 @@ void invokeApplyRotaryEmbedding(T*           k_cache,
     dim3 blocks(max_k_len, head_num, batch_size);
 
     applyRotaryEmbedding<<<blocks, threads, 0, stream>>>(k_cache, max_k_len, head_num, head_dim, rope_base, rope_dim);
+    TM_CUDA_CHECK(cudaGetLastError());
 }
 
 template void invokeApplyRotaryEmbedding(half*        k_cache,
@@ -238,6 +241,7 @@ void Reference<T>::Reshape(size_t max_q_len,
     kv_head_num_ = kv_head_num;
     batch_size_  = batch_size;
     window_size_ = window_size;
+    TM_CUDA_CHECK(cudaGetLastError());
 }
 
 template<class T>
@@ -315,7 +319,7 @@ void Reference<T>::Execute(
     params.k_length        = max_k_len_;
     params.num_heads       = head_num_;
     params.sinks           = sinks;
-    invokeMaskedSoftmax(params, stream_);
+    TM_SCOPE_CALL(invokeMaskedSoftmax(params, stream_));
 
     alpha = 1.f;
     cublasGemmStridedBatchedEx(cublas_,
@@ -343,17 +347,18 @@ void Reference<T>::Execute(
                                CUBLAS_GEMM_DEFAULT);
 
     // [B, H, Q, D] -> [B, Q, H, D]
-    invokeTransposeAttentionOutRemovePadding(out_.data().get(),
-                                             output,
-                                             batch_size_ * max_q_len_,
-                                             batch_size_,
-                                             max_q_len_,
-                                             head_num_,
-                                             head_dim_,
-                                             nullptr,
-                                             nullptr,
-                                             0,
-                                             stream_);
+    TM_SCOPE_CALL(invokeTransposeAttentionOutRemovePadding(out_.data().get(),
+                                                           output,
+                                                           batch_size_ * max_q_len_,
+                                                           batch_size_,
+                                                           max_q_len_,
+                                                           head_num_,
+                                                           head_dim_,
+                                                           nullptr,
+                                                           nullptr,
+                                                           0,
+                                                           stream_));
+    TM_CUDA_CHECK(cudaGetLastError());
 }
 
 template class Reference<half>;

--- a/src/turbomind/kernels/attention/registry.cu
+++ b/src/turbomind/kernels/attention/registry.cu
@@ -11,6 +11,7 @@
 #include "src/turbomind/kernels/attention/arch.h"
 #include "src/turbomind/kernels/attention/registrar.h"
 #include "src/turbomind/kernels/core/math.h"
+#include "src/turbomind/utils/cuda_utils.h"
 
 namespace turbomind::attention {
 
@@ -90,7 +91,7 @@ Registry& Registry::instance()
 
     static std::vector<std::unique_ptr<DeviceState>> states = [] {
         int count{};
-        TM_CHECK_EQ(cudaGetDeviceCount(&count), cudaSuccess);
+        TM_CUDA_CHECK(cudaGetDeviceCount(&count));
         std::vector<std::unique_ptr<DeviceState>> vec(count);
         for (auto& s : vec) {
             s = std::make_unique<DeviceState>();
@@ -99,13 +100,13 @@ Registry& Registry::instance()
     }();
 
     int device_id{};
-    TM_CHECK_EQ(cudaGetDevice(&device_id), cudaSuccess);
+    TM_CUDA_CHECK(cudaGetDevice(&device_id));
 
     auto& state = *states.at(device_id);
 
     std::call_once(state.flag, [&]() {
         auto prop = std::make_shared<cudaDeviceProp>();
-        TM_CHECK_EQ(cudaGetDeviceProperties(prop.get(), device_id), cudaSuccess);
+        TM_CUDA_CHECK(cudaGetDeviceProperties(prop.get(), device_id));
         state.registry = std::make_unique<Registry>(std::move(prop));
     });
 

--- a/src/turbomind/kernels/attention/test_attention.cu
+++ b/src/turbomind/kernels/attention/test_attention.cu
@@ -4,6 +4,7 @@
 #include "block.h"
 #include "decoding.h"
 #include "kv_cache_utils_v2.h"
+#include "src/turbomind/core/scope.h"
 #include "src/turbomind/kernels/attention/attention_params.h"
 #include "src/turbomind/kernels/attention/reference.h"
 #include "src/turbomind/models/llama/llama_utils.h"
@@ -143,28 +144,28 @@ void TestBlocks(const thrust::universal_vector<T>& k_cache,        // [B, H, S, 
     // [B, 2H, S, D] -> [B, S/s] x [2H, s, D]
     for (int i = 0; i < 1; ++i) {
         // (B, 2, H, S, D) -> blocks
-        invokeProcessKV_v2(k_ptrs.data().get(),
-                           kv_cache.data().get(),
-                           kv_cache.data().get() + head_num * seq_len * head_dim,
-                           (T*)nullptr,
-                           (T*)nullptr,
-                           cu_seq_lens.data().get(),
-                           cu_seq_lens.data().get(),
-                           cu_block_cnts.data().get(),
-                           RopeKernelParam{},
-                           2 * head_num * seq_len,
-                           0,
-                           seq_len,
-                           1,
-                           block_seq_len,
-                           0,  // layer_id
-                           0,  // cp_rank
-                           1,  // cp_size
-                           seq_len,
-                           head_num,
-                           head_dim,
-                           batch_size,
-                           quant_policy);
+        TM_SCOPE_CALL(invokeProcessKV_v2(k_ptrs.data().get(),
+                                         kv_cache.data().get(),
+                                         kv_cache.data().get() + head_num * seq_len * head_dim,
+                                         (T*)nullptr,
+                                         (T*)nullptr,
+                                         cu_seq_lens.data().get(),
+                                         cu_seq_lens.data().get(),
+                                         cu_block_cnts.data().get(),
+                                         RopeKernelParam{},
+                                         2 * head_num * seq_len,
+                                         0,
+                                         seq_len,
+                                         1,
+                                         block_seq_len,
+                                         0,  // layer_id
+                                         0,  // cp_rank
+                                         1,  // cp_size
+                                         seq_len,
+                                         head_num,
+                                         head_dim,
+                                         batch_size,
+                                         quant_policy));
     }
 
     thrust::universal_vector<T> kv_cache_2(kv_cache.size());
@@ -172,25 +173,25 @@ void TestBlocks(const thrust::universal_vector<T>& k_cache,        // [B, H, S, 
     // round trip test
     for (int i = 0; i < 1; ++i) {
         // kv_cache_2 is [B, 2, H, S, D]
-        invokeFlattenKV_v2(kv_cache_2.data().get(),
-                           kv_cache_2.data().get() + head_num * seq_len * head_dim,
-                           k_ptrs.data().get(),
-                           cu_seq_lens.data().get(),
-                           cu_block_cnts.data().get(),
-                           RopeKernelParam{},
-                           2 * head_num * seq_len,
-                           0,
-                           seq_len,
-                           1,
-                           block_seq_len,
-                           0,  // layer_id
-                           0,  // cp_rank
-                           1,  // cp_size
-                           seq_len,
-                           head_num,
-                           head_dim,
-                           batch_size,
-                           quant_policy);
+        TM_SCOPE_CALL(invokeFlattenKV_v2(kv_cache_2.data().get(),
+                                         kv_cache_2.data().get() + head_num * seq_len * head_dim,
+                                         k_ptrs.data().get(),
+                                         cu_seq_lens.data().get(),
+                                         cu_block_cnts.data().get(),
+                                         RopeKernelParam{},
+                                         2 * head_num * seq_len,
+                                         0,
+                                         seq_len,
+                                         1,
+                                         block_seq_len,
+                                         0,  // layer_id
+                                         0,  // cp_rank
+                                         1,  // cp_size
+                                         seq_len,
+                                         head_num,
+                                         head_dim,
+                                         batch_size,
+                                         quant_policy));
     }
 
     cudaDeviceSynchronize();
@@ -355,7 +356,8 @@ int test_attention()
                           kBatchSize * KvHeadNum);
     }
 
-    invokeApplyRotaryEmbedding(k_cache.data().get(), kContextLen, KvHeadNum, kHeadDim, kRoPEBase, kRoPEDim, kBatchSize);
+    TM_SCOPE_CALL(invokeApplyRotaryEmbedding(
+        k_cache.data().get(), kContextLen, KvHeadNum, kHeadDim, kRoPEBase, kRoPEDim, kBatchSize));
 
     thrust::universal_vector<T> k_cache_ref = k_cache;
     thrust::universal_vector<T> v_cache_ref = v_cache;
@@ -517,9 +519,9 @@ int test_attention()
         cudaEventRecord(ev_end[i]);
 #else
         // input -> blocked
-        invokeProcessKV_v2_(params);
+        TM_SCOPE_CALL(invokeProcessKV_v2_(params));
         // blocked -> linear
-        invokeFlattenKV_v2_(params, cu_kv_lens[kBatchSize]);
+        TM_SCOPE_CALL(invokeFlattenKV_v2_(params, cu_kv_lens[kBatchSize]));
 
         cudaEventRecord(ev_start[i]);
         dispatchAttention(params);
@@ -557,25 +559,25 @@ int test_attention()
         }
     }
 
-    invokeFlattenKV_v2(k_cache.data().get(),  // [B, H, S, D]
-                       v_cache.data().get(),
-                       k_ptrs.data().get(),
-                       cu_kv_lens.data().get(),
-                       cu_block_cnts.data().get(),
-                       RopeKernelParam{},  // DECODING ? nullptr : params.rope_theta,
-                       KvHeadNum * kContextLen,
-                       0,
-                       kContextLen,
-                       1,
-                       kBlockSz,
-                       0,  // layer_id
-                       0,  // cp_rank
-                       1,  // cp_size
-                       kContextLen,
-                       KvHeadNum,
-                       kHeadDim,
-                       kBatchSize,
-                       kQuantPolicy);
+    TM_SCOPE_CALL(invokeFlattenKV_v2(k_cache.data().get(),  // [B, H, S, D]
+                                     v_cache.data().get(),
+                                     k_ptrs.data().get(),
+                                     cu_kv_lens.data().get(),
+                                     cu_block_cnts.data().get(),
+                                     RopeKernelParam{},  // DECODING ? nullptr : params.rope_theta,
+                                     KvHeadNum * kContextLen,
+                                     0,
+                                     kContextLen,
+                                     1,
+                                     kBlockSz,
+                                     0,  // layer_id
+                                     0,  // cp_rank
+                                     1,  // cp_size
+                                     kContextLen,
+                                     KvHeadNum,
+                                     kHeadDim,
+                                     kBatchSize,
+                                     kQuantPolicy));
     cudaDeviceSynchronize();
 
     const size_t nbytes = blocks.size() / kContextLen * std::min(kContextLen, (size_t)params.window_size);

--- a/src/turbomind/kernels/ban_bad_words.cu
+++ b/src/turbomind/kernels/ban_bad_words.cu
@@ -17,7 +17,7 @@
 #include "src/turbomind/kernels/ban_bad_words.h"
 #include <cfloat>
 // #include "src/turbomind/kernels/reduce_kernel_utils.cuh"
-// #include "src/turbomind/utils/cuda_utils.h"
+#include "src/turbomind/utils/cuda_utils.h"
 #include <cuda_bf16.h>
 #include <cuda_fp16.h>
 
@@ -122,6 +122,7 @@ void BanBadWords(Tensor&             logits,
     };
 
     invoke(float{});
+    TM_CUDA_CHECK(cudaGetLastError());
 }
 
 }  // namespace turbomind

--- a/src/turbomind/kernels/decoding_kernels.cu
+++ b/src/turbomind/kernels/decoding_kernels.cu
@@ -150,9 +150,9 @@ void invokeEmbeddingLookupPosEncoding(T*                    from_tensor,
     dim3 grid(min(local_token_num, 65536));
     dim3 block(min(hidden_units, 1024));
     if (position_encoding != nullptr) {
-        FT_CHECK_WITH_INFO(prompt_param.use_request_p_prompt_embedding == false
-                               && prompt_param.p_prompt_tuning_batch_weights == nullptr,
-                           fmtstr("embeddingLookupPosEncoding still not support prompt tuning"));
+        TM_CHECK(prompt_param.use_request_p_prompt_embedding == false
+                 && prompt_param.p_prompt_tuning_batch_weights == nullptr)
+            << fmtstr("embeddingLookupPosEncoding still not support prompt tuning");
         embeddingLookupPosEncoding<T><<<grid, block, 0, stream>>>(from_tensor,
                                                                   embedding_table,
                                                                   position_encoding,
@@ -178,6 +178,7 @@ void invokeEmbeddingLookupPosEncoding(T*                    from_tensor,
             EMBEDDING_LOOKUP(0);
         }
     }
+    TM_CUDA_CHECK(cudaGetLastError());
 }
 
 #undef EMBEDDING_LOOKUP
@@ -290,6 +291,7 @@ void invokePaddingEmbedding(T*           padded_embedding_kernel,
                                                  hidden_unit,
                                                  vocab_size,
                                                  vocab_size_padded);
+    TM_CUDA_CHECK(cudaGetLastError());
 }
 
 // template void invokePaddingEmbedding(float*       padded_embedding_kernel,
@@ -352,6 +354,7 @@ void invokePaddingEmbeddingKernel(T*           padded_embedding_kernel,
     dim3 grid((int)(ceil(hidden_unit * vocab_size_padded / 512.)));
     paddingEmbeddingKernel<<<grid, block, 0, stream>>>(
         padded_embedding_kernel, embedding_kernel, hidden_unit, vocab_size, vocab_size_padded);
+    TM_CUDA_CHECK(cudaGetLastError());
 }
 
 // template void invokePaddingEmbeddingKernel(float*       padded_embedding_kernel,
@@ -391,6 +394,7 @@ void invokePlusScalar(T* buf, const T val, const int size, cudaStream_t stream)
     dim3 block(min(256, size));
     dim3 grid(ceil(size / 256.));
     plusScalar<<<block, grid, 0, stream>>>(buf, val, size);
+    TM_CUDA_CHECK(cudaGetLastError());
 }
 
 template void invokePlusScalar(int* buf, const int val, const int size, cudaStream_t stream);

--- a/src/turbomind/kernels/gemm/cast.cu
+++ b/src/turbomind/kernels/gemm/cast.cu
@@ -6,6 +6,7 @@
 #include "src/turbomind/kernels/core/array_ops.h"
 #include "src/turbomind/kernels/core/common.h"
 #include "src/turbomind/kernels/core/math.h"
+#include "src/turbomind/utils/cuda_utils.h"
 
 namespace turbomind {
 
@@ -94,21 +95,22 @@ template<int VecSize, class Ti, class To>
 void invokeCast(To* dst, const Ti* src, size_t n, cudaStream_t st)
 {
     cast_kernel<VecSize><<<256, 256, 0, st>>>(dst, src, n);
+    TM_CUDA_CHECK(cudaGetLastError());
 }
 
 void extend_to_u8(uint8_t* dst, const uint4_t* src, size_t n, cudaStream_t st)
 {
-    invokeCast<8>(dst, src, n, st);
+    TM_SCOPE_CALL(invokeCast<8>(dst, src, n, st));
 }
 
 void compact_to_u4(uint4_t* dst, const uint8_t* src, size_t n, cudaStream_t st)
 {
-    invokeCast<8>(dst, src, n, st);
+    TM_SCOPE_CALL(invokeCast<8>(dst, src, n, st));
 }
 
 void extend_to_u16(uint16_t* dst, const uint4_t* src, size_t n, cudaStream_t st)
 {
-    invokeCast<8>(dst, src, n, st);
+    TM_SCOPE_CALL(invokeCast<8>(dst, src, n, st));
 }
 
 namespace {
@@ -126,6 +128,7 @@ __global__ void extend_u16_u8(uint16_t* dst, const uint8_t* src, size_t n)
 void extend_to_u16(uint16_t* dst, const uint8_t* src, size_t n, cudaStream_t st)
 {
     extend_u16_u8<<<(n + 511) / 512, 512, 0, st>>>(dst, src, n);
+    TM_CUDA_CHECK(cudaGetLastError());
 }
 
 template<int VecSize, class T>
@@ -158,6 +161,7 @@ __global__ void fuse_scales_and_zeros_kernel(T* fused, const T* scales, T* zeros
 void fuse_scales_and_zeros(half* fused, const half* scales, half* zeros, size_t n, cudaStream_t st)
 {
     fuse_scales_and_zeros_kernel<4><<<256, 256, 0, st>>>(fused, scales, zeros, n);
+    TM_CUDA_CHECK(cudaGetLastError());
 }
 
 template<int VecSize, class T>
@@ -203,6 +207,7 @@ void interleave_output_dims_impl(T* fused, const T* a, const T* b, int m, int k,
     const dim3    grid(1, k);  // x is a grid stride loop
 
     interleave_output_dims_kernel<kVecSize><<<grid, block, 0, st>>>(fused, a, b, m, k);
+    TM_CUDA_CHECK(cudaGetLastError());
 }
 
 template void
@@ -226,6 +231,7 @@ void AdjustUe8m0ScaleForHalf(uint8_t* data, int n, cudaStream_t st)
     constexpr int block = 512;
     const int     grid  = cdiv(n, block);
     adjust_ue8m0_scale_for_half_kernel<<<grid, block, 0, st>>>(data, n);
+    TM_CUDA_CHECK(cudaGetLastError());
 }
 
 template<class T0, class T1>
@@ -252,6 +258,8 @@ Tensor BlockscaleToGroupscale(const Tensor& scales, DataType data_type, int bloc
     };
 
     TM_DISPATCH_DTYPES(data_type, invoke, half_t, bfloat16_t);
+
+    TM_CUDA_CHECK(cudaGetLastError());
 
     return ret;
 }

--- a/src/turbomind/kernels/gemm/convert_v3.cu
+++ b/src/turbomind/kernels/gemm/convert_v3.cu
@@ -6,6 +6,7 @@
 #include "src/turbomind/kernels/gemm/convert.cuh"
 #include "src/turbomind/kernels/gemm/convert.h"
 #include "src/turbomind/kernels/gemm/types.h"
+#include "src/turbomind/utils/cuda_utils.h"
 
 #include "src/turbomind/kernels/gemm/arch/operand_simt.h"
 #include "src/turbomind/kernels/gemm/arch/operand_sm70_s884.h"
@@ -159,8 +160,7 @@ std::array<const LayoutConverter*, 2> GetConverters(DataType data_type,
         // clang-format on
     }
 
-    TM_CHECK(0) << "Invalid combination: " << sm << " " << data_type << " " << weight_type << " " << input_type << " "
-                << grouped;
+    TM_LOG_FATAL("Invalid combination: {} {} {} {} {}", sm, data_type, weight_type, input_type, grouped);
 
     return {};
 }
@@ -203,6 +203,7 @@ void* MakeStridedPtrs(const std::vector<std::pair<void*, int>>& ptrs, cudaStream
         fill_strided_ptrs<<<1, N, 0, stream>>>(param);
         param.ptr += N;
     }
+    TM_CUDA_CHECK(cudaGetLastError());
     return ptr;
 }
 
@@ -235,6 +236,7 @@ void* MakeBlockedPtrs(const std::vector<std::pair<void*, int>>& ptrs, cudaStream
         fill_blocked_ptrs<<<1, N, 0, stream>>>(src, dst, n);
         dst += n;
     }
+    TM_CUDA_CHECK(cudaGetLastError());
     return dst - ptrs.size();
 }
 

--- a/src/turbomind/kernels/gemm/gemm.cu
+++ b/src/turbomind/kernels/gemm/gemm.cu
@@ -1,6 +1,7 @@
 // Copyright (c) OpenMMLab. All rights reserved.
 
 #include "src/turbomind/core/check.h"
+#include "src/turbomind/core/logger.h"
 #include "src/turbomind/kernels/gemm/context.h"
 #include "src/turbomind/kernels/gemm/desc.h"
 #include "src/turbomind/kernels/gemm/dispatch_cache.h"
@@ -267,8 +268,7 @@ int Gemm::Run(const Operation&    operation,
     const auto desc = context.Init(operation, Adesc, Udesc, Bdesc, Vdesc, Cdesc, Ddesc);
 
     if (!desc) {
-        fprintf(stderr, "invalid argument.\n");
-        TM_CHECK(0);
+        TM_LOG_FATAL("invalid argument");
         return -1;
     }
 
@@ -324,7 +324,7 @@ int Gemm::Run(const Operation&    operation,
         return launch(spec, stream);
     }
 
-    TM_CHECK(0) << "No feasible kernel found for the problem: " << to_string(context.desc());
+    TM_LOG_FATAL("No feasible kernel found for the problem: {}", to_string(context.desc()));
 
     return -1;
 }

--- a/src/turbomind/kernels/gemm/kernel_impl_sm90.h
+++ b/src/turbomind/kernels/gemm/kernel_impl_sm90.h
@@ -211,7 +211,7 @@ public:
         constexpr int kTileN = Gemm::TILE_N;
 
         if (Gemm::Scheduler::is_dynamic) {
-            check_cuda_error(cudaMemsetAsync(workspace.flags, 0, sizeof(int), stream));
+            TM_CUDA_CHECK(cudaMemsetAsync(workspace.flags, 0, sizeof(int), stream));
         }
 
         // std::cout << "A: " << Adesc << "\n";
@@ -296,7 +296,7 @@ public:
                                      to_param((void*)D, Ddesc),
                                      sched,
                                      workspace.tensormaps);
-        TM_CHECK_EQ(ec, cudaSuccess) << cudaGetErrorString(ec);
+        TM_CUDA_CHECK(ec);
 
         return 0;
     }

--- a/src/turbomind/kernels/gemm/moe_utils_v2.cu
+++ b/src/turbomind/kernels/gemm/moe_utils_v2.cu
@@ -20,6 +20,7 @@
 #include "src/turbomind/kernels/core/math.h"
 #include "src/turbomind/kernels/gemm/moe_utils_v2.h"
 #include "src/turbomind/kernels/reduce_kernel_utils.cuh"
+#include "src/turbomind/utils/cuda_utils.h"
 
 namespace turbomind {
 
@@ -625,7 +626,7 @@ void invokeMoeGate_V2(int*         f2n,            // [e*n] -> n
 
     if (!softmax && norm_topk) {
         // norm top-k is part of softmax impl
-        TM_CHECK(0) << softmax << " " << norm_topk;
+        TM_LOG_FATAL("unsupported moe config: softmax={} norm_topk={}", softmax, norm_topk);
     }
 
     auto dispatch = [&] {
@@ -665,8 +666,6 @@ void invokeMoeGate_V2(int*         f2n,            // [e*n] -> n
 
     auto success = dispatch();
 
-    sync_check_cuda_error();
-
     TM_CHECK(success) << "unsupported moe config: expert_num=" << experts << ", top_k=" << experts_per_token
                       << ", softmax=" << softmax << ", norm_topk=" << norm_topk;
 
@@ -686,6 +685,7 @@ void invokeMoeGate_V2(int*         f2n,            // [e*n] -> n
                                                               tokens_padded,
                                                               experts);
     }
+    TM_CUDA_CHECK(cudaGetLastError());
 }
 
 // noaux_tc: scores = scoring_func(logits), scores_for_choice = scores + correction_bias,
@@ -877,6 +877,8 @@ void invokeMoeGate_NoAuxTC(int*         f2n,
     const dim3    scan_blocks(tiles, experts + 1);
     MoeScanKernel_v2<scan_threads><<<scan_blocks, scan_threads, 0, st>>>(
         f2n, f2E, en2f, offsets, (int8_t*)masks, accum, log_tile, tiles, tokens, tokens_padded, experts);
+
+    TM_CUDA_CHECK(cudaGetLastError());
 }
 
 template<int vec_size, int block_dim, class T>
@@ -911,16 +913,19 @@ void invokeMoeDispatch(Ref<Tensor> out_, const Tensor& src, const int* f2n, int 
             (const T*)src.raw_data(),
             f2n,
             dim / vec_size);
+        TM_CUDA_CHECK(cudaGetLastError());
     };
     TM_CHECK_EQ(src.dtype(), out.dtype());
     const auto elem_size = byte_size(src.dtype());
     if (elem_size == sizeof(uint16_t)) {
-        return invoke(uint16_t{});
+        invoke(uint16_t{});
     }
     else if (elem_size == sizeof(uint8_t)) {
-        return invoke(uint8_t{});
+        invoke(uint8_t{});
     }
-    TM_CHECK(0) << "unsupported data type: " << src.dtype();
+    else {
+        TM_LOG_FATAL("unsupported data type: {}", src.dtype());
+    }
 }
 
 template<int alignment, int block_dim, class T>
@@ -997,6 +1002,8 @@ void invokeMoeDispatchScales(Ref<Tensor> out_, const Tensor& src, const int* f2n
                                                             src.stride(0),
                                                             f2n,
                                                             dim);
+
+    TM_CUDA_CHECK(cudaGetLastError());
 }
 
 template<int vec_size, int exp_k, bool has_bias, int block_dim, class T>
@@ -1102,19 +1109,25 @@ void invokeMoeReduce(T*           dst,
             tokens,
             bscale,
             dst_scale);
+        TM_CUDA_CHECK(cudaGetLastError());
     };
 
     switch (experts_per_token) {
         case 1:
-            return invoke(std::integral_constant<int, 1>{});
+            invoke(std::integral_constant<int, 1>{});
+            break;
         case 2:
-            return invoke(std::integral_constant<int, 2>{});
+            invoke(std::integral_constant<int, 2>{});
+            break;
         case 4:
-            return invoke(std::integral_constant<int, 4>{});
+            invoke(std::integral_constant<int, 4>{});
+            break;
         case 6:
-            return invoke(std::integral_constant<int, 6>{});
+            invoke(std::integral_constant<int, 6>{});
+            break;
         case 8:
-            return invoke(std::integral_constant<int, 8>{});
+            invoke(std::integral_constant<int, 8>{});
+            break;
         default:
             fprintf(stderr, "Unsupported experts_per_token %d\n", experts_per_token);
             std::abort();
@@ -1140,28 +1153,28 @@ void invokeMoeCombine(Ref<Tensor>   out_,
 
     auto invoke = [&](auto has_bias, auto t) {
         using T = decltype(t);
-        return invokeMoeReduce<has_bias.value>(out.data<T>(),
-                                               src.data<T>(),
-                                               bias.data_or((T*)nullptr),
-                                               scales,
-                                               en2f,
-                                               f2E,
-                                               dst_scales,
-                                               tokens,
-                                               experts_per_token,
-                                               src.shape(1),
-                                               (T)bscale,
-                                               dst_scale,
-                                               st);
+        invokeMoeReduce<has_bias.value>(out.data<T>(),
+                                        src.data<T>(),
+                                        bias.data_or((T*)nullptr),
+                                        scales,
+                                        en2f,
+                                        f2E,
+                                        dst_scales,
+                                        tokens,
+                                        experts_per_token,
+                                        src.shape(1),
+                                        (T)bscale,
+                                        dst_scale,
+                                        st);
     };
 
     auto dispatch_dtype = [&](auto t) {
         if (bias) {
             TM_CHECK_NOTNULL(f2E);
-            return invoke(std::true_type{}, t);
+            invoke(std::true_type{}, t);
         }
         else {
-            return invoke(std::false_type{}, t);
+            invoke(std::false_type{}, t);
         }
     };
 
@@ -1321,10 +1334,12 @@ void invokeMoeSoftmaxMaskTopKGroups(
         const int     blocks       = ceil_div(token_num, threads / thrs_per_tok);
         MoeSoftmaxMaskTopKGroups<max_expert_num.value, items_per_thread.value, vec_size.value>
             <<<blocks, threads, 0, st>>>(logits, token_num, expert_num, top_k);
+        TM_CUDA_CHECK(cudaGetLastError());
     };
 
     if (expert_num == 160 && group_size == 20) {
-        return invoke(_Int<160>, _Int<20>, _Int<4>);
+        invoke(_Int<160>, _Int<20>, _Int<4>);
+        return;
     }
 
     std::cerr << __FILE__ << "(" << __LINE__ << "): unsupported moe config: expert_num=" << expert_num

--- a/src/turbomind/kernels/gemm/test/test_moe_utils.cu
+++ b/src/turbomind/kernels/gemm/test/test_moe_utils.cu
@@ -1,7 +1,9 @@
+#include "src/turbomind/core/scope.h"
 #include "src/turbomind/kernels/gemm/moe_utils_v2.h"
 #include "src/turbomind/kernels/gemm/test/test_utils.h"
 #include "src/turbomind/kernels/gemm/tuner/cache_utils.h"
 #include "src/turbomind/kernels/gemm/types.h"
+#include "src/turbomind/utils/cuda_utils.h"
 #include <algorithm>
 #include <iomanip>
 #include <numeric>
@@ -210,7 +212,8 @@ bool test_moe_gate(int                     tokens,  //
     bool softmax = true;
 
     if (1) {
-        invokeMoeSoftmaxMaskTopKGroups(logits.data().get(), tokens, expert_num, expert_num / 8, 8, nullptr);
+        TM_SCOPE_CALL(
+            invokeMoeSoftmaxMaskTopKGroups(logits.data().get(), tokens, expert_num, expert_num / 8, 8, nullptr));
         softmax = false;
     }
 

--- a/src/turbomind/kernels/gemm/test/testbed_v3.h
+++ b/src/turbomind/kernels/gemm/test/testbed_v3.h
@@ -10,6 +10,7 @@
 #include "src/turbomind/kernels/gemm/test/test_utils.h"
 #include "src/turbomind/kernels/gemm/types.h"
 #include "src/turbomind/kernels/quantization.h"
+#include "src/turbomind/utils/cuda_utils.h"
 
 #include "src/turbomind/models/linear_weight.h"
 #include "src/turbomind/models/llama/LlamaLinear.h"
@@ -55,8 +56,8 @@ static Tensor CopyTransposed(const Tensor& src, Tensor out = {})
 
     auto invoke = [&](auto t) {
         using T = decltype(t);
-        invokeTransposeAxis01(
-            (T*)out.raw_data(), (T*)src.raw_data(), src.shape(0), src.shape(1), 1, core::Context::stream().handle());
+        TM_SCOPE_CALL(invokeTransposeAxis01(
+            (T*)out.raw_data(), (T*)src.raw_data(), src.shape(0), src.shape(1), 1, core::Context::stream().handle()));
     };
 
     const int bits = byte_size(src.dtype(), 8);
@@ -377,7 +378,7 @@ struct Testbed_v3: Parameter {
         Tensor xe{{x.shape(0) * experts_per_token, input_dim}, data_type, kDEVICE};
         Tensor de{{x.shape(0) * experts_per_token, output_dim}, data_type, kDEVICE};
 
-        invokeMoeDispatch(xe, x, f2n_.data(), experts_per_token, stream_);
+        TM_SCOPE_CALL(invokeMoeDispatch(xe, x, f2n_.data(), experts_per_token, stream_));
 
         for (int i = 0; i < expert_num; ++i) {
             const int base = h_offsets_[i], size = h_offsets_[i + 1] - base;
@@ -387,17 +388,17 @@ struct Testbed_v3: Parameter {
         auto& d = d_.get();
         if (combine_experts) {
             d = Tensor{{x.shape(0), output_dim}, data_type, kDEVICE};
-            invokeMoeCombine(d,  //
-                             de,
-                             {},
-                             scales_.data(),
-                             en2f_.data(),
-                             nullptr,
-                             nullptr,
-                             experts_per_token,
-                             1.,
-                             0.,
-                             stream_);
+            TM_SCOPE_CALL(invokeMoeCombine(d,  //
+                                           de,
+                                           {},
+                                           scales_.data(),
+                                           en2f_.data(),
+                                           nullptr,
+                                           nullptr,
+                                           experts_per_token,
+                                           1.,
+                                           0.,
+                                           stream_));
         }
         else {
             d = de;
@@ -410,27 +411,28 @@ struct Testbed_v3: Parameter {
             linear_.set_measure(true);
         }
         if (expert_num) {
-            auto de = linear_.Forward(x_original_, *w_quant_, f2n_, offsets_);
+            Tensor de;
+            TM_SCOPE_CALL(linear_.Forward(x_original_, *w_quant_, f2n_, offsets_, de));
             if (combine_experts) {
                 d_quant_ = Tensor{{x_original_.shape(0), output_dim}, data_type, kDEVICE};
-                invokeMoeCombine(d_quant_,
-                                 de,
-                                 {},
-                                 scales_.data(),
-                                 en2f_.data(),
-                                 nullptr,
-                                 nullptr,
-                                 experts_per_token,
-                                 1.,
-                                 0.,
-                                 stream_);
+                TM_SCOPE_CALL(invokeMoeCombine(d_quant_,
+                                               de,
+                                               {},
+                                               scales_.data(),
+                                               en2f_.data(),
+                                               nullptr,
+                                               nullptr,
+                                               experts_per_token,
+                                               1.,
+                                               0.,
+                                               stream_));
             }
             else {
                 d_quant_ = de;
             }
         }
         else {
-            d_quant_ = linear_.Forward(x_original_, *w_quant_);
+            TM_SCOPE_CALL(linear_.Forward(x_original_, *w_quant_, d_quant_));
         }
         if (tuning_) {
             linear_.set_measure(false);

--- a/src/turbomind/kernels/gemm/unpack.cu
+++ b/src/turbomind/kernels/gemm/unpack.cu
@@ -3,6 +3,7 @@
 #include "src/turbomind/kernels/core/array_ops.h"
 #include "src/turbomind/kernels/core/common.h"
 #include "src/turbomind/kernels/core/data_type.h"
+#include "src/turbomind/utils/cuda_utils.h"
 #include <iostream>
 
 namespace turbomind {
@@ -69,6 +70,7 @@ void unpack_awq_gemm(uint4_t* dst, const uint4_t* src, int rows, int cols, cudaS
 {
     Array<int, 4> shape{cols, rows / 8, 2, 4};
     permute_u4<0, 1, 3, 2><<<512, 512, 0, st>>>((uint*)dst, (const uint*)src, shape);
+    TM_CUDA_CHECK(cudaGetLastError());
 }
 
 __global__ void transpose_u4_kernel(uint4_t* dst, const uint4_t* src, int s, int c)
@@ -109,6 +111,7 @@ void transpose_u4(uint4_t* dst, const uint4_t* src, int s, int c, cudaStream_t s
     const dim3 block(16, 16);
     const dim3 grid((c + 15) / 16, (s + 15) / 16);
     transpose_u4_kernel<<<grid, block, 0, st>>>(dst, src, s, c);
+    TM_CUDA_CHECK(cudaGetLastError());
 }
 
 // load -> unpack -> extend_to_u8 -> manipulation -> compat_to_u4 -> store

--- a/src/turbomind/kernels/gpt_kernels.cu
+++ b/src/turbomind/kernels/gpt_kernels.cu
@@ -72,9 +72,12 @@ void invokeEmbeddingLookup(Ref<Tensor>         out_,
     };
 
     if (byte_size(out.dtype()) == byte_size<uint16_t>()) {
-        return invoke(uint16_t{});
+        invoke(uint16_t{});
+        TM_CUDA_CHECK(cudaGetLastError());
     }
-    TM_CHECK(0) << "not implemented";
+    else {
+        TM_LOG_FATAL("not implemented");
+    }
 }
 
 // TODO Add half2 implementation
@@ -100,6 +103,7 @@ void invokeTransposeAxis01(T* out, T* in, const int dim0, const int dim1, const 
     dim3 block(512);
     dim3 grid((int)(ceil(dim0 * dim1 * dim2 / 512.)));
     transposeAxis01<<<grid, block, 0, stream>>>(out, in, dim0, dim1, dim2);
+    TM_CUDA_CHECK(cudaGetLastError());
 }
 
 template void
@@ -147,6 +151,7 @@ void invokeTransposeAxis01(
     dim3 block(512);
     dim3 grid((int)(ceil(dim0 * dim1 / 512.)));
     transposeAxis01<<<grid, block, 0, stream>>>(out, in, in_skipping_dim1, dim0, dim1);
+    TM_CUDA_CHECK(cudaGetLastError());
 }
 
 template void invokeTransposeAxis01(
@@ -205,6 +210,7 @@ void invokeTranspose2D_(T* dst, const T* src, int rows, int cols, cudaStream_t s
     }
 
     transpose_2d_kernel<TILE_DIM, BLOCK_ROWS><<<grid, block, 0, st>>>(dst, src, rows, cols, swap_xy);
+    TM_CUDA_CHECK(cudaGetLastError());
 }
 
 template void invokeTranspose2D_(uint32_t*, const uint32_t*, int, int, cudaStream_t);

--- a/src/turbomind/kernels/gpt_kernels.h
+++ b/src/turbomind/kernels/gpt_kernels.h
@@ -231,11 +231,10 @@ template<class T>
 void invokeTranspose2D(T* dst, const T* src, int rows, int cols, cudaStream_t st)
 {
     if constexpr (sizeof(T) == 4) {
-        // FT_CHECK(0);
         invokeTranspose2D_((uint32_t*)dst, (const uint32_t*)src, rows, cols, st);
     }
     else {
-        FT_CHECK(0);
+        TM_LOG_FATAL("unreachable");
     }
 }
 

--- a/src/turbomind/kernels/logprob_kernels.cu
+++ b/src/turbomind/kernels/logprob_kernels.cu
@@ -30,6 +30,7 @@
 #include "src/turbomind/kernels/logprob_kernels.h"
 #include "src/turbomind/kernels/reduce_kernel_utils.cuh"
 #include "src/turbomind/macro.h"
+#include "src/turbomind/utils/cuda_utils.h"
 
 namespace turbomind {
 
@@ -181,6 +182,7 @@ void invokeLogProbFromLogits(float*       cum_log_probs,
                                                          batch_first);
     accumulate_log_probs<<<batch_size, block_size, 0, stream>>>(
         cum_log_probs, log_probs, input_lengths, max_input_length, batch_size, batch_first);
+    TM_CUDA_CHECK(cudaGetLastError());
 }
 
 template void invokeLogProbFromLogits(float*       cum_log_probs,

--- a/src/turbomind/kernels/norm/rms_norm.cu
+++ b/src/turbomind/kernels/norm/rms_norm.cu
@@ -11,6 +11,7 @@
 #include "src/turbomind/kernels/core/meta.h"
 
 #include "src/turbomind/kernels/norm/rms_norm.h"
+#include "src/turbomind/utils/cuda_utils.h"
 
 namespace turbomind {
 
@@ -117,6 +118,7 @@ void invokeRMSNorm(Tensor& out, const Tensor& x, const Tensor& w, float eps, cud
     };
 
     TM_DISPATCH_PRIMARY_DTYPES(x.dtype(), invoke);
+    TM_CUDA_CHECK(cudaGetLastError());
 }
 
 namespace kernel {
@@ -202,7 +204,7 @@ void invokeQkRMSNorm(void*        data,
             constexpr int vec_size   = sizeof(uint4) / sizeof(T);
             constexpr int thr_per_qk = kMaxDim / vec_size;
 
-            FT_CHECK(head_dim % vec_size == 0);
+            TM_CHECK(head_dim % vec_size == 0);
 
             const int threads   = thr_per_qk * n * (int64_t)token_num;
             const int block_dim = 512;
@@ -221,6 +223,7 @@ void invokeQkRMSNorm(void*        data,
     };
 
     TM_DISPATCH_PRIMARY_DTYPES(dtype, invoke);
+    TM_CUDA_CHECK(cudaGetLastError());
 }
 
 void invokeRMSNormQK(Tensor& x, const Tensor& w, float eps, cudaStream_t st)
@@ -264,6 +267,7 @@ void invokeRMSNormQK(Tensor& x, const Tensor& w, float eps, cudaStream_t st)
     };
 
     TM_DISPATCH_PRIMARY_DTYPES(x.dtype(), invoke);
+    TM_CUDA_CHECK(cudaGetLastError());
 }
 
 // r' <- r + (h + b)
@@ -363,6 +367,7 @@ void invokeBiasResidualRMSNorm(
                                                                                        num,
                                                                                        eps,
                                                                                        1.f / dims);
+    TM_CUDA_CHECK(cudaGetLastError());
 }
 
 template void invokeBiasResidualRMSNorm(half*        residual,
@@ -414,6 +419,7 @@ void invokeResidualBiasRMSNorm(void*        hidden_states,
     };
 
     TM_DISPATCH_PRIMARY_DTYPES(dtype, invoke);
+    TM_CUDA_CHECK(cudaGetLastError());
 }
 
 template<class T, class B, int vec_size>
@@ -465,6 +471,7 @@ void ApplyBias(Tensor& data, const Tensor& bias, cudaStream_t st)
         }
     };
     TM_DISPATCH_DTYPES(data.dtype(), invoke0, float, half, nv_bfloat16);
+    TM_CUDA_CHECK(cudaGetLastError());
 }
 
 template<class T, int vec_size>
@@ -545,6 +552,7 @@ void ApplyBias(Tensor& data, const Tensor& bias, const Buffer_<int>& offsets, fl
     };
 
     TM_DISPATCH_PRIMARY_DTYPES(data.dtype(), invoke);
+    TM_CUDA_CHECK(cudaGetLastError());
 }
 
 }  // namespace turbomind

--- a/src/turbomind/kernels/quantization.cu
+++ b/src/turbomind/kernels/quantization.cu
@@ -24,6 +24,7 @@
 #include "src/turbomind/kernels/quantization.h"
 
 #include "src/turbomind/kernels/attention/quantization.h"
+#include "src/turbomind/utils/cuda_utils.h"
 
 namespace turbomind {
 
@@ -113,6 +114,7 @@ void QuantizeSymm(Tensor& out, Tensor& scale, const Tensor& src, cudaStream_t st
     };
 
     TM_DISPATCH_PRIMARY_DTYPES(src.dtype(), invoke);
+    TM_CUDA_CHECK(cudaGetLastError());
 }
 
 template<int vec_size, int group_size, class Tout, class Tscale, class T>
@@ -165,6 +167,7 @@ void DequantizeSymm(Tensor& out, const Tensor& src, const Tensor& scale, cudaStr
                                                                                        scale.stride(0),
                                                                                        num,
                                                                                        dim);
+    TM_CUDA_CHECK(cudaGetLastError());
 }
 
 template<int vec_size, int cta_size, int block_size, class Tout, class Tscale, class T>
@@ -272,6 +275,7 @@ void QuantizeSymmBlock(Ref<Tensor> out_, Ref<Tensor> scale_, const Tensor& src, 
     };
 
     TM_DISPATCH_PRIMARY_DTYPES(src.dtype(), invoke);
+    TM_CUDA_CHECK(cudaGetLastError());
 }
 
 template<int vec_size, int cta_size, int block_size, class Tout, class Tscale, class T>
@@ -345,6 +349,7 @@ void DequantizeSymmBlock(Ref<Tensor> out_, Ref<Tensor> src_, const Tensor& scale
     }
 
     TM_DISPATCH_PRIMARY_DTYPES(out_.get().dtype(), invoke);
+    TM_CUDA_CHECK(cudaGetLastError());
 }
 
 template<int start_bit, int end_bit, class D, class T>
@@ -665,8 +670,9 @@ void QuantizeGroupwise(Tensor            quant,    // (m,k)
         invoke(FloatingPointQuantizer<half_t, 2, 1, uint16_t>{});
     }
     else {
-        TM_CHECK(0) << "Unsupported types: " << to_string(src.dtype()) << ", " << to_string(quant.dtype());
+        TM_LOG_FATAL("Unsupported types: {}, {}", to_string(src.dtype()), to_string(quant.dtype()));
     }
+    TM_CUDA_CHECK(cudaGetLastError());
 }
 
 }  // namespace turbomind

--- a/src/turbomind/kernels/sampling_kernels.cu
+++ b/src/turbomind/kernels/sampling_kernels.cu
@@ -8,6 +8,7 @@
 #include "src/turbomind/kernels/sampling_kernels.h"
 #include "src/turbomind/kernels/sampling_topp_kernels.h"
 #include "src/turbomind/utils/constant.h"
+#include "src/turbomind/utils/cuda_utils.h"
 
 namespace turbomind {
 
@@ -95,6 +96,7 @@ void invokeSampling(SamplingParams& params, cudaStream_t stream)
                                                    (T*)params.sampled_logprobs,
                                                    params.sampled_indexes,
                                                    params.sampled_nums);
+    TM_CUDA_CHECK(cudaGetLastError());
 }
 
 template void invokeSampling<float>(SamplingParams& params, cudaStream_t stream);

--- a/src/turbomind/kernels/sampling_penalty_kernels.cu
+++ b/src/turbomind/kernels/sampling_penalty_kernels.cu
@@ -118,6 +118,7 @@ void invokeBatchApplyTemperaturePenalty_v2(T*           logits,
     else {
         invoke(std::integral_constant<int, 1>{});
     }
+    TM_CUDA_CHECK(cudaGetLastError());
 }
 
 #define INSTANTIATE_INVOKE_BATCH_APPLY_TEMPERATURE_PENALTY_V2(T)                                                       \
@@ -192,6 +193,7 @@ void ApplyRepetitionPenalty(Tensor&               logits,
             logits.data<T>(), penalties.data(), token_ids_ptrs.data(), sequence_length.data(), vocab_size, mask_size);
     };
     invoke(float{});
+    TM_CUDA_CHECK(cudaGetLastError());
 }
 
 template<typename T>
@@ -229,6 +231,7 @@ void invokeMinLengthPenalty(T*           logits,
     const dim3 grid((batch_size * end_ids_size + block.x - 1) / block.x);
     batchApplyMinLengthPenalty<<<block, grid, 0, stream>>>(
         logits, min_lengths, sequnece_lengths, vocab_size_padded, batch_size, end_ids, end_ids_size);
+    TM_CUDA_CHECK(cudaGetLastError());
 }
 
 #define INSTANTIATE_INVOKE_MIN_LENGTH_PENALTY(T)                                                                       \

--- a/src/turbomind/kernels/sampling_topk_kernels.cu
+++ b/src/turbomind/kernels/sampling_topk_kernels.cu
@@ -30,6 +30,7 @@
 #include "src/turbomind/kernels/sampling_topk_kernels.h"
 
 #include "src/turbomind/utils/constant.h"
+#include "src/turbomind/utils/cuda_utils.h"
 #include "src/turbomind/utils/string_utils.h"
 
 namespace turbomind {
@@ -90,6 +91,7 @@ void InitializeRandomStates(
 
     InitializeRandomStates_Kernel<<<blocks, threads, 0, stream>>>(
         (curandState_t*)states, (const unsigned long long*)random_seeds, mask, batch_size);
+    TM_CUDA_CHECK(cudaGetLastError());
 }
 
 template<typename T, int BLOCK_SIZE, int BLOCKS_PER_BEAM>
@@ -264,6 +266,7 @@ void invokeTopKSortFilter(TopKSortFilterParams& params, cudaStream_t stream)
     else {
         throw std::domain_error(fmtstr("top-k kernel supports 1<=k<=1024 but got k=%d", max_top_k));
     }
+    TM_CUDA_CHECK(cudaGetLastError());
 }
 
 template void invokeTopKSortFilter<float>(TopKSortFilterParams& params, cudaStream_t stream);

--- a/src/turbomind/kernels/sampling_topp_kernels.cu
+++ b/src/turbomind/kernels/sampling_topp_kernels.cu
@@ -83,6 +83,7 @@ void invokeTopPSortInitialize(const int    vocab_size_padded,
     const size_t grid_size  = (batch_size * vocab_size_padded + block_size - 1) / block_size;
     topPSortInitialize<<<grid_size, block_size, 0, stream>>>(
         vocab_size_padded, vocab_size, batch_size, top_ks, topp_id_val_buf, begin_offset_buf, end_offset_buf);
+    TM_CUDA_CHECK(cudaGetLastError());
 }
 
 template<typename T>
@@ -140,6 +141,7 @@ void invokeSoftmax(T*           logits,
     dim3 grid(batch_size);
     dim3 block(std::min(vocab_size_padded, 1024));
     softmax<<<grid, block, 0, stream>>>(logits, vocab_size_padded, vocab_size, kept);
+    TM_CUDA_CHECK(cudaGetLastError());
 }
 
 #define INSTANTIATE_INVOKE_SOFTMAX(T)                                                                                  \
@@ -221,19 +223,19 @@ void invokeTopPSort(TopPSortParams& params, cudaStream_t stream)
     const int num_items = params.vocab_size_padded * (params.batch_size - 1) + params.vocab_size;
 
     size_t cub_temp_storage_size{};
-    check_cuda_error(cub::DeviceSegmentedRadixSort::SortPairsDescending(nullptr,
-                                                                        cub_temp_storage_size,
-                                                                        (T*)nullptr,
-                                                                        (T*)nullptr,
-                                                                        (int*)nullptr,
-                                                                        (int*)nullptr,
-                                                                        num_items,
-                                                                        params.batch_size,
-                                                                        (int*)nullptr,
-                                                                        (int*)nullptr,
-                                                                        0,              // begin_bit
-                                                                        sizeof(T) * 8,  // end_bit = sizeof(KeyT) * 8
-                                                                        stream));       // cudaStream_t
+    TM_CUDA_CHECK(cub::DeviceSegmentedRadixSort::SortPairsDescending(nullptr,
+                                                                     cub_temp_storage_size,
+                                                                     (T*)nullptr,
+                                                                     (T*)nullptr,
+                                                                     (int*)nullptr,
+                                                                     (int*)nullptr,
+                                                                     num_items,
+                                                                     params.batch_size,
+                                                                     (int*)nullptr,
+                                                                     (int*)nullptr,
+                                                                     0,              // begin_bit
+                                                                     sizeof(T) * 8,  // end_bit = sizeof(KeyT) * 8
+                                                                     stream));       // cudaStream_t
 
     TM_CHECK(core::Context::stream().handle() == stream);
 
@@ -247,14 +249,14 @@ void invokeTopPSort(TopPSortParams& params, cudaStream_t stream)
     auto beg_offset_buf = beg_offset.data();
     auto end_offset_buf = end_offset.data();
 
-    invokeTopPSortInitialize(params.vocab_size_padded,
-                             params.vocab_size,
-                             params.batch_size,
-                             params.top_ks,
-                             topp_ids_buf,
-                             beg_offset_buf,
-                             end_offset_buf,
-                             stream);
+    TM_SCOPE_CALL(invokeTopPSortInitialize(params.vocab_size_padded,
+                                           params.vocab_size,
+                                           params.batch_size,
+                                           params.top_ks,
+                                           topp_ids_buf,
+                                           beg_offset_buf,
+                                           end_offset_buf,
+                                           stream));
 
     topp_beam_topk_kernel<T, 1, 256><<<params.batch_size, 256, 0, stream>>>((T*)params.logits,
                                                                             (T*)params.sorted_logits,
@@ -267,19 +269,20 @@ void invokeTopPSort(TopPSortParams& params, cudaStream_t stream)
                                                                             params.top_ps,
                                                                             params.top_ks);
 
-    check_cuda_error(cub::DeviceSegmentedRadixSort::SortPairsDescending(cub_temp_storage.data(),
-                                                                        cub_temp_storage_size,
-                                                                        (T*)params.logits,
-                                                                        (T*)params.sorted_logits,
-                                                                        topp_ids_buf,
-                                                                        params.sorted_indices,
-                                                                        num_items,
-                                                                        params.batch_size,
-                                                                        beg_offset_buf,
-                                                                        end_offset_buf,
-                                                                        0,              // begin_bit
-                                                                        sizeof(T) * 8,  // end_bit = sizeof(KeyT) * 8
-                                                                        stream));       // cudaStream_t
+    TM_CUDA_CHECK(cub::DeviceSegmentedRadixSort::SortPairsDescending(cub_temp_storage.data(),
+                                                                     cub_temp_storage_size,
+                                                                     (T*)params.logits,
+                                                                     (T*)params.sorted_logits,
+                                                                     topp_ids_buf,
+                                                                     params.sorted_indices,
+                                                                     num_items,
+                                                                     params.batch_size,
+                                                                     beg_offset_buf,
+                                                                     end_offset_buf,
+                                                                     0,              // begin_bit
+                                                                     sizeof(T) * 8,  // end_bit = sizeof(KeyT) * 8
+                                                                     stream));       // cudaStream_t
+    TM_CUDA_CHECK(cudaGetLastError());
 }
 
 template void invokeTopPSort<float>(TopPSortParams& params, cudaStream_t stream);
@@ -388,6 +391,7 @@ void invokeTopPMinPFilter(TopPMinPFilterParams& params, cudaStream_t stream)
                                                                   params.vocab_size_padded,
                                                                   params.top_ps,
                                                                   params.min_ps);
+    TM_CUDA_CHECK(cudaGetLastError());
 }
 
 template void invokeTopPMinPFilter<float>(TopPMinPFilterParams& params, cudaStream_t stream);

--- a/src/turbomind/kernels/stop_criteria_kernels.cu
+++ b/src/turbomind/kernels/stop_criteria_kernels.cu
@@ -16,6 +16,7 @@
 
 #include "src/turbomind/kernels/core/math.h"
 #include "src/turbomind/kernels/stop_criteria_kernels.h"
+#include "src/turbomind/utils/cuda_utils.h"
 
 namespace turbomind {
 
@@ -70,6 +71,7 @@ void invokeStopWordsCriterion_v2(const int**  token_ids_ptrs,
 
     stop_words_criterion_v2<<<grid, block, 0, stream>>>(
         token_ids_ptrs, sequence_length, stop_words, finished, stop_words_len, batch_size);
+    TM_CUDA_CHECK(cudaGetLastError());
 }
 
 __global__ void length_criterion_v2(bool*      finished,  //
@@ -98,6 +100,7 @@ void invokeLengthCriterion_v2(bool*        finished,  //
     const int     grid  = cdiv(batch_size, block);
 
     length_criterion_v2<<<grid, block, 0, stream>>>(finished, sequence_length, sequence_length_limit, batch_size);
+    TM_CUDA_CHECK(cudaGetLastError());
 }
 
 }  // namespace turbomind

--- a/src/turbomind/kernels/unfused_attention_kernels.cu
+++ b/src/turbomind/kernels/unfused_attention_kernels.cu
@@ -126,7 +126,7 @@ void invokeMaskedSoftmax(MaskedSoftmaxParam<T>& param, cudaStream_t stream)
 
     auto invoke = [&](auto items_per_thread) {
         const int block = round_up(cdiv(param.k_length, items_per_thread.value), WARP_SIZE);
-        FT_CHECK(block <= 1024);
+        TM_CHECK(block <= 1024);
         softmax_kernel<T, items_per_thread.value><<<grid, block, 0, stream>>>(param.attention_score,
                                                                               param.qk,
                                                                               param.attention_mask,
@@ -166,6 +166,7 @@ void invokeMaskedSoftmax(MaskedSoftmaxParam<T>& param, cudaStream_t stream)
     else {
         throw std::runtime_error("not impelmented");
     }
+    TM_CUDA_CHECK(cudaGetLastError());
 }
 
 template void invokeMaskedSoftmax(MaskedSoftmaxParam<half>& param, cudaStream_t stream);
@@ -262,16 +263,16 @@ __global__ void transpose_remove_padding(const T*     src,
 // clang-format off
 template<typename T>
 void invokeTransposeAttentionOutRemovePadding(T*           src,
-                                              T*           dst,
-                                              const int    valid_word_num,
-                                              const int    batch_size,
-                                              const int    seq_len,
-                                              const int    head_num,
-                                              const int    size_per_head,
-                                              const int*   mask_offset,
-                                              const float* scale,
-                                              const int    int8_mode,
-                                              cudaStream_t stream)
+                                                     T*           dst,
+                                                     const int    valid_word_num,
+                                                     const int    batch_size,
+                                                     const int    seq_len,
+                                                     const int    head_num,
+                                                     const int    size_per_head,
+                                                     const int*   mask_offset,
+                                                     const float* scale,
+                                                     const int    int8_mode,
+                                                     cudaStream_t stream)
 {
 #ifdef ENABLE_BF16
     bool is_half2 = (std::is_same<T, half>::value || std::is_same<T, __nv_bfloat16>::value) && (size_per_head % 2 == 0);
@@ -304,6 +305,7 @@ void invokeTransposeAttentionOutRemovePadding(T*           src,
         transpose_remove_padding<<<valid_word_num, block_size, 0, stream>>>(
             src, dst, batch_size, seq_len, head_num, size_per_head, mask_offset, scale, int8_mode);
     }
+    TM_CUDA_CHECK(cudaGetLastError());
 }
 // clang-format on
 
@@ -368,6 +370,7 @@ void invokeAddRelativeAttentionBias(T*           qk_buf,
         addRelativeAttentionBias<<<grid, block, 0, stream>>>(
             qk_buf, relative_attention_bias, batch_size, head_num, seq_len);
     }
+    TM_CUDA_CHECK(cudaGetLastError());
 }
 
 #define INSTANTIATEADDRELATIVEATTENTIONBIAS(T)                                                                         \

--- a/src/turbomind/models/language_model.cc
+++ b/src/turbomind/models/language_model.cc
@@ -9,6 +9,7 @@
 #include "src/turbomind/core/context.h"
 #include "src/turbomind/core/copy.h"
 #include "src/turbomind/core/interval.h"
+#include "src/turbomind/core/scope.h"
 #include "src/turbomind/core/state.h"
 #include "src/turbomind/engine/batch.h"
 #include "src/turbomind/engine/request.h"
@@ -177,6 +178,7 @@ LanguageModel::Impl::Impl(const EngineParam& engine, const Context& ctx, const M
 
 Tensor LanguageModel::Impl::LookupEmbedding(const Buffer_<int>& input_ids, Buffer symm_buf)
 {
+    TM_FUNCTION_SCOPE();
     const auto st = core::Context::stream().handle();
 
     const int hidden_units = weights_.hidden_units;
@@ -194,7 +196,7 @@ Tensor LanguageModel::Impl::LookupEmbedding(const Buffer_<int>& input_ids, Buffe
 
     if (tp_size_ == 1) {
         invokeEmbeddingLookup(input_embeds, input_ids, embedding_table, st);
-        sync_check_cuda_error();
+        TM_CUDA_CHECK(cudaGetLastError());
     }
     else if (use_ag2d_) {
         const auto local_hidden_units = embedding_table.shape(1);
@@ -203,7 +205,7 @@ Tensor LanguageModel::Impl::LookupEmbedding(const Buffer_<int>& input_ids, Buffe
         Tensor local{temp.slice({0, tp_rank_, 0}, {-1, 1, -1}).squeeze(1)};
 
         invokeEmbeddingLookup(local, input_ids, embedding_table, st);
-        sync_check_cuda_error();
+        TM_CUDA_CHECK(cudaGetLastError());
 
         comm_.d_comm->AllGather2D(local.raw_data(),
                                   temp.raw_data(),
@@ -215,7 +217,7 @@ Tensor LanguageModel::Impl::LookupEmbedding(const Buffer_<int>& input_ids, Buffe
                                   {true, true},
                                   comm_.d_tp_group,
                                   st);
-        sync_check_cuda_error();
+        TM_CUDA_CHECK(cudaGetLastError());
 
         Copy(temp.buffer(), input_embeds.buffer());
     }
@@ -226,11 +228,11 @@ Tensor LanguageModel::Impl::LookupEmbedding(const Buffer_<int>& input_ids, Buffe
         Tensor local{temp.slice(tp_rank_).squeeze(0)};
 
         invokeEmbeddingLookup(local, input_ids, embedding_table, st);
-        sync_check_cuda_error();
+        TM_CUDA_CHECK(cudaGetLastError());
 
         comm_.d_comm->AllGather(
             local.raw_data(), temp.raw_data(), local.size(), weights_.data_type, comm_.d_tp_group, st);
-        sync_check_cuda_error();
+        TM_CUDA_CHECK(cudaGetLastError());
 
         invokeInPlaceTranspose102((uint16_t*)input_embeds.raw_data(),
                                   (uint16_t*)temp.raw_data(),
@@ -239,7 +241,7 @@ Tensor LanguageModel::Impl::LookupEmbedding(const Buffer_<int>& input_ids, Buffe
                                   local_hidden_units,
                                   false,
                                   st);
-        sync_check_cuda_error();
+        TM_CUDA_CHECK(cudaGetLastError());
     }
 
     return input_embeds;
@@ -247,6 +249,7 @@ Tensor LanguageModel::Impl::LookupEmbedding(const Buffer_<int>& input_ids, Buffe
 
 Tensor LanguageModel::Impl::PostEmbedding(const Tensor& features, Buffer symm_buf)
 {
+    TM_FUNCTION_SCOPE();
     NvtxScope scope("postDecodeEmbedding");
 
     const auto st = core::Context::stream().handle();
@@ -261,16 +264,14 @@ Tensor LanguageModel::Impl::PostEmbedding(const Tensor& features, Buffer symm_bu
 
     if (tp_size_ == 1) {
         Tensor logits{{bsz, vocab_size}, weights_.data_type, kDEVICE};
-        linear_.Forward(features, *weights_.output, logits);
-        sync_check_cuda_error();
+        TM_SCOPE_CALL(linear_.Forward(features, *weights_.output, logits));
         TM_DEBUG_TENSOR(logits, "logits", 1);
         return logits;
     }
     else if (use_ag2d_) {
         Tensor logits{symm_buf.view(weights_.data_type), {bsz, tp_size_, local_vocab_size}};
         Tensor local = logits.slice({0, tp_rank_, 0}, {-1, 1, -1});
-        linear_.Forward(features, *weights_.output, local.squeeze(1));
-        sync_check_cuda_error();
+        TM_SCOPE_CALL(linear_.Forward(features, *weights_.output, local.squeeze(1)));
         comm_.d_comm->AllGather2D(local.raw_data(),
                                   logits.raw_data(),
                                   vocab_size,
@@ -281,20 +282,19 @@ Tensor LanguageModel::Impl::PostEmbedding(const Tensor& features, Buffer symm_bu
                                   {true, true},
                                   comm_.d_tp_group,
                                   st);
-        sync_check_cuda_error();
+        TM_CUDA_CHECK(cudaGetLastError());
         return logits.view({bsz, -1});
     }
     else {
         Tensor logits{symm_buf.view(weights_.data_type), {tp_size_, bsz, local_vocab_size}};
         Tensor local = logits.slice({tp_rank_, 0, 0}, {1, -1, -1});
-        linear_.Forward(features, *weights_.output, local.squeeze(0));
-        sync_check_cuda_error();
+        TM_SCOPE_CALL(linear_.Forward(features, *weights_.output, local.squeeze(0)));
         comm_.d_comm->AllGather(local.raw_data(), logits.raw_data(), local.size(), local.dtype(), comm_.d_tp_group, st);
-        sync_check_cuda_error();
+        TM_CUDA_CHECK(cudaGetLastError());
         Tensor out{{bsz, vocab_size}, features.dtype(), features.device()};
         invokeTransposeAxis01(
             (uint16_t*)out.raw_data(), (uint16_t*)logits.raw_data(), tp_size_, bsz, local_vocab_size, st);
-        sync_check_cuda_error();
+        TM_CUDA_CHECK(cudaGetLastError());
         return out;
     }
 }
@@ -390,6 +390,7 @@ void LanguageModel::Impl::Prepare(int phase, TensorMap& env)
 
 void LanguageModel::Impl::Forward(int phase, TensorMap& env)
 {
+    TM_FUNCTION_SCOPE();
 
     auto& d = data_.at(phase);
     auto& b = *env.at("batch").data<BatchData*>()[0];

--- a/src/turbomind/models/linear_weight.cc
+++ b/src/turbomind/models/linear_weight.cc
@@ -162,14 +162,12 @@ void LinearWeight::prepare()
 
             if (bits == 4) {
                 extend_to_u16(tmp.data(), (const uint4_t*)weight.raw_data(), tmp.size(), stream);
-                sync_check_cuda_error();
             }
             else if (bits == 8) {
                 extend_to_u16(tmp.data(), (const uint8_t*)weight.raw_data(), tmp.size(), stream);
-                sync_check_cuda_error();
             }
             else if (bits == 16) {
-                check_cuda_error(
+                TM_CUDA_CHECK(
                     cudaMemcpyAsync(tmp.raw_data(), weight.raw_data(), weight.byte_size(), cudaMemcpyDefault, stream));
             }
 
@@ -202,9 +200,8 @@ void LinearWeight::prepare()
             }
             kd.pack = conv_w->pack;
 
-            check_cuda_error(cudaMemsetAsync(weight.raw_data(), 0, weight.byte_size(), stream));
+            TM_CUDA_CHECK(cudaMemsetAsync(weight.raw_data(), 0, weight.byte_size(), stream));
             TM_CHECK(conv_w->Convert(tmp.data(), w_desc, weight.raw_data(), kd, stream) == 0);
-            sync_check_cuda_error();
 
             kd.type = weight_format.dtype;
             if (is_A) {
@@ -242,7 +239,6 @@ void LinearWeight::prepare()
 
             if (data_type == kHalf && weight_format.dtype == kFloat4_e2m1) {
                 AdjustUe8m0ScaleForHalf(tmp_q.data<uint8_t>(), tmp_q.size(), stream);
-                sync_check_cuda_error();
             }
 
             int          gs = weight_format.block_sizes[0];  // K-axis, tensor-shape order
@@ -263,7 +259,6 @@ void LinearWeight::prepare()
             qd.pack         = pack_s;
 
             TM_CHECK(conv_s->Convert(tmp_q.raw_data(), s_desc, scales.raw_data(), qd, stream) == 0);
-            sync_check_cuda_error();
 
             if (is_A) {
                 qd = transpose(qd);

--- a/src/turbomind/models/llama/Barrier.h
+++ b/src/turbomind/models/llama/Barrier.h
@@ -2,8 +2,8 @@
 
 #pragma once
 
+#include "src/turbomind/core/check.h"
 #include "src/turbomind/core/logger.h"
-#include "src/turbomind/utils/cuda_utils.h"
 #ifndef _MSC_VER
 #include <pthread.h>
 #endif
@@ -17,7 +17,7 @@ public:
     Barrier(unsigned count)
     {
         TM_LOG_INFO("Barrier({})", (int)count);
-        FT_CHECK(count == 1);
+        TM_CHECK(count == 1);
     }
 
     Barrier(const Barrier&) = delete;

--- a/src/turbomind/models/llama/GatedDeltaNetLayer.cc
+++ b/src/turbomind/models/llama/GatedDeltaNetLayer.cc
@@ -3,6 +3,7 @@
 #include "src/turbomind/core/check.h"
 #include "src/turbomind/core/data_type.h"
 #include "src/turbomind/core/logger.h"
+#include "src/turbomind/core/scope.h"
 #include "src/turbomind/models/llama/SequenceManager.h"
 #include "src/turbomind/models/llama/gated_delta_net_kernels.h"
 #include "src/turbomind/utils/cuda_utils.h"
@@ -40,9 +41,9 @@ GatedDeltaNetLayer::GatedDeltaNetLayer(DataType                state_dtype,
     cudaDeviceGetAttribute(&sm_count_, cudaDevAttrMultiProcessorCount, device);
     work_counter_ = {1, kDEVICE};
 
-    check_cuda_error(cudaStreamCreateWithPriority(&aux_stream_, cudaStreamNonBlocking, -1));
-    check_cuda_error(cudaEventCreateWithFlags(&ev_before_, cudaEventDisableTiming));
-    check_cuda_error(cudaEventCreateWithFlags(&ev_after_, cudaEventDisableTiming));
+    TM_CUDA_CHECK(cudaStreamCreateWithPriority(&aux_stream_, cudaStreamNonBlocking, -1));
+    TM_CUDA_CHECK(cudaEventCreateWithFlags(&ev_before_, cudaEventDisableTiming));
+    TM_CUDA_CHECK(cudaEventCreateWithFlags(&ev_after_, cudaEventDisableTiming));
 }
 
 GatedDeltaNetLayer::~GatedDeltaNetLayer()
@@ -120,7 +121,7 @@ static int linear_layer_index(int layer_id, const std::vector<int>& layer_types)
 
 void GatedDeltaNetLayer::Forward(ForwardParam p)
 {
-    TM_LOG_DEBUG(__PRETTY_FUNCTION__);
+    TM_FUNCTION_SCOPE();
 
     const int token_num = p.input.shape(0);
     if (token_num == 0)
@@ -152,8 +153,8 @@ void GatedDeltaNetLayer::Forward(ForwardParam p)
         //    where the split dims are: conv_dim, value_dim, v_heads_tp, v_heads_tp
         // =================================================================
         const int v_heads_tp = num_v_heads;  // already TP-sharded
-        Tensor    all_proj   = linear_.Forward(p.input, *weights.in_proj_all);
-        sync_check_cuda_error();
+        Tensor    all_proj;
+        TM_SCOPE_CALL(linear_.Forward(p.input, *weights.in_proj_all, all_proj));
 
         // Column offsets per token (all_proj is token-major, row-major):
         //   [0, conv_dim)           -> mixed_qkv
@@ -181,6 +182,8 @@ void GatedDeltaNetLayer::Forward(ForwardParam p)
 
         ComputeBetaG_v2(beta, g, b, a, weights.A_log, weights.dt_bias, stream);
 
+        TM_CUDA_CHECK(cudaGetLastError());
+
         // =================================================================
         // 3. Process all requests at once via batched kernel launches
         // =================================================================
@@ -206,7 +209,7 @@ void GatedDeltaNetLayer::Forward(ForwardParam p)
                               sm_count_,
                               work_counter_.data(),
                               stream);
-        sync_check_cuda_error();
+        TM_CUDA_CHECK(cudaGetLastError());
 
         // ----- 3b. Gated Delta Rule -----
         // Requests are sorted by input_len: decode (seq_len==1) first, prefill last.
@@ -224,8 +227,8 @@ void GatedDeltaNetLayer::Forward(ForwardParam p)
 
             if (decode_count > 0 && prefill_count > 0) {
                 // Fork: aux_stream (high priority) waits for prior work on main stream
-                check_cuda_error(cudaEventRecord(ev_before_, stream));
-                check_cuda_error(cudaStreamWaitEvent(aux_stream_, ev_before_));
+                TM_CUDA_CHECK(cudaEventRecord(ev_before_, stream));
+                TM_CUDA_CHECK(cudaStreamWaitEvent(aux_stream_, ev_before_));
 
                 // Decode on main stream
                 auto dc_state = pd.recurrent_state_ptrs.slice(0, decode_count);
@@ -262,8 +265,8 @@ void GatedDeltaNetLayer::Forward(ForwardParam p)
                                                    aux_stream_);
 
                 // Join: main stream waits for prefill to finish
-                check_cuda_error(cudaEventRecord(ev_after_, aux_stream_));
-                check_cuda_error(cudaStreamWaitEvent(stream, ev_after_));
+                TM_CUDA_CHECK(cudaEventRecord(ev_after_, aux_stream_));
+                TM_CUDA_CHECK(cudaStreamWaitEvent(stream, ev_after_));
             }
             else if (decode_count > 0) {
                 auto state_slice = pd.recurrent_state_ptrs.slice(0, decode_count);
@@ -301,20 +304,19 @@ void GatedDeltaNetLayer::Forward(ForwardParam p)
                 // invokeChunkedGatedDeltaRuleBatched
             }
         }
-        sync_check_cuda_error();
+        TM_CUDA_CHECK(cudaGetLastError());
 
         // ----- 3c. RMSNormGated (all tokens at once) -----
         // Gate (z) lives at column conv_dim of all_proj with row-stride all_col.
         Tensor gate        = all_proj.slice({0, conv_dim}, {-1, value_dim});
         Tensor hidden_view = attn_out.view({token_num * num_v_heads, value_head_dim});
         invokeRMSNormGated(hidden_view, gate, weights.norm->weight, weights.norm->norm_eps_, stream);
-        sync_check_cuda_error();
+        TM_CUDA_CHECK(cudaGetLastError());
 
         // =================================================================
         // 4. Output projection (all tokens at once)
         // =================================================================
-        (void)linear_.Forward(attn_out, *weights.out_proj, p.output);
-        sync_check_cuda_error();
+        TM_SCOPE_CALL(linear_.Forward(attn_out, *weights.out_proj, p.output));
     };
 
     if (dtype == kHalf) {
@@ -324,7 +326,7 @@ void GatedDeltaNetLayer::Forward(ForwardParam p)
         dispatch(nv_bfloat16{});
     }
     else {
-        TM_CHECK(0) << "Unsupported dtype for GatedDeltaNetLayer";
+        TM_LOG_FATAL("Unsupported dtype for GatedDeltaNetLayer");
     }
 }
 

--- a/src/turbomind/models/llama/LlamaFfnLayer.cc
+++ b/src/turbomind/models/llama/LlamaFfnLayer.cc
@@ -18,6 +18,7 @@
 // Modified from https://github.com/NVIDIA/FasterTransformer/blob/main/src/fastertransformer/layers/FfnLayer.h
 
 #include "src/turbomind/models/llama/LlamaFfnLayer.h"
+#include "src/turbomind/core/scope.h"
 #include "src/turbomind/kernels/activation.h"
 #include "src/turbomind/models/llama/llama_utils.h"
 #include "src/turbomind/utils/anomaly_handler.h"
@@ -26,6 +27,8 @@ namespace turbomind {
 
 void LlamaFfnLayer::forward(ForwardParam param)
 {
+    TM_FUNCTION_SCOPE();
+
     NvtxScope scope("ffn");
 
     const auto& mlp = *param.weights;
@@ -43,8 +46,8 @@ void LlamaFfnLayer::forward(ForwardParam param)
     bool  use_fused = fused && fused->weight;
 
     if (use_fused) {
-        auto mix = linear_.Forward(param.input, *fused);
-        sync_check_cuda_error();
+        Tensor mix;
+        TM_SCOPE_CALL(linear_.Forward(param.input, *fused, mix));
 
         gating = mix.slice({0, 0}, {(int)token_num, inter_size});
         if (!mlp.is_fused_silu) {
@@ -52,12 +55,10 @@ void LlamaFfnLayer::forward(ForwardParam param)
         }
     }
     else {
-        gating = linear_.Forward(param.input, *mlp.w1);
-        sync_check_cuda_error();
+        TM_SCOPE_CALL(linear_.Forward(param.input, *mlp.w1, gating));
         TM_DEBUG_TENSOR(gating, Concat("w1", layer_id), 3);
 
-        inter = linear_.Forward(param.input, *mlp.w3);
-        sync_check_cuda_error();
+        TM_SCOPE_CALL(linear_.Forward(param.input, *mlp.w3, inter));
         TM_DEBUG_TENSOR(inter, Concat("w3", layer_id), 3);
     }
 
@@ -66,14 +67,13 @@ void LlamaFfnLayer::forward(ForwardParam param)
     if (!use_fused || !mlp.is_fused_silu) {
         // gate' = silu(gate) * up
         Activation(gating, inter, mlp.act_type, stream);
-        sync_check_cuda_error();
+        TM_CUDA_CHECK(cudaGetLastError());
         TM_DEBUG_TENSOR(gating, Concat("act", layer_id), 3);
     }
 
     {  // w2(x)
         NvtxScope scope("w2");
-        linear_.Forward(gating, *mlp.w2, param.output);
-        sync_check_cuda_error();
+        TM_SCOPE_CALL(linear_.Forward(gating, *mlp.w2, param.output));
     }
 }
 

--- a/src/turbomind/models/llama/LlamaLinear.cu
+++ b/src/turbomind/models/llama/LlamaLinear.cu
@@ -5,6 +5,7 @@
 #include "src/turbomind/core/core.h"
 #include "src/turbomind/core/cuda_data_type.h"
 #include "src/turbomind/core/data_type.h"
+#include "src/turbomind/core/scope.h"
 
 #include "src/turbomind/kernels/gemm/gemm.h"
 #include "src/turbomind/kernels/gemm/moe_utils_v2.h"
@@ -33,11 +34,11 @@ struct LlamaLinear::Impl {
 
         auto st = core::Context::stream().handle();
 
-        check_cuda_error(cudaMallocAsync(&workspace_.barriers, workspace_.barriers_size, st));
-        check_cuda_error(cudaMallocAsync(&workspace_.partials, workspace_.partials_size, st));
-        check_cuda_error(cudaMallocAsync(&workspace_.tensormaps, workspace_.partials_size, st));
-        check_cuda_error(cudaMemsetAsync(workspace_.barriers, 0, workspace_.barriers_size, st));
-        check_cuda_error(cudaMallocAsync(&workspace_.flags, sizeof(int), st));
+        TM_CUDA_CHECK(cudaMallocAsync(&workspace_.barriers, workspace_.barriers_size, st));
+        TM_CUDA_CHECK(cudaMallocAsync(&workspace_.partials, workspace_.partials_size, st));
+        TM_CUDA_CHECK(cudaMallocAsync(&workspace_.tensormaps, workspace_.partials_size, st));
+        TM_CUDA_CHECK(cudaMemsetAsync(workspace_.barriers, 0, workspace_.barriers_size, st));
+        TM_CUDA_CHECK(cudaMallocAsync(&workspace_.flags, sizeof(int), st));
 
         core::Context::stream().Sync();
     }
@@ -74,8 +75,7 @@ struct LlamaLinear::Impl {
 
         // Currently, FP8 only; INT8 may be added later
         if (input.dtype() != weight.input_dtype()) {
-            QuantizeSymm(A, U, input, st);
-            sync_check_cuda_error();
+            TM_SCOPE_CALL(QuantizeSymm(A, U, input, st));
         }
         else {
             A = input;
@@ -87,12 +87,10 @@ struct LlamaLinear::Impl {
             const auto [bsz, k] = A.shapes(0, 1);
             const int e         = indices.size() / bsz;
             Tensor    A_e       = {{m, k}, A.dtype(), kDEVICE};
-            invokeMoeDispatch(A_e, A, indices.data(), e, st);
-            sync_check_cuda_error();
+            TM_SCOPE_CALL(invokeMoeDispatch(A_e, A, indices.data(), e, st));
             if (U) {
                 Tensor U_e;
-                invokeMoeDispatchScales(U_e, U, indices.data(), e, st);
-                sync_check_cuda_error();
+                TM_SCOPE_CALL(invokeMoeDispatchScales(U_e, U, indices.data(), e, st));
                 U = U_e;
             }
             A       = A_e;
@@ -121,6 +119,7 @@ struct LlamaLinear::Impl {
                  const Buffer_<int>& indices,
                  const Buffer_<int>& offsets)
     {
+        TM_FUNCTION_SCOPE();
         using namespace gemm;
 
         Operation op{};
@@ -185,29 +184,26 @@ struct LlamaLinear::Impl {
 
 LlamaLinear::LlamaLinear(): impl_{std::make_shared<Impl>()} {}
 
-Tensor LlamaLinear::Forward(const Tensor&         input,  //
-                            const LinearWeight&   weight,
-                            std::optional<Tensor> output)
+void LlamaLinear::Forward(const Tensor&       input,  //
+                          const LinearWeight& weight,
+                          Ref<Tensor>         output)
 {
-    return Forward(input, weight, {}, {}, output);
+    Forward(input, weight, {}, {}, output);
 }
 
-Tensor LlamaLinear::Forward(const Tensor&         input,  //
-                            const LinearWeight&   weight,
-                            const Buffer_<int>&   indices,
-                            const Buffer_<int>&   offsets,
-                            std::optional<Tensor> output)
+void LlamaLinear::Forward(const Tensor&       input,  //
+                          const LinearWeight& weight,
+                          const Buffer_<int>& indices,
+                          const Buffer_<int>& offsets,
+                          Ref<Tensor>         output)
 {
     Tensor in = input.view({-1, input.shape(-1)});
-    Tensor out;
 
-    if (output) {
-        out = output->view({-1, output->shape(-1)});
+    if (output.get()) {
+        output.get() = output.get().view({-1, output.get().shape(-1)});
     }
 
-    impl_->Forward(out, in, weight, indices, offsets);
-
-    return out;
+    impl_->Forward(output.get(), in, weight, indices, offsets);
 }
 
 void LlamaLinear::set_measure(bool measure)

--- a/src/turbomind/models/llama/LlamaLinear.h
+++ b/src/turbomind/models/llama/LlamaLinear.h
@@ -14,15 +14,15 @@ class LlamaLinear {
 public:
     explicit LlamaLinear();
 
-    Tensor Forward(const Tensor&         input,  //
-                   const LinearWeight&   weight,
-                   std::optional<Tensor> output = {});
+    void Forward(const Tensor&       input,  //
+                 const LinearWeight& weight,
+                 Ref<Tensor>         output);
 
-    Tensor Forward(const Tensor&         input,
-                   const LinearWeight&   weight,
-                   const Buffer_<int>&   indices,
-                   const Buffer_<int>&   offsets,
-                   std::optional<Tensor> output = {});
+    void Forward(const Tensor&       input,
+                 const LinearWeight& weight,
+                 const Buffer_<int>& indices,
+                 const Buffer_<int>& offsets,
+                 Ref<Tensor>         output);
 
     void set_measure(bool measure);
 

--- a/src/turbomind/models/llama/SequenceManager.cc
+++ b/src/turbomind/models/llama/SequenceManager.cc
@@ -129,8 +129,8 @@ SequenceManager::SequenceManager(int                     head_dim,
             TM_LOG_ERROR("[SeqMgr] Linear-state memory ({:.2f} MB) >= cache budget ({:.2f} MB). ",
                          linear_bytes / (1024. * 1024.),
                          target_bytes / (1024. * 1024.));
-            TM_CHECK(0)
-                << "Please decrease max_batch_size to reduce total linear state size or increase cache_max_entry_count.";
+            TM_LOG_FATAL(
+                "Please decrease max_batch_size to reduce total linear state size or increase cache_max_entry_count.");
         }
         const size_t cache_bytes = target_bytes - linear_bytes;
         block_count              = static_cast<double>(cache_bytes) / static_cast<double>(block_size);

--- a/src/turbomind/models/llama/bench_conv1d_silu.cc
+++ b/src/turbomind/models/llama/bench_conv1d_silu.cc
@@ -11,6 +11,7 @@
 #include "src/turbomind/core/core.h"
 #include "src/turbomind/kernels/gemm/test/test_utils.h"
 #include "src/turbomind/models/llama/gated_delta_net_kernels.h"
+#include "src/turbomind/utils/cuda_utils.h"
 
 using namespace turbomind;
 using namespace turbomind::core;
@@ -236,18 +237,18 @@ int main(int argc, char** argv)
     stream.Sync();
 
     auto launch_v2 = [&] {
-        invokeFusedConv1dSiLU(out_v2,
-                              all_proj,
-                              weight,
-                              Tensor{},
-                              state_ptrs_v2_dev,
-                              q_offsets_dev,
-                              k_offsets_dev,
-                              batch_size,
-                              0,
-                              sm_count,
-                              work_counter.data(),
-                              cu_stream);
+        TM_SCOPE_CALL(invokeFusedConv1dSiLU(out_v2,
+                                            all_proj,
+                                            weight,
+                                            Tensor{},
+                                            state_ptrs_v2_dev,
+                                            q_offsets_dev,
+                                            k_offsets_dev,
+                                            batch_size,
+                                            0,
+                                            sm_count,
+                                            work_counter.data(),
+                                            cu_stream));
     };
 
     // === Benchmark ===

--- a/src/turbomind/models/llama/bench_gated_delta_net.cc
+++ b/src/turbomind/models/llama/bench_gated_delta_net.cc
@@ -8,6 +8,7 @@
 #include "src/turbomind/core/core.h"
 #include "src/turbomind/kernels/gemm/test/test_utils.h"
 #include "src/turbomind/models/llama/gated_delta_net_kernels.h"
+#include "src/turbomind/utils/cuda_utils.h"
 
 using namespace turbomind;
 using namespace turbomind::core;
@@ -203,37 +204,37 @@ int main(int argc, char** argv)
     // --- Benchmark recurrent (v2) kernel ---
     printf("\n=== Benchmarks ===\n");
     auto launch_v2 = [&] {
-        invokeGatedDeltaRuleBatched_v2(v_out_v2,
-                                       qkv_in,
-                                       beta,
-                                       g,
-                                       state_ptrs_v2_dev,
-                                       q_offsets_dev,
-                                       batch_size,
-                                       num_k_heads,
-                                       0,
-                                       state_dtype,
-                                       sm_count,
-                                       work_counter,
-                                       cu_stream);
+        TM_SCOPE_CALL(invokeGatedDeltaRuleBatched_v2(v_out_v2,
+                                                     qkv_in,
+                                                     beta,
+                                                     g,
+                                                     state_ptrs_v2_dev,
+                                                     q_offsets_dev,
+                                                     batch_size,
+                                                     num_k_heads,
+                                                     0,
+                                                     state_dtype,
+                                                     sm_count,
+                                                     work_counter,
+                                                     cu_stream));
     };
     float v2_ms = benchmark_kernel("invokeGatedDeltaRuleBatched_v2", launch_v2, cu_stream, args.warmup, args.iters);
 
     // --- Benchmark chunked kernel ---
     auto launch_chunked = [&] {
-        invokeChunkedGatedDeltaRuleBatched(v_out_chunked,
-                                           qkv_in,
-                                           beta,
-                                           g,
-                                           state_ptrs_chunked_dev,
-                                           q_offsets_dev,
-                                           batch_size,
-                                           num_k_heads,
-                                           0,
-                                           state_dtype,
-                                           sm_count,
-                                           work_counter,
-                                           cu_stream);
+        TM_SCOPE_CALL(invokeChunkedGatedDeltaRuleBatched(v_out_chunked,
+                                                         qkv_in,
+                                                         beta,
+                                                         g,
+                                                         state_ptrs_chunked_dev,
+                                                         q_offsets_dev,
+                                                         batch_size,
+                                                         num_k_heads,
+                                                         0,
+                                                         state_dtype,
+                                                         sm_count,
+                                                         work_counter,
+                                                         cu_stream));
     };
     float chunked_ms =
         benchmark_kernel("invokeChunkedGatedDeltaRuleBatched", launch_chunked, cu_stream, args.warmup, args.iters);
@@ -241,19 +242,19 @@ int main(int argc, char** argv)
     // --- Benchmark v3 persistent decode kernel (seq_len == 1 only) ---
     float v3_ms     = -1.f;
     auto  launch_v3 = [&] {
-        invokeGatedDeltaRuleBatched_v3(v_out_v3,
-                                       qkv_in,
-                                       beta,
-                                       g,
-                                       state_ptrs_v3_dev,
-                                       q_offsets_dev,
-                                       batch_size,
-                                       num_k_heads,
-                                       0,
-                                       state_dtype,
-                                       sm_count,
-                                       work_counter,
-                                       cu_stream);
+        TM_SCOPE_CALL(invokeGatedDeltaRuleBatched_v3(v_out_v3,
+                                                     qkv_in,
+                                                     beta,
+                                                     g,
+                                                     state_ptrs_v3_dev,
+                                                     q_offsets_dev,
+                                                     batch_size,
+                                                     num_k_heads,
+                                                     0,
+                                                     state_dtype,
+                                                     sm_count,
+                                                     work_counter,
+                                                     cu_stream));
     };
     if (is_decode) {
         v3_ms = benchmark_kernel(

--- a/src/turbomind/models/llama/context.h
+++ b/src/turbomind/models/llama/context.h
@@ -46,7 +46,7 @@ struct Context {
     {
         core::ContextGuard guard{core_stream};
         linear = std::make_unique<LlamaLinear>();
-        check_cuda_error(cudaGetDeviceProperties(&device_prop, device_id));
+        TM_CUDA_CHECK(cudaGetDeviceProperties(&device_prop, device_id));
     }
 };
 

--- a/src/turbomind/models/llama/gated_delta_net_kernels.cu
+++ b/src/turbomind/models/llama/gated_delta_net_kernels.cu
@@ -306,6 +306,7 @@ void invokeGatedDeltaRuleBatched_v2(Ref<Tensor>           v_out_,
         }
     };
     TM_DISPATCH_PRIMARY_DTYPES(v_out.dtype(), invoke);
+    TM_CUDA_CHECK(cudaGetLastError());
 }
 
 // =============================================================================
@@ -544,6 +545,7 @@ void invokeGatedDeltaRuleBatched_v3(Ref<Tensor>           v_out_,
             launch(T{});
     };
     TM_DISPATCH_PRIMARY_DTYPES(v_out.dtype(), invoke);
+    TM_CUDA_CHECK(cudaGetLastError());
 }
 
 // =============================================================================
@@ -914,6 +916,7 @@ void invokeChunkedGatedDeltaRuleBatched(Ref<Tensor>           v_out_,
         }
     };
     TM_DISPATCH_PRIMARY_DTYPES(v_out.dtype(), invoke);
+    TM_CUDA_CHECK(cudaGetLastError());
 }
 
 template<class T>
@@ -980,6 +983,7 @@ void ComputeBetaG_v2(Ref<Tensor>   beta_out_,
     };
 
     TM_DISPATCH_PRIMARY_DTYPES(beta_out.dtype(), invoke);
+    TM_CUDA_CHECK(cudaGetLastError());
 }
 
 // =============================================================================
@@ -1049,6 +1053,7 @@ void invokeRMSNormGated(Ref<Tensor> hidden_, const Tensor& gate, const Tensor& w
             hidden.data<T>(), gate.data<T>(), weight.data<T>(), eps, N, head_dim, gate_stride, num_heads);
     };
     TM_DISPATCH_PRIMARY_DTYPES(hidden.dtype(), invoke);
+    TM_CUDA_CHECK(cudaGetLastError());
 }
 
 // =============================================================================
@@ -1297,10 +1302,11 @@ void invokeFusedConv1dSiLU(Ref<Tensor>           out_,
                 launch(std::integral_constant<int, 1>{});
         }
         else {
-            TM_CHECK(0) << "Only d_conv == 4 is supported by fused_conv1d_batched_kernel_v2";
+            TM_LOG_FATAL("Only d_conv == 4 is supported by fused_conv1d_batched_kernel_v2");
         }
     };
     TM_DISPATCH_PRIMARY_DTYPES(out.dtype(), invoke);
+    TM_CUDA_CHECK(cudaGetLastError());
 }
 
 }  // namespace turbomind

--- a/src/turbomind/models/llama/llama_kernels.cu
+++ b/src/turbomind/models/llama/llama_kernels.cu
@@ -57,6 +57,7 @@ void invokeGatherOutput(int*         output_ids,
     int grid_size  = batch_size;
     gatherOutput<<<grid_size, block_size, 0, stream>>>(
         output_ids, ids, context_length, max_context_len, max_gen_step, max_output_len, batch_size);
+    TM_CUDA_CHECK(cudaGetLastError());
 }
 
 __global__ void updateOutput(int**      request_output_ids_ptrs,
@@ -104,6 +105,7 @@ void invokeUpdateOutput(int**        request_output_ids_ptrs,
                                                        request_output_ids_lens,
                                                        max_session_len,
                                                        token_generated);
+    TM_CUDA_CHECK(cudaGetLastError());
 }
 
 template<int BLOCK_DIM>
@@ -152,6 +154,7 @@ void invokeCompactOutputIds(int*         cu_output_ids,
     constexpr int BLOCK_DIM = 128;
     compactOutputIds<BLOCK_DIM><<<batch_size, BLOCK_DIM, 0, stream>>>(
         cu_output_ids, output_ids, sequence_lengths, max_session_len, token_generated);
+    TM_CUDA_CHECK(cudaGetLastError());
 }
 
 template<int N, int C>
@@ -201,7 +204,7 @@ void invokeIndexedCopyImpl(void**       h_src_ptr,
             std::copy_n(h_dst_ptr, N, param.dst_ptr.data());
             std::transform(h_elem_sz, h_elem_sz + N, param.stride.data(), [](int size) {
                 // Basic alignment check
-                FT_CHECK_WITH_INFO(size % sizeof(T) == 0, fmtstr("misalignment: %d %% %d", size, (int)sizeof(T)));
+                TM_CHECK(size % sizeof(T) == 0) << fmtstr("misalignment: %d %% %d", size, (int)sizeof(T));
                 return size / sizeof(T);
             });
             param.max_stride = *std::max_element(param.stride.begin(), param.stride.end());
@@ -215,6 +218,7 @@ void invokeIndexedCopyImpl(void**       h_src_ptr,
                 indexedCopy<T><<<batch_size, 128, 0, st>>>(param);
             }
         });
+    TM_CUDA_CHECK(cudaGetLastError());
 }
 
 void invokeIndexedCopy(void**       h_src_ptr,
@@ -233,7 +237,8 @@ void invokeIndexedCopy(void**       h_src_ptr,
         }
         return false;
     });
-    FT_CHECK(success);
+    TM_CHECK(success);
+    TM_CUDA_CHECK(cudaGetLastError());
 }
 
 __global__ void padLastTokenIds(int* token_ids, const int* context_length, int max_context_len, int batch_size)
@@ -247,6 +252,7 @@ void invokePadLastTokenIds(
     int* token_ids, const int* context_length, int max_context_len, int batch_size, cudaStream_t stream)
 {
     padLastTokenIds<<<1, 512, 0, stream>>>(token_ids, context_length, max_context_len, batch_size);
+    TM_CUDA_CHECK(cudaGetLastError());
 }
 
 template<typename T>
@@ -263,6 +269,7 @@ void invokeGetFeatureOfLastToken(
     uint16_t* output, const uint16_t* input, const int* cu_seqlens, int dims, int batch_size, cudaStream_t stream)
 {
     getFeatureOfLastToken<<<batch_size, 256, 0, stream>>>(output, input, cu_seqlens, dims);
+    TM_CUDA_CHECK(cudaGetLastError());
 }
 
 template<class T, int C>
@@ -323,7 +330,7 @@ void invokeBatchedCopy(void** src_ptr, void** dst_ptr, int* size, int count, cud
                 for (int i = 0; i < bsz; ++i) {
                     params.src_ptr[i] = (T*)src_ptr[c + i];
                     params.dst_ptr[i] = (T*)dst_ptr[c + i];
-                    FT_CHECK(size[c + i] % sizeof(T) == 0);
+                    TM_CHECK(size[c + i] % sizeof(T) == 0);
                     params.size[i] = size[c + i] / sizeof(T);
                 }
                 const int max_size = *std::max_element(params.size.begin(), params.size.end());
@@ -333,6 +340,7 @@ void invokeBatchedCopy(void** src_ptr, void** dst_ptr, int* size, int count, cud
                     BatchedCopyLauncher<BatchedCopyParam<T, C>>{max_size, count, &params, st});
             }
         });
+    TM_CUDA_CHECK(cudaGetLastError());
 }
 
 template<typename T>
@@ -350,6 +358,7 @@ template<typename T>
 void invokeMask(T* output, const int* mask, int batch_size, int dim, cudaStream_t stream)
 {
     maskOutput<<<batch_size, 1024, 0, stream>>>(output, mask, dim);
+    TM_CUDA_CHECK(cudaGetLastError());
 }
 
 #ifdef ENABLE_FP32
@@ -413,14 +422,14 @@ void invokeCastFloat2D(const core::Tensor& src, core::Tensor& dst, cudaStream_t 
     auto dispatch_t = [&](auto vec_size) {
         switch (src.dtype()) {
             case kFloat32:
-                return invoke(float{}, vec_size);
+                invoke(float{}, vec_size);
                 break;
             case kFloat16:
-                return invoke(half{}, vec_size);
+                invoke(half{}, vec_size);
                 break;
 #ifdef ENABLE_BF16
             case kBfloat16:
-                return invoke(__nv_bfloat16{}, vec_size);
+                invoke(__nv_bfloat16{}, vec_size);
                 break;
 #endif
             default:
@@ -429,14 +438,15 @@ void invokeCastFloat2D(const core::Tensor& src, core::Tensor& dst, cudaStream_t 
     };
 
     if (channels % 4 == 0) {
-        return dispatch_t(std::integral_constant<int, 4>{});
+        dispatch_t(std::integral_constant<int, 4>{});
     }
     else if (channels % 2 == 0) {
-        return dispatch_t(std::integral_constant<int, 2>{});
+        dispatch_t(std::integral_constant<int, 2>{});
     }
     else {
-        return dispatch_t(std::integral_constant<int, 1>{});
+        dispatch_t(std::integral_constant<int, 1>{});
     }
+    TM_CUDA_CHECK(cudaGetLastError());
 }
 
 template<class T>
@@ -483,8 +493,9 @@ void CollectHiddenStates(const Tensor& src, const Buffer_<int>& idxs, Ref<Tensor
         invoke(ushort{});
     }
     else {
-        TM_CHECK(0) << "unsupported byte stride: " << stride;
+        TM_LOG_FATAL("unsupported byte stride: {}", stride);
     }
+    TM_CUDA_CHECK(cudaGetLastError());
 }
 
 template<int BLOCK_DIM, int MAX_COUNT>
@@ -539,6 +550,7 @@ void BatchPrefixSum(const int** srcs, const int* ns, int** dsts, int count, cuda
     const int     grid  = count;
 
     BatchPrefixSumKernel<block><<<grid, block, 0, st>>>(p_srcs, p_ns, p_dsts);
+    TM_CUDA_CHECK(cudaGetLastError());
 }
 
 __global__ void AppendTokenIdsKernel(int** token_ids_ptrs, const int* output_ids, const int* positions, int batch_size)
@@ -557,6 +569,7 @@ void AppendTokenIds(
     constexpr int block = 128;
     const int     grid  = cdiv(batch_size, block);
     AppendTokenIdsKernel<<<grid, block, 0, stream>>>(token_ids_ptrs, output_ids, positions, batch_size);
+    TM_CUDA_CHECK(cudaGetLastError());
 }
 
 template<typename T>
@@ -586,6 +599,7 @@ void invokeSigmoidGateMultiply(
     };
 
     TM_DISPATCH_PRIMARY_DTYPES(dtype, invoke);
+    TM_CUDA_CHECK(cudaGetLastError());
 }
 
 }  // namespace turbomind

--- a/src/turbomind/models/llama/llama_utils.cu
+++ b/src/turbomind/models/llama/llama_utils.cu
@@ -27,7 +27,7 @@ void CheckNan(const T* ptr, size_t size, std::string key, cudaStream_t stream)
     std::vector<T> h_data(size);
     cudaMemcpyAsync(h_data.data(), ptr, sizeof(T) * size, cudaMemcpyDefault, stream);
 
-    check_cuda_error(cudaStreamSynchronize(stream));
+    TM_CUDA_CHECK(cudaStreamSynchronize(stream));
 
     size_t nan_cnt = 0;
     for (const auto& x : h_data) {
@@ -62,8 +62,8 @@ void CmpRead(T* ptr, size_t size, std::string key, cudaStream_t stream)
         ifs.read((char*)h_a.data(), sizeof(T) * h_a.size());
     }
     std::vector<T> h_b(size);
-    check_cuda_error(cudaMemcpyAsync(h_b.data(), ptr, sizeof(T) * size, cudaMemcpyDefault, stream));
-    check_cuda_error(cudaStreamSynchronize(stream));
+    TM_CUDA_CHECK(cudaMemcpyAsync(h_b.data(), ptr, sizeof(T) * size, cudaMemcpyDefault, stream));
+    TM_CUDA_CHECK(cudaStreamSynchronize(stream));
 
     using Tacc         = std::conditional_t<std::is_integral_v<T>, int64_t, float>;
     constexpr Tacc eps = std::is_integral_v<T> ? 1 : 1e-8f;
@@ -92,8 +92,8 @@ void CmpRead(T* ptr, size_t size, std::string key, cudaStream_t stream)
             (float)asum / (float)size,
             (float)rsum / (float)size);
 
-    check_cuda_error(cudaMemcpyAsync(ptr, h_a.data(), sizeof(T) * h_a.size(), cudaMemcpyDefault, stream));
-    check_cuda_error(cudaStreamSynchronize(stream));
+    TM_CUDA_CHECK(cudaMemcpyAsync(ptr, h_a.data(), sizeof(T) * h_a.size(), cudaMemcpyDefault, stream));
+    TM_CUDA_CHECK(cudaStreamSynchronize(stream));
 }
 
 template<typename T>
@@ -101,8 +101,8 @@ void CmpWrite(T* ptr, size_t size, std::string key, cudaStream_t stream)
 {
     std::vector<T> a(size);
     // copy a to host
-    check_cuda_error(cudaMemcpyAsync(a.data(), ptr, sizeof(T) * size, cudaMemcpyDefault, stream));
-    check_cuda_error(cudaStreamSynchronize(stream));
+    TM_CUDA_CHECK(cudaMemcpyAsync(a.data(), ptr, sizeof(T) * size, cudaMemcpyDefault, stream));
+    TM_CUDA_CHECK(cudaStreamSynchronize(stream));
     // write to file
     {
         std::ofstream ofs("tmp/" + key + ".cmp", std::ios::binary);

--- a/src/turbomind/models/llama/mla_utils.cu
+++ b/src/turbomind/models/llama/mla_utils.cu
@@ -3,9 +3,11 @@
 #include <cuda_bf16.h>
 
 #include "src/turbomind/core/check.h"
+#include "src/turbomind/core/scope.h"
 #include "src/turbomind/kernels/core/array_ops.h"
 #include "src/turbomind/kernels/core/common.h"
 #include "src/turbomind/kernels/core/math.h"
+#include "src/turbomind/utils/cuda_utils.h"
 
 namespace turbomind {
 
@@ -70,6 +72,7 @@ void invokeMLACopyQKV(T*           qkv,
 
     mla_copy_qkv_kernel<T, vec_size>
         <<<grid, block, 0, stream>>>(qkv, q, kv_a_k_pe, head_num, head_dim, kv_lora_rank, rope_dim);
+    TM_CUDA_CHECK(cudaGetLastError());
 }
 
 void MLACopyQKV(DataType     dtype,
@@ -84,13 +87,13 @@ void MLACopyQKV(DataType     dtype,
 {
     auto invoke = [&](auto t) {
         using T = decltype(t);
-        invokeMLACopyQKV(
-            (T*)qkv, (const T*)q, (const T*)kv_a_k_pe, token_num, head_num, kv_lora_rank, rope_dim, stream);
+        TM_SCOPE_CALL(invokeMLACopyQKV(
+            (T*)qkv, (const T*)q, (const T*)kv_a_k_pe, token_num, head_num, kv_lora_rank, rope_dim, stream));
     };
 
     TM_CHECK_EQ(byte_size(dtype, 1), 2) << "unsupported data type: " << dtype;
 
-    return invoke(uint16_t{});
+    invoke(uint16_t{});
 }
 
 }  // namespace turbomind

--- a/src/turbomind/models/llama/moe_ffn_layer.cc
+++ b/src/turbomind/models/llama/moe_ffn_layer.cc
@@ -3,6 +3,7 @@
 #include <cuda_runtime.h>
 
 #include "src/turbomind/core/context.h"
+#include "src/turbomind/core/scope.h"
 #include "src/turbomind/kernels/activation.h"
 #include "src/turbomind/kernels/norm/rms_norm.h"
 
@@ -49,18 +50,20 @@ void MoeFfnLayer::Init(ForwardParam& p)
 
 Tensor_<float> MoeFfnLayer::Gate(const Tensor& input, const LinearWeight& gate)
 {
+    TM_FUNCTION_SCOPE();
+
     auto& w = gate.weight;
     TM_CHECK_EQ(input.shape(1), w.shape(0));
     Tensor_<float> logits{{input.shape(0), w.shape(1)}, kDEVICE};
-    linear_.Forward(input, gate, logits);
-    sync_check_cuda_error();
+    TM_SCOPE_CALL(linear_.Forward(input, gate, logits));
     ApplyBias(logits, gate.bias, core::Context::stream().handle());
-    sync_check_cuda_error();
+    TM_CUDA_CHECK(cudaGetLastError());
     return logits;
 }
 
 void MoeFfnLayer::Forward(ForwardParam& p)
 {
+    TM_FUNCTION_SCOPE();
     if (!initialized_) {
         Init(p);
     }
@@ -76,7 +79,7 @@ void MoeFfnLayer::Forward(ForwardParam& p)
     const size_t padded     = (tokens + kMoeGateVecSize - 1) / kMoeGateVecSize * kMoeGateVecSize;
     const int    expert_num = moe.num_experts();
 
-    FT_CHECK(expert_num);
+    TM_CHECK(expert_num);
 
     auto logits = Gate(p.input, *moe.gate.get());
 
@@ -112,13 +115,13 @@ void MoeFfnLayer::Forward(ForwardParam& p)
     }
     else {
         // V2: accum must be cleared by caller; masks cleared internally
-        check_cuda_error(cudaMemsetAsync(accum_.data(), 0, sizeof(int) * expert_num * kMoeGateMaxTiles, st));
+        TM_CUDA_CHECK(cudaMemsetAsync(accum_.data(), 0, sizeof(int) * expert_num * kMoeGateMaxTiles, st));
 
         bool softmax = true;
         if (p.weights->topk_method == "group_limited_greedy") {
             invokeMoeSoftmaxMaskTopKGroups(
                 logits.data(), tokens, expert_num, expert_num / p.weights->n_group, p.weights->topk_group, st);
-            sync_check_cuda_error();
+            TM_CUDA_CHECK(cudaGetLastError());
             softmax = false;
         }
 
@@ -140,7 +143,7 @@ void MoeFfnLayer::Forward(ForwardParam& p)
                          p.weights->routed_scale,
                          st);
     }
-    sync_check_cuda_error();
+    TM_CUDA_CHECK(cudaGetLastError());
 
     if (is_warm_up_) {
         std::mt19937     g;
@@ -153,7 +156,7 @@ void MoeFfnLayer::Forward(ForwardParam& p)
         for (int i = 0; i < expert_num; ++i) {
             h_offsets_[i + 1] = h_offsets_[i] + cnt[i];
         }
-        check_cuda_error(
+        TM_CUDA_CHECK(
             cudaMemcpyAsync(offsets_.data(), h_offsets_.data(), sizeof(int) * (expert_num + 1), cudaMemcpyDefault, st));
     }
 
@@ -164,30 +167,28 @@ void MoeFfnLayer::Forward(ForwardParam& p)
 
     if (block.w1w3) {
         // Fused w1w3 path
-        Tensor inter = linear_.Forward(p.input, *block.w1w3, indices, offsets_);
-        sync_check_cuda_error();
+        Tensor inter;
+        TM_SCOPE_CALL(linear_.Forward(p.input, *block.w1w3, indices, offsets_, inter));
 
         if (!block.is_fused_silu) {
             Activation(inter, block.w1w3->bias, f2E_, block.act_type, st);
-            sync_check_cuda_error();
+            TM_CUDA_CHECK(cudaGetLastError());
         }
 
-        linear_.Forward(inter.slice({0, 0}, {-1, inter_size}), *block.w2, {}, offsets, temp_);
-        sync_check_cuda_error();
+        TM_SCOPE_CALL(linear_.Forward(inter.slice({0, 0}, {-1, inter_size}), *block.w2, {}, offsets, temp_));
     }
     else {
         // Separate w1/w3 path
-        Tensor gating = linear_.Forward(p.input, *block.w1, indices, offsets_);
-        sync_check_cuda_error();
+        Tensor gating;
+        TM_SCOPE_CALL(linear_.Forward(p.input, *block.w1, indices, offsets_, gating));
 
-        Tensor up = linear_.Forward(p.input, *block.w3, indices, offsets_);
-        sync_check_cuda_error();
+        Tensor up;
+        TM_SCOPE_CALL(linear_.Forward(p.input, *block.w3, indices, offsets_, up));
 
         Activation(gating, up, block.act_type, st);
-        sync_check_cuda_error();
+        TM_CUDA_CHECK(cudaGetLastError());
 
-        linear_.Forward(gating, *block.w2, {}, offsets, temp_);
-        sync_check_cuda_error();
+        TM_SCOPE_CALL(linear_.Forward(gating, *block.w2, {}, offsets, temp_));
     }
 
     if (moe.shared_gate) {
@@ -197,6 +198,7 @@ void MoeFfnLayer::Forward(ForwardParam& p)
 
 void MoeFfnLayer::Combine(ForwardParam& p)
 {
+    TM_FUNCTION_SCOPE();
     auto& moe = *p.weights;
 
     invokeMoeCombine(p.output,
@@ -210,7 +212,7 @@ void MoeFfnLayer::Combine(ForwardParam& p)
                      1.f / tp_size_,
                      p.scale,
                      core::Context::stream().handle());
-    sync_check_cuda_error();
+    TM_CUDA_CHECK(cudaGetLastError());
 
     temp_          = {};
     shared_scales_ = {};

--- a/src/turbomind/models/llama/unified_attention_layer.cc
+++ b/src/turbomind/models/llama/unified_attention_layer.cc
@@ -46,6 +46,7 @@
 #include "src/turbomind/models/llama/unified_attention_layer.h"
 
 #include "src/turbomind/core/logger.h"
+#include "src/turbomind/core/scope.h"
 #include "src/turbomind/utils/anomaly_handler.h"
 #include "src/turbomind/utils/cuda_utils.h"
 
@@ -83,9 +84,9 @@ struct AttentionData {
 UnifiedAttentionLayer::~UnifiedAttentionLayer()
 {
 
-    check_cuda_error(cudaEventDestroy(aux_event_));
-    check_cuda_error(cudaEventDestroy(qkv_event_));
-    check_cuda_error(cudaStreamDestroy(aux_stream_));
+    TM_CUDA_CHECK(cudaEventDestroy(aux_event_));
+    TM_CUDA_CHECK(cudaEventDestroy(qkv_event_));
+    TM_CUDA_CHECK(cudaStreamDestroy(aux_stream_));
 
     aux_event_ = qkv_event_ = {};
     aux_stream_             = {};
@@ -112,9 +113,9 @@ UnifiedAttentionLayer::UnifiedAttentionLayer(int                           quant
     TM_CHECK(!attn_weights.empty()) << "attn_weights must not be empty";
     TM_CHECK(attn_weights[0]) << "attn_weights[0] must not be null";
 
-    check_cuda_error(cudaStreamCreateWithFlags(&aux_stream_, cudaStreamNonBlocking));
-    check_cuda_error(cudaEventCreateWithFlags(&qkv_event_, cudaEventDisableTiming));
-    check_cuda_error(cudaEventCreateWithFlags(&aux_event_, cudaEventDisableTiming));
+    TM_CUDA_CHECK(cudaStreamCreateWithFlags(&aux_stream_, cudaStreamNonBlocking));
+    TM_CUDA_CHECK(cudaEventCreateWithFlags(&qkv_event_, cudaEventDisableTiming));
+    TM_CUDA_CHECK(cudaEventCreateWithFlags(&aux_event_, cudaEventDisableTiming));
 
     init_rope_kernel_param(rope_, rope_param_);
 
@@ -304,7 +305,7 @@ void UnifiedAttentionLayer::Setup(int phase, TensorMap& env)
 
 void UnifiedAttentionLayer::Forward(ForwardParam p)
 {
-    TM_LOG_DEBUG("{}", __PRETTY_FUNCTION__);
+    TM_FUNCTION_SCOPE();
 
     /////////////////////////////////////////////
     /// parse inputs
@@ -330,8 +331,7 @@ void UnifiedAttentionLayer::Forward(ForwardParam p)
 
     if (weights.w_qkv && weights.w_qkv->output_dim) {
         // [token_num, hidden_dim] -> [token_num, local_q_kv_head_num, head_dim]
-        qkv = linear_.Forward(p.input, *weights.w_qkv);
-        sync_check_cuda_error();
+        TM_SCOPE_CALL(linear_.Forward(p.input, *weights.w_qkv, qkv));
 
         qk_norm(qkv, weights);
     }
@@ -367,7 +367,7 @@ void UnifiedAttentionLayer::Forward(ForwardParam p)
                                   q_count,
                                   qkv.dtype(),
                                   stream);
-        sync_check_cuda_error();
+        TM_CUDA_CHECK(cudaGetLastError());
     }
 
     TM_DEBUG_TENSOR(attn, Concat("attn", layer_id), 3);
@@ -378,13 +378,13 @@ void UnifiedAttentionLayer::Forward(ForwardParam p)
 
     //////////////////////////////////////////////
     /// output gemm <Bs,HD> -> <Bs,HD>
-    (void)linear_.Forward(attn, *weights.wo, p.output);
-    sync_check_cuda_error();
+    TM_SCOPE_CALL(linear_.Forward(attn, *weights.wo, p.output));
 }
 
 template<class T>
 Tensor UnifiedAttentionLayer::core_attention(Tensor& qkv, const ForwardParam& p, const WeightType& weights)
 {
+    TM_FUNCTION_SCOPE();
     const int tp_size           = weights.tp_size;
     const int local_head_num    = weights.head_num / tp_size;
     const int local_kv_head_num = weights.kv_head_num / tp_size;
@@ -559,8 +559,8 @@ Tensor UnifiedAttentionLayer::core_attention(Tensor& qkv, const ForwardParam& p,
 
     if (d.decode.n && d.prefill.n) {
         pf_stream = aux_stream_;
-        check_cuda_error(cudaEventRecord(qkv_event_, stream));
-        check_cuda_error(cudaStreamWaitEvent(aux_stream_, qkv_event_));
+        TM_CUDA_CHECK(cudaEventRecord(qkv_event_, stream));
+        TM_CUDA_CHECK(cudaStreamWaitEvent(aux_stream_, qkv_event_));
     }
 
     if (d.prefill.n && !is_warm_up_) {
@@ -570,14 +570,14 @@ Tensor UnifiedAttentionLayer::core_attention(Tensor& qkv, const ForwardParam& p,
         auto params = CreateParams(offset, d.prefill, 1, pf_stream);
         if constexpr (sizeof(T) == 2) {
             invokeProcessKV_v2_(params);
-            sync_check_cuda_error();
+            TM_CUDA_CHECK(cudaGetLastError());
 
             /// TODO: skip flattening for `sm_80`
             invokeFlattenKV_v2_(params, d.prefill.k_sum);
-            sync_check_cuda_error();
+            TM_CUDA_CHECK(cudaGetLastError());
 
             dispatchAttention(params);
-            sync_check_cuda_error();
+            TM_CUDA_CHECK(cudaGetLastError());
         }
     }
 
@@ -585,13 +585,13 @@ Tensor UnifiedAttentionLayer::core_attention(Tensor& qkv, const ForwardParam& p,
         auto params = CreateParams(0, d.decode, kMaxKVSplits, dc_stream);
         if constexpr (sizeof(T) == 2) {
             dispatchDecoding<T>(params);
-            sync_check_cuda_error();
+            TM_CUDA_CHECK(cudaGetLastError());
         }
     }
 
     if (d.decode.n && d.prefill.n) {
-        check_cuda_error(cudaEventRecord(aux_event_, aux_stream_));
-        check_cuda_error(cudaStreamWaitEvent(stream, aux_event_));
+        TM_CUDA_CHECK(cudaEventRecord(aux_event_, aux_stream_));
+        TM_CUDA_CHECK(cudaStreamWaitEvent(stream, aux_event_));
     }
 
     if (is_warm_up_) {
@@ -604,6 +604,7 @@ Tensor UnifiedAttentionLayer::core_attention(Tensor& qkv, const ForwardParam& p,
 
 Tensor UnifiedAttentionLayer::forward_mla(const Tensor& hidden_state, const WeightType& w)
 {
+    TM_FUNCTION_SCOPE();
 
     const int tp_size           = w.tp_size;
     const int local_head_num    = w.head_num / tp_size;
@@ -622,26 +623,24 @@ Tensor UnifiedAttentionLayer::forward_mla(const Tensor& hidden_state, const Weig
     const auto stream = core::Context::stream().handle();
 
     if (w.q_proj && w.q_proj->weight) {
-        q = linear_.Forward(hidden_state, *w.q_proj);
-        sync_check_cuda_error();
+        TM_SCOPE_CALL(linear_.Forward(hidden_state, *w.q_proj, q));
     }
     else {
-        Tensor q_a = linear_.Forward(hidden_state, *w.q_a_proj);
-        sync_check_cuda_error();
+        Tensor q_a;
+        TM_SCOPE_CALL(linear_.Forward(hidden_state, *w.q_a_proj, q_a));
 
         invokeRMSNorm(q_a, q_a, w.q_a_layernorm->weight, w.q_a_layernorm->norm_eps_, stream);
-        sync_check_cuda_error();
+        TM_CUDA_CHECK(cudaGetLastError());
 
-        q = linear_.Forward(q_a, *w.q_b_proj);
-        sync_check_cuda_error();
+        TM_SCOPE_CALL(linear_.Forward(q_a, *w.q_b_proj, q));
     }
 
-    Tensor kv_a_k_pe = linear_.Forward(hidden_state, *w.kv_a_proj);
-    sync_check_cuda_error();
+    Tensor kv_a_k_pe;
+    TM_SCOPE_CALL(linear_.Forward(hidden_state, *w.kv_a_proj, kv_a_k_pe));
 
     auto kv_a = kv_a_k_pe.slice({0, 0}, {-1, kv_lora_rank});
     invokeRMSNorm(kv_a, kv_a, w.kv_a_layernorm->weight, w.kv_a_layernorm->norm_eps_, stream);
-    sync_check_cuda_error();
+    TM_CUDA_CHECK(cudaGetLastError());
 
     const int local_q_kv_head_num = local_head_num + 1 * local_kv_head_num;
 
@@ -655,7 +654,7 @@ Tensor UnifiedAttentionLayer::forward_mla(const Tensor& hidden_state, const Weig
                kv_lora_rank,
                qk_rope_dim,
                stream);
-    sync_check_cuda_error();
+    TM_CUDA_CHECK(cudaGetLastError());
 
     return qkv;
 }
@@ -675,8 +674,8 @@ void UnifiedAttentionLayer::qk_norm(Tensor& qkv, const WeightType& weights)
 
     const auto stream = core::Context::stream().handle();
 
-    check_cuda_error(cudaEventRecord(qkv_event_, stream));
-    check_cuda_error(cudaStreamWaitEvent(aux_stream_, qkv_event_));
+    TM_CUDA_CHECK(cudaEventRecord(qkv_event_, stream));
+    TM_CUDA_CHECK(cudaStreamWaitEvent(aux_stream_, qkv_event_));
 
     const auto token_num = qkv.shape(0);
 
@@ -684,14 +683,14 @@ void UnifiedAttentionLayer::qk_norm(Tensor& qkv, const WeightType& weights)
 
     auto q = qkv3.slice({0, 0, 0}, {-1, local_head_num, -1});
     invokeRMSNormQK(q, weights.q_norm->weight, weights.q_norm->norm_eps_, stream);
-    sync_check_cuda_error();
+    TM_CUDA_CHECK(cudaGetLastError());
 
     auto k = qkv3.slice({0, local_head_num, 0}, {-1, local_kv_head_num, -1});
     invokeRMSNormQK(k, weights.k_norm->weight, weights.k_norm->norm_eps_, aux_stream_);
-    sync_check_cuda_error();
+    TM_CUDA_CHECK(cudaGetLastError());
 
-    check_cuda_error(cudaEventRecord(aux_event_, aux_stream_));
-    check_cuda_error(cudaStreamWaitEvent(stream, aux_event_));
+    TM_CUDA_CHECK(cudaEventRecord(aux_event_, aux_stream_));
+    TM_CUDA_CHECK(cudaStreamWaitEvent(stream, aux_event_));
 }
 
 }  // namespace turbomind

--- a/src/turbomind/models/llama/unified_decoder.cc
+++ b/src/turbomind/models/llama/unified_decoder.cc
@@ -6,6 +6,7 @@
 #include <cuda_runtime.h>
 
 #include "src/turbomind/core/allocator.h"
+#include "src/turbomind/core/scope.h"
 #include "src/turbomind/kernels/core/math.h"
 #include "src/turbomind/kernels/norm/rms_norm.h"
 #include "src/turbomind/models/decoder_layer_weight.h"
@@ -126,7 +127,7 @@ void UnifiedDecoder::AllreduceResidualRMSnorm(Tensor&       hidden_states,
                                                 group1,
                                                 local_token_nums,
                                                 stream);
-        sync_check_cuda_error();
+        TM_CUDA_CHECK(cudaGetLastError());
     }
     else if (d_comm_) {
         d_comm_->AllreduceResidualBiasRMSnorm(hidden_states.raw_data(),
@@ -139,7 +140,7 @@ void UnifiedDecoder::AllreduceResidualRMSnorm(Tensor&       hidden_states,
                                               dtype,
                                               0,
                                               stream);
-        sync_check_cuda_error();
+        TM_CUDA_CHECK(cudaGetLastError());
     }
     else {
         invokeResidualBiasRMSNorm(hidden_states.raw_data(),
@@ -151,12 +152,13 @@ void UnifiedDecoder::AllreduceResidualRMSnorm(Tensor&       hidden_states,
                                   token_num,
                                   eps,
                                   stream);
-        sync_check_cuda_error();
+        TM_CUDA_CHECK(cudaGetLastError());
     }
 }
 
 void UnifiedDecoder::Forward(int phase, TensorMap& args, const std::vector<WeightType*>& weights)
 {
+    TM_FUNCTION_SCOPE();
     /**
      * input tensors:
      *   \param decoder_input [token_num, hidden_units], float
@@ -222,7 +224,7 @@ void UnifiedDecoder::Forward(int phase, TensorMap& args, const std::vector<Weigh
                   weights.at(0)->attention_norm->norm_eps_,
                   stream);
 
-    sync_check_cuda_error();
+    TM_CUDA_CHECK(cudaGetLastError());
 
     TM_DEBUG_TENSOR(local_hidden_states, Concat("norm0", 0), 2);
 
@@ -230,6 +232,9 @@ void UnifiedDecoder::Forward(int phase, TensorMap& args, const std::vector<Weigh
     // core::ContextGuard ctx{Allocator{stack_alloc}};
 
     for (int layer = 0; layer < layer_num_; ++layer) {
+
+        std::string _tm_layer_name = Concat("layer", layer);
+        TM_SCOPE(_tm_layer_name.c_str());
 
         // stack_alloc->iter();
 
@@ -315,7 +320,7 @@ void UnifiedDecoder::Forward(int phase, TensorMap& args, const std::vector<Weigh
                                  0,
                                  attn_tp_group_,
                                  local_token_nums.data());
-        sync_check_cuda_error();
+        TM_CUDA_CHECK(cudaGetLastError());
 
         TM_DEBUG_TENSOR(local_residual, Concat("residual1", layer), 2);
         TM_DEBUG_TENSOR(local_hidden_states, Concat("norm0", layer + 1), 2);

--- a/src/turbomind/python/bind.cpp
+++ b/src/turbomind/python/bind.cpp
@@ -242,27 +242,27 @@ static void safe_memcpy(void* dst, const void* src, size_t size)
 {
     cudaPointerAttributes dat{};
     cudaPointerAttributes sat{};
-    ft::check_cuda_error(cudaPointerGetAttributes(&dat, dst));
-    ft::check_cuda_error(cudaPointerGetAttributes(&sat, src));
+    TM_CUDA_CHECK(cudaPointerGetAttributes(&dat, dst));
+    TM_CUDA_CHECK(cudaPointerGetAttributes(&sat, src));
     try {
         if (dat.devicePointer && sat.devicePointer) {
             // Both can be accessed from current context
-            ft::check_cuda_error(cudaMemcpy(dst, src, size, cudaMemcpyDefault));
+            TM_CUDA_CHECK(cudaMemcpy(dst, src, size, cudaMemcpyDefault));
         }
         else if (dat.type == cudaMemoryTypeDevice && sat.type == cudaMemoryTypeDevice) {
             if (dat.device != sat.device) {
                 // On different devices, try peer memcpy
-                ft::check_cuda_error(cudaMemcpyPeer(dst, dat.device, src, sat.device, size));
+                TM_CUDA_CHECK(cudaMemcpyPeer(dst, dat.device, src, sat.device, size));
             }
             else {
                 // Same device, switch to the device first (this is unlikely)
                 ft::CudaDeviceGuard guard(dat.device);
-                ft::check_cuda_error(cudaMemcpy(dst, src, size, cudaMemcpyDefault));
+                TM_CUDA_CHECK(cudaMemcpy(dst, src, size, cudaMemcpyDefault));
             }
         }
         else {
             // Unknown case, give it a try anyway
-            ft::check_cuda_error(cudaMemcpy(dst, src, size, cudaMemcpyDefault));
+            TM_CUDA_CHECK(cudaMemcpy(dst, src, size, cudaMemcpyDefault));
         }
     }
     catch (...) {

--- a/src/turbomind/turbomind.cc
+++ b/src/turbomind/turbomind.cc
@@ -90,11 +90,11 @@ struct TurboMind::Impl {
     void ProcessWeights(int index)
     {
         CudaDeviceGuard dev_guard(engine_param_.devices[index]);
-        FT_CHECK(weights_[index] != nullptr);
+        TM_CHECK(weights_[index] != nullptr);
 
         auto ctx_guard = weights_[index]->context();
         weights_[index]->prepare();
-        sync_check_cuda_error();
+        TM_CUDA_CHECK(cudaGetLastError());
     }
 
     void CreateEngine(int index);
@@ -165,7 +165,7 @@ TurboMind::Impl::Impl(string model_dir, EngineConfig config, FFICtxFactory ffi_c
     }
 
     comm_size_ = engine_param_.attn_dp_size * engine_param_.attn_tp_size * engine_param_.attn_cp_size;
-    FT_CHECK(engine_param_.mlp_tp_size == comm_size_);
+    TM_CHECK(engine_param_.mlp_tp_size == comm_size_);
 
     communicator_type_ = std::move(config.communicator);
 

--- a/src/turbomind/utils/anomaly_handler.cu
+++ b/src/turbomind/utils/anomaly_handler.cu
@@ -200,8 +200,8 @@ struct AnomalyHandler::Impl {
                 TM_LOG_WARN("fallback: {}", fallback_);
             }
 
-            FT_CHECK(0 <= fallback_);
-            FT_CHECK(fallback_ < vocab_size);
+            TM_CHECK(0 <= fallback_);
+            TM_CHECK(fallback_ < vocab_size);
 
             TM_LOG_WARN("max_batch_size: {}", max_batch_size);
             TM_LOG_WARN("vocab_size: {}", vocab_size);
@@ -211,19 +211,19 @@ struct AnomalyHandler::Impl {
     void Summarize(std::function<void(const int*, int)> handler)
     {
         if (g_level) {
-            check_cuda_error(cudaMemcpyAsync(h_count_.data(),
-                                             d_count_.data().get(),
-                                             sizeof(size_type) * info_.size() * 2,
-                                             cudaMemcpyDefault,
-                                             stream_));
+            TM_CUDA_CHECK(cudaMemcpyAsync(h_count_.data(),
+                                          d_count_.data().get(),
+                                          sizeof(size_type) * info_.size() * 2,
+                                          cudaMemcpyDefault,
+                                          stream_));
 
-            check_cuda_error(cudaMemcpyAsync(h_is_anomaly_.data(),
-                                             d_is_anomaly_.data().get(),
-                                             sizeof(int) * batch_size_,
-                                             cudaMemcpyDefault,
-                                             stream_));
+            TM_CUDA_CHECK(cudaMemcpyAsync(h_is_anomaly_.data(),
+                                          d_is_anomaly_.data().get(),
+                                          sizeof(int) * batch_size_,
+                                          cudaMemcpyDefault,
+                                          stream_));
 
-            check_cuda_error(cudaStreamSynchronize(stream_));
+            TM_CUDA_CHECK(cudaStreamSynchronize(stream_));
 
 #if 0
             int die = 0;
@@ -251,14 +251,13 @@ struct AnomalyHandler::Impl {
         if (g_level) {
             if (!info_.empty()) {
                 std::fill_n(h_count_.data(), info_.size() * 2, 0);
-                check_cuda_error(
-                    cudaMemsetAsync(d_count_.data().get(), 0, sizeof(size_type) * info_.size() * 2, stream_));
+                TM_CUDA_CHECK(cudaMemsetAsync(d_count_.data().get(), 0, sizeof(size_type) * info_.size() * 2, stream_));
                 info_.clear();
             }
 
             if (batch_size_) {
                 std::fill_n(h_is_anomaly_.data(), batch_size_, 0);
-                check_cuda_error(cudaMemsetAsync(d_is_anomaly_.data().get(), 0, sizeof(int) * batch_size_, stream_));
+                TM_CUDA_CHECK(cudaMemsetAsync(d_is_anomaly_.data().get(), 0, sizeof(int) * batch_size_, stream_));
                 batch_size_ = 0;
             }
         }
@@ -268,7 +267,7 @@ struct AnomalyHandler::Impl {
     void invokeCountAndFixAnomaly(T* data, int64_t size, const std::string& key, int level)
     {
         if (g_level && level <= g_level) {
-            FT_CHECK(size >= 0);
+            TM_CHECK(size >= 0);
 
             constexpr int block = 512;
             const int     grid  = (size + block - 1) / block;
@@ -278,7 +277,7 @@ struct AnomalyHandler::Impl {
 
             info_.push_back(key);
 
-            FT_CHECK(info_.size() <= max_entries);
+            TM_CHECK(info_.size() <= max_entries);
 
             CountAndFixAnormaly<T, block><<<grid, block, 0, stream_>>>(data,  //
                                                                        size,
@@ -287,16 +286,15 @@ struct AnomalyHandler::Impl {
                                                                        g_pinf_val_,
                                                                        g_ninf_val_,
                                                                        g_nan_val_);
-
-            sync_check_cuda_error();
         }
+        TM_CUDA_CHECK(cudaGetLastError());
     }
 
     template<class T>
     void invokeFixLogitsAnomaly(T* logits, int batch_size, int level)
     {
         if (g_level && level <= g_level) {
-            FT_CHECK(batch_size <= max_batch_size_);
+            TM_CHECK(batch_size <= max_batch_size_);
 
             batch_size_ = batch_size;
 
@@ -307,9 +305,8 @@ struct AnomalyHandler::Impl {
                                                                           vocab_size_,
                                                                           batch_size,
                                                                           fallback_);
-
-            sync_check_cuda_error();
         }
+        TM_CUDA_CHECK(cudaGetLastError());
     }
 
     static int   g_level;
@@ -372,7 +369,7 @@ void AnomalyHandler::Reset()
 template<class T>
 void AnomalyHandler::CountAndFix(T* data, int64_t size, std::string key, int level)
 {
-    return impl_->invokeCountAndFixAnomaly(data, size, key, level);
+    impl_->invokeCountAndFixAnomaly(data, size, key, level);
 }
 
 template void AnomalyHandler::CountAndFix(float*, int64_t, std::string, int);

--- a/src/turbomind/utils/cuda_utils.cc
+++ b/src/turbomind/utils/cuda_utils.cc
@@ -15,28 +15,25 @@
  */
 
 #include "src/turbomind/utils/cuda_utils.h"
+#include "src/turbomind/core/scope.h"
 #include "src/turbomind/macro.h"
 #include <driver_types.h>
 #include <regex>
 
 namespace turbomind {
 
-void syncAndCheck(const char* const file, int const line)
+void ReportCudaError(cudaError_t ec, const char* file, int line)
 {
-    // When FT_DEBUG_LEVEL=DEBUG, must check error
-    static char* level_name = std::getenv("TM_DEBUG_LEVEL");
-    if (level_name != nullptr) {
-        static std::string level = std::string(level_name);
-        if (level == "DEBUG") {
-            cudaDeviceSynchronize();
-            cudaError_t result = cudaGetLastError();
-            if (result) {
-                TM_LOG_FATAL("CUDA runtime error: {} {}:{}", _cudaGetErrorEnum(result), file, line);
-                std::abort();
-            }
-            TM_LOG_DEBUG("run syncAndCheck at {}:{}", file, line);
-        }
-    }
+    core::Scope _("TM_CUDA_CHECK", file, line);
+    core::Logger::Instance().LogFatalImpl(file, line, fmt::format("CUDA error: {}", cudaGetErrorString(ec)));
+}
+
+void ReportCuDrvError(CUresult ec, const char* file, int line)
+{
+    core::Scope _("TM_CUDRV_CHECK", file, line);
+    const char* str{};
+    cuGetErrorString(ec, &str);
+    core::Logger::Instance().LogFatalImpl(file, line, fmt::format("CUDA Driver error: {}", str ? str : "Unknown"));
 }
 
 /* **************************** debug tools ********************************* */
@@ -48,7 +45,7 @@ void printMatrix(T* ptr, int m, int k, int stride, bool is_device_ptr)
     if (is_device_ptr) {
         // k < stride ; stride = col-dimension.
         tmp = reinterpret_cast<T*>(malloc(m * stride * sizeof(T)));
-        check_cuda_error(cudaMemcpy(tmp, ptr, sizeof(T) * m * stride, cudaMemcpyDeviceToHost));
+        TM_CUDA_CHECK(cudaMemcpy(tmp, ptr, sizeof(T) * m * stride, cudaMemcpyDeviceToHost));
         cudaDeviceSynchronize();
     }
     else {
@@ -91,7 +88,7 @@ void printMatrix(unsigned long long* ptr, int m, int k, int stride, bool is_devi
     if (is_device_ptr) {
         // k < stride ; stride = col-dimension.
         tmp = reinterpret_cast<T*>(malloc(m * stride * sizeof(T)));
-        check_cuda_error(cudaMemcpy(tmp, ptr, sizeof(T) * m * stride, cudaMemcpyDeviceToHost));
+        TM_CUDA_CHECK(cudaMemcpy(tmp, ptr, sizeof(T) * m * stride, cudaMemcpyDeviceToHost));
         cudaDeviceSynchronize();
     }
     else {
@@ -128,7 +125,7 @@ void printMatrix(int* ptr, int m, int k, int stride, bool is_device_ptr)
     if (is_device_ptr) {
         // k < stride ; stride = col-dimension.
         tmp = reinterpret_cast<T*>(malloc(m * stride * sizeof(T)));
-        check_cuda_error(cudaMemcpy(tmp, ptr, sizeof(T) * m * stride, cudaMemcpyDeviceToHost));
+        TM_CUDA_CHECK(cudaMemcpy(tmp, ptr, sizeof(T) * m * stride, cudaMemcpyDeviceToHost));
         cudaDeviceSynchronize();
     }
     else {
@@ -167,7 +164,7 @@ void printMatrix(size_t* ptr, int m, int k, int stride, bool is_device_ptr)
     if (is_device_ptr) {
         // k < stride ; stride = col-dimension.
         tmp = reinterpret_cast<T*>(malloc(m * stride * sizeof(T)));
-        check_cuda_error(cudaMemcpy(tmp, ptr, sizeof(T) * m * stride, cudaMemcpyDeviceToHost));
+        TM_CUDA_CHECK(cudaMemcpy(tmp, ptr, sizeof(T) * m * stride, cudaMemcpyDeviceToHost));
         cudaDeviceSynchronize();
     }
     else {
@@ -244,51 +241,51 @@ template void check_abs_mean_val(const __nv_bfloat16* result, const int size);
 int getSMVersion()
 {
     int device{-1};
-    check_cuda_error(cudaGetDevice(&device));
+    TM_CUDA_CHECK(cudaGetDevice(&device));
     int sm_major = 0;
     int sm_minor = 0;
-    check_cuda_error(cudaDeviceGetAttribute(&sm_major, cudaDevAttrComputeCapabilityMajor, device));
-    check_cuda_error(cudaDeviceGetAttribute(&sm_minor, cudaDevAttrComputeCapabilityMinor, device));
+    TM_CUDA_CHECK(cudaDeviceGetAttribute(&sm_major, cudaDevAttrComputeCapabilityMajor, device));
+    TM_CUDA_CHECK(cudaDeviceGetAttribute(&sm_minor, cudaDevAttrComputeCapabilityMinor, device));
     return sm_major * 10 + sm_minor;
 }
 
 int getSMCount()
 {
     int device{-1};
-    check_cuda_error(cudaGetDevice(&device));
+    TM_CUDA_CHECK(cudaGetDevice(&device));
     int sm_count{};
-    check_cuda_error(cudaDeviceGetAttribute(&sm_count, cudaDevAttrMultiProcessorCount, device));
+    TM_CUDA_CHECK(cudaDeviceGetAttribute(&sm_count, cudaDevAttrMultiProcessorCount, device));
     return sm_count;
 }
 
 std::string getDeviceName()
 {
     int device{-1};
-    check_cuda_error(cudaGetDevice(&device));
+    TM_CUDA_CHECK(cudaGetDevice(&device));
     cudaDeviceProp props;
-    check_cuda_error(cudaGetDeviceProperties(&props, device));
+    TM_CUDA_CHECK(cudaGetDeviceProperties(&props, device));
     return std::string(props.name);
 }
 
 int getDevice()
 {
     int current_dev_id = 0;
-    check_cuda_error(cudaGetDevice(&current_dev_id));
+    TM_CUDA_CHECK(cudaGetDevice(&current_dev_id));
     return current_dev_id;
 }
 
 int getDeviceCount()
 {
     int count = 0;
-    check_cuda_error(cudaGetDeviceCount(&count));
+    TM_CUDA_CHECK(cudaGetDeviceCount(&count));
     return count;
 }
 
 void trim_default_mempool(int device_id)
 {
     cudaMemPool_t mempool;
-    check_cuda_error(cudaDeviceGetDefaultMemPool(&mempool, device_id));
-    check_cuda_error(cudaMemPoolTrimTo(mempool, 0));
+    TM_CUDA_CHECK(cudaDeviceGetDefaultMemPool(&mempool, device_id));
+    TM_CUDA_CHECK(cudaMemPoolTrimTo(mempool, 0));
 }
 
 /* ************************** end of common utils ************************** */

--- a/src/turbomind/utils/cuda_utils.h
+++ b/src/turbomind/utils/cuda_utils.h
@@ -80,30 +80,24 @@ static const char* _cudaGetErrorEnum(cublasStatus_t error)
     return "<unknown>";
 }
 
-template<typename T>
-void check(T result, char const* const func, const char* const file, int const line)
-{
-    if (result) {
-        TM_LOG_ERROR("CUDA runtime error: {} {}:{}", _cudaGetErrorEnum(result), file, line);
-        std::abort();
-    }
-}
+// --- Unified CUDA error checking ---
 
-#define check_cuda_error(val) check((val), #val, __FILE__, __LINE__)
-#define check_cuda_error_2(val, file, line) check((val), #val, file, line)
+void ReportCudaError(cudaError_t ec, const char* file, int line);
+void ReportCuDrvError(CUresult ec, const char* file, int line);
 
-void syncAndCheck(const char* const file, int const line);
+#define TM_CUDA_CHECK(expr)                                                                                            \
+    do {                                                                                                               \
+        if (auto _ec = (expr); TM_UNLIKELY(_ec != cudaSuccess)) {                                                      \
+            ::turbomind::ReportCudaError(_ec, __FILE__, __LINE__);                                                     \
+        }                                                                                                              \
+    } while (0)
 
-#define sync_check_cuda_error() syncAndCheck(__FILE__, __LINE__)
-
-#define CUDRVCHECK(expr)                                                                                               \
-    if (auto ec = expr; ec != CUDA_SUCCESS) {                                                                          \
-        const char* p_str{};                                                                                           \
-        cuGetErrorString(ec, &p_str);                                                                                  \
-        p_str    = p_str ? p_str : "Unknown error";                                                                    \
-        auto msg = fmt::format("[TM][ERROR] CUDA driver error: {}:{} '{}'", __FILE__, __LINE__, p_str);                \
-        throw std::runtime_error(msg.c_str());                                                                         \
-    }
+#define TM_CUDRV_CHECK(expr)                                                                                           \
+    do {                                                                                                               \
+        if (auto _ec = (expr); TM_UNLIKELY(_ec != CUDA_SUCCESS)) {                                                     \
+            ::turbomind::ReportCuDrvError(_ec, __FILE__, __LINE__);                                                    \
+        }                                                                                                              \
+    } while (0)
 
 template<typename T>
 void printMatrix(T* ptr, int m, int k, int stride, bool is_device_ptr);
@@ -122,30 +116,6 @@ void check_abs_mean_val(const T* result, const int size);
     do {                                                                                                               \
         std::cout << "[TM][CALL] " << __FUNCTION__ << " " << std::endl;                                                \
     } while (0)
-
-[[noreturn]] inline void throwRuntimeError(const char* const file, int const line, std::string const& info = "")
-{
-    throw std::runtime_error(std::string("[TM][ERROR] ") + info + " Assertion fail: " + file + ":"
-                             + std::to_string(line) + " \n");
-}
-
-inline void myAssert(bool result, const char* const file, int const line, std::string const& info = "")
-{
-    if (!result) {
-        throwRuntimeError(file, line, info);
-    }
-}
-
-#define FT_CHECK(val) myAssert(bool(val), __FILE__, __LINE__)
-#define FT_CHECK_WITH_INFO(val, info)                                                                                  \
-    do {                                                                                                               \
-        bool is_valid_val = bool(val);                                                                                 \
-        if (!is_valid_val) {                                                                                           \
-            turbomind::myAssert(is_valid_val, __FILE__, __LINE__, (info));                                             \
-        }                                                                                                              \
-    } while (0)
-
-#define FT_THROW(info) throwRuntimeError(__FILE__, __LINE__, info)
 
 /* ***************************** common utils ****************************** */
 
@@ -169,15 +139,15 @@ class CudaDeviceGuard {
 public:
     CudaDeviceGuard(int device)
     {
-        check_cuda_error(cudaGetDevice(&last_device_id_));
+        TM_CUDA_CHECK(cudaGetDevice(&last_device_id_));
         if (device != last_device_id_) {
-            check_cuda_error(cudaSetDevice(device));
+            TM_CUDA_CHECK(cudaSetDevice(device));
         }
     }
 
     ~CudaDeviceGuard()
     {
-        TM_CHECK_EQ(cudaSetDevice(last_device_id_), cudaSuccess);
+        TM_CUDA_CHECK(cudaSetDevice(last_device_id_));
     }
 
 private:

--- a/src/turbomind/utils/memory_utils.cu
+++ b/src/turbomind/utils/memory_utils.cu
@@ -47,11 +47,12 @@ void invokeInPlaceTranspose102(
     // Note that this kernel is used for pre-processing and not very efficient.
     const size_t count = dim0 * dim1 * dim2;
     if (copy) {
-        check_cuda_error(cudaMemcpyAsync(workspace, data, sizeof(T) * count, cudaMemcpyDefault, stream));
+        TM_CUDA_CHECK(cudaMemcpyAsync(workspace, data, sizeof(T) * count, cudaMemcpyDefault, stream));
     }
     const int block = 512;
     const int grid  = std::min((count + block - 1) / block, (size_t)8192);
     transpose102<<<grid, block, 0, stream>>>(data, workspace, dim0, dim1, dim2);
+    TM_CUDA_CHECK(cudaGetLastError());
 }
 
 template void invokeInPlaceTranspose102(uint16_t*    data,


### PR DESCRIPTION

- Add TM_CUDA_CHECK / TM_CUDRV_CHECK unified error macros
- Migrate all FT_CHECK, check_cuda_error, sync_check_cuda_error sites
- Make all kernel invoke* wrappers return cudaError_t with [[nodiscard]]
- Add RAII Scope class with scope stack, signal handler, and trace output
- Strip function return types and params from scope stack traces

example
```
[TM][FATAL][0429.13:00:23.088713][unified_attention_layer.cc:586] CUDA error: invalid argument
*** stacktrace of thread 0x7f807b7fe640 ***
  [ 0] TM_CUDA_CHECK @ unified_attention_layer.cc:586
  [ 1] UnifiedAttentionLayer::core_attention() @ unified_attention_layer.cc:376
  [ 2] UnifiedAttentionLayer::Forward() @ unified_attention_layer.cc:302
  [ 3] layer_0 @ unified_decoder.cc:191
  [ 4] UnifiedDecoder::Forward() @ unified_decoder.cc:139
  [ 5] LanguageModel::Impl::Forward() @ language_model.cc:406
  [ 6] ModelExecutor::Impl::Run() @ model_executor.cc:59
  [ 7] ModelExecutor::Impl::InternalThreadEntry() @ model_executor.cc:35
```