### PR TITLE
perf(guided-decoding): optimize with async D2H copy and xgrammar v0.2.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,7 +101,7 @@ FetchContent_MakeAvailable(yaml-cpp)
 FetchContent_Declare(
   xgrammar
   GIT_REPOSITORY          https://github.com/mlc-ai/xgrammar.git
-  GIT_TAG                 v0.1.27
+  GIT_TAG                 v0.2.1
   GIT_SUBMODULES          "3rdparty/dlpack"
   GIT_PROGRESS            TRUE
   USES_TERMINAL_DOWNLOAD  TRUE

--- a/lmdeploy/pytorch/engine/guided_process.py
+++ b/lmdeploy/pytorch/engine/guided_process.py
@@ -101,7 +101,7 @@ class GuidedDecodingManager:
         processor.fill_next_token_bitmask(guided_bitmask, index)
 
     def accept_token(self, processor: xgr.GrammarMatcher, token: int) -> None:
-        processor.accept_token(token)
+        processor.accept_token(token, debug_print=False)
 
     def is_terminated(self, processor: xgr.GrammarMatcher) -> bool:
         return processor.is_terminated()

--- a/lmdeploy/pytorch/engine/logits_process.py
+++ b/lmdeploy/pytorch/engine/logits_process.py
@@ -362,7 +362,8 @@ class FusedLogitsProcessor:
         for i, processor in self.guided_processors.items():
             if self.guided_decoding_manager.is_terminated(processor):
                 continue
-            self.guided_decoding_manager.accept_token(processor, cpu_result[i])
+            token = cpu_result[i]
+            self.guided_decoding_manager.accept_token(processor, int(token))
 
     async def accept_guided_tokens(self, next_token_ids: torch.Tensor):
         if self.guided_decoding_manager and self.guided_processors:

--- a/lmdeploy/turbomind/turbomind.py
+++ b/lmdeploy/turbomind/turbomind.py
@@ -166,6 +166,7 @@ class TurboMind:
         self.source_model = model_loader.model
         self.is_dummy = self.model_comm.is_dummy_node()
         self.tokenizer = Tokenizer(model_path, trust_remote_code=trust_remote_code)
+        self._grammar_compiler = None
         if not _engine_config.empty_init:
             with torch.cuda.device(self.devices[0]):
                 model_loader.export()
@@ -174,6 +175,15 @@ class TurboMind:
 
         self.session_len = _engine_config.session_len
         self.health_executor = ThreadPoolExecutor(max_workers=1)
+
+    @property
+    def grammar_compiler(self):
+        """Lazy-initialized GrammarCompiler shared across all requests."""
+        if self._grammar_compiler is None:
+            tokenizer_info = TokenizerInfo.from_huggingface(
+                self.tokenizer.model.model, vocab_size=self._vocab_size)
+            self._grammar_compiler = _xgr.GrammarCompiler(tokenizer_info)
+        return self._grammar_compiler
 
     def _process_weights(self):
         """Process weight."""
@@ -735,11 +745,8 @@ class TurboMindInstance:
                                                 gen_config=gen_config)
 
         if gen_config.response_format is not None:
-            tokenizer = self.tm_model.tokenizer
-            vocab_size = self.tm_model._vocab_size
-
             try:
-                tokenizer_info = TokenizerInfo.from_huggingface(tokenizer.model.model, vocab_size=vocab_size)
+                compiler = self.tm_model.grammar_compiler
                 decode_grammar_type = gen_config.response_format['type']
                 if decode_grammar_type == 'json_schema':
                     decode_grammar = gen_config.response_format[decode_grammar_type]['schema']
@@ -747,8 +754,6 @@ class TurboMindInstance:
                     decode_grammar = gen_config.response_format[decode_grammar_type]
                 elif decode_grammar_type == 'json_object':
                     decode_grammar = '{"type" : "object", "additionalProperties": true}'
-
-                compiler = _xgr.GrammarCompiler(tokenizer_info)
 
                 if decode_grammar_type == 'json_schema':
                     decode_grammar = json.dumps(decode_grammar)
@@ -765,7 +770,7 @@ class TurboMindInstance:
 
                 self.model_inst.set_grammar(grammar)
             except ValueError as e:
-                logger.warning(f'Failed to initialize guided decoding for tokenizer {tokenizer}, '
+                logger.warning(f'Failed to initialize guided decoding, '
                                f'disable guided decoding: {e}')
                 gen_config.response_format = None
 

--- a/src/turbomind/generation/CMakeLists.txt
+++ b/src/turbomind/generation/CMakeLists.txt
@@ -15,10 +15,9 @@
 cmake_minimum_required(VERSION 3.25)
 
 add_library(guided_decoding STATIC guided_decoding.cc)
-target_link_libraries(guided_decoding PUBLIC
-    apply_token_bitmask_inplace_cuda
-    xgrammar
-    core)
+target_link_libraries(guided_decoding
+    PUBLIC xgrammar core
+    PRIVATE apply_token_bitmask_inplace_cuda)
 set_property(TARGET guided_decoding PROPERTY POSITION_INDEPENDENT_CODE ON)
 
 add_library(generation STATIC

--- a/src/turbomind/generation/CMakeLists.txt
+++ b/src/turbomind/generation/CMakeLists.txt
@@ -15,7 +15,7 @@
 cmake_minimum_required(VERSION 3.25)
 
 add_library(guided_decoding STATIC guided_decoding.cc)
-target_link_libraries(guided_decoding PRIVATE
+target_link_libraries(guided_decoding PUBLIC
     apply_token_bitmask_inplace_cuda
     xgrammar
     core)

--- a/src/turbomind/generation/generation.cc
+++ b/src/turbomind/generation/generation.cc
@@ -293,7 +293,7 @@ struct Generation::Impl {
 
             stop_criteria_->Forward(phase, env);
 
-            guided_decoding_->FinishUpdate(phase);
+            guided_decoding_->FinishUpdate(phase, env);
         }
     }
 };

--- a/src/turbomind/generation/generation.cc
+++ b/src/turbomind/generation/generation.cc
@@ -287,11 +287,13 @@ struct Generation::Impl {
 
             sampling_->Forward(phase, env);
 
-            guided_decoding_->Update(phase, env);
+            guided_decoding_->ScheduleUpdate(phase, env);
 
             AppendTokenIds(d.token_ids_ptrs.data(), output_ids_.data(), output_pos.data(), gs, stream);
 
             stop_criteria_->Forward(phase, env);
+
+            guided_decoding_->FinishUpdate(phase);
         }
     }
 };

--- a/src/turbomind/generation/guided_decoding.cc
+++ b/src/turbomind/generation/guided_decoding.cc
@@ -12,6 +12,7 @@ namespace turbomind {
 struct GuidedDecoding::Data {
     Tensor_<int32_t> bitmask;
     bool             active{};
+    bool             needs_apply{};
 
     std::vector<std::shared_ptr<xgrammar::GrammarMatcher>> matchers;
 };
@@ -60,10 +61,17 @@ void GuidedDecoding::FillMask(int phase, TensorMap& env)
                            (int64_t*)bitmask_buf_.shape().data(),
                            nullptr,
                            0};
+
+        std::vector<xgrammar::GrammarMatcher> active_matchers;
+        std::vector<int32_t>                  active_indices;
+
+        d.needs_apply = false;
+
         if (tp_group_->rank() == 0) {
             for (size_t i = 0; i < d.matchers.size(); ++i) {
-                if (const auto& matcher = d.matchers[i]; matcher && !matcher->IsTerminated()) {
-                    matcher->FillNextTokenBitmask(&dlbitmask, i);
+                if (const auto& m = d.matchers[i]; m && !m->IsTerminated()) {
+                    active_matchers.push_back(*m);
+                    active_indices.push_back(static_cast<int32_t>(i));
                 }
                 else {
                     std::fill_n(bitmask_buf_.data() + i * bitmask_buf_.stride(0),
@@ -71,13 +79,18 @@ void GuidedDecoding::FillMask(int phase, TensorMap& env)
                                 static_cast<int32_t>(-1));
                 }
             }
+
+            if (!active_matchers.empty()) {
+                batch_matcher_.BatchFillNextTokenBitmask(&active_matchers, &dlbitmask, active_indices);
+                d.needs_apply = true;
+            }
         }
     }
 }
 
 void GuidedDecoding::ApplyMask(int phase, TensorMap& env)
 {
-    if (auto& d = *data_.at(phase); d.active) {
+    if (auto& d = *data_.at(phase); d.active && d.needs_apply) {
         const ssize_t numel = d.matchers.size() * bitmask_buf_.stride(0);
         if (tp_group_->n_ranks() > 1) {
             // bcast the data instead of `bitmask_buf` instance (which may avoid copying the data)
@@ -96,13 +109,24 @@ void GuidedDecoding::Update(int phase, TensorMap& env)
     if (auto& d = *data_.at(phase); d.active) {
         Copy(env.at("output_ids").buffer(), d.matchers.size(), output_ids_buf_);
         core::Context::stream().Sync();
+
         if (tp_group_->rank() == 0) {
+            // Collect active matchers and their token IDs for batch AcceptToken
+            std::vector<xgrammar::GrammarMatcher> active_matchers;
+            std::vector<int32_t>                  active_token_ids;
+
             for (size_t i = 0; i < d.matchers.size(); ++i) {
-                if (const auto& matcher = d.matchers[i]; matcher && !matcher->IsTerminated()) {
-                    matcher->AcceptToken(output_ids_buf_[i]);
+                if (const auto& m = d.matchers[i]; m && !m->IsTerminated()) {
+                    active_matchers.push_back(*m);  // copy: refcount++
+                    active_token_ids.push_back(output_ids_buf_[i]);
                 }
             }
+
+            if (!active_matchers.empty()) {
+                xgrammar::BatchGrammarMatcher::BatchAcceptToken(&active_matchers, active_token_ids);
+            }
         }
+        // active_matchers destroyed here: refcount-- for each entry
     }
 }
 

--- a/src/turbomind/generation/guided_decoding.cc
+++ b/src/turbomind/generation/guided_decoding.cc
@@ -31,7 +31,7 @@ GuidedDecoding::GuidedDecoding(const BaseGenerationParam& base, const comm::Host
 
     for (int i = 0; i < phases; ++i) {
         auto& d    = data_.emplace_back(std::make_shared<Data>());
-        d->bitmask = empty_like(bitmask_buf_);
+        d->bitmask = empty_like(bitmask_buf_, kDEVICE);
     }
 }
 

--- a/src/turbomind/generation/guided_decoding.cc
+++ b/src/turbomind/generation/guided_decoding.cc
@@ -56,6 +56,11 @@ void GuidedDecoding::Setup(int phase, TensorMap& env)
 void GuidedDecoding::FillMask(int phase, TensorMap& env)
 {
     if (auto& d = *data_.at(phase); d.active) {
+        // Only the first `generation_size` (= logits.shape(0)) slots are actively
+        // generating; matchers beyond this index belong to idle/prefill requests
+        // whose output_ids are stale and whose bitmasks are never applied.
+        const int gs = env.at("logits").shape(0);
+
         static_assert(sizeof(ssize_t) == sizeof(int64_t));
         DLTensor dlbitmask{bitmask_buf_.data(),
                            DLDevice{kDLCPU, 0},
@@ -67,11 +72,11 @@ void GuidedDecoding::FillMask(int phase, TensorMap& env)
 
         std::vector<xgrammar::GrammarMatcher> active_matchers;
         std::vector<int32_t>                  active_indices;
-        active_matchers.reserve(d.matchers.size());
-        active_indices.reserve(d.matchers.size());
+        active_matchers.reserve(gs);
+        active_indices.reserve(gs);
 
         if (tp_group_->rank() == 0) {
-            for (size_t i = 0; i < d.matchers.size(); ++i) {
+            for (int i = 0; i < gs; ++i) {
                 if (const auto& m = d.matchers[i]; m && !m->IsTerminated()) {
                     active_matchers.emplace_back(*m);
                     active_indices.emplace_back(static_cast<int32_t>(i));
@@ -116,26 +121,32 @@ void GuidedDecoding::ScheduleUpdate(int phase, TensorMap& env)
 
         // D2H copy on secondary stream — overlaps with subsequent GPU kernels
         // on the main stream (AppendTokenIds, stop_criteria).
+        // Only copy the first `generation_size` entries: sampling writes exactly
+        // that many output_ids, and entries beyond it contain stale values.
+        const int gs = env.at("logits").shape(0);
         d2h_stream_.Wait(sampling_done_);
-        Copy(env.at("output_ids").buffer(), d.matchers.size(), output_ids_buf_, d2h_stream_);
+        Copy(env.at("output_ids").buffer(), gs, output_ids_buf_, d2h_stream_);
         d2h_done_.Record(d2h_stream_);
     }
 }
 
-void GuidedDecoding::FinishUpdate(int phase)
+void GuidedDecoding::FinishUpdate(int phase, TensorMap& env)
 {
     if (auto& d = *data_.at(phase); d.active && tp_group_->rank() == 0) {
         // Wait only for the D2H copy to complete — the main stream's
         // AppendTokenIds + stop_criteria may still be executing on GPU.
         d2h_done_.Sync();
 
-        // Collect active matchers and their token IDs for batch AcceptToken
+        // Collect active matchers and their token IDs for batch AcceptToken.
+        // Only iterate over the first `generation_size` (= logits.shape(0)) slots —
+        // beyond that index the output_ids buffer contains stale data from prior steps.
+        const int                             gs = env.at("logits").shape(0);
         std::vector<xgrammar::GrammarMatcher> active_matchers;
         std::vector<int32_t>                  active_token_ids;
-        active_matchers.reserve(d.matchers.size());
-        active_token_ids.reserve(d.matchers.size());
+        active_matchers.reserve(gs);
+        active_token_ids.reserve(gs);
 
-        for (size_t i = 0; i < d.matchers.size(); ++i) {
+        for (int i = 0; i < gs; ++i) {
             if (const auto& m = d.matchers[i]; m && !m->IsTerminated()) {
                 active_matchers.emplace_back(*m);
                 active_token_ids.emplace_back(output_ids_buf_[i]);

--- a/src/turbomind/generation/guided_decoding.cc
+++ b/src/turbomind/generation/guided_decoding.cc
@@ -12,7 +12,6 @@ namespace turbomind {
 struct GuidedDecoding::Data {
     Tensor_<int32_t> bitmask;
     bool             active{};
-    bool             needs_apply{};
 
     std::vector<std::shared_ptr<xgrammar::GrammarMatcher>> matchers;
 };
@@ -68,14 +67,14 @@ void GuidedDecoding::FillMask(int phase, TensorMap& env)
 
         std::vector<xgrammar::GrammarMatcher> active_matchers;
         std::vector<int32_t>                  active_indices;
-
-        d.needs_apply = false;
+        active_matchers.reserve(d.matchers.size());
+        active_indices.reserve(d.matchers.size());
 
         if (tp_group_->rank() == 0) {
             for (size_t i = 0; i < d.matchers.size(); ++i) {
                 if (const auto& m = d.matchers[i]; m && !m->IsTerminated()) {
-                    active_matchers.push_back(*m);
-                    active_indices.push_back(static_cast<int32_t>(i));
+                    active_matchers.emplace_back(*m);
+                    active_indices.emplace_back(static_cast<int32_t>(i));
                 }
                 else {
                     std::fill_n(bitmask_buf_.data() + i * bitmask_buf_.stride(0),
@@ -86,7 +85,6 @@ void GuidedDecoding::FillMask(int phase, TensorMap& env)
 
             if (!active_matchers.empty()) {
                 batch_matcher_.BatchFillNextTokenBitmask(&active_matchers, &dlbitmask, active_indices);
-                d.needs_apply = true;
             }
         }
     }
@@ -94,7 +92,7 @@ void GuidedDecoding::FillMask(int phase, TensorMap& env)
 
 void GuidedDecoding::ApplyMask(int phase, TensorMap& env)
 {
-    if (auto& d = *data_.at(phase); d.active && d.needs_apply) {
+    if (auto& d = *data_.at(phase); d.active) {
         const ssize_t numel = d.matchers.size() * bitmask_buf_.stride(0);
         if (tp_group_->n_ranks() > 1) {
             // bcast the data instead of `bitmask_buf` instance (which may avoid copying the data)
@@ -135,11 +133,13 @@ void GuidedDecoding::FinishUpdate(int phase)
             // Collect active matchers and their token IDs for batch AcceptToken
             std::vector<xgrammar::GrammarMatcher> active_matchers;
             std::vector<int32_t>                  active_token_ids;
+            active_matchers.reserve(d.matchers.size());
+            active_token_ids.reserve(d.matchers.size());
 
             for (size_t i = 0; i < d.matchers.size(); ++i) {
                 if (const auto& m = d.matchers[i]; m && !m->IsTerminated()) {
-                    active_matchers.push_back(*m);  // copy: refcount++
-                    active_token_ids.push_back(output_ids_buf_[i]);
+                    active_matchers.emplace_back(*m);
+                    active_token_ids.emplace_back(output_ids_buf_[i]);
                 }
             }
 

--- a/src/turbomind/generation/guided_decoding.cc
+++ b/src/turbomind/generation/guided_decoding.cc
@@ -108,7 +108,7 @@ void GuidedDecoding::ApplyMask(int phase, TensorMap& env)
 
 void GuidedDecoding::ScheduleUpdate(int phase, TensorMap& env)
 {
-    if (auto& d = *data_.at(phase); d.active) {
+    if (auto& d = *data_.at(phase); d.active && tp_group_->rank() == 0) {
         // Record event on main stream after sampling GPU work is submitted.
         // The secondary stream will wait for this before issuing the D2H copy,
         // ensuring it reads the output_ids written by sampling.
@@ -124,30 +124,27 @@ void GuidedDecoding::ScheduleUpdate(int phase, TensorMap& env)
 
 void GuidedDecoding::FinishUpdate(int phase)
 {
-    if (auto& d = *data_.at(phase); d.active) {
+    if (auto& d = *data_.at(phase); d.active && tp_group_->rank() == 0) {
         // Wait only for the D2H copy to complete — the main stream's
         // AppendTokenIds + stop_criteria may still be executing on GPU.
         d2h_done_.Sync();
 
-        if (tp_group_->rank() == 0) {
-            // Collect active matchers and their token IDs for batch AcceptToken
-            std::vector<xgrammar::GrammarMatcher> active_matchers;
-            std::vector<int32_t>                  active_token_ids;
-            active_matchers.reserve(d.matchers.size());
-            active_token_ids.reserve(d.matchers.size());
+        // Collect active matchers and their token IDs for batch AcceptToken
+        std::vector<xgrammar::GrammarMatcher> active_matchers;
+        std::vector<int32_t>                  active_token_ids;
+        active_matchers.reserve(d.matchers.size());
+        active_token_ids.reserve(d.matchers.size());
 
-            for (size_t i = 0; i < d.matchers.size(); ++i) {
-                if (const auto& m = d.matchers[i]; m && !m->IsTerminated()) {
-                    active_matchers.emplace_back(*m);
-                    active_token_ids.emplace_back(output_ids_buf_[i]);
-                }
-            }
-
-            if (!active_matchers.empty()) {
-                xgrammar::BatchGrammarMatcher::BatchAcceptToken(&active_matchers, active_token_ids);
+        for (size_t i = 0; i < d.matchers.size(); ++i) {
+            if (const auto& m = d.matchers[i]; m && !m->IsTerminated()) {
+                active_matchers.emplace_back(*m);
+                active_token_ids.emplace_back(output_ids_buf_[i]);
             }
         }
-        // active_matchers destroyed here: refcount-- for each entry
+
+        if (!active_matchers.empty()) {
+            xgrammar::BatchGrammarMatcher::BatchAcceptToken(&active_matchers, active_token_ids);
+        }
     }
 }
 

--- a/src/turbomind/generation/guided_decoding.cc
+++ b/src/turbomind/generation/guided_decoding.cc
@@ -26,6 +26,10 @@ GuidedDecoding::GuidedDecoding(const BaseGenerationParam& base, const comm::Host
     bitmask_buf_    = {{max_batch_size_, bitmask_size}, kCPUpinned};
     output_ids_buf_ = {max_batch_size_, kCPUpinned};
 
+    d2h_stream_    = core::Stream::create();
+    sampling_done_ = core::Event::create();
+    d2h_done_      = core::Event::create();
+
     for (int i = 0; i < phases; ++i) {
         auto& d    = data_.emplace_back(std::make_shared<Data>());
         d->bitmask = empty_like(bitmask_buf_);
@@ -104,11 +108,28 @@ void GuidedDecoding::ApplyMask(int phase, TensorMap& env)
     }
 }
 
-void GuidedDecoding::Update(int phase, TensorMap& env)
+void GuidedDecoding::ScheduleUpdate(int phase, TensorMap& env)
 {
     if (auto& d = *data_.at(phase); d.active) {
-        Copy(env.at("output_ids").buffer(), d.matchers.size(), output_ids_buf_);
-        core::Context::stream().Sync();
+        // Record event on main stream after sampling GPU work is submitted.
+        // The secondary stream will wait for this before issuing the D2H copy,
+        // ensuring it reads the output_ids written by sampling.
+        sampling_done_.Record(core::Context::stream());
+
+        // D2H copy on secondary stream — overlaps with subsequent GPU kernels
+        // on the main stream (AppendTokenIds, stop_criteria).
+        d2h_stream_.Wait(sampling_done_);
+        Copy(env.at("output_ids").buffer(), d.matchers.size(), output_ids_buf_, d2h_stream_);
+        d2h_done_.Record(d2h_stream_);
+    }
+}
+
+void GuidedDecoding::FinishUpdate(int phase)
+{
+    if (auto& d = *data_.at(phase); d.active) {
+        // Wait only for the D2H copy to complete — the main stream's
+        // AppendTokenIds + stop_criteria may still be executing on GPU.
+        d2h_done_.Sync();
 
         if (tp_group_->rank() == 0) {
             // Collect active matchers and their token IDs for batch AcceptToken

--- a/src/turbomind/generation/guided_decoding.cc
+++ b/src/turbomind/generation/guided_decoding.cc
@@ -70,12 +70,12 @@ void GuidedDecoding::FillMask(int phase, TensorMap& env)
                            nullptr,
                            0};
 
-        std::vector<xgrammar::GrammarMatcher> active_matchers;
-        std::vector<int32_t>                  active_indices;
-        active_matchers.reserve(gs);
-        active_indices.reserve(gs);
-
         if (tp_group_->rank() == 0) {
+            std::vector<xgrammar::GrammarMatcher> active_matchers;
+            std::vector<int32_t>                  active_indices;
+            active_matchers.reserve(gs);
+            active_indices.reserve(gs);
+
             for (int i = 0; i < gs; ++i) {
                 if (const auto& m = d.matchers[i]; m && !m->IsTerminated()) {
                     active_matchers.emplace_back(*m);

--- a/src/turbomind/generation/guided_decoding.cc
+++ b/src/turbomind/generation/guided_decoding.cc
@@ -71,25 +71,15 @@ void GuidedDecoding::FillMask(int phase, TensorMap& env)
                            0};
 
         if (tp_group_->rank() == 0) {
-            std::vector<xgrammar::GrammarMatcher> active_matchers;
-            std::vector<int32_t>                  active_indices;
-            active_matchers.reserve(gs);
-            active_indices.reserve(gs);
-
             for (int i = 0; i < gs; ++i) {
                 if (const auto& m = d.matchers[i]; m && !m->IsTerminated()) {
-                    active_matchers.emplace_back(*m);
-                    active_indices.emplace_back(static_cast<int32_t>(i));
+                    m->FillNextTokenBitmask(&dlbitmask, i);
                 }
                 else {
                     std::fill_n(bitmask_buf_.data() + i * bitmask_buf_.stride(0),
                                 bitmask_buf_.stride(0),
                                 static_cast<int32_t>(-1));
                 }
-            }
-
-            if (!active_matchers.empty()) {
-                batch_matcher_.BatchFillNextTokenBitmask(&active_matchers, &dlbitmask, active_indices);
             }
         }
     }
@@ -137,24 +127,15 @@ void GuidedDecoding::FinishUpdate(int phase, TensorMap& env)
         // AppendTokenIds + stop_criteria may still be executing on GPU.
         d2h_done_.Sync();
 
-        // Collect active matchers and their token IDs for batch AcceptToken.
+        // Accept tokens for active matchers.
         // Only iterate over the first `generation_size` (= logits.shape(0)) slots —
         // beyond that index the output_ids buffer contains stale data from prior steps.
-        const int                             gs = env.at("logits").shape(0);
-        std::vector<xgrammar::GrammarMatcher> active_matchers;
-        std::vector<int32_t>                  active_token_ids;
-        active_matchers.reserve(gs);
-        active_token_ids.reserve(gs);
+        const int gs = env.at("logits").shape(0);
 
         for (int i = 0; i < gs; ++i) {
             if (const auto& m = d.matchers[i]; m && !m->IsTerminated()) {
-                active_matchers.emplace_back(*m);
-                active_token_ids.emplace_back(output_ids_buf_[i]);
+                m->AcceptToken(output_ids_buf_[i]);
             }
-        }
-
-        if (!active_matchers.empty()) {
-            xgrammar::BatchGrammarMatcher::BatchAcceptToken(&active_matchers, active_token_ids);
         }
     }
 }

--- a/src/turbomind/generation/guided_decoding.h
+++ b/src/turbomind/generation/guided_decoding.h
@@ -6,6 +6,7 @@
 
 #include "src/turbomind/comm/host_comm.h"
 #include "src/turbomind/core/core.h"
+#include "xgrammar/matcher.h"
 
 namespace turbomind {
 
@@ -26,6 +27,8 @@ private:
 
     struct Data;
     std::vector<std::shared_ptr<Data>> data_;
+
+    xgrammar::BatchGrammarMatcher batch_matcher_;
 
     Tensor_<int32_t> bitmask_buf_;
     Buffer_<int>     output_ids_buf_;

--- a/src/turbomind/generation/guided_decoding.h
+++ b/src/turbomind/generation/guided_decoding.h
@@ -6,6 +6,7 @@
 
 #include "src/turbomind/comm/host_comm.h"
 #include "src/turbomind/core/core.h"
+#include "src/turbomind/core/stream.h"
 #include "xgrammar/matcher.h"
 
 namespace turbomind {
@@ -20,7 +21,8 @@ public:
 
     void ApplyMask(int phase, TensorMap& env);
 
-    void Update(int phase, TensorMap& env);
+    void ScheduleUpdate(int phase, TensorMap& env);
+    void FinishUpdate(int phase);
 
 private:
     comm::HostComm tp_group_;
@@ -32,6 +34,10 @@ private:
 
     Tensor_<int32_t> bitmask_buf_;
     Buffer_<int>     output_ids_buf_;
+
+    core::Stream d2h_stream_;     // secondary stream for D2H copy of output_ids
+    core::Event  sampling_done_;  // recorded on main stream after sampling
+    core::Event  d2h_done_;       // recorded on d2h_stream_ after copy completes
 };
 
 }  // namespace turbomind

--- a/src/turbomind/generation/guided_decoding.h
+++ b/src/turbomind/generation/guided_decoding.h
@@ -22,7 +22,7 @@ public:
     void ApplyMask(int phase, TensorMap& env);
 
     void ScheduleUpdate(int phase, TensorMap& env);
-    void FinishUpdate(int phase);
+    void FinishUpdate(int phase, TensorMap& env);
 
 private:
     comm::HostComm tp_group_;

--- a/src/turbomind/generation/guided_decoding.h
+++ b/src/turbomind/generation/guided_decoding.h
@@ -30,8 +30,6 @@ private:
     struct Data;
     std::vector<std::shared_ptr<Data>> data_;
 
-    xgrammar::BatchGrammarMatcher batch_matcher_;
-
     Tensor_<int32_t> bitmask_buf_;
     Buffer_<int>     output_ids_buf_;
 


### PR DESCRIPTION
## Motivation

Improve guided decoding performance in TurboMind by reducing synchronization overhead and upgrading to xgrammar v0.2.1 for API compatibility.

## Modification

This PR includes the following optimizations and fixes:

### Performance Optimizations

1. **Async D2H Copy Overlap** (main optimization):
   - Split `GuidedDecoding::Update()` into `ScheduleUpdate()` + `FinishUpdate()` to enable D2H copy overlap with GPU work
   - Added secondary CUDA stream (`d2h_stream_`) for asynchronous output_ids D2H transfer
   - Added CUDA events (`sampling_done_`, `d2h_done_`) for stream synchronization
   - D2H copy now overlaps with `AppendTokenIds` and `stop_criteria` GPU kernels on the main stream
   - Eliminates a blocking `cudaStreamSynchronize` in the decode step hot path

2. **Grammar Compiler Caching**:
   - Lazy-initialized `GrammarCompiler` shared across all requests in `TurboMindModel`
   - Avoids recreating compiler + tokenizer info on every request

### Correctness Fixes

3. **Limit Iteration to Active Generation Slots**:
   - Limited iteration in `FillMask`, `ScheduleUpdate`, and `FinishUpdate` to `generation_size` (= `logits.shape(0)`)
   - Previous code iterated over all `matchers.size()` entries, including idle/prefill slots with stale `output_ids`
   - Prevents processing stale data beyond active generation slots

### Dependency Updates

4. **xgrammar v0.2.1 Upgrade**:
   - Updated from v0.1.27 to v0.2.1 in `CMakeLists.txt`
   - Added required `debug_print=False` argument to `accept_token()` API
   - Ensured token conversion to plain Python `int` before passing to `accept_token()`

### Build System

5. **CMake Dependency Cleanup**:
   - Changed `xgrammar` and `core` from `PRIVATE` to `PUBLIC` linkage in `guided_decoding` library
   - Ensures proper transitive dependency resolution for downstream targets

## BC-breaking (Optional)

No backward compatibility issues. The API changes are internal to the TurboMind engine and PyTorch engine's guided decoding implementation.

## Use cases (Optional)

This optimization benefits all users of structured generation features:
- JSON schema constrained generation
- Regex pattern constrained generation  
- JSON object generation

Example usage:
```python
from lmdeploy import pipeline, GenerationConfig

pipe = pipeline('Qwen/Qwen2.5-7B-Instruct')
response = pipe(
    'Generate a user profile',
    gen_config=GenerationConfig(
        response_format={'type': 'json_schema', 'json_schema': {...}}
    )
)
```

## Checklist

1. ✅ Pre-commit or other linting tools are used to fix the potential lint issues.
2. ✅ The modification is covered by complete unit tests. All tests pass:
   - Qwen/Qwen3-0.6B: all tests pass
   - Qwen/Qwen3-VL-2B-Instruct: all tests pass (JSON schema, regex schema, json_object)
3. ✅ No dependency on downstream projects with version changes.
4. ✅ Documentation not required for internal optimization changes.

## Test Results

All guided decoding tests pass with the new implementation:
- JSON schema constrained generation: ✅
- Regex pattern constrained generation: ✅
- JSON object generation: ✅