### PR TITLE
Add raw chat completion logprob output

### DIFF
--- a/benchmark/benchmark_chat_completion.py
+++ b/benchmark/benchmark_chat_completion.py
@@ -6,8 +6,8 @@ chat ``messages``, or a string/list ``prompt`` (e.g. dapo-math-17k). List-type
 aggregates TTFT/ITL/TPOT metrics, and writes table plus report artifacts for concurrency/RPS sweeps.
 
 Generation options include ``--output-tokens`` (``max_completion_tokens``),
-``--ignore-eos``, ``--return-token-ids``, ``--return-routed-experts``, and
-``--logprobs`` / ``--top-logprobs``.
+``--ignore-eos``, ``--return-token-ids``, ``--return-routed-experts``,
+and ``--return-logprob``.
 """
 
 from __future__ import annotations
@@ -336,8 +336,7 @@ def build_payload(
     ignore_eos: bool = False,
     return_token_ids: bool = False,
     return_routed_experts: bool = False,
-    logprobs: bool = False,
-    top_logprobs: int | None = None,
+    return_logprob: bool = False,
     extra_body: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     payload: dict[str, Any] = {
@@ -365,10 +364,8 @@ def build_payload(
         payload['return_token_ids'] = True
     if return_routed_experts:
         payload['return_routed_experts'] = True
-    if logprobs:
-        payload['logprobs'] = True
-        if top_logprobs is not None:
-            payload['top_logprobs'] = top_logprobs
+    if return_logprob:
+        payload['return_logprob'] = True
     if extra_body:
         payload.update(extra_body)
     return payload
@@ -415,8 +412,7 @@ async def request_chat_completion(
     ignore_eos: bool,
     return_token_ids: bool,
     return_routed_experts: bool,
-    logprobs: bool,
-    top_logprobs: int | None,
+    return_logprob: bool,
     extra_body: dict[str, Any] | None,
     headers: dict[str, str] | None = None,
     save_response_text: bool = False,
@@ -432,8 +428,7 @@ async def request_chat_completion(
         ignore_eos=ignore_eos,
         return_token_ids=return_token_ids,
         return_routed_experts=return_routed_experts,
-        logprobs=logprobs,
-        top_logprobs=top_logprobs,
+        return_logprob=return_logprob,
         extra_body=extra_body,
     )
     trace = RequestTrace(
@@ -1005,8 +1000,8 @@ async def run_benchmark(args: argparse.Namespace) -> tuple[list[RequestTrace], l
             print('return_token_ids=True')
         if args.return_routed_experts:
             print('return_routed_experts=True')
-        if args.logprobs:
-            print(f'logprobs=True top_logprobs={args.top_logprobs!r}')
+        if args.return_logprob:
+            print('return_logprob=True')
 
         async def send_one(request: BenchmarkRequest, mode: str, setting: float, repeat: int) -> RequestTrace:
             return await request_chat_completion(
@@ -1024,8 +1019,7 @@ async def run_benchmark(args: argparse.Namespace) -> tuple[list[RequestTrace], l
                 ignore_eos=args.ignore_eos,
                 return_token_ids=args.return_token_ids,
                 return_routed_experts=args.return_routed_experts,
-                logprobs=args.logprobs,
-                top_logprobs=args.top_logprobs,
+                return_logprob=args.return_logprob,
                 extra_body=extra_body,
                 headers=headers,
                 save_response_text=args.save_response_text,
@@ -1219,16 +1213,9 @@ def parse_args() -> argparse.Namespace:
         help='Set return_routed_experts=true to include MoE routed expert indices (LMDeploy extension).',
     )
     parser.add_argument(
-        '--logprobs',
+        '--return-logprob',
         action='store_true',
-        help='Set logprobs=true to return per-token logprobs (requires logprobs_mode in server config).',
-    )
-    parser.add_argument(
-        '--top-logprobs',
-        type=int,
-        default=None,
-        metavar='N',
-        help='When --logprobs is set, request top_logprobs=N (default: server uses 1).',
+        help='Set return_logprob=true to include raw (logprob, token_id) pairs without OpenAI token formatting.',
     )
     parser.add_argument(
         '--extra-request-body',

--- a/benchmark/benchmark_chat_completion.py
+++ b/benchmark/benchmark_chat_completion.py
@@ -7,7 +7,7 @@ aggregates TTFT/ITL/TPOT metrics, and writes table plus report artifacts for con
 
 Generation options include ``--output-tokens`` (``max_completion_tokens``),
 ``--ignore-eos``, ``--return-token-ids``, ``--return-routed-experts``,
-and ``--return-logprob``.
+``--return-logprob``, and ``--logprobs`` / ``--top-logprobs``.
 """
 
 from __future__ import annotations
@@ -337,6 +337,8 @@ def build_payload(
     return_token_ids: bool = False,
     return_routed_experts: bool = False,
     return_logprob: bool = False,
+    logprobs: bool = False,
+    top_logprobs: int | None = None,
     extra_body: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     payload: dict[str, Any] = {
@@ -366,6 +368,10 @@ def build_payload(
         payload['return_routed_experts'] = True
     if return_logprob:
         payload['return_logprob'] = True
+    if logprobs:
+        payload['logprobs'] = True
+        if top_logprobs is not None:
+            payload['top_logprobs'] = top_logprobs
     if extra_body:
         payload.update(extra_body)
     return payload
@@ -413,6 +419,8 @@ async def request_chat_completion(
     return_token_ids: bool,
     return_routed_experts: bool,
     return_logprob: bool,
+    logprobs: bool,
+    top_logprobs: int | None,
     extra_body: dict[str, Any] | None,
     headers: dict[str, str] | None = None,
     save_response_text: bool = False,
@@ -429,6 +437,8 @@ async def request_chat_completion(
         return_token_ids=return_token_ids,
         return_routed_experts=return_routed_experts,
         return_logprob=return_logprob,
+        logprobs=logprobs,
+        top_logprobs=top_logprobs,
         extra_body=extra_body,
     )
     trace = RequestTrace(
@@ -1002,6 +1012,8 @@ async def run_benchmark(args: argparse.Namespace) -> tuple[list[RequestTrace], l
             print('return_routed_experts=True')
         if args.return_logprob:
             print('return_logprob=True')
+        if args.logprobs:
+            print(f'logprobs=True top_logprobs={args.top_logprobs!r}')
 
         async def send_one(request: BenchmarkRequest, mode: str, setting: float, repeat: int) -> RequestTrace:
             return await request_chat_completion(
@@ -1020,6 +1032,8 @@ async def run_benchmark(args: argparse.Namespace) -> tuple[list[RequestTrace], l
                 return_token_ids=args.return_token_ids,
                 return_routed_experts=args.return_routed_experts,
                 return_logprob=args.return_logprob,
+                logprobs=args.logprobs,
+                top_logprobs=args.top_logprobs,
                 extra_body=extra_body,
                 headers=headers,
                 save_response_text=args.save_response_text,
@@ -1216,6 +1230,18 @@ def parse_args() -> argparse.Namespace:
         '--return-logprob',
         action='store_true',
         help='Set return_logprob=true to include raw (logprob, token_id) pairs without OpenAI token formatting.',
+    )
+    parser.add_argument(
+        '--logprobs',
+        action='store_true',
+        help='Set logprobs=true to return OpenAI-compatible per-token logprobs.',
+    )
+    parser.add_argument(
+        '--top-logprobs',
+        type=int,
+        default=None,
+        metavar='N',
+        help='When --logprobs is set, request top_logprobs=N (default: server uses 1).',
     )
     parser.add_argument(
         '--extra-request-body',

--- a/benchmark/benchmark_generate.py
+++ b/benchmark/benchmark_generate.py
@@ -87,7 +87,7 @@ def _normalize_row(
     row_index: int,
     tokenizer,
 ) -> GenerateBenchmarkRequest:
-    request_id = str(row.get('id', f"{dataset}-{row_index}"))
+    request_id = str(row.get('id', f'{dataset}-{row_index}'))
     messages = _extract_messages(row)
     prompt_str = tokenizer.apply_chat_template(
         messages,
@@ -242,7 +242,7 @@ async def request_generate(
         async with session.post(url, json=payload, headers=headers) as response:
             trace.http_status = response.status
             if response.status != 200:
-                trace.error = f"{response.status} {response.reason}: {await response.text()}"
+                trace.error = f'{response.status} {response.reason}: {await response.text()}'
                 trace.end_time = time.perf_counter()
                 return trace
 
@@ -287,12 +287,12 @@ async def run_benchmark(args: argparse.Namespace) -> tuple[list[RequestTrace], l
     url = _generate_url(args.base_url)
     headers = {}
     if args.api_key:
-        headers['Authorization'] = f"Bearer {args.api_key}"
+        headers['Authorization'] = f'Bearer {args.api_key}'
     extra_body = json.loads(args.extra_request_body) if args.extra_request_body else {}
 
-    print(f"POST {url}")
+    print(f'POST {url}')
     if args.max_tokens is not None:
-        print(f"max_tokens={args.max_tokens}")
+        print(f'max_tokens={args.max_tokens}')
     if args.ignore_eos:
         print('ignore_eos=True')
     if args.return_logprob:
@@ -317,7 +317,7 @@ async def run_benchmark(args: argparse.Namespace) -> tuple[list[RequestTrace], l
     )
     pool_limit, pool_limit_per_host = _client_connector_limits(args.mode, args.levels, len(requests))
     connector = aiohttp.TCPConnector(limit=pool_limit, limit_per_host=pool_limit_per_host)
-    print(f"aiohttp connection pool: limit={pool_limit}, limit_per_host={pool_limit_per_host}")
+    print(f'aiohttp connection pool: limit={pool_limit}, limit_per_host={pool_limit_per_host}')
 
     async with aiohttp.ClientSession(
         connector=connector,
@@ -355,14 +355,14 @@ async def run_benchmark(args: argparse.Namespace) -> tuple[list[RequestTrace], l
         for repeat in range(args.repeats):
             if args.mode == 'concurrency':
                 for concurrency in args.levels:
-                    print(f"benchmark {len(requests)} requests, concurrency={concurrency}...")
+                    print(f'benchmark {len(requests)} requests, concurrency={concurrency}...')
                     completed_count = 0
                     failed_count = 0
                     pbar = None
                     if tqdm is not None:
                         pbar = tqdm(
                             total=len(requests),
-                            desc=f"repeat-{repeat} concurrency-{int(concurrency)}",
+                            desc=f'repeat-{repeat} concurrency-{int(concurrency)}',
                             unit='req',
                             dynamic_ncols=True,
                         )
@@ -388,7 +388,7 @@ async def run_benchmark(args: argparse.Namespace) -> tuple[list[RequestTrace], l
                     )
                     if pbar is not None:
                         pbar.close()
-                    print(f"write report for concurrency-{concurrency}...")
+                    print(f'write report for concurrency-{concurrency}...')
                     summaries = aggregate_traces(all_traces)
                     write_report_artifacts(
                         args.output_dir,
@@ -400,14 +400,14 @@ async def run_benchmark(args: argparse.Namespace) -> tuple[list[RequestTrace], l
 
             elif args.mode == 'request-rate':
                 for request_rate in args.levels:
-                    print(f"benchmark {len(requests)} requests, request_rate={request_rate}...")
+                    print(f'benchmark {len(requests)} requests, request_rate={request_rate}...')
                     completed_count = 0
                     failed_count = 0
                     pbar = None
                     if tqdm is not None:
                         pbar = tqdm(
                             total=len(requests),
-                            desc=f"repeat-{repeat} request-rate-{request_rate}",
+                            desc=f'repeat-{repeat} request-rate-{request_rate}',
                             unit='req',
                             dynamic_ncols=True,
                         )
@@ -560,7 +560,7 @@ def main() -> None:
     traces, summaries = asyncio.run(run_benchmark(args))
     completed = sum(summary['completed'] for summary in summaries)
     failed = sum(summary['failed'] for summary in summaries)
-    print(f"Recorded {len(traces)} requests: {completed} completed, {failed} failed.")
+    print(f'Recorded {len(traces)} requests: {completed} completed, {failed} failed.')
 
 
 if __name__ == '__main__':

--- a/benchmark/benchmark_generate.py
+++ b/benchmark/benchmark_generate.py
@@ -1,0 +1,567 @@
+"""Benchmark LMDeploy ``POST /generate`` with eval-style JSONL datasets.
+
+Each JSONL row provides chat ``messages`` or ``prompt`` (a string or message list).
+Rows are converted with ``apply_chat_template`` using
+``--model-path`` (or the model id from ``/v1/models``). The script records streaming
+latency (TTFT / ITL / TPOT), aggregates metrics, and writes summary tables plus
+optional PNG plots.
+
+Example::
+
+    python benchmark/benchmark_generate.py \\
+        --dataset-dir ./workspace/oc_data/ \\
+        --datasets aime2025 \\
+        --base-url http://127.0.0.1:23333 \\
+        --output-tokens 100 \\
+        --ignore-eos \\
+        --levels 8 32 64 \\
+        --output-dir build/benchmark_generate_outputs/
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import importlib
+import json
+import sys
+import time
+from collections.abc import Awaitable, Callable, Sequence
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+_BENCHMARK_DIR = Path(__file__).resolve().parent
+if str(_BENCHMARK_DIR) not in sys.path:
+    sys.path.insert(0, str(_BENCHMARK_DIR))
+
+from benchmark_chat_completion import (  # noqa: E402
+    RequestTrace,
+    _client_connector_limits,
+    _extract_messages,
+    _load_tokenizer,
+    _read_raw_rows,
+    _run_warmup,
+    _split_csv,
+    aggregate_traces,
+    closed_loop_runner,
+    fetch_model_id,
+    request_rate_runner,
+    write_report_artifacts,
+)
+
+try:
+    from tqdm import tqdm
+except Exception:  # noqa: BLE001
+    tqdm = None
+
+
+@dataclass
+class GenerateBenchmarkRequest:
+    dataset: str
+    id: str
+    input_ids: list[int]
+    image_data: Any = None
+
+
+@dataclass
+class GenerateStreamEvent:
+    text: str = ''
+    finish_reason: str | None = None
+    prompt_tokens: int = 0
+    completion_tokens: int = 0
+    done: bool = False
+
+    @property
+    def token_text(self) -> str:
+        return self.text
+
+
+SendOne = Callable[[GenerateBenchmarkRequest, str, float, int], Awaitable[RequestTrace]]
+
+
+def _normalize_row(
+    row: dict[str, Any],
+    dataset: str,
+    row_index: int,
+    tokenizer,
+) -> GenerateBenchmarkRequest:
+    request_id = str(row.get('id', f"{dataset}-{row_index}"))
+    messages = _extract_messages(row)
+    prompt_str = tokenizer.apply_chat_template(
+        messages,
+        tokenize=False,
+        add_generation_prompt=True,
+    )
+    return GenerateBenchmarkRequest(
+        dataset=dataset,
+        id=request_id,
+        input_ids=tokenizer.encode(prompt_str, add_special_tokens=False),
+        image_data=row.get('image_data'),
+    )
+
+
+def load_requests(
+    dataset_dir: str | Path | None = None,
+    dataset_files: Sequence[str | Path] | None = None,
+    datasets: Sequence[str] | None = None,
+    num_prompts: int | None = None,
+    shuffle: bool = False,
+    seed: int = 1,
+    tokenizer=None,
+) -> list[GenerateBenchmarkRequest]:
+    import random
+
+    raw_rows = _read_raw_rows(
+        dataset_dir=dataset_dir,
+        dataset_files=dataset_files,
+        datasets=datasets,
+        num_prompts=num_prompts,
+        shuffle=shuffle,
+    )
+    if shuffle:
+        random.Random(seed).shuffle(raw_rows)
+    if num_prompts is not None:
+        raw_rows = raw_rows[:num_prompts]
+    if not raw_rows:
+        raise ValueError('No benchmark requests were loaded.')
+
+    return [_normalize_row(row, dataset, row_index, tokenizer) for row, dataset, row_index in raw_rows]
+
+
+def parse_generate_sse_line(line: bytes | str) -> GenerateStreamEvent:
+    if isinstance(line, bytes):
+        line = line.decode('utf-8')
+    line = line.strip()
+    if not line:
+        return GenerateStreamEvent()
+    if line.startswith('data:'):
+        line = line[len('data:'):].strip()
+    if line == '[DONE]':
+        return GenerateStreamEvent(done=True)
+
+    data = json.loads(line)
+    meta = data.get('meta_info') or {}
+    finish_reason = None
+    finish_obj = meta.get('finish_reason')
+    if isinstance(finish_obj, dict):
+        finish_reason = finish_obj.get('type')
+    elif isinstance(finish_obj, str):
+        finish_reason = finish_obj
+
+    prompt_tokens = int(meta.get('prompt_tokens') or 0)
+    completion_tokens = int(meta.get('completion_tokens') or 0)
+    return GenerateStreamEvent(
+        text=data.get('text') or '',
+        finish_reason=finish_reason,
+        prompt_tokens=prompt_tokens,
+        completion_tokens=completion_tokens,
+    )
+
+
+def build_payload(
+    request: GenerateBenchmarkRequest,
+    temperature: float,
+    top_p: float,
+    top_k: int,
+    max_tokens: int | None,
+    ignore_eos: bool,
+    return_logprob: bool,
+    return_routed_experts: bool,
+    extra_body: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        'temperature': temperature,
+        'top_p': top_p,
+        'top_k': top_k,
+        'stream': True,
+    }
+    payload['input_ids'] = request.input_ids
+    if request.image_data is not None:
+        payload['image_data'] = request.image_data
+    if max_tokens is not None:
+        payload['max_tokens'] = max_tokens
+    if ignore_eos:
+        payload['ignore_eos'] = True
+    if return_logprob:
+        payload['return_logprob'] = True
+    if return_routed_experts:
+        payload['return_routed_experts'] = True
+    if extra_body:
+        payload.update(extra_body)
+    return payload
+
+
+def _generate_url(base_url: str) -> str:
+    base_url = base_url.rstrip('/')
+    if base_url.endswith('/v1'):
+        base_url = base_url[:-3]
+    return f'{base_url}/generate'
+
+
+async def request_generate(
+    session: Any,
+    request: GenerateBenchmarkRequest,
+    url: str,
+    mode: str,
+    setting: float,
+    repeat: int,
+    temperature: float,
+    top_p: float,
+    top_k: int,
+    max_tokens: int | None,
+    ignore_eos: bool,
+    return_logprob: bool,
+    return_routed_experts: bool,
+    extra_body: dict[str, Any] | None,
+    headers: dict[str, str] | None = None,
+    save_response_text: bool = False,
+) -> RequestTrace:
+    payload = build_payload(
+        request=request,
+        temperature=temperature,
+        top_p=top_p,
+        top_k=top_k,
+        max_tokens=max_tokens,
+        ignore_eos=ignore_eos,
+        return_logprob=return_logprob,
+        return_routed_experts=return_routed_experts,
+        extra_body=extra_body,
+    )
+    trace = RequestTrace(
+        dataset=request.dataset,
+        request_id=request.id,
+        mode=mode,
+        setting=setting,
+        repeat=repeat,
+        success=False,
+        start_time=time.perf_counter(),
+    )
+    try:
+        async with session.post(url, json=payload, headers=headers) as response:
+            trace.http_status = response.status
+            if response.status != 200:
+                trace.error = f"{response.status} {response.reason}: {await response.text()}"
+                trace.end_time = time.perf_counter()
+                return trace
+
+            async for chunk in response.content:
+                for raw_line in chunk.splitlines():
+                    if not raw_line.strip():
+                        continue
+                    event = parse_generate_sse_line(raw_line)
+                    if event.done:
+                        continue
+                    now = time.perf_counter()
+                    if event.token_text:
+                        if trace.first_token_time is None:
+                            trace.first_token_time = now
+                        trace.chunk_times.append(now)
+                    if save_response_text and event.text:
+                        trace.generated_text += event.text
+                    if event.finish_reason is not None:
+                        trace.finish_reason = event.finish_reason
+                    if event.prompt_tokens or event.completion_tokens:
+                        trace.usage_available = True
+                        if event.prompt_tokens:
+                            trace.prompt_tokens = event.prompt_tokens
+                        if event.completion_tokens:
+                            trace.completion_tokens = event.completion_tokens
+            trace.end_time = time.perf_counter()
+            trace.success = trace.error == ''
+            return trace
+    except Exception as e:  # noqa: BLE001
+        trace.end_time = time.perf_counter()
+        trace.error = repr(e)
+        return trace
+
+
+async def run_benchmark(args: argparse.Namespace) -> tuple[list[RequestTrace], list[dict[str, Any]]]:
+    try:
+        aiohttp = importlib.import_module('aiohttp')
+    except ImportError as e:
+        raise RuntimeError('aiohttp is required for live /generate benchmarking.') from e
+
+    dataset_files = [Path(path) for path in args.dataset_files] if args.dataset_files else None
+    url = _generate_url(args.base_url)
+    headers = {}
+    if args.api_key:
+        headers['Authorization'] = f"Bearer {args.api_key}"
+    extra_body = json.loads(args.extra_request_body) if args.extra_request_body else {}
+
+    print(f"POST {url}")
+    if args.max_tokens is not None:
+        print(f"max_tokens={args.max_tokens}")
+    if args.ignore_eos:
+        print('ignore_eos=True')
+    if args.return_logprob:
+        print('return_logprob=True')
+    if args.return_routed_experts:
+        print('return_routed_experts=True')
+
+    model_path = args.model_path
+    if not model_path:
+        async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=30)) as probe_session:
+            model_path = await fetch_model_id(probe_session, args.base_url, args.api_key or None)
+    print(f'Using tokenizer from: {model_path}')
+    tokenizer = _load_tokenizer(model_path, trust_remote_code=args.trust_remote_code)
+    requests = load_requests(
+        dataset_dir=args.dataset_dir,
+        dataset_files=dataset_files,
+        datasets=_split_csv(args.datasets),
+        num_prompts=args.num_prompts,
+        shuffle=args.shuffle,
+        seed=args.seed,
+        tokenizer=tokenizer,
+    )
+    pool_limit, pool_limit_per_host = _client_connector_limits(args.mode, args.levels, len(requests))
+    connector = aiohttp.TCPConnector(limit=pool_limit, limit_per_host=pool_limit_per_host)
+    print(f"aiohttp connection pool: limit={pool_limit}, limit_per_host={pool_limit_per_host}")
+
+    async with aiohttp.ClientSession(
+        connector=connector,
+        timeout=aiohttp.ClientTimeout(total=None),
+    ) as session:
+
+        async def send_one(
+            request: GenerateBenchmarkRequest,
+            mode: str,
+            setting: float,
+            repeat: int,
+        ) -> RequestTrace:
+            return await request_generate(
+                session=session,
+                request=request,
+                url=url,
+                mode=mode,
+                setting=setting,
+                repeat=repeat,
+                temperature=args.temperature,
+                top_p=args.top_p,
+                top_k=args.top_k,
+                max_tokens=args.max_tokens,
+                ignore_eos=args.ignore_eos,
+                return_logprob=args.return_logprob,
+                return_routed_experts=args.return_routed_experts,
+                extra_body=extra_body,
+                headers=headers,
+                save_response_text=args.save_response_text,
+            )
+
+        all_traces: list[RequestTrace] = []
+        summaries: list[dict[str, Any]] = []
+        await _run_warmup(requests, args.warmup_requests, send_one)
+        for repeat in range(args.repeats):
+            if args.mode == 'concurrency':
+                for concurrency in args.levels:
+                    print(f"benchmark {len(requests)} requests, concurrency={concurrency}...")
+                    completed_count = 0
+                    failed_count = 0
+                    pbar = None
+                    if tqdm is not None:
+                        pbar = tqdm(
+                            total=len(requests),
+                            desc=f"repeat-{repeat} concurrency-{int(concurrency)}",
+                            unit='req',
+                            dynamic_ncols=True,
+                        )
+
+                    def on_done(trace: RequestTrace) -> None:
+                        nonlocal completed_count, failed_count
+                        if trace.success:
+                            completed_count += 1
+                        else:
+                            failed_count += 1
+                        if pbar is not None:
+                            pbar.update(1)
+                            pbar.set_postfix(completed=completed_count, failed=failed_count)
+
+                    all_traces.extend(
+                        await closed_loop_runner(
+                            requests,
+                            concurrency=int(concurrency),
+                            repeat=repeat,
+                            send_one=send_one,
+                            on_done=on_done,
+                        )
+                    )
+                    if pbar is not None:
+                        pbar.close()
+                    print(f"write report for concurrency-{concurrency}...")
+                    summaries = aggregate_traces(all_traces)
+                    write_report_artifacts(
+                        args.output_dir,
+                        all_traces,
+                        summaries,
+                        mode=args.mode,
+                        save_raw_requests=args.save_raw_requests,
+                    )
+
+            elif args.mode == 'request-rate':
+                for request_rate in args.levels:
+                    print(f"benchmark {len(requests)} requests, request_rate={request_rate}...")
+                    completed_count = 0
+                    failed_count = 0
+                    pbar = None
+                    if tqdm is not None:
+                        pbar = tqdm(
+                            total=len(requests),
+                            desc=f"repeat-{repeat} request-rate-{request_rate}",
+                            unit='req',
+                            dynamic_ncols=True,
+                        )
+
+                    def on_done(trace: RequestTrace) -> None:
+                        nonlocal completed_count, failed_count
+                        if trace.success:
+                            completed_count += 1
+                        else:
+                            failed_count += 1
+                        if pbar is not None:
+                            pbar.update(1)
+                            pbar.set_postfix(completed=completed_count, failed=failed_count)
+
+                    all_traces.extend(
+                        await request_rate_runner(
+                            requests,
+                            request_rate=request_rate,
+                            repeat=repeat,
+                            send_one=send_one,
+                            seed=args.seed + repeat,
+                            on_done=on_done,
+                        )
+                    )
+                    if pbar is not None:
+                        pbar.close()
+                    summaries = aggregate_traces(all_traces)
+                    write_report_artifacts(
+                        args.output_dir,
+                        all_traces,
+                        summaries,
+                        mode=args.mode,
+                        save_raw_requests=args.save_raw_requests,
+                    )
+
+    return all_traces, summaries
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description='Benchmark LMDeploy POST /generate with JSONL datasets.')
+    parser.add_argument(
+        '--base-url',
+        default='http://127.0.0.1:23333',
+        help='API server base URL. Requests go to /generate.',
+    )
+    parser.add_argument('--api-key', default='', help='Optional Bearer token for authenticated servers.')
+    parser.add_argument(
+        '--model-path',
+        default='',
+        help='Tokenizer/model path for apply_chat_template. Defaults to the id from /v1/models.',
+    )
+    parser.add_argument(
+        '--trust-remote-code',
+        action='store_true',
+        help='Pass trust_remote_code=True when loading the tokenizer.',
+    )
+    parser.add_argument(
+        '--dataset-dir',
+        type=Path,
+        default=None,
+        help='Directory containing eval JSONL files. Each file stem is used as the dataset name.',
+    )
+    parser.add_argument(
+        '--dataset-files',
+        type=Path,
+        nargs='*',
+        help='Explicit JSONL files to benchmark. Overrides dataset discovery from --dataset-dir.',
+    )
+    parser.add_argument(
+        '--datasets',
+        help='Comma-separated dataset names or filename-stem prefixes.',
+    )
+    parser.add_argument('--num-prompts', type=int, help='Maximum number of prompts sampled per dataset.')
+    parser.add_argument('--shuffle', action='store_true', help='Shuffle requests before applying --num-prompts.')
+    parser.add_argument('--seed', type=int, default=1, help='Random seed for shuffling and request-rate scheduling.')
+    parser.add_argument(
+        '--mode',
+        choices=['concurrency', 'request-rate'],
+        default='concurrency',
+        help='Benchmark mode: closed-loop concurrency or open-loop request rate.',
+    )
+    parser.add_argument(
+        '--levels',
+        nargs='+',
+        type=int,
+        default=[1, 2, 4, 8, 16, 32, 64, 128],
+        help='Space-separated sweep values (concurrency levels or request rates).',
+    )
+    parser.add_argument('--repeats', type=int, default=1, help='Number of times to repeat each level run.')
+    parser.add_argument(
+        '--warmup-requests',
+        type=int,
+        default=1,
+        help='Number of unmeasured warmup requests before measured runs.',
+    )
+    parser.add_argument('--temperature', type=float, default=0.0, help='Sampling temperature.')
+    parser.add_argument('--top-p', type=float, default=1.0, help='Sampling top_p.')
+    parser.add_argument('--top-k', type=int, default=40, help='Sampling top_k.')
+    parser.add_argument(
+        '--output-tokens',
+        '--max-tokens',
+        type=int,
+        dest='max_tokens',
+        metavar='N',
+        help='Set max_tokens in the /generate request. If omitted, server default (128) applies.',
+    )
+    parser.add_argument(
+        '--ignore-eos',
+        action='store_true',
+        help='Set ignore_eos=true. Use with --output-tokens for fixed-length decode benchmarks.',
+    )
+    parser.add_argument(
+        '--return-logprob',
+        action='store_true',
+        help='Set return_logprob=true (requires logprobs_mode in server config).',
+    )
+    parser.add_argument(
+        '--return-routed-experts',
+        action='store_true',
+        help='Set return_routed_experts=true for MoE routed expert indices.',
+    )
+    parser.add_argument(
+        '--extra-request-body',
+        default='',
+        help='JSON object merged into every /generate request body.',
+    )
+    parser.add_argument(
+        '--save-raw-requests',
+        action='store_true',
+        help='Save per-request traces as requests.jsonl, requests.csv, and requests.json.',
+    )
+    parser.add_argument(
+        '--save-response-text',
+        action='store_true',
+        help='Retain generated text in memory and raw traces.',
+    )
+    parser.add_argument(
+        '--output-dir',
+        type=Path,
+        default=Path('benchmark_outputs') / f"generate_{datetime.now().strftime('%Y%m%d_%H%M%S')}",
+        help='Directory for summary CSV/JSON, PNG plots, HTML report, and optional raw traces.',
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    if args.dataset_dir is None and not args.dataset_files:
+        raise SystemExit('Provide --dataset-dir or --dataset-files.')
+    traces, summaries = asyncio.run(run_benchmark(args))
+    completed = sum(summary['completed'] for summary in summaries)
+    failed = sum(summary['failed'] for summary in summaries)
+    print(f"Recorded {len(traces)} requests: {completed} completed, {failed} failed.")
+
+
+if __name__ == '__main__':
+    main()

--- a/lmdeploy/serve/openai/api_server.py
+++ b/lmdeploy/serve/openai/api_server.py
@@ -603,7 +603,8 @@ async def chat_completions_v1(request: ChatCompletionRequest, raw_request: Reque
                     streaming_tools = True
 
                 is_last_delta = delta_index == len(stream_deltas) - 1
-
+                # The chat parser may split one engine yield into multiple protocol deltas,
+                # so attach the engine-level metadata to the last parsed delta.
                 finish_reason = res.finish_reason if is_last_delta else None
                 chunk_logprobs = logprobs if is_last_delta else None
                 chunk_output_token_logprobs = output_token_logprobs if is_last_delta else None

--- a/lmdeploy/serve/openai/api_server.py
+++ b/lmdeploy/serve/openai/api_server.py
@@ -239,6 +239,18 @@ def _create_chat_completion_logprobs(tokenizer: PreTrainedTokenizerBase,
     return ChoiceLogprobs(content=content)
 
 
+def _create_output_token_logprobs(token_ids: list[int] | None = None,
+                                  logprobs: list[dict[int, float]] | None = None):
+    """Create raw (logprob, token_id) pairs for output tokens."""
+    if token_ids is None or logprobs is None:
+        return None
+
+    output_token_logprobs = []
+    for tok, tok_logprobs in zip(token_ids, logprobs):
+        output_token_logprobs.append((tok_logprobs[tok], tok))
+    return output_token_logprobs or None
+
+
 @router.get('/health')
 async def health() -> JSONResponse:
     """Health check."""
@@ -431,6 +443,8 @@ async def chat_completions_v1(request: ChatCompletionRequest, raw_request: Reque
     gen_logprobs, logits_processors = None, None
     if request.logprobs:
         gen_logprobs = request.top_logprobs or 1
+    elif request.return_logprob:
+        gen_logprobs = 1
     if request.logit_bias is not None:
         try:
             logits_processors = [
@@ -515,13 +529,15 @@ async def chat_completions_v1(request: ChatCompletionRequest, raw_request: Reque
     def create_stream_response_json(index: int,
                                     delta_message: DeltaMessage,
                                     finish_reason: str | None = None,
-                                    logprobs: LogProbs | None = None,
+                                    logprobs: ChoiceLogprobs | None = None,
+                                    output_token_logprobs: list[tuple[float, int]] | None = None,
                                     routed_experts=None,
                                     output_ids=None) -> dict:
         choice_data = ChatCompletionResponseStreamChoice(index=index,
                                                          delta=delta_message,
                                                          finish_reason=finish_reason,
                                                          logprobs=logprobs,
+                                                         output_token_logprobs=output_token_logprobs,
                                                          output_ids=output_ids,
                                                          routed_experts=routed_experts)
         response = ChatCompletionStreamResponse(
@@ -551,8 +567,11 @@ async def chat_completions_v1(request: ChatCompletionRequest, raw_request: Reque
         final_usage = None
         async for res in result_generator:
             logprobs = None
-            if gen_logprobs and res.logprobs:
+            output_token_logprobs = None
+            if request.logprobs and res.logprobs:
                 logprobs = _create_chat_completion_logprobs(tokenizer, res.token_ids, res.logprobs)
+            if request.return_logprob:
+                output_token_logprobs = _create_output_token_logprobs(res.token_ids, res.logprobs)
             if res.finish_reason and include_usage:
                 total_tokens = sum([res.input_token_len, res.generate_token_len])
                 final_usage = UsageInfo(
@@ -569,7 +588,7 @@ async def chat_completions_v1(request: ChatCompletionRequest, raw_request: Reque
                 # Parser may buffer partial protocol tags and emit no visible delta
                 # while the engine still produced new tokens (e.g. MTP batch). Do not
                 # drop those token ids; emit them once on a placeholder delta.
-                if res.finish_reason is None and logprobs is None and not delta_token_ids:
+                if res.finish_reason is None and not delta_token_ids:
                     continue
                 stream_deltas = [(DeltaMessage(role='assistant', content=''), False)]
             should_validate_complete = (
@@ -587,6 +606,7 @@ async def chat_completions_v1(request: ChatCompletionRequest, raw_request: Reque
 
                 finish_reason = res.finish_reason if is_last_delta else None
                 chunk_logprobs = logprobs if is_last_delta else None
+                chunk_output_token_logprobs = output_token_logprobs if is_last_delta else None
 
                 if (request.tool_choice != 'none' and response_parser.tool_parser is not None):
                     if finish_reason == 'stop' and streaming_tools is True:
@@ -602,6 +622,7 @@ async def chat_completions_v1(request: ChatCompletionRequest, raw_request: Reque
                                                             delta_message=delta_message,
                                                             finish_reason=finish_reason,
                                                             logprobs=chunk_logprobs,
+                                                            output_token_logprobs=chunk_output_token_logprobs,
                                                             routed_experts=routed_experts,
                                                             output_ids=stream_output_ids)
                 if res.cache_block_ids is not None and is_last_delta:
@@ -663,8 +684,11 @@ async def chat_completions_v1(request: ChatCompletionRequest, raw_request: Reque
                             reasoning_content=reasoning_content)
 
     logprobs = None
-    if gen_logprobs and len(final_logprobs):
+    if request.logprobs and len(final_logprobs):
         logprobs = _create_chat_completion_logprobs(tokenizer, final_token_ids, final_logprobs)
+    output_token_logprobs = None
+    if request.return_logprob and len(final_logprobs):
+        output_token_logprobs = _create_output_token_logprobs(final_token_ids, final_logprobs)
 
     assert final_res is not None
     choices = []
@@ -672,6 +696,7 @@ async def chat_completions_v1(request: ChatCompletionRequest, raw_request: Reque
         index=0,
         message=message,
         logprobs=logprobs,
+        output_token_logprobs=output_token_logprobs,
         finish_reason=final_res.finish_reason,
         output_ids=final_token_ids if request.return_token_ids else None,
         routed_experts=final_res.routed_experts if request.return_routed_experts else None,

--- a/lmdeploy/serve/openai/protocol.py
+++ b/lmdeploy/serve/openai/protocol.py
@@ -171,6 +171,7 @@ class ChatCompletionRequest(BaseModel):
     min_p: float = 0.0
     enable_thinking: bool | None = None  # will be deprecated in the future
     return_token_ids: bool | None = False
+    return_logprob: bool | None = False
     include_stop_str_in_output: bool | None = False
     # kwargs for chat template renderer
     chat_template_kwargs: dict[str, Any] | None = Field(
@@ -270,6 +271,7 @@ class ChatCompletionResponseChoice(BaseModel):
     index: int
     message: ChatMessage
     logprobs: ChoiceLogprobs | None = None
+    output_token_logprobs: list[tuple[float, int]] | None = None
     finish_reason: Literal['stop', 'length', 'tool_calls', 'parse_error', 'error', 'abort'] | None = None
     output_ids: list[int] | None = None
     routed_experts: list[list[list[int]]] | str | None = None
@@ -311,6 +313,7 @@ class ChatCompletionResponseStreamChoice(BaseModel):
     index: int
     delta: DeltaMessage
     logprobs: ChoiceLogprobs | None = None
+    output_token_logprobs: list[tuple[float, int]] | None = None
     output_ids: list[int] | None = None
     finish_reason: Literal['stop', 'length', 'tool_calls', 'parse_error', 'error', 'abort'] | None = None
     routed_experts: list[list[list[int]]] | str | None = None

--- a/lmdeploy/serve/openai/serving_chat_completion.py
+++ b/lmdeploy/serve/openai/serving_chat_completion.py
@@ -15,9 +15,14 @@ def check_request(request: ChatCompletionRequest, server_context: 'VariableInter
         logprobs_mode = engine_config.logprobs_mode
         logprobs = request.logprobs
         top_logprobs = request.top_logprobs or 0
-        if logprobs_mode is None and (logprobs or top_logprobs > 0):
-            return (f'Logprobs({logprobs})/top_logprobs({top_logprobs}) requested '
-                    'but not enabled logprobs_mode in engine configuration')
+        return_logprob = request.return_logprob
+        if logprobs_mode is None:
+            if logprobs or top_logprobs > 0:
+                return (f'Logprobs({logprobs})/top_logprobs({top_logprobs}) requested '
+                        'but not enabled logprobs_mode in engine configuration')
+            if return_logprob:
+                return (f'return_logprob({return_logprob}) requested '
+                        'but not enabled logprobs_mode in engine configuration.')
         if logprobs_mode is not None and (top_logprobs < 0 or (not logprobs and top_logprobs > 0)):
             return (f'Invalid logprobs({logprobs})/top_logprobs({top_logprobs}) requested '
                     'when logprobs_mode is enabled in engine configuration.')

--- a/lmdeploy/serve/parsers/reasoning_parser/reasoning_parser.py
+++ b/lmdeploy/serve/parsers/reasoning_parser/reasoning_parser.py
@@ -21,11 +21,15 @@ class ReasoningParser:
     @classmethod
     def validate_tokenizer(cls, tokenizer: PreTrainedTokenizerBase) -> None:
         """Validate static reasoning tags once at parser setup time."""
-        start_token_id = tokenizer.convert_tokens_to_ids(cls.get_reasoning_open_tag())
-        end_token_id = tokenizer.convert_tokens_to_ids(cls.get_reasoning_close_tag())
-        if start_token_id is None or end_token_id is None:
-            raise RuntimeError(f'{cls.__name__} reasoning parser could not get '
-                'reasoning tokens from the tokenizer!')
+        vocab = tokenizer.get_vocab()
+        missing_tags = [
+            tag for tag in (cls.get_reasoning_open_tag(), cls.get_reasoning_close_tag())
+            if tag not in vocab
+        ]
+        if missing_tags:
+            raise RuntimeError(
+                f'{cls.__name__} reasoning parser could not get reasoning tokens '
+                f'from the tokenizer: {missing_tags!r}')
 
     @classmethod
     def get_reasoning_open_tag(cls) -> str:


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily receiving feedbacks. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

`logprobs=true` on `/v1/chat/completions` builds OpenAI-compatible token logprob objects, which requires tokenizer-side token conversion and byte formatting for every output token. This adds noticeable CPU overhead in benchmarking. For LMDeploy benchmarking, we only need the selected output token ids and their logprobs, so the full OpenAI logprob formatting path is unnecessary.


## Modification

Add `return_logprob` to `ChatCompletionRequest` and return raw output_token_logprobs as (logprob, token_id) pairs in chat completion responses.

When `return_logprob=true`, chat completions request engine logprobs but skip `_create_chat_completion_logprobs`, avoiding tokenizer-based OpenAI formatting. The existing `logprobs=true` behavior is unchanged.

Also add `--return-logprob` to `benchmark_chat_completion.py`
