### PR TITLE
Fix legacy VLM preprocessors for normalized image data

### DIFF
--- a/lmdeploy/vl/model/deepseek_vl2.py
+++ b/lmdeploy/vl/model/deepseek_vl2.py
@@ -76,7 +76,8 @@ class DeepSeek2VisionModel(VisionModel):
         formatted_messages = []
         for message in messages:
             text_content = DeepSeek2VisionModel.proc_single_message(message)
-            image_content = [x['image'] for x in message['content'] if x['type'] == 'image']
+            mm_items = self.collect_multimodal_items([message])
+            image_content = [data for modality, data, _ in mm_items if modality == 'image']
             formatted_messages.append(dict(role=message['role'], content=text_content, images=image_content))
 
         # NOTE: DeepseekVLV2Processor inputs

--- a/lmdeploy/vl/model/glm4_v.py
+++ b/lmdeploy/vl/model/glm4_v.py
@@ -49,7 +49,8 @@ class GLM4VisionModel(VisionModel):
         for message in messages:
             if not isinstance(message['content'], list):
                 continue
-            images = [x['image'] for x in message['content'] if x['type'] == 'image']
+            mm_items = self.collect_multimodal_items([message])
+            images = [data for modality, data, _ in mm_items if modality == 'image']
             if len(images) > 1:
                 logger.warning(f'glm4v does not support the input of multiple images'
                                f' in a single chat round, but got {len(images)} images.')

--- a/lmdeploy/vl/model/minicpmv.py
+++ b/lmdeploy/vl/model/minicpmv.py
@@ -132,14 +132,12 @@ class MiniCPMVModel(VisionModel):
 
     def preprocess(self, messages: list[dict]) -> list[dict]:
         """Refer to `super().preprocess() for spec."""
-        outputs = []
         for i, message in enumerate(messages):
             if message['role'] != 'user' or not isinstance(message['content'], list):
                 continue
-            for item in message['content']:
-                if item['type'] == 'image':
-                    image = item['image']
-                    params = {k: v for k, v in item.items() if k not in {'type', 'image'}}
+            outputs = []
+            for modality, image, params in self.collect_multimodal_items([message]):
+                if modality == 'image':
                     result = self._preprocess_func(image, params)
                     outputs.append(result)
             messages[i].update(dict(preprocess=outputs))

--- a/lmdeploy/vl/model/molmo.py
+++ b/lmdeploy/vl/model/molmo.py
@@ -54,7 +54,8 @@ class MolmoVisionModel(VisionModel):
         for i, message in enumerate(messages):
             if not isinstance(message['content'], list):
                 continue
-            images = [x['image'] for x in message['content'] if x['type'] == 'image']
+            mm_items = self.collect_multimodal_items([message])
+            images = [data for modality, data, _ in mm_items if modality == 'image']
             content = [x.get('text', '') for x in message['content'] if x['type'] == 'text']
             prompt = f' User: {content[0]}'
             tokens = self.processor.tokenizer.encode(prompt, add_special_tokens=False)


### PR DESCRIPTION
## Summary
- Fix legacy VLM preprocessors to read decoded image payloads from the normalized multimodal `data` field.
- This PR was originally created to resolve a GLM4-V API-server failure where image_url input raised `KeyError: 'image'` during preprocessing.
- Apply the same schema fix to Molmo, MiniCPM-V, and DeepSeek-VL2 paths that still used the stale `image` key.
- Keep MiniCPM-V preprocess outputs scoped to each user message so image features do not leak across chat rounds.