### PR TITLE
Allow W8A8Linear to accept dtype during initialization instead of hard code

### DIFF
--- a/lmdeploy/pytorch/nn/linear/w8a8.py
+++ b/lmdeploy/pytorch/nn/linear/w8a8.py
@@ -25,7 +25,7 @@ class W8A8Linear(LinearBase):
                  all_reduce: bool = True,
                  quant_dtype: torch.dtype | None = torch.int8,
                  layer_type: str = 'attn'):
-        super().__init__(dtype=torch.float16,
+        super().__init__(dtype=dtype,
                          device=device,
                          colwise=colwise,
                          is_tp=is_tp,


### PR DESCRIPTION

## Motivation

This pull request makes a minor but important fix to the initialization of a class in `lmdeploy/pytorch/nn/linear/w8a8.py`. The change ensures that the `dtype` argument passed to the constructor is respected, instead of always defaulting to `torch.float16`.

## Modification

lmdeploy/pytorch/nn/linear/w8a8.py: Allow W8A8Linear to accept dtype during initialization instead of hard code.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
