### PR TITLE
Include spec stats in metrics

### DIFF
--- a/lmdeploy/metrics/loggers.py
+++ b/lmdeploy/metrics/loggers.py
@@ -229,6 +229,22 @@ class PrometheusStatLogger(StatLoggerBase):
         self.counter_spec_decode_num_accepted_tokens_per_pos: dict[int, prometheus_client.Counter] = {}
         self.spec_decode_labelvalues = labelvalues
 
+        self.gauge_spec_decode_mean_accept_rate = prometheus_client.Gauge(
+            name='lmdeploy:spec_decode_mean_accept_rate',
+            documentation='Mean speculative decoding acceptance rate. 1 means 100 percent accepted.',
+            labelnames=labelnames).labels(*labelvalues)
+
+        self.gauge_spec_decode_mean_accept_length = prometheus_client.Gauge(
+            name='lmdeploy:spec_decode_mean_accept_length',
+            documentation='Mean speculative decoding acceptance length, including the bonus token.',
+            labelnames=labelnames).labels(*labelvalues)
+
+        self.gauge_spec_decode_per_position_accept_rate_base = prometheus_client.Gauge(
+            name='lmdeploy:spec_decode_per_position_accept_rate',
+            documentation='Speculative decoding acceptance rate per draft position. 1 means 100 percent accepted.',
+            labelnames=labelnames + ['position'])
+        self.gauge_spec_decode_per_position_accept_rate: dict[int, prometheus_client.Gauge] = {}
+
         from lmdeploy.messages import ResponseType
         self.counter_request_success: dict[ResponseType, prometheus_client.Counter] = {}
         counter_request_success_base = prometheus_client.Counter(
@@ -370,6 +386,11 @@ class PrometheusStatLogger(StatLoggerBase):
         self.histogram_num_prompt_tokens_request.observe(stats.prompt_tokens)
         self.histogram_num_generation_tokens_request.observe(stats.generation_tokens)
 
+    @staticmethod
+    def _get_counter_value(counter) -> float:
+        """Get the current value from a prometheus counter child."""
+        return counter._value.get()
+
     def record_specdecode(self, stats: SpeculativeDecodingStats) -> None:
         """Report speculative decoding metrics to prometheus."""
         if stats.num_drafts <= 0:
@@ -379,12 +400,27 @@ class PrometheusStatLogger(StatLoggerBase):
         self.counter_spec_decode_num_draft_tokens.inc(stats.num_draft_tokens)
         self.counter_spec_decode_num_accepted_tokens.inc(stats.num_accepted_tokens)
 
+        num_drafts = self._get_counter_value(self.counter_spec_decode_num_drafts)
+        num_draft_tokens = self._get_counter_value(self.counter_spec_decode_num_draft_tokens)
+        num_accepted_tokens = self._get_counter_value(self.counter_spec_decode_num_accepted_tokens)
+        mean_accept_rate = num_accepted_tokens / num_draft_tokens if num_draft_tokens > 0 else 0.0
+        mean_accept_length = 1 + num_accepted_tokens / num_drafts
+        self.gauge_spec_decode_mean_accept_rate.set(mean_accept_rate)
+        self.gauge_spec_decode_mean_accept_length.set(mean_accept_length)
+
         for pos, num_accepted_tokens in enumerate(stats.num_accepted_tokens_per_pos):
+            num_accepted_tokens = float(num_accepted_tokens)
             if pos not in self.counter_spec_decode_num_accepted_tokens_per_pos:
                 labelvalues = self.spec_decode_labelvalues + [str(pos)]
                 counter = self.counter_spec_decode_num_accepted_tokens_per_pos_base.labels(*labelvalues)
                 self.counter_spec_decode_num_accepted_tokens_per_pos[pos] = counter
-            self.counter_spec_decode_num_accepted_tokens_per_pos[pos].inc(float(num_accepted_tokens))
+                gauge = self.gauge_spec_decode_per_position_accept_rate_base.labels(*labelvalues)
+                self.gauge_spec_decode_per_position_accept_rate[pos] = gauge
+            self.counter_spec_decode_num_accepted_tokens_per_pos[pos].inc(num_accepted_tokens)
+            per_pos_accepted_tokens = self._get_counter_value(
+                self.counter_spec_decode_num_accepted_tokens_per_pos[pos])
+            self.gauge_spec_decode_per_position_accept_rate[pos].set(
+                per_pos_accepted_tokens / num_drafts)
 
 
 def build_buckets(mantissa_lst: list[int], max_value: int) -> list[int]:

--- a/lmdeploy/metrics/loggers.py
+++ b/lmdeploy/metrics/loggers.py
@@ -203,6 +203,32 @@ class PrometheusStatLogger(StatLoggerBase):
             documentation='Number of generation tokens processed.',
             labelnames=labelnames).labels(*labelvalues)
 
+        # Speculative decoding counters. Acceptance rate and mean acceptance
+        # length are derived in PromQL from these raw counters.
+        #   rate(accepted_tokens) / rate(draft_tokens)
+        #   1 + rate(accepted_tokens) / rate(drafts)
+        self.counter_spec_decode_num_drafts = prometheus_client.Counter(
+            name='lmdeploy:spec_decode_num_drafts_total',
+            documentation='Number of speculative decoding drafts.',
+            labelnames=labelnames).labels(*labelvalues)
+
+        self.counter_spec_decode_num_draft_tokens = prometheus_client.Counter(
+            name='lmdeploy:spec_decode_num_draft_tokens_total',
+            documentation='Number of speculative decoding draft tokens.',
+            labelnames=labelnames).labels(*labelvalues)
+
+        self.counter_spec_decode_num_accepted_tokens = prometheus_client.Counter(
+            name='lmdeploy:spec_decode_num_accepted_tokens_total',
+            documentation='Number of speculative decoding accepted tokens.',
+            labelnames=labelnames).labels(*labelvalues)
+
+        self.counter_spec_decode_num_accepted_tokens_per_pos_base = prometheus_client.Counter(
+            name='lmdeploy:spec_decode_num_accepted_tokens_per_pos_total',
+            documentation='Number of accepted speculative decoding tokens per draft position.',
+            labelnames=labelnames + ['position'])
+        self.counter_spec_decode_num_accepted_tokens_per_pos: dict[int, prometheus_client.Counter] = {}
+        self.spec_decode_labelvalues = labelvalues
+
         from lmdeploy.messages import ResponseType
         self.counter_request_success: dict[ResponseType, prometheus_client.Counter] = {}
         counter_request_success_base = prometheus_client.Counter(
@@ -345,7 +371,20 @@ class PrometheusStatLogger(StatLoggerBase):
         self.histogram_num_generation_tokens_request.observe(stats.generation_tokens)
 
     def record_specdecode(self, stats: SpeculativeDecodingStats) -> None:
-        pass
+        """Report speculative decoding metrics to prometheus."""
+        if stats.num_drafts <= 0:
+            return
+
+        self.counter_spec_decode_num_drafts.inc(stats.num_drafts)
+        self.counter_spec_decode_num_draft_tokens.inc(stats.num_draft_tokens)
+        self.counter_spec_decode_num_accepted_tokens.inc(stats.num_accepted_tokens)
+
+        for pos, num_accepted_tokens in enumerate(stats.num_accepted_tokens_per_pos):
+            if pos not in self.counter_spec_decode_num_accepted_tokens_per_pos:
+                labelvalues = self.spec_decode_labelvalues + [str(pos)]
+                counter = self.counter_spec_decode_num_accepted_tokens_per_pos_base.labels(*labelvalues)
+                self.counter_spec_decode_num_accepted_tokens_per_pos[pos] = counter
+            self.counter_spec_decode_num_accepted_tokens_per_pos[pos].inc(float(num_accepted_tokens))
 
 
 def build_buckets(mantissa_lst: list[int], max_value: int) -> list[int]:

--- a/tests/test_lmdeploy/test_metrics_loggers.py
+++ b/tests/test_lmdeploy/test_metrics_loggers.py
@@ -1,0 +1,39 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+
+import pytest
+
+from lmdeploy.metrics.loggers import PrometheusStatLogger
+from lmdeploy.metrics.stats import SpeculativeDecodingStats
+
+prometheus_client = pytest.importorskip('prometheus_client')
+
+
+def _get_sample_value(name: str, labels: dict[str, str]) -> float:
+    for metric in prometheus_client.REGISTRY.collect():
+        for sample in metric.samples:
+            if sample.name != name:
+                continue
+            if all(sample.labels.get(key) == value for key, value in labels.items()):
+                return sample.value
+    raise AssertionError(f'Missing prometheus sample: {name}{labels}')
+
+
+def test_prometheus_stat_logger_records_specdecode_metrics():
+    logger = PrometheusStatLogger('test-model', max_model_len=16, dp_rank=2)
+    stats = SpeculativeDecodingStats(num_spec_tokens=3)
+    stats.update_per_draft(num_draft_tokens=3, num_accepted_tokens=2)
+    stats.update_per_draft(num_draft_tokens=3, num_accepted_tokens=1)
+
+    logger.record_specdecode(stats)
+
+    labels = {'model_name': 'test-model', 'engine': '2'}
+    assert _get_sample_value('lmdeploy:spec_decode_num_drafts_total', labels) == 2
+    assert _get_sample_value('lmdeploy:spec_decode_num_draft_tokens_total', labels) == 6
+    assert _get_sample_value('lmdeploy:spec_decode_num_accepted_tokens_total', labels) == 3
+
+    position_labels = labels | {'position': '0'}
+    assert _get_sample_value('lmdeploy:spec_decode_num_accepted_tokens_per_pos_total', position_labels) == 2
+    position_labels = labels | {'position': '1'}
+    assert _get_sample_value('lmdeploy:spec_decode_num_accepted_tokens_per_pos_total', position_labels) == 1
+    position_labels = labels | {'position': '2'}
+    assert _get_sample_value('lmdeploy:spec_decode_num_accepted_tokens_per_pos_total', position_labels) == 0

--- a/tests/test_lmdeploy/test_metrics_loggers.py
+++ b/tests/test_lmdeploy/test_metrics_loggers.py
@@ -30,10 +30,15 @@ def test_prometheus_stat_logger_records_specdecode_metrics():
     assert _get_sample_value('lmdeploy:spec_decode_num_drafts_total', labels) == 2
     assert _get_sample_value('lmdeploy:spec_decode_num_draft_tokens_total', labels) == 6
     assert _get_sample_value('lmdeploy:spec_decode_num_accepted_tokens_total', labels) == 3
+    assert _get_sample_value('lmdeploy:spec_decode_mean_accept_rate', labels) == 0.5
+    assert _get_sample_value('lmdeploy:spec_decode_mean_accept_length', labels) == 2.5
 
     position_labels = labels | {'position': '0'}
     assert _get_sample_value('lmdeploy:spec_decode_num_accepted_tokens_per_pos_total', position_labels) == 2
+    assert _get_sample_value('lmdeploy:spec_decode_per_position_accept_rate', position_labels) == 1
     position_labels = labels | {'position': '1'}
     assert _get_sample_value('lmdeploy:spec_decode_num_accepted_tokens_per_pos_total', position_labels) == 1
+    assert _get_sample_value('lmdeploy:spec_decode_per_position_accept_rate', position_labels) == 0.5
     position_labels = labels | {'position': '2'}
     assert _get_sample_value('lmdeploy:spec_decode_num_accepted_tokens_per_pos_total', position_labels) == 0
+    assert _get_sample_value('lmdeploy:spec_decode_per_position_accept_rate', position_labels) == 0


### PR DESCRIPTION


## Motivation

Include spec stats in metrics
get spec stats info from service
```bash
curl -s http://127.0.0.1:23333/metrics | grep 'lmdeploy:spec_decode'
```

## Modification

Please briefly describe what modification is made in this PR.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
