### PR TITLE
chore: gate request logs behind request level

### DIFF
--- a/lmdeploy/logger.py
+++ b/lmdeploy/logger.py
@@ -37,7 +37,7 @@ class RequestLogger:
         if not logger.isEnabledFor(REQUEST_LOG_LEVEL):
             return
         max_log_len = self.max_log_len
-        input_tokens = len(prompt_token_ids)
+        input_tokens = len(prompt_token_ids) if prompt_token_ids is not None else 0
         if max_log_len is not None:
             if prompt is not None:
                 prompt = prompt[:max_log_len]

--- a/lmdeploy/logger.py
+++ b/lmdeploy/logger.py
@@ -2,7 +2,7 @@
 # modify from https://github.com/vllm-project/vllm/blob/main/vllm/entrypoints/logger.py  # noqa
 
 from .messages import GenerationConfig
-from .utils import get_logger
+from .utils import REQUEST_LOG_LEVEL, get_logger
 
 logger = get_logger('lmdeploy')
 
@@ -20,6 +20,8 @@ class RequestLogger:
         self.max_log_len = max_log_len
 
     def log_prompt(self, session_id: int, prompt: str) -> None:
+        if not logger.isEnabledFor(REQUEST_LOG_LEVEL):
+            return
         if not isinstance(prompt, str):
             # Prompt may be a GPT4V message with base64 images;
             # logging might be impractical due to length
@@ -27,11 +29,13 @@ class RequestLogger:
         if self.max_log_len is not None:
             if prompt is not None:
                 prompt = prompt[:self.max_log_len]
-        logger.info(f'session={session_id}, '
-                    f'prompt={prompt!r}')
+        logger.log(REQUEST_LOG_LEVEL, f'session={session_id}, '
+                   f'prompt={prompt!r}')
 
     def log_inputs(self, session_id: int, prompt: str | None, prompt_token_ids: list[int] | None,
                    gen_config: GenerationConfig, adapter_name: str) -> None:
+        if not logger.isEnabledFor(REQUEST_LOG_LEVEL):
+            return
         max_log_len = self.max_log_len
         input_tokens = len(prompt_token_ids)
         if max_log_len is not None:
@@ -41,9 +45,9 @@ class RequestLogger:
             if prompt_token_ids is not None:
                 prompt_token_ids = prompt_token_ids[:max_log_len]
 
-        logger.info(f'session={session_id}, '
-                    f'adapter_name={adapter_name}, '
-                    f'input_tokens={input_tokens}, '
-                    f'gen_config={gen_config}, '
-                    f'prompt={prompt!r}, '
-                    f'prompt_token_id={prompt_token_ids}')
+        logger.log(REQUEST_LOG_LEVEL, f'session={session_id}, '
+                   f'adapter_name={adapter_name}, '
+                   f'input_tokens={input_tokens}, '
+                   f'gen_config={gen_config}, '
+                   f'prompt={prompt!r}, '
+                   f'prompt_token_id={prompt_token_ids}')

--- a/lmdeploy/utils.py
+++ b/lmdeploy/utils.py
@@ -13,6 +13,10 @@ import torch
 from transformers import PretrainedConfig
 
 logger_initialized = {}
+# Put REQUEST between DEBUG(10) and INFO(20): INFO hides request
+# payload logs, while REQUEST shows them together with normal INFO logs.
+REQUEST_LOG_LEVEL = 15
+logging.addLevelName(REQUEST_LOG_LEVEL, 'REQUEST')
 
 
 class _ASNI_COLOR:
@@ -59,6 +63,7 @@ class ColorFormatter(logging.Formatter):
                                 ERROR=_ASNI_COLOR.RED,
                                 WARN=_ASNI_COLOR.YELLOW,
                                 WARNING=_ASNI_COLOR.YELLOW,
+                                REQUEST=_ASNI_COLOR.WHITE,
                                 INFO=_ASNI_COLOR.WHITE,
                                 DEBUG=_ASNI_COLOR.GREEN)
 

--- a/tests/test_lmdeploy/test_logger.py
+++ b/tests/test_lmdeploy/test_logger.py
@@ -1,0 +1,81 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+import logging
+
+import pytest
+
+import lmdeploy.logger as request_logger_module
+from lmdeploy.cli.utils import ArgumentHelper
+from lmdeploy.logger import RequestLogger
+from lmdeploy.utils import REQUEST_LOG_LEVEL
+
+
+@pytest.fixture(autouse=True)
+def restore_request_logger_level():
+    logger = request_logger_module.logger
+    old_level = logger.level
+    yield
+    logger.setLevel(old_level)
+
+
+def _capture_request_logs(monkeypatch, log_level):
+    records = []
+
+    class CaptureHandler(logging.Handler):
+
+        def emit(self, record):
+            records.append(record)
+
+    logger = request_logger_module.logger
+    handler = CaptureHandler()
+    handler.setLevel(logging.DEBUG)
+    monkeypatch.setattr(logger, 'handlers', [handler])
+    logger.setLevel(log_level)
+    return records
+
+
+def test_request_logger_log_inputs_hidden_at_info(monkeypatch):
+    records = _capture_request_logs(monkeypatch, logging.INFO)
+
+    RequestLogger(max_log_len=None).log_inputs(1, 'hello', [1, 2], 'gen_config', 'default')
+
+    assert not records
+
+
+def test_request_logger_log_inputs_skips_formatting_at_info(monkeypatch):
+
+    class UnformattableConfig:
+
+        def __str__(self):
+            raise AssertionError('gen_config should not be formatted')
+
+    _capture_request_logs(monkeypatch, logging.INFO)
+
+    RequestLogger(max_log_len=None).log_inputs(1, 'hello', [1, 2], UnformattableConfig(), 'default')
+
+
+def test_request_logger_log_inputs_visible_at_request(monkeypatch):
+    records = _capture_request_logs(monkeypatch, REQUEST_LOG_LEVEL)
+
+    RequestLogger(max_log_len=None).log_inputs(1, 'hello', [1, 2], 'gen_config', 'default')
+
+    assert len(records) == 1
+    assert records[0].levelno == REQUEST_LOG_LEVEL
+    assert 'input_tokens=2' in records[0].getMessage()
+
+
+def test_request_log_level_includes_info_logs(monkeypatch):
+    records = _capture_request_logs(monkeypatch, REQUEST_LOG_LEVEL)
+
+    request_logger_module.logger.info('normal info')
+
+    assert len(records) == 1
+    assert records[0].levelno == logging.INFO
+
+
+def test_log_level_argument_accepts_request():
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    action = ArgumentHelper.log_level(parser)
+
+    assert 'REQUEST' in action.choices

--- a/tests/test_lmdeploy/test_logger.py
+++ b/tests/test_lmdeploy/test_logger.py
@@ -63,6 +63,16 @@ def test_request_logger_log_inputs_visible_at_request(monkeypatch):
     assert 'input_tokens=2' in records[0].getMessage()
 
 
+def test_request_logger_log_inputs_handles_none_token_ids(monkeypatch):
+    records = _capture_request_logs(monkeypatch, REQUEST_LOG_LEVEL)
+
+    RequestLogger(max_log_len=None).log_inputs(1, 'hello', None, 'gen_config', 'default')
+
+    assert len(records) == 1
+    assert 'input_tokens=0' in records[0].getMessage()
+    assert 'prompt_token_id=None' in records[0].getMessage()
+
+
 def test_request_log_level_includes_info_logs(monkeypatch):
     records = _capture_request_logs(monkeypatch, REQUEST_LOG_LEVEL)
 


### PR DESCRIPTION
## Summary

- add a `REQUEST` log level for verbose request payload logs
- keep request payload logging hidden at `INFO` by default
- skip request log formatting unless `REQUEST` is enabled

## Motivation

This keeps ordinary `INFO` logs concise while preserving an explicit opt-in path for request-level diagnostics, broadly matching SGLang's default request logging behavior where payload logging is disabled unless requested.

## Tests

- `/nvme1/zhouxinyu/miniconda3/envs/vl/bin/python -m pytest tests/test_lmdeploy/test_logger.py -q`
- `/nvme1/zhouxinyu/miniconda3/envs/vl/bin/python -m py_compile lmdeploy/utils.py lmdeploy/logger.py tests/test_lmdeploy/test_logger.py`
- `pre-commit run --files lmdeploy/utils.py lmdeploy/logger.py tests/test_lmdeploy/test_logger.py`
