### PR TITLE
fix: compact split multimodal tensors

### DIFF
--- a/lmdeploy/vl/model/preprocess_utils.py
+++ b/lmdeploy/vl/model/preprocess_utils.py
@@ -125,7 +125,7 @@ def get_expanded_mm_items(collected_mm_items, mm_tokens: 'MultimodalSpecialToken
                 expanded_mm_items.append(
                     dict(
                         modality=modality,
-                        pixel_values=item['feature'][start_idx:end_idx],
+                        pixel_values=item['feature'][start_idx:end_idx].clone(),
                         image_grid_thw=image_grid_thw[i],
                         offset=item['offset'][i],
                         image_token_id=token_id,
@@ -173,7 +173,7 @@ def get_expanded_mm_items(collected_mm_items, mm_tokens: 'MultimodalSpecialToken
                     expanded_mm_items.append(
                         dict(
                             modality=modality,
-                            pixel_values_videos=video_feature[frame_idx * h * w:(frame_idx + 1) * h * w],
+                            pixel_values_videos=video_feature[frame_idx * h * w:(frame_idx + 1) * h * w].clone(),
                             video_grid_thw=torch.tensor([1, h, w]),
                             offset=item['offset'][frame_start:frame_end][frame_idx],
                             video_token_id=token_id,

--- a/tests/test_lmdeploy/test_vl/test_preprocess_utils.py
+++ b/tests/test_lmdeploy/test_vl/test_preprocess_utils.py
@@ -1,0 +1,57 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+
+import torch
+
+from lmdeploy.vl.constants import Modality
+from lmdeploy.vl.model.preprocess_utils import get_expanded_mm_items
+
+
+class _Tokens:
+
+    image_token_id = 42
+    video_token_id = 43
+
+    def get_token_id_by_modality(self, modality):
+        if modality == Modality.IMAGE:
+            return self.image_token_id
+        if modality == Modality.VIDEO:
+            return self.video_token_id
+        raise AssertionError(f'unexpected modality: {modality}')
+
+
+def _assert_compact_storage(tensor):
+    assert tensor.untyped_storage().nbytes() == tensor.numel() * tensor.element_size()
+
+
+def test_expand_bundled_image_items_use_compact_tensor_storage():
+    feature = torch.arange(6, dtype=torch.float32).reshape(6, 1)
+    items = {
+        Modality.IMAGE: {
+            'feature': feature,
+            'image_grid_thw': torch.tensor([[1, 2, 1], [1, 2, 1], [1, 2, 1]]),
+            'offset': [(0, 1), (1, 2), (2, 3)],
+        }
+    }
+
+    expanded = get_expanded_mm_items(items, _Tokens())
+
+    assert len(expanded) == 3
+    for entry in expanded:
+        _assert_compact_storage(entry['pixel_values'])
+
+
+def test_expand_bundled_video_items_use_compact_tensor_storage():
+    feature = torch.arange(8, dtype=torch.float32).reshape(8, 1)
+    items = {
+        Modality.VIDEO: {
+            'feature': feature,
+            'video_grid_thw': torch.tensor([[2, 2, 1], [2, 2, 1]]),
+            'offset': [(0, 1), (1, 2), (2, 3), (3, 4)],
+        }
+    }
+
+    expanded = get_expanded_mm_items(items, _Tokens())
+
+    assert len(expanded) == 4
+    for entry in expanded:
+        _assert_compact_storage(entry['pixel_values_videos'])


### PR DESCRIPTION
## Summary
- clone split image/video multimodal tensor slices so each slice owns compact storage
- avoid serializing full parent tensor storage for each split item in MP/ZMQ serving paths
- add unit coverage for compact storage after bundled image/video expansion

## Validation
- python -m pytest tests/test_lmdeploy/test_vl/test_preprocess_utils.py -q
- python -m py_compile lmdeploy/vl/model/preprocess_utils.py tests/test_lmdeploy/test_vl/test_preprocess_utils.py
- pre-commit run --files lmdeploy/vl/model/preprocess_utils.py tests/test_lmdeploy/test_vl/test_preprocess_utils.py

Base: v0.13.0 release commit e6948c110e568511795e427234ce98d73bc2cd1d