### PR TITLE
fix: enable FA3 for SM80+ GPUs and fix CUDA version comparison

### DIFF
--- a/lmdeploy/pytorch/backends/cuda/attention/__init__.py
+++ b/lmdeploy/pytorch/backends/cuda/attention/__init__.py
@@ -12,8 +12,8 @@ logger = get_logger('lmdeploy')
 
 use_fa3 = False
 try:
-    # Now flash-attention only support FA3 for sm90a && cuda >= 12.3
-    if (torch.cuda.get_device_capability()[0] == 9) and (torch.version.cuda >= '12.3'):
+    # flash-attention supports FA3 for sm80+ (Ampere and above) && cuda >= 12.3
+    if (torch.cuda.get_device_capability()[0] >= 8) and (torch.version.cuda >= '12.3'):
         import lmdeploy.pytorch.third_party.flash_attn_interface  # noqa: F401
         assert torch.ops.flash_attn_3 is not None
         use_fa3 = True

--- a/lmdeploy/pytorch/backends/cuda/attention/__init__.py
+++ b/lmdeploy/pytorch/backends/cuda/attention/__init__.py
@@ -13,7 +13,8 @@ logger = get_logger('lmdeploy')
 use_fa3 = False
 try:
     # flash-attention supports FA3 for sm80+ (Ampere and above) && cuda >= 12.3
-    if (torch.cuda.get_device_capability()[0] >= 8) and (torch.version.cuda >= '12.3'):
+    _cuda_ver = tuple(int(x) for x in torch.version.cuda.split('.')[:2]) if torch.version.cuda else (0, 0)
+    if (torch.cuda.get_device_capability()[0] >= 8) and _cuda_ver >= (12, 3):
         import lmdeploy.pytorch.third_party.flash_attn_interface  # noqa: F401
         assert torch.ops.flash_attn_3 is not None
         use_fa3 = True

--- a/lmdeploy/pytorch/backends/cuda/attention/fa3.py
+++ b/lmdeploy/pytorch/backends/cuda/attention/fa3.py
@@ -14,7 +14,7 @@ class FA3Impl(TritonAttentionImpl):
 
     This implementation leverages Flash Attention 3's optimized kernels for both
     prefill and decoding stages. FA3 provides significant performance improvements
-    on Hopper architecture (SM90) with CUDA >= 12.3.
+    on Ampere and above (SM80+) with CUDA >= 12.3.
 
     Key features:
     - Optimized prefill using flash_attn_varlen_func

--- a/lmdeploy/pytorch/backends/cuda/graph_runner.py
+++ b/lmdeploy/pytorch/backends/cuda/graph_runner.py
@@ -153,6 +153,20 @@ class CUDAGraphRunner(GraphRunner):
         self.max_tokens = cache_config.max_prefill_token_num
         self.num_blocks = cache_config.num_gpu_blocks
 
+        # Speculative decoding on CUDA requires FlashAttention-3 (FA3).
+        # FA3 is available on SM80+ (Ampere and above) GPUs with CUDA >= 12.3.
+        # Without FA3, the Triton paged attention kernel cannot handle
+        # multi-token decoding queries (max_q_seqlen > 1) used in spec decoding.
+        if model_config.model_paradigm == 'ar_spec':
+            from .attention import use_fa3
+            if not use_fa3:
+                raise RuntimeError(
+                    'Speculative decoding on CUDA requires FlashAttention-3 (FA3), '
+                    'which is available on SM80+ GPUs (Ampere architecture and above) '
+                    'with CUDA >= 12.3. Current GPU does not meet these requirements. '
+                    'Please use a SM80+ GPU with CUDA >= 12.3 and install flash-attn, '
+                    'or disable speculative decoding.')
+
         self.enable_graph = self.check_enable_graph()
 
         self.graph_pool_handle = torch.cuda.graph_pool_handle()

--- a/lmdeploy/pytorch/backends/cuda/graph_runner.py
+++ b/lmdeploy/pytorch/backends/cuda/graph_runner.py
@@ -160,12 +160,14 @@ class CUDAGraphRunner(GraphRunner):
         if model_config.model_paradigm == 'ar_spec':
             from .attention import use_fa3
             if not use_fa3:
+                sm = torch.cuda.get_device_capability()
+                cuda_ver = torch.version.cuda or 'N/A'
                 raise RuntimeError(
-                    'Speculative decoding on CUDA requires FlashAttention-3 (FA3), '
-                    'which is available on SM80+ GPUs (Ampere architecture and above) '
-                    'with CUDA >= 12.3. Current GPU does not meet these requirements. '
-                    'Please use a SM80+ GPU with CUDA >= 12.3 and install flash-attn, '
-                    'or disable speculative decoding.')
+                    f'Speculative decoding on CUDA requires FlashAttention-3 (FA3), '
+                    f'which needs SM80+ (Ampere and above) with CUDA >= 12.3 and '
+                    f'flash-attn installed. Detected: SM{sm[0]}.{sm[1]}, CUDA {cuda_ver}. '
+                    f'Please ensure your GPU meets SM80+, CUDA >= 12.3, and flash-attn '
+                    f'is installed, or disable speculative decoding.')
 
         self.enable_graph = self.check_enable_graph()
 

--- a/lmdeploy/pytorch/backends/cuda/graph_runner.py
+++ b/lmdeploy/pytorch/backends/cuda/graph_runner.py
@@ -88,7 +88,8 @@ class CUDASingleGraphRunner:
             use_flash_mla=getattr(self.model_config, 'use_flash_mla', False),
             mla_index_topk=getattr(self.model_config, 'mla_index_topk', None),
             decode_query_len=decode_query_len,
-            use_fa3_decoding=model_config.model_paradigm == 'ar_spec',
+            use_fa3_decoding=(model_config.model_paradigm == 'ar_spec'
+                              and not getattr(model_config, 'use_flash_mla', False)),
             is_ssm=len(model_config.states_shapes) > 0,
             use_mrope=model_config.use_mrope,
             block_size=model_config.block_size,
@@ -153,11 +154,13 @@ class CUDAGraphRunner(GraphRunner):
         self.max_tokens = cache_config.max_prefill_token_num
         self.num_blocks = cache_config.num_gpu_blocks
 
-        # Speculative decoding on CUDA requires FlashAttention-3 (FA3).
+        # Speculative decoding on CUDA requires FlashAttention-3 (FA3),
+        # unless the model uses FlashMLA (e.g., DeepSeek MTP) which handles
+        # multi-token decoding queries natively.
         # FA3 is available on SM80+ (Ampere and above) GPUs with CUDA >= 12.3.
         # Without FA3, the Triton paged attention kernel cannot handle
         # multi-token decoding queries (max_q_seqlen > 1) used in spec decoding.
-        if model_config.model_paradigm == 'ar_spec':
+        if model_config.model_paradigm == 'ar_spec' and not getattr(model_config, 'use_flash_mla', False):
             from .attention import use_fa3
             if not use_fa3:
                 sm = torch.cuda.get_device_capability()

--- a/lmdeploy/pytorch/backends/cuda/op_backend.py
+++ b/lmdeploy/pytorch/backends/cuda/op_backend.py
@@ -140,10 +140,15 @@ class CudaOpsBackend(DefaultOpsBackend):
         batch_size = attn_metadata.q_seqlens.size(0)
         max_seqlen_q = step_context.input_ids.size(1) // batch_size
         window_size = (step_context.model_config.sliding_window, ) * 2
+        # FA3's mha_fwd internally computes seqlen_k as
+        # page_table.size(1) * page_size when cu_seqlens_k is None
+        # (paged KV without varlen_k). get_scheduler_metadata must use
+        # the same value to produce a correctly-sized metadata buffer.
+        max_seqlen_k = attn_metadata.block_offsets.size(1) * step_context.model_config.block_size
         scheduler_metadata = _get_meta_flashattn(
             batch_size=batch_size,
             max_seqlen_q=max_seqlen_q,
-            max_seqlen_k=step_context.max_kv_seqlen,
+            max_seqlen_k=max_seqlen_k,
             num_heads_q=step_context.model_config.num_attention_heads,
             num_heads_kv=step_context.model_config.num_key_value_heads,
             headdim=step_context.model_config.head_dim,
@@ -153,7 +158,7 @@ class CudaOpsBackend(DefaultOpsBackend):
             window_size=window_size,
         )
         attn_metadata.scheduler_metadata = scheduler_metadata
-        attn_metadata.max_kv_seqlen = step_context.max_kv_seqlen
+        attn_metadata.max_kv_seqlen = max_seqlen_k
         return attn_metadata
 
     @classmethod

--- a/lmdeploy/pytorch/backends/cuda/op_backend.py
+++ b/lmdeploy/pytorch/backends/cuda/op_backend.py
@@ -137,9 +137,11 @@ class CudaOpsBackend(DefaultOpsBackend):
     @classmethod
     def update_meta_flashattn(cls, attn_metadata, step_context):
         from lmdeploy.pytorch.models.utils.cudagraph import _get_meta_flashattn
+
+        from .attention import _normalize_sliding_window
         batch_size = attn_metadata.q_seqlens.size(0)
         max_seqlen_q = step_context.input_ids.size(1) // batch_size
-        window_size = (step_context.model_config.sliding_window, ) * 2
+        window_size = _normalize_sliding_window(step_context.model_config.sliding_window)
         # FA3's mha_fwd internally computes seqlen_k as
         # page_table.size(1) * page_size when cu_seqlens_k is None
         # (paged KV without varlen_k). get_scheduler_metadata must use
@@ -233,12 +235,14 @@ class CudaOpsBackend(DefaultOpsBackend):
             elif use_flash_attn3_decoding:
                 from .attention import use_fa3
                 if not use_fa3:
+                    sm = torch.cuda.get_device_capability()
+                    cuda_ver = torch.version.cuda or 'N/A'
                     raise RuntimeError(
-                        'Speculative decoding on CUDA requires FlashAttention-3 (FA3), '
-                        'which is available on SM80+ GPUs (Ampere architecture and above) '
-                        'with CUDA >= 12.3. Current GPU does not meet these requirements. '
-                        'Please use a SM80+ GPU with CUDA >= 12.3 and install flash-attn, '
-                        'or disable speculative decoding.')
+                        f'Speculative decoding on CUDA requires FlashAttention-3 (FA3), '
+                        f'which needs SM80+ (Ampere and above) with CUDA >= 12.3 and '
+                        f'flash-attn installed. Detected: SM{sm[0]}.{sm[1]}, CUDA {cuda_ver}. '
+                        f'Please ensure your GPU meets SM80+, CUDA >= 12.3, and flash-attn '
+                        f'is installed, or disable speculative decoding.')
                 attn_metadata = cls.update_meta_flashattn(attn_metadata, step_context)
 
         # update chunk gated delta indices

--- a/lmdeploy/pytorch/backends/cuda/op_backend.py
+++ b/lmdeploy/pytorch/backends/cuda/op_backend.py
@@ -231,6 +231,14 @@ class CudaOpsBackend(DefaultOpsBackend):
                 decode_query_len = step_context.input_ids.size(1) // q_seqlens.size(0)
                 cls.update_meta_flashmla(attn_metadata, model_config, decode_query_len)
             elif use_flash_attn3_decoding:
+                from .attention import use_fa3
+                if not use_fa3:
+                    raise RuntimeError(
+                        'Speculative decoding on CUDA requires FlashAttention-3 (FA3), '
+                        'which is available on SM80+ GPUs (Ampere architecture and above) '
+                        'with CUDA >= 12.3. Current GPU does not meet these requirements. '
+                        'Please use a SM80+ GPU with CUDA >= 12.3 and install flash-attn, '
+                        'or disable speculative decoding.')
                 attn_metadata = cls.update_meta_flashattn(attn_metadata, step_context)
 
         # update chunk gated delta indices

--- a/lmdeploy/pytorch/configurations/utils.py
+++ b/lmdeploy/pytorch/configurations/utils.py
@@ -27,8 +27,8 @@ def flash_attn_v3_available():
     """Check if flash attn v3 is available."""
     use_fa3 = False
     try:
-        # Now flash-attention only support FA3 for sm90a && cuda >= 12.3
-        if (torch.cuda.get_device_capability()[0] == 9) and (torch.version.cuda >= '12.3'):
+        # flash-attention supports FA3 for sm80+ (Ampere and above) && cuda >= 12.3
+        if (torch.cuda.get_device_capability()[0] >= 8) and (torch.version.cuda >= '12.3'):
             import flash_attn_interface  # noqa: F401
             assert torch.ops.flash_attn_3 is not None
             use_fa3 = True

--- a/lmdeploy/pytorch/configurations/utils.py
+++ b/lmdeploy/pytorch/configurations/utils.py
@@ -21,18 +21,3 @@ def flash_mla_available():
     except ImportError:
         logger.warning('For higher performance, please install flash_mla https://github.com/deepseek-ai/FlashMLA')
     return use_flash_mla
-
-
-def flash_attn_v3_available():
-    """Check if flash attn v3 is available."""
-    use_fa3 = False
-    try:
-        # flash-attention supports FA3 for sm80+ (Ampere and above) && cuda >= 12.3
-        if (torch.cuda.get_device_capability()[0] >= 8) and (torch.version.cuda >= '12.3'):
-            import flash_attn_interface  # noqa: F401
-            assert torch.ops.flash_attn_3 is not None
-            use_fa3 = True
-    except Exception:
-        logger.warning('For higher performance, please install FlashAttention-3 '
-                       'https://github.com/Dao-AILab/flash-attention')
-    return use_fa3

--- a/lmdeploy/pytorch/models/utils/cudagraph.py
+++ b/lmdeploy/pytorch/models/utils/cudagraph.py
@@ -189,10 +189,11 @@ class CudaGraphMixin:
 
         # use fa3 decode kernel for spec decode
         elif graph_meta.use_fa3_decoding is True:
+            max_seqlen_k = graph_meta.num_blocks * graph_meta.block_size
             input_buffers['scheduler_metadata'] = self.update_meta_flashattn(graph_meta.max_batchs,
                                                                              graph_meta.decode_query_len,
                                                                              block_size=graph_meta.block_size,
-                                                                             max_seqlen_k=decode_query_len,
+                                                                             max_seqlen_k=max_seqlen_k,
                                                                              cache_seqlens=input_buffers['kv_seqlens'])
 
         # mrope
@@ -274,11 +275,16 @@ class CudaGraphMixin:
 
         # use fa3 decode kernel for spec decode
         elif graph_meta.use_fa3_decoding is True:
+            # FA3's mha_fwd internally computes seqlen_k = page_table.size(1) * page_size
+            # where page_table is the (padded) block_offsets buffer. We must use
+            # graph_meta.num_blocks * graph_meta.block_size to match the buffer shape
+            # allocated in make_buffers_cudagraph, not the runtime attn_metadata value.
+            max_seqlen_k = graph_meta.num_blocks * graph_meta.block_size
             scheduler_metadata = self.update_meta_flashattn(
                 new_batch_size,
                 decode_query_len,
                 block_size=graph_meta.block_size,
-                max_seqlen_k=attn_metadata.max_kv_seqlen,
+                max_seqlen_k=max_seqlen_k,
                 cache_seqlens=input_buffers['kv_seqlens'],
             )
             num_meta = scheduler_metadata.size(0)


### PR DESCRIPTION
## Motivation

FlashAttention-3 now supports SM80+ (Ampere and above) GPUs with CUDA >= 12.3, not just SM90 (Hopper). The existing code had several issues preventing proper FA3 usage on Ampere GPUs and could produce incorrect results or unhelpful errors.

## Modification

### 1. Enable FA3 for SM80+ GPUs (`attention/__init__.py`)
- Changed SM capability check from `== 9` (Hopper-only) to `>= 8` (Ampere and above), matching the current flash-attention support matrix.
- Fixed CUDA version comparison: `torch.version.cuda >= "12.3"` used **string** comparison, which incorrectly evaluates `"12.10" < "12.3"`. Replaced with numeric tuple comparison `(12, 10) >= (12, 3)`.

### 2. Align `max_seqlen_k` with FA3 internal computation (`op_backend.py`, `cudagraph.py`)
- FA3's `mha_fwd` internally computes `seqlen_k = page_table.size(1) * page_size` when `cu_seqlens_k` is None (paged KV without varlen_k). The scheduler metadata buffer must be sized to match, otherwise buffer size mismatches cause incorrect results.
- Updated all call sites (`update_meta_flashattn`, `update_meta_flashattn_decoding`, and both `CudaGraphMixin` paths) to use `num_blocks * block_size` instead of `max_kv_seqlen`.

### 3. Add FA3 availability check in eager path for speculative decoding (`op_backend.py`, `graph_runner.py`)
- `graph_runner.py` already validates FA3 availability at CUDA Graph init time, but the **eager mode** path (through `update_step_context`) had no such check. Without FA3, speculative decoding would fail with an unhelpful `ImportError` deep inside `update_meta_flashattn`.
- Added a `RuntimeError` with a clear message in `op_backend.py:update_step_context` when `model_paradigm == "ar_spec"` and FA3 is unavailable, matching the graph runner check.
- Error messages include detected SM version and CUDA version for easier diagnosis, and correctly attribute failure to either missing flash-attn installation or insufficient GPU capability.

### 4. Normalize `sliding_window` in `update_meta_flashattn` (`op_backend.py`)
- Replaced raw tuple multiply `(sliding_window,) * 2` with `_normalize_sliding_window()`, consistent with how `cudagraph.py` and `attention/__init__.py` handle `None`/`int`/`tuple` sliding_window values. This prevents producing invalid `(None, None)` or nested tuples.

### 5. Remove dead code (`configurations/utils.py`)
- Removed `flash_attn_v3_available()` which was only defined but never called anywhere. The canonical FA3 availability check is the `use_fa3` module variable in `attention/__init__.py`.

## BC-breaking (Optional)

No BC-breaking changes. The SM capability threshold is relaxed (SM90 → SM80+), which only enables FA3 on more hardware. The `max_seqlen_k` fix corrects a correctness issue. The eager-mode check raises an explicit error where previously an opaque `ImportError` would occur.

## Checklist

1. [x] Pre-commit or other linting tools are used to fix the potential lint issues.
2. [ ] The modification is covered by complete unit tests. (FA3 availability depends on GPU hardware and flash-attn installation; changes are validated by pre-commit and manual testing on target hardware.)
3. [ ] If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
4. [ ] The documentation has been modified accordingly, like docstring or example tutorials.