### PR TITLE
Fix mtp cudagraph when no warmup in RL

### DIFF
--- a/lmdeploy/pytorch/engine/engine.py
+++ b/lmdeploy/pytorch/engine/engine.py
@@ -539,6 +539,8 @@ class Engine(EngineBase):
         logger.info('PyTorch engine wakeup requested: tags=%s, sleeping_tags=%s.',
                     wakeup_tags, sorted(self._sleeping_tags))
         self.executor.wakeup(wakeup_tags)
+        if wakeup_tags is None or 'kv_cache' in wakeup_tags:
+            self.executor.warmup()
         if wakeup_tags is None:
             self._sleeping_tags.clear()
         else:

--- a/lmdeploy/pytorch/engine/executor/base.py
+++ b/lmdeploy/pytorch/engine/executor/base.py
@@ -362,6 +362,9 @@ class ExecutorBase:
             if spec_cache_config := self.specdecode_config.cache_config:
                 logger.info(f'Building Spec CacheEngine with config: \n{spec_cache_config}.')
         self.build_cache_engine()
+        if self.misc_config.empty_init:
+            logger.info('Skip warming up model during empty init.')
+            return
         logger.info('Warming up model.')
         self.warmup()
 

--- a/lmdeploy/pytorch/engine/executor/mp_executor.py
+++ b/lmdeploy/pytorch/engine/executor/mp_executor.py
@@ -382,7 +382,8 @@ class MPExecutor(ExecutorBase):
 
     def wakeup(self, tags: list[str] | None = None):
         """Wakeup."""
-        self.collective_rpc('wakeup', args=(tags, ), return_mask=0)
+        return_mask = 0xff if tags is None or 'kv_cache' in tags else 0
+        self.collective_rpc('wakeup', args=(tags, ), return_mask=return_mask)
 
     async def _prefetch_outputs(self):
         while True:

--- a/lmdeploy/pytorch/engine/model_agent/agent.py
+++ b/lmdeploy/pytorch/engine/model_agent/agent.py
@@ -1102,10 +1102,11 @@ class BaseModelAgent:
 
     def reset_graph_runner(self):
         """Reset graph runner to prevent tp hanging."""
-        if hasattr(self.patched_model, 'reset'):
-            self.patched_model.reset()
+        with self.all_context():
+            if hasattr(self.patched_model, 'reset'):
+                self.patched_model.reset()
 
-        self.spec_agent.reset_graph_runner()
+            self.spec_agent.reset_graph_runner()
 
     @torch.inference_mode()
     def update_params(self, request: UpdateParamsRequest):

--- a/lmdeploy/pytorch/engine/model_agent/agent.py
+++ b/lmdeploy/pytorch/engine/model_agent/agent.py
@@ -348,8 +348,11 @@ class BaseModelAgent:
         """warmup."""
         from lmdeploy.pytorch.envs import skip_warmup
         if skip_warmup:
+            if self.rank == 0:
+                logger.warning('Engine warmup is skipped. Set LMDEPLOY_SKIP_WARMUP=0 to enable warmup.')
             return
-
+        if self.rank == 0:
+            logger.info('Starting engine warmup. This may take a while...')
         with self.all_context(), torch.cuda.stream(self.stream):
             max_batches = self.cache_config.max_batches
             world_size = self.dist_config.world_size
@@ -1179,7 +1182,7 @@ class BaseModelAgent:
                     continue
 
                 w = list(ModelWeightLoader._rename_weights_iterator(w, m))
-                logger.info(f'Update_params: {tag}_num_tensors={len(w)}')
+                logger.debug(f'Update_params: {tag}_num_tensors={len(w)}')
                 m.load_weights(iter(w))
 
                 if self._update_params_ipc_event is not None:

--- a/lmdeploy/pytorch/models/utils/cudagraph.py
+++ b/lmdeploy/pytorch/models/utils/cudagraph.py
@@ -84,9 +84,9 @@ class CudaGraphMeta:
     block_size: int = 64
 
 
-def get_decode_query_len(input_ids: Tensor, q_seqlens: Tensor) -> int:
-    """Get decode query length from graph inputs."""
-    return input_ids.size(-1) // q_seqlens.size(0)
+def get_graph_decode_query_len(graph_meta: CudaGraphMeta) -> int:
+    """Get decode query length from padded graph buffers."""
+    return graph_meta.max_tokens // graph_meta.max_batchs
 
 
 class CudaGraphMixin:
@@ -154,7 +154,7 @@ class CudaGraphMixin:
         max_tokens = graph_meta.max_tokens
         num_blocks = graph_meta.num_blocks
         device = graph_meta.device
-        decode_query_len = get_decode_query_len(input_ids, attn_metadata.q_seqlens)
+        decode_query_len = get_graph_decode_query_len(graph_meta)
 
         input_buffers: BuffType = dict()
         input_buffers['input_ids'] = torch.randint(0,
@@ -226,7 +226,7 @@ class CudaGraphMixin:
 
         batch_size, num_blocks = block_offsets.size()
         num_tokens = input_ids.size(-1)
-        decode_query_len = get_decode_query_len(input_ids, q_seqlens)
+        decode_query_len = get_graph_decode_query_len(graph_meta)
         # fill buffer
         input_buffers['input_ids'].random_(0, graph_meta.vocab_size)
         input_buffers['input_ids'][:, :num_tokens] = input_ids

--- a/lmdeploy/pytorch/strategies/ar_spec/__init__.py
+++ b/lmdeploy/pytorch/strategies/ar_spec/__init__.py
@@ -27,7 +27,7 @@ class ARSpecStrategyFactory(StrategyFactoryBase):
     def build_cudagraph_strategy(self) -> 'CudagraphStrategy':
         """Build cudagraph strategy."""
         from .cudagraph import ARSpecCudagraphStrategy
-        return ARSpecCudagraphStrategy(self.specdecode_config.num_speculative_tokens)
+        return ARSpecCudagraphStrategy(self.specdecode_config.num_speculative_tokens, self.specdecode_config.method)
 
     def build_sampling_strategy(self) -> 'SamplingStrategy':
         """Build sampling strategy."""

--- a/lmdeploy/pytorch/strategies/ar_spec/cudagraph.py
+++ b/lmdeploy/pytorch/strategies/ar_spec/cudagraph.py
@@ -4,14 +4,16 @@ from ..base.cudagraph import CudagraphStrategy
 
 class ARSpecCudagraphStrategy(CudagraphStrategy):
 
-    def __init__(self, num_spec_tokens: int):
+    def __init__(self, num_spec_tokens: int, method: str):
         super().__init__()
         self.num_spec_tokens = num_spec_tokens
+        self.method = method
 
     def get_max_tokens(self, batch_size: int, origin_batch_size: int, num_tokens: int) -> int:
         """Get max tokens."""
-        if num_tokens == origin_batch_size:
+
+        # only eagle3 have two sets of cudagraph due to different target_hidden_size
+        if num_tokens == origin_batch_size and self.method == 'eagle3':
             return batch_size
 
-        assert num_tokens % (self.num_spec_tokens + 1) == 0, 'The input_ids length must be divisible by batch_size.'
         return batch_size * (self.num_spec_tokens + 1)

--- a/lmdeploy/pytorch/strategies/ar_spec/cudagraph.py
+++ b/lmdeploy/pytorch/strategies/ar_spec/cudagraph.py
@@ -12,7 +12,7 @@ class ARSpecCudagraphStrategy(CudagraphStrategy):
     def get_max_tokens(self, batch_size: int, origin_batch_size: int, num_tokens: int) -> int:
         """Get max tokens."""
 
-        # only eagle3 have two sets of cudagraph due to different target_hidden_size
+        # only eagle3 has two sets of cudagraph due to different target_hidden_size
         if num_tokens == origin_batch_size and self.method == 'eagle3':
             return batch_size
 

--- a/tests/pytorch/engine/test_engine_sleep.py
+++ b/tests/pytorch/engine/test_engine_sleep.py
@@ -7,6 +7,7 @@ import pytest
 from lmdeploy.messages import EngineOutput, ResponseType
 from lmdeploy.pytorch.engine.engine import Engine
 from lmdeploy.pytorch.engine.engine_instance import EngineInstance
+from lmdeploy.pytorch.engine.executor.mp_executor import MPExecutor
 from lmdeploy.pytorch.engine.request import RequestManager, RequestType, Response
 
 
@@ -46,9 +47,8 @@ class _FakeEngineLoop:
         self.drained = True
 
     def resume_from_sleep(self):
+        self.engine.events.append('resume')
         self.resumed = True
-
-
 
 
 class _FakeExecutor:
@@ -57,6 +57,7 @@ class _FakeExecutor:
         self.engine = engine
         self.sleep_calls = []
         self.wakeup_calls = []
+        self.warmup_calls = []
 
     async def sleep(self, level=1):
         assert self.engine.req_manager.is_request_blocked(RequestType.ADD_SESSION)
@@ -65,6 +66,13 @@ class _FakeExecutor:
 
     def wakeup(self, tags=None):
         self.wakeup_calls.append(tags)
+        self.engine.events.append(('wakeup', tags))
+
+    def warmup(self):
+        assert self.engine.req_manager.is_request_blocked(RequestType.ADD_SESSION)
+        assert self.engine.req_manager.is_request_blocked(RequestType.ADD_MESSAGE)
+        self.warmup_calls.append(self.wakeup_calls[-1])
+        self.engine.events.append(('warmup', self.wakeup_calls[-1]))
 
 
 @pytest.fixture
@@ -98,6 +106,7 @@ def _build_sleeping_test_engine(event_loop):
     session = _FakeSession(seq)
     engine.scheduler = _FakeScheduler(session)
     engine._sleeping_tags = set()
+    engine.events = []
     engine._engine_loop = _FakeEngineLoop(engine)
     engine.executor = _FakeExecutor(engine)
     return engine, resp
@@ -128,6 +137,8 @@ def test_engine_wakeup_reenables_inputs_only_after_all_tags(event_loop):
     assert engine.req_manager.is_request_blocked(RequestType.ADD_SESSION)
     assert engine.req_manager.is_request_blocked(RequestType.ADD_MESSAGE)
     assert not engine._engine_loop.resumed
+    assert engine.executor.warmup_calls == []
+    assert engine.events == [('wakeup', ['weights'])]
 
     engine.wakeup(['kv_cache'])
 
@@ -135,6 +146,48 @@ def test_engine_wakeup_reenables_inputs_only_after_all_tags(event_loop):
     assert not engine.req_manager.is_request_blocked(RequestType.ADD_MESSAGE)
     assert engine._engine_loop.resumed
     assert engine.executor.wakeup_calls == [['weights'], ['kv_cache']]
+    assert engine.executor.warmup_calls == [['kv_cache']]
+    assert engine.events == [
+        ('wakeup', ['weights']),
+        ('wakeup', ['kv_cache']),
+        ('warmup', ['kv_cache']),
+        'resume',
+    ]
+
+
+def test_engine_wakeup_all_warms_before_resume(event_loop):
+    engine, _ = _build_sleeping_test_engine(event_loop)
+    engine.req_manager.block_request_types({RequestType.ADD_SESSION, RequestType.ADD_MESSAGE})
+    engine._sleeping_tags = {'weights', 'kv_cache'}
+
+    engine.wakeup()
+
+    assert not engine.req_manager.is_request_blocked(RequestType.ADD_SESSION)
+    assert not engine.req_manager.is_request_blocked(RequestType.ADD_MESSAGE)
+    assert engine._engine_loop.resumed
+    assert engine.executor.wakeup_calls == [None]
+    assert engine.executor.warmup_calls == [None]
+    assert engine.events == [('wakeup', None), ('warmup', None), 'resume']
+
+
+def test_mp_executor_wakeup_waits_for_kv_cache():
+    executor = MPExecutor.__new__(MPExecutor)
+    calls = []
+
+    def _collective_rpc(method, args=None, return_mask=0xff):
+        calls.append((method, args, return_mask))
+
+    executor.collective_rpc = _collective_rpc
+
+    executor.wakeup(['weights'])
+    executor.wakeup(['kv_cache'])
+    executor.wakeup()
+
+    assert calls == [
+        ('wakeup', (['weights'], ), 0),
+        ('wakeup', (['kv_cache'], ), 0xff),
+        ('wakeup', (None, ), 0xff),
+    ]
 
 
 def test_engine_instance_new_request_after_sleep_returns_cancel(event_loop):

--- a/tests/pytorch/engine/test_executor_base.py
+++ b/tests/pytorch/engine/test_executor_base.py
@@ -8,6 +8,62 @@ from lmdeploy.pytorch.engine.cache_engine import CacheEngine
 from lmdeploy.pytorch.engine.executor.base import ExecutorBase, _CacheBlockSize
 
 
+class _RecordingExecutor(ExecutorBase):
+
+    def __init__(self, empty_init: bool):
+        super().__init__(
+            model_path='',
+            model_config=SimpleNamespace(sliding_window=None, states_shapes=None),
+            cache_config=SimpleNamespace(),
+            backend_config=SimpleNamespace(),
+            dist_config=SimpleNamespace(dp=1, world_size=1),
+            misc_config=SimpleNamespace(empty_init=empty_init),
+        )
+        self.calls = []
+
+    def build_model(self):
+        self.calls.append('build_model')
+
+    def update_configs(self):
+        self.calls.append('update_configs')
+
+    def build_graph_runner(self):
+        self.calls.append('build_graph_runner')
+
+    def build_cache_engine(self):
+        self.calls.append('build_cache_engine')
+
+    def warmup(self):
+        self.calls.append('warmup')
+
+
+def test_init_warms_up_model_by_default():
+    executor = _RecordingExecutor(empty_init=False)
+
+    executor.init()
+
+    assert executor.calls == [
+        'build_model',
+        'update_configs',
+        'build_graph_runner',
+        'build_cache_engine',
+        'warmup',
+    ]
+
+
+def test_init_skips_model_warmup_for_empty_init():
+    executor = _RecordingExecutor(empty_init=True)
+
+    executor.init()
+
+    assert executor.calls == [
+        'build_model',
+        'update_configs',
+        'build_graph_runner',
+        'build_cache_engine',
+    ]
+
+
 def test_get_num_gpu_blocks_without_spec_cache():
     available_mem = 4096
     cache_block_size = 256

--- a/tests/pytorch/engine/test_model_agent.py
+++ b/tests/pytorch/engine/test_model_agent.py
@@ -1,5 +1,6 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import asyncio
+from contextlib import contextmanager
 
 import pytest
 import torch
@@ -217,3 +218,71 @@ class TestDPForwardMeta:
         assert gathered.all_batch_sizes == [2, 1]
         assert gathered.draft_num_tokens is None
         assert gathered.enable_microbatch is None
+
+
+class TestResetGraphRunner:
+
+    def test_model_agent_reset_graph_runner_uses_all_context(self):
+        from lmdeploy.pytorch.engine.model_agent.agent import BaseModelAgent
+
+        events = []
+
+        class _PatchedModel:
+
+            def reset(self):
+                events.append('main_reset')
+
+        class _SpecAgent:
+
+            def reset_graph_runner(self):
+                events.append('spec_reset')
+
+        agent = BaseModelAgent.__new__(BaseModelAgent)
+        agent.patched_model = _PatchedModel()
+        agent.spec_agent = _SpecAgent()
+
+        @contextmanager
+        def _all_context():
+            events.append('enter_all_context')
+            yield
+            events.append('exit_all_context')
+
+        agent.all_context = _all_context
+
+        agent.reset_graph_runner()
+
+        assert events == [
+            'enter_all_context',
+            'main_reset',
+            'spec_reset',
+            'exit_all_context',
+        ]
+
+    def test_spec_agent_reset_graph_runner_uses_draft_context(self):
+        from lmdeploy.pytorch.spec_decode.spec_agent import SpecModelAgent
+
+        events = []
+
+        class _Model:
+
+            def reset(self):
+                events.append('reset')
+
+        agent = SpecModelAgent.__new__(SpecModelAgent)
+        agent.proposer = type('Proposer', (), {'model': _Model()})()
+
+        @contextmanager
+        def _draft_context():
+            events.append('enter_draft_context')
+            yield
+            events.append('exit_draft_context')
+
+        agent.draft_context = _draft_context
+
+        agent.reset_graph_runner()
+
+        assert events == [
+            'enter_draft_context',
+            'reset',
+            'exit_draft_context',
+        ]

--- a/tests/pytorch/spec_decode/test_cudagraph_strategy.py
+++ b/tests/pytorch/spec_decode/test_cudagraph_strategy.py
@@ -1,0 +1,75 @@
+from lmdeploy.pytorch.strategies.ar_spec.cudagraph import ARSpecCudagraphStrategy
+
+
+def test_arspec_cudagraph_allocates_max_decode_width_for_single_token_capture():
+    strategy = ARSpecCudagraphStrategy(num_spec_tokens=4, method='qwen3_5_mtp')
+
+    assert strategy.get_max_tokens(batch_size=8, origin_batch_size=8, num_tokens=8) == 40
+
+
+def test_arspec_cudagraph_uses_same_allocation_for_full_spec_capture():
+    strategy = ARSpecCudagraphStrategy(num_spec_tokens=4, method='qwen3_5_mtp')
+
+    assert strategy.get_max_tokens(batch_size=8, origin_batch_size=8, num_tokens=40) == 40
+
+
+def test_arspec_cudagraph_keeps_single_token_graph_for_eagle3():
+    strategy = ARSpecCudagraphStrategy(num_spec_tokens=4, method='eagle3')
+
+    assert strategy.get_max_tokens(batch_size=8, origin_batch_size=8, num_tokens=8) == 8
+    assert strategy.get_max_tokens(batch_size=8, origin_batch_size=8, num_tokens=40) == 40
+
+
+def test_cudagraph_fa3_metadata_uses_padded_query_len_for_single_token_capture():
+    from types import SimpleNamespace
+
+    import torch
+
+    from lmdeploy.pytorch.models.utils.cudagraph import CudaGraphMeta, CudaGraphMixin
+
+    class DummyCudaGraphModel(CudaGraphMixin):
+
+        def __init__(self):
+            self.max_seqlen_q_calls = []
+
+        def update_meta_flashattn(self, batch_size, max_seqlen_q, block_size, max_seqlen_k, cache_seqlens):
+            self.max_seqlen_q_calls.append(max_seqlen_q)
+            return torch.zeros(4, dtype=torch.int32)
+
+    model = DummyCudaGraphModel()
+    graph_meta = CudaGraphMeta(
+        max_batchs=8,
+        max_tokens=32,
+        num_blocks=1,
+        is_decoding=True,
+        device=torch.device('cpu'),
+        input_buffers={},
+        output_buffers={},
+        use_fa3_decoding=True,
+    )
+    input_ids = torch.zeros((1, 8), dtype=torch.long)
+    position_ids = torch.zeros_like(input_ids)
+    attn_metadata = SimpleNamespace(
+        q_seqlens=torch.ones(8, dtype=torch.long),
+        block_offsets=torch.zeros((8, 1), dtype=torch.long),
+        q_start_loc=torch.arange(8, dtype=torch.long),
+        kv_seqlens=torch.ones(8, dtype=torch.long),
+    )
+
+    graph_meta.input_buffers = model.make_buffers_cudagraph(
+        graph_meta,
+        input_ids=input_ids,
+        position_ids=position_ids,
+        past_key_values=[],
+        attn_metadata=attn_metadata,
+    )
+    model.fill_buffers_cudagraph(
+        graph_meta,
+        input_ids=input_ids,
+        position_ids=position_ids,
+        past_key_values=[],
+        attn_metadata=attn_metadata,
+        inputs_embeds=None,
+    )
+
+    assert model.max_seqlen_q_calls == [4, 4]


### PR DESCRIPTION


## Motivation

- [x] Fix mtp cudagraph when warmup is skipped
- [x] Add warmup after engine wakeup
- [x] Skil warmup if `empty_init=True`

## Modification

Please briefly describe what modification is made in this PR.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
