### PR TITLE
Fix qwen3.5-moe mtp with tp>1

### DIFF
--- a/lmdeploy/pytorch/models/qwen3_5_mtp.py
+++ b/lmdeploy/pytorch/models/qwen3_5_mtp.py
@@ -37,7 +37,6 @@ class Qwen3_5MtpDecoderLayer(Qwen3_5DecoderLayer):
                                           layer_idx,
                                           dtype=dtype,
                                           device=device,
-                                          is_tp=False,
                                           prefix=add_prefix('self_attn', prefix=prefix),
                                           )
 
@@ -47,16 +46,12 @@ class Qwen3_5MtpDecoderLayer(Qwen3_5DecoderLayer):
                                                 layer_idx,
                                                 dtype=dtype,
                                                 device=device,
-                                                is_tp=False,
                                                 prefix=add_prefix('mlp', prefix=prefix),
                                                 )
-            self.mlp._all_reduce = False
         else:
             self.mlp = Qwen3_5MLP(config,
                                   dtype=dtype,
                                   device=device,
-                                  is_tp=False,
-                                  all_reduce=False,
                                   prefix=add_prefix('mlp', prefix=prefix),
                                   )
 
@@ -146,7 +141,6 @@ class Qwen3_5MultiTokenPredictor(nn.Module):
         layer_idx = self.mtp_start_layer_idx + current_step_idx
         past_key_value = past_key_values[current_step_idx]
 
-        # TODO: fix input mrope position ids
         if inputs_embeds is None:
             inputs_embeds = self.embed_tokens(input_ids)
 

--- a/lmdeploy/pytorch/spec_decode/__init__.py
+++ b/lmdeploy/pytorch/spec_decode/__init__.py
@@ -20,6 +20,7 @@ def build_spec_agent(specdecode_config: SpecDecodeConfig,
                               inputs_strategy,
                               agent_strategy,
                               misc_config,
+                              dist_ctx,
                               device=device)
     else:
         from .base import BaseSpecModelAgent

--- a/lmdeploy/pytorch/spec_decode/spec_agent.py
+++ b/lmdeploy/pytorch/spec_decode/spec_agent.py
@@ -127,7 +127,7 @@ class SpecModelAgent(BaseSpecModelAgent):
         self.method = specdecode_config.method
         self.model_config = specdecode_config.model_config
         self.cache_config = specdecode_config.cache_config
-        self.draft_dist_ctx = DistContext.build(rank=0, dist_config=DistConfig())
+        self.draft_dist_ctx = DistContext.build(rank=dist_ctx.rank, dist_config=DistConfig())
 
         # make dummy meta
         self.make_dummy_meta = self.inputs_strategy.create_make_dummy_meta(self.model_config)
@@ -137,9 +137,6 @@ class SpecModelAgent(BaseSpecModelAgent):
     @contextmanager
     def draft_context(self):
         """Draft-local dist context."""
-        if self.draft_dist_ctx is None:
-            yield
-            return
         dist_mgr = get_dist_manager()
         with dist_mgr.context(self.draft_dist_ctx):
             yield
@@ -479,32 +476,31 @@ class SpecModelAgent(BaseSpecModelAgent):
         capture_batch_sizes = self.proposer.model.get_capture_batch_sizes()
         capture_batch_sizes = sorted(capture_batch_sizes, reverse=True)
 
-        with self.draft_context():
-            # warmup prefill
-            self._forward_impl(inputs)
+        # warmup prefill
+        self._forward_impl(inputs)
 
-            # warmup decode
-            for batch_size in capture_batch_sizes:
-                # decode with num_spec_tokens + 1 per seq
-                inputs = self.inputs_strategy.make_dummy(batch_size,
-                                                        is_decoding=True,
-                                                        device='cuda',
-                                                        vocab_size=self.model_config.vocab_size,
-                                                        max_q_seqlen=self.num_spec_tokens + 1,
-                                                        target_hidden_size=target_hidden_size,
-                                                        target_dtype=self.model_config.dtype,
-                                                        meta=self.make_dummy_meta)
-                self._forward_impl(inputs)
-                # decode 1 tokens per sequence
-                inputs = self.inputs_strategy.make_dummy(batch_size,
-                                                        is_decoding=True,
-                                                        device='cuda',
-                                                        vocab_size=self.model_config.vocab_size,
-                                                        max_q_seqlen=1,
-                                                        target_hidden_size=self.model_config.hidden_size,
-                                                        target_dtype=self.model_config.dtype,
-                                                        meta=self.make_dummy_meta)
-                self._forward_impl(inputs)
+        # warmup decode
+        for batch_size in capture_batch_sizes:
+            # decode with num_spec_tokens + 1 per seq
+            inputs = self.inputs_strategy.make_dummy(batch_size,
+                                                    is_decoding=True,
+                                                    device='cuda',
+                                                    vocab_size=self.model_config.vocab_size,
+                                                    max_q_seqlen=self.num_spec_tokens + 1,
+                                                    target_hidden_size=target_hidden_size,
+                                                    target_dtype=self.model_config.dtype,
+                                                    meta=self.make_dummy_meta)
+            self._forward_impl(inputs)
+            # decode 1 tokens per sequence
+            inputs = self.inputs_strategy.make_dummy(batch_size,
+                                                    is_decoding=True,
+                                                    device='cuda',
+                                                    vocab_size=self.model_config.vocab_size,
+                                                    max_q_seqlen=1,
+                                                    target_hidden_size=self.model_config.hidden_size,
+                                                    target_dtype=self.model_config.dtype,
+                                                    meta=self.make_dummy_meta)
+            self._forward_impl(inputs)
 
     def reset_graph_runner(self):
         """Reset graph runner."""

--- a/lmdeploy/pytorch/spec_decode/spec_agent.py
+++ b/lmdeploy/pytorch/spec_decode/spec_agent.py
@@ -1,12 +1,15 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 
+from contextlib import contextmanager
+
 import torch
 from torch.profiler import record_function
 
 from lmdeploy.utils import get_logger
 
 from ..backends import get_backend
-from ..config import BackendConfig, CacheConfig, MiscConfig, ModelConfig, SpecDecodeConfig
+from ..config import BackendConfig, CacheConfig, DistConfig, MiscConfig, ModelConfig, SpecDecodeConfig
+from ..distributed import DistContext, get_dist_manager
 from ..engine.cache_engine import CacheEngine
 from ..engine.logits_process import FusedLogitsProcessor, SamplingInputs, _torch_topk
 from ..engine.model_agent.agent import BatchedLogProbs
@@ -107,11 +110,13 @@ class SpecModelAgent(BaseSpecModelAgent):
         inputs_strategy,
         agent_strategy,
         misc_config: MiscConfig,
+        dist_ctx: DistContext,
         device: str = 'cuda',
     ):
         super().__init__(specdecode_config, enable=True)
 
         self.backend_config = backend_config
+        self.dist_ctx = dist_ctx
         self.device = device
         self.cache_engine = None
         self.inputs_strategy = inputs_strategy
@@ -122,11 +127,22 @@ class SpecModelAgent(BaseSpecModelAgent):
         self.method = specdecode_config.method
         self.model_config = specdecode_config.model_config
         self.cache_config = specdecode_config.cache_config
+        self.draft_dist_ctx = DistContext.build(rank=0, dist_config=DistConfig())
 
         # make dummy meta
         self.make_dummy_meta = self.inputs_strategy.create_make_dummy_meta(self.model_config)
         # for long context carry-over in chunked decoding
         self._prev_chunk_last = {}
+
+    @contextmanager
+    def draft_context(self):
+        """Draft-local dist context."""
+        if self.draft_dist_ctx is None:
+            yield
+            return
+        dist_mgr = get_dist_manager()
+        with dist_mgr.context(self.draft_dist_ctx):
+            yield
 
     def set_cache_config(self, cache_config: CacheConfig):
         """Set all cache config."""
@@ -141,26 +157,29 @@ class SpecModelAgent(BaseSpecModelAgent):
 
     def build_model(self, empty_init: bool, target_model=None, build_model_ctx=None):
         """Build draft model."""
-        self.proposer.build_model(empty_init, target_model=target_model, build_model_ctx=build_model_ctx)
+        with self.draft_context():
+            self.proposer.build_model(empty_init, target_model=target_model, build_model_ctx=build_model_ctx)
 
     def build_graph_runner(self):
         """Build graph runner."""
-        backend = get_backend()
-        self.proposer.model = backend.build_graph_runner(self.proposer.model,
-                                                         model_config=self.model_config,
-                                                         cache_config=self.cache_config,
-                                                         backend_config=self.backend_config,
-                                                         device=self.device)
+        with self.draft_context():
+            backend = get_backend()
+            self.proposer.model = backend.build_graph_runner(self.proposer.model,
+                                                             model_config=self.model_config,
+                                                             cache_config=self.cache_config,
+                                                             backend_config=self.backend_config,
+                                                             device=self.device)
 
     def build_cache_engine(self, cache_stream: torch.cuda.Stream):
         """Build cache engine."""
         if self.cache_config is not None:
-            self.cache_engine = CacheEngine(self.cache_config,
-                                            self.model_config,
-                                            rank=0,
-                                            tp_rank=0,
-                                            world_size=1,
-                                            cache_stream=cache_stream)
+            with self.draft_context():
+                self.cache_engine = CacheEngine(self.cache_config,
+                                                self.model_config,
+                                                rank=0,
+                                                tp_rank=0,
+                                                world_size=1,
+                                                cache_stream=cache_stream)
 
     def _prepare_inputs_from_main(self, model_inputs: ModelInputs, extra_inputs: ExtraInputs):
         """Update inputs from main model inputs."""
@@ -382,7 +401,8 @@ class SpecModelAgent(BaseSpecModelAgent):
 
     def _forward_impl(self, inputs: ModelInputs):
         """Forward impl."""
-        output = self.proposer._forward(inputs, cache_engine=self.cache_engine)
+        with self.draft_context():
+            output = self.proposer._forward(inputs, cache_engine=self.cache_engine)
         return output
 
     async def _async_model_forward(self, inputs: ModelInputs, extra_inputs: ARSpecExtraInputs,
@@ -456,37 +476,41 @@ class SpecModelAgent(BaseSpecModelAgent):
                                                  target_dtype=self.model_config.dtype,
                                                  meta=self.make_dummy_meta)
 
-        self._forward_impl(inputs)
-
         capture_batch_sizes = self.proposer.model.get_capture_batch_sizes()
         capture_batch_sizes = sorted(capture_batch_sizes, reverse=True)
 
-        for batch_size in capture_batch_sizes:
-            # decode with num_spec_tokens + 1 per seq
-            inputs = self.inputs_strategy.make_dummy(batch_size,
-                                                     is_decoding=True,
-                                                     device='cuda',
-                                                     vocab_size=self.model_config.vocab_size,
-                                                     max_q_seqlen=self.num_spec_tokens + 1,
-                                                     target_hidden_size=target_hidden_size,
-                                                     target_dtype=self.model_config.dtype,
-                                                     meta=self.make_dummy_meta)
+        with self.draft_context():
+            # warmup prefill
             self._forward_impl(inputs)
-            # decode 1 tokens per sequence
-            inputs = self.inputs_strategy.make_dummy(batch_size,
-                                                     is_decoding=True,
-                                                     device='cuda',
-                                                     vocab_size=self.model_config.vocab_size,
-                                                     max_q_seqlen=1,
-                                                     target_hidden_size=self.model_config.hidden_size,
-                                                     target_dtype=self.model_config.dtype,
-                                                     meta=self.make_dummy_meta)
-            self._forward_impl(inputs)
+
+            # warmup decode
+            for batch_size in capture_batch_sizes:
+                # decode with num_spec_tokens + 1 per seq
+                inputs = self.inputs_strategy.make_dummy(batch_size,
+                                                        is_decoding=True,
+                                                        device='cuda',
+                                                        vocab_size=self.model_config.vocab_size,
+                                                        max_q_seqlen=self.num_spec_tokens + 1,
+                                                        target_hidden_size=target_hidden_size,
+                                                        target_dtype=self.model_config.dtype,
+                                                        meta=self.make_dummy_meta)
+                self._forward_impl(inputs)
+                # decode 1 tokens per sequence
+                inputs = self.inputs_strategy.make_dummy(batch_size,
+                                                        is_decoding=True,
+                                                        device='cuda',
+                                                        vocab_size=self.model_config.vocab_size,
+                                                        max_q_seqlen=1,
+                                                        target_hidden_size=self.model_config.hidden_size,
+                                                        target_dtype=self.model_config.dtype,
+                                                        meta=self.make_dummy_meta)
+                self._forward_impl(inputs)
 
     def reset_graph_runner(self):
         """Reset graph runner."""
-        if self.proposer.model is not None and hasattr(self.proposer.model, 'reset'):
-            self.proposer.model.reset()
+        with self.draft_context():
+            if self.proposer.model is not None and hasattr(self.proposer.model, 'reset'):
+                self.proposer.model.reset()
 
     def get_model(self):
         """Get model."""


### PR DESCRIPTION

## Motivation

Fix qwen3.5 moe with tp>1 by changing dist ctx:
-  `is_tp` is disabled in pr https://github.com/InternLM/lmdeploy/pull/4535


## Modification

Please briefly describe what modification is made in this PR.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
