### PR TITLE
fix: remove hard CUDA_PATH assert on Windows, search DLL paths from multiple sources

### DIFF
--- a/lmdeploy/turbomind/__init__.py
+++ b/lmdeploy/turbomind/__init__.py
@@ -9,12 +9,23 @@ def bootstrap():
     if os.path.exists(os.path.join(pwd, '..', 'lib')):
         has_turbomind = True
     if os.name == 'nt' and has_turbomind:
-        CUDA_PATH = os.getenv('CUDA_PATH')
-        assert CUDA_PATH is not None, 'Can not find $env:CUDA_PATH'
-        dll_path = os.path.join(CUDA_PATH, 'bin')
-        print(f'Add dll path {dll_path}, please note cuda version '
-              'should >= 11.3 when compiled with cuda 11')
-        os.add_dll_directory(dll_path)
+        dll_paths = []
+        cuda_path = os.getenv('CUDA_PATH')
+        if cuda_path is not None:
+            dll_paths.append(os.path.join(cuda_path, 'bin'))
+        try:
+            import torch
+            dll_paths.append(os.path.join(os.path.dirname(torch.__file__), 'lib'))
+        except ImportError:
+            pass
+        conda_prefix = os.getenv('CONDA_PREFIX')
+        if conda_prefix is not None:
+            dll_paths.append(os.path.join(conda_prefix, 'Library', 'bin'))
+        for dll_path in dll_paths:
+            if os.path.isdir(dll_path):
+                print(f'Add dll path {dll_path}, please note cuda version '
+                      'should >= 11.3 when compiled with cuda 11')
+                os.add_dll_directory(dll_path)
 
 
 bootstrap()

--- a/lmdeploy/turbomind/__init__.py
+++ b/lmdeploy/turbomind/__init__.py
@@ -21,14 +21,14 @@ def bootstrap():
         conda_prefix = os.getenv('CONDA_PREFIX')
         if conda_prefix is not None:
             dll_paths.append(os.path.join(conda_prefix, 'Library', 'bin'))
-        added = False
+        # de-duplicate while preserving order
+        seen = set()
+        dll_paths = [p for p in dll_paths if not (p in seen or seen.add(p))]
+        _dll_dirs = []  # keep directory handles alive
         for dll_path in dll_paths:
             if os.path.isdir(dll_path):
-                print(f'Add dll path {dll_path}, please note cuda version '
-                      'should >= 11.3 when compiled with cuda 11')
-                os.add_dll_directory(dll_path)
-                added = True
-        if not added:
+                _dll_dirs.append(os.add_dll_directory(dll_path))
+        if not _dll_dirs:
             print('Warning: no CUDA DLL directory found. Set CUDA_PATH or '
                   'install PyTorch with CUDA support, otherwise TurboMind '
                   'may fail to load.')

--- a/lmdeploy/turbomind/__init__.py
+++ b/lmdeploy/turbomind/__init__.py
@@ -21,9 +21,17 @@ def bootstrap():
         conda_prefix = os.getenv('CONDA_PREFIX')
         if conda_prefix is not None:
             dll_paths.append(os.path.join(conda_prefix, 'Library', 'bin'))
-        # de-duplicate while preserving order
+        # de-duplicate while preserving order; normalize Windows paths so
+        # case and slash differences do not bypass de-duplication
         seen = set()
-        dll_paths = [p for p in dll_paths if not (p in seen or seen.add(p))]
+        deduped_dll_paths = []
+        for dll_path in dll_paths:
+            dll_path_key = os.path.normcase(os.path.normpath(dll_path))
+            if dll_path_key in seen:
+                continue
+            seen.add(dll_path_key)
+            deduped_dll_paths.append(dll_path)
+        dll_paths = deduped_dll_paths
         _dll_dirs = []  # keep directory handles alive
         for dll_path in dll_paths:
             if os.path.isdir(dll_path):

--- a/lmdeploy/turbomind/__init__.py
+++ b/lmdeploy/turbomind/__init__.py
@@ -1,7 +1,14 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 
+# Module-level list to keep DLL directory handles alive for the process
+# lifetime. os.add_dll_directory() returns a handle that removes the
+# directory from the search path when garbage-collected, so we must
+# retain a reference.
+_dll_dirs = []
+
 
 def bootstrap():
+    import importlib.util
     import os
 
     has_turbomind = False
@@ -13,11 +20,9 @@ def bootstrap():
         cuda_path = os.getenv('CUDA_PATH')
         if cuda_path is not None:
             dll_paths.append(os.path.join(cuda_path, 'bin'))
-        try:
-            import torch
-            dll_paths.append(os.path.join(os.path.dirname(torch.__file__), 'lib'))
-        except ImportError:
-            pass
+        torch_spec = importlib.util.find_spec('torch')
+        if torch_spec is not None and torch_spec.origin is not None:
+            dll_paths.append(os.path.join(os.path.dirname(torch_spec.origin), 'lib'))
         conda_prefix = os.getenv('CONDA_PREFIX')
         if conda_prefix is not None:
             dll_paths.append(os.path.join(conda_prefix, 'Library', 'bin'))
@@ -32,7 +37,7 @@ def bootstrap():
             seen.add(dll_path_key)
             deduped_dll_paths.append(dll_path)
         dll_paths = deduped_dll_paths
-        _dll_dirs = []  # keep directory handles alive
+        global _dll_dirs
         for dll_path in dll_paths:
             if os.path.isdir(dll_path):
                 _dll_dirs.append(os.add_dll_directory(dll_path))

--- a/lmdeploy/turbomind/__init__.py
+++ b/lmdeploy/turbomind/__init__.py
@@ -21,11 +21,17 @@ def bootstrap():
         conda_prefix = os.getenv('CONDA_PREFIX')
         if conda_prefix is not None:
             dll_paths.append(os.path.join(conda_prefix, 'Library', 'bin'))
+        added = False
         for dll_path in dll_paths:
             if os.path.isdir(dll_path):
                 print(f'Add dll path {dll_path}, please note cuda version '
                       'should >= 11.3 when compiled with cuda 11')
                 os.add_dll_directory(dll_path)
+                added = True
+        if not added:
+            print('Warning: no CUDA DLL directory found. Set CUDA_PATH or '
+                  'install PyTorch with CUDA support, otherwise TurboMind '
+                  'may fail to load.')
 
 
 bootstrap()


### PR DESCRIPTION
## Motivation

Resolves #4627

On Windows venv, `lmdeploy` crashes with `AssertionError: Can not find $env:CUDA_PATH` when the `CUDA_PATH` environment variable is not set, even if PyTorch already ships CUDA DLLs accessible via `torch/lib`. This makes lmdeploy unusable in standard Python venv setups on Windows.

## Modification

- Remove the hard `assert CUDA_PATH is not None` in `lmdeploy/turbomind/__init__.py` `bootstrap()`.
- Instead of requiring `CUDA_PATH` unconditionally, search for CUDA DLL directories from multiple sources:
  1. `CUDA_PATH/bin` — the existing system CUDA installation (if set)
  2. `torch/lib` — PyTorch bundled CUDA runtime (works in venv without CUDA_PATH)
  3. `CONDA_PREFIX/Library/bin` — Conda environments on Windows
- Only call `os.add_dll_directory()` when the candidate directory actually exists on disk.

## BC-breaking

No. The change is purely additive — `CUDA_PATH/bin` is still searched first when the variable is set. Existing workflows are unaffected.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.