### PR TITLE
docs: update multimodal model support docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ LMDeploy is a toolkit for compressing, deploying, and serving LLM, developed by 
   <li>Qwen2.5-VL (3B, 7B, 72B)</li>
   <li>Qwen3-VL (2B - 235B)</li>
   <li>Qwen3.5 (0.8B - 397B)</li>
+  <li>Qwen3-Omni (30B-A3B)</li>
   <li>DeepSeek-VL (7B)</li>
   <li>DeepSeek-VL2 (3B, 16B, 27B)</li>
   <li>InternVL-Chat (v1.1-v1.5)</li>
@@ -188,6 +189,7 @@ LMDeploy is a toolkit for compressing, deploying, and serving LLM, developed by 
   <li>Intern-S1 (241B)</li>
   <li>Intern-S1-mini (8.3B)</li>
   <li>Intern-S1-Pro (1TB)</li>
+  <li>Intern-S2-Preview (35B-A3B)</li>
   <li>Mono-InternVL (2B)</li>
   <li>ChemVLM (8B-26B)</li>
   <li>CogVLM-Chat (17B)</li>

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -180,6 +180,7 @@ LMDeploy TurboMind 引擎拥有卓越的推理能力，在各种规模的模型�
   <li>Qwen2.5-VL (3B, 7B, 72B)</li>
   <li>Qwen3-VL (2B - 235B)</li>
   <li>Qwen3.5 (0.8B - 397B)</li>
+  <li>Qwen3-Omni (30B-A3B)</li>
   <li>DeepSeek-VL (7B)</li>
   <li>DeepSeek-VL2 (3B, 16B, 27B)</li>
   <li>InternVL-Chat (v1.1-v1.5)</li>
@@ -190,6 +191,7 @@ LMDeploy TurboMind 引擎拥有卓越的推理能力，在各种规模的模型�
   <li>Intern-S1 (241B)</li>
   <li>Intern-S1-mini (8.3B)</li>
   <li>Intern-S1-Pro (1TB)</li>
+  <li>Intern-S2-Preview (35B-A3B)</li>
   <li>Mono-InternVL (2B)</li>
   <li>ChemVLM (8B-26B)</li>
   <li>CogVLM-Chat (17B)</li>

--- a/docs/en/multi_modal/multimodal_inputs.md
+++ b/docs/en/multi_modal/multimodal_inputs.md
@@ -134,7 +134,7 @@ ______________________________________________________________________
 
 ## Single Video
 
-> **Note:** Native video input is currently supported for **Qwen3-VL**, **Qwen3.5**, **Qwen3-Omni**, and **InternS1-Pro** models only.
+> **Note:** Native video input is currently supported for **Qwen3-VL**, **Qwen3.5**, **Qwen3-Omni**, **InternS1-Pro**, and **Intern-S2-Preview** models only.
 
 <details>
 <summary>Complete example</summary>
@@ -177,7 +177,7 @@ ______________________________________________________________________
 
 ## Multiple Videos
 
-> **Note:** Native video input is currently supported for **Qwen3-VL**, **Qwen3.5**, **Qwen3-Omni**, and **InternS1-Pro** models only.
+> **Note:** Native video input is currently supported for **Qwen3-VL**, **Qwen3.5**, **Qwen3-Omni**, **InternS1-Pro**, and **Intern-S2-Preview** models only.
 
 <details>
 <summary>Complete example</summary>
@@ -223,7 +223,7 @@ ______________________________________________________________________
 
 ## Mixed Image and Video
 
-> **Note:** Native video input is currently supported for **Qwen3-VL**, **Qwen3.5**, **Qwen3-Omni**, and **InternS1-Pro** models only.
+> **Note:** Native mixed image/video input is currently supported for **Qwen3-VL**, **Qwen3.5**, **Qwen3-Omni**, **InternS1-Pro**, and **Intern-S2-Preview** models only.
 
 <details>
 <summary>Complete example</summary>
@@ -493,6 +493,37 @@ print(response.choices[0].message.content)
 </details>
 
 <details>
+<summary>Base64 encoding example (audio)</summary>
+
+```python
+from openai import OpenAI
+from lmdeploy.vl.utils import encode_audio_base64
+
+client = OpenAI(api_key='EMPTY', base_url='http://localhost:23333/v1')
+model_name = client.models.list().data[0].id
+
+b64 = encode_audio_base64('/path/to/your/audio.wav')
+audio_url = f'data:audio/wav;base64,{b64}'
+
+response = client.chat.completions.create(
+    model=model_name,
+    messages=[{
+        'role': 'user',
+        'content': [
+            {
+                'type': 'audio_url',
+                'audio_url': {'url': audio_url},
+            },
+            {'type': 'text', 'text': 'Describe this audio.'},
+        ],
+    }],
+)
+print(response.choices[0].message.content)
+```
+
+</details>
+
+<details>
 <summary>Base64 encoding example (time series)</summary>
 
 ```python
@@ -533,7 +564,7 @@ ______________________________________________________________________
 Two optional parameters let you control media processing:
 
 - **`mm_processor_kwargs`**: controls vision token resolution (min/max pixels per image or video frame)
-- **`media_io_kwargs`**: controls how media is loaded (e.g. video frame sampling rate and count)
+- **`media_io_kwargs`**: controls how media is loaded (e.g. video frame sampling rate/count and audio sampling rate)
 
 Both are passed as extra fields in the API request body via `extra_body`, or directly to `pipe()` when using the pipeline API.
 

--- a/docs/en/supported_models/supported_models.md
+++ b/docs/en/supported_models/supported_models.md
@@ -46,6 +46,7 @@ The following tables detail the models supported by LMDeploy's TurboMind engine 
 |       MiniCPM-Llama3-V-2_5       |        -         | MLLM |    Yes    |   Yes   |   Yes   |  Yes  |
 |          MiniCPM-V-2_6           |        -         | MLLM |    Yes    |   Yes   |   Yes   |  Yes  |
 |               GLM4               |        9B        | LLM  |    Yes    |   Yes   |   Yes   |  Yes  |
+|         GLM-4.7-Flash            |       30B        | LLM  |    Yes    |   No    |   No    |  No   |
 |            CodeGeeX4             |        9B        | LLM  |    Yes    |   Yes   |   Yes   |   -   |
 |              Molmo               |     7B-D,72B     | MLLM |    Yes    |   Yes   |   Yes   |  No   |
 |             gpt-oss              |     20B,120B     | LLM  |    Yes    |   Yes   |   Yes   |  Yes  |
@@ -75,6 +76,7 @@ The following tables detail the models supported by LMDeploy's TurboMind engine 
 |           Intern-S1            |      241B       | MLLM |    Yes    |   Yes   |   Yes   | Yes  |   -   |
 |         Intern-S1-mini         |      8.3B       | MLLM |    Yes    |   Yes   |   Yes   | Yes  |   -   |
 |         Intern-S1-Pro          |       1TB       | MLLM |    Yes    |    -    |    -    |  -   |  No   |
+|       Intern-S2-Preview        |     35B-A3B     | MLLM |    Yes    |   No    |   No    |  No  |  No   |
 |           Baichuan2            |       7B        | LLM  |    Yes    |   Yes   |   Yes   | Yes  |  No   |
 |           Baichuan2            |       13B       | LLM  |    Yes    |   Yes   |   Yes   |  No  |  No   |
 |            ChatGLM2            |       6B        | LLM  |    Yes    |   Yes   |   Yes   |  No  |  No   |
@@ -92,6 +94,7 @@ The following tables detail the models supported by LMDeploy's TurboMind engine 
 |           QWen2.5-VL           |    3B - 72B     | MLLM |    Yes    |   No    |   No    |  No  |  No   |
 |            QWen3-VL            |    2B - 235B    | MLLM |    Yes    |   No    |   No    |  No  |  No   |
 |            QWen3.5             |    0.8B-397B    | MLLM |    Yes    |   No    |   No    |  No  |  No   |
+|          Qwen3-Omni            |     30B-A3B     | MLLM |    Yes    |   No    |   No    |  No  |  No   |
 |          DeepSeek-MoE          |       16B       | LLM  |    Yes    |   No    |   No    |  No  |  No   |
 |          DeepSeek-V2           |    16B, 236B    | LLM  |    Yes    |   No    |   No    |  No  |  No   |
 |         DeepSeek-V2.5          |      236B       | LLM  |    Yes    |   No    |   No    |  No  |  No   |

--- a/docs/en/supported_models/supported_models.md
+++ b/docs/en/supported_models/supported_models.md
@@ -46,7 +46,7 @@ The following tables detail the models supported by LMDeploy's TurboMind engine 
 |       MiniCPM-Llama3-V-2_5       |        -         | MLLM |    Yes    |   Yes   |   Yes   |  Yes  |
 |          MiniCPM-V-2_6           |        -         | MLLM |    Yes    |   Yes   |   Yes   |  Yes  |
 |               GLM4               |        9B        | LLM  |    Yes    |   Yes   |   Yes   |  Yes  |
-|         GLM-4.7-Flash            |       30B        | LLM  |    Yes    |   No    |   No    |  No   |
+|          GLM-4.7-Flash           |       30B        | LLM  |    Yes    |   No    |   No    |  No   |
 |            CodeGeeX4             |        9B        | LLM  |    Yes    |   Yes   |   Yes   |   -   |
 |              Molmo               |     7B-D,72B     | MLLM |    Yes    |   Yes   |   Yes   |  No   |
 |             gpt-oss              |     20B,120B     | LLM  |    Yes    |   Yes   |   Yes   |  Yes  |
@@ -94,7 +94,7 @@ The following tables detail the models supported by LMDeploy's TurboMind engine 
 |           QWen2.5-VL           |    3B - 72B     | MLLM |    Yes    |   No    |   No    |  No  |  No   |
 |            QWen3-VL            |    2B - 235B    | MLLM |    Yes    |   No    |   No    |  No  |  No   |
 |            QWen3.5             |    0.8B-397B    | MLLM |    Yes    |   No    |   No    |  No  |  No   |
-|          Qwen3-Omni            |     30B-A3B     | MLLM |    Yes    |   No    |   No    |  No  |  No   |
+|           Qwen3-Omni           |     30B-A3B     | MLLM |    Yes    |   No    |   No    |  No  |  No   |
 |          DeepSeek-MoE          |       16B       | LLM  |    Yes    |   No    |   No    |  No  |  No   |
 |          DeepSeek-V2           |    16B, 236B    | LLM  |    Yes    |   No    |   No    |  No  |  No   |
 |         DeepSeek-V2.5          |      236B       | LLM  |    Yes    |   No    |   No    |  No  |  No   |

--- a/docs/zh_cn/multi_modal/multimodal_inputs.md
+++ b/docs/zh_cn/multi_modal/multimodal_inputs.md
@@ -134,7 +134,7 @@ ______________________________________________________________________
 
 ## 单个视频
 
-> **注意：** 原生视频输入目前仅支持 **Qwen3-VL**、**Qwen3.5**、**Qwen3-Omni** 和 **InternS1-Pro** 模型。
+> **注意：** 原生视频输入目前仅支持 **Qwen3-VL**、**Qwen3.5**、**Qwen3-Omni**、**InternS1-Pro** 和 **Intern-S2-Preview** 模型。
 
 <details>
 <summary>完整示例</summary>
@@ -177,7 +177,7 @@ ______________________________________________________________________
 
 ## 多个视频
 
-> **注意：** 原生视频输入目前仅支持 **Qwen3-VL**、**Qwen3.5**、**Qwen3-Omni** 和 **InternS1-Pro** 模型。
+> **注意：** 原生视频输入目前仅支持 **Qwen3-VL**、**Qwen3.5**、**Qwen3-Omni**、**InternS1-Pro** 和 **Intern-S2-Preview** 模型。
 
 <details>
 <summary>完整示例</summary>
@@ -223,7 +223,7 @@ ______________________________________________________________________
 
 ## 图像与视频混合
 
-> **注意：** 原生视频输入目前仅支持 **Qwen3-VL**、**Qwen3.5**、**Qwen3-Omni** 和 **InternS1-Pro** 模型。
+> **注意：** 原生图像/视频混合输入目前仅支持 **Qwen3-VL**、**Qwen3.5**、**Qwen3-Omni**、**InternS1-Pro** 和 **Intern-S2-Preview** 模型。
 
 <details>
 <summary>完整示例</summary>
@@ -492,6 +492,37 @@ print(response.choices[0].message.content)
 </details>
 
 <details>
+<summary>Base64 编码示例（音频）</summary>
+
+```python
+from openai import OpenAI
+from lmdeploy.vl.utils import encode_audio_base64
+
+client = OpenAI(api_key='EMPTY', base_url='http://localhost:23333/v1')
+model_name = client.models.list().data[0].id
+
+b64 = encode_audio_base64('/path/to/your/audio.wav')
+audio_url = f'data:audio/wav;base64,{b64}'
+
+response = client.chat.completions.create(
+    model=model_name,
+    messages=[{
+        'role': 'user',
+        'content': [
+            {
+                'type': 'audio_url',
+                'audio_url': {'url': audio_url},
+            },
+            {'type': 'text', 'text': '描述这段音频。'},
+        ],
+    }],
+)
+print(response.choices[0].message.content)
+```
+
+</details>
+
+<details>
 <summary>Base64 编码示例（时序数据）</summary>
 
 ```python
@@ -532,7 +563,7 @@ ______________________________________________________________________
 两个可选参数用于控制媒体处理行为：
 
 - **`mm_processor_kwargs`**：控制视觉 token 的分辨率（每张图片或视频帧的最小/最大像素数）
-- **`media_io_kwargs`**：控制媒体加载方式（如视频帧采样率和帧数）
+- **`media_io_kwargs`**：控制媒体加载方式（如视频帧采样率/帧数和音频采样率）
 
 两者均通过 `extra_body` 作为请求体中的额外字段传入 API，或在使用 pipeline API 时直接传给 `pipe()`。
 

--- a/docs/zh_cn/supported_models/supported_models.md
+++ b/docs/zh_cn/supported_models/supported_models.md
@@ -47,7 +47,7 @@
 |       MiniCPM-Llama3-V-2_5       |       -        | MLLM |    Yes    |   Yes   |   Yes   |  Yes  |
 |          MiniCPM-V-2_6           |       -        | MLLM |    Yes    |   Yes   |   Yes   |  Yes  |
 |               GLM4               |       9B       | LLM  |    Yes    |   Yes   |   Yes   |  Yes  |
-|         GLM-4.7-Flash            |      30B       | LLM  |    Yes    |   No    |   No    |  No   |
+|          GLM-4.7-Flash           |      30B       | LLM  |    Yes    |   No    |   No    |  No   |
 |            CodeGeeX4             |       9B       | LLM  |    Yes    |   Yes   |   Yes   |   -   |
 |              Molmo               |    7B-D,72B    | MLLM |    Yes    |   Yes   |   Yes   |  No   |
 |             gpt-oss              |    20B,120B    | LLM  |    Yes    |   Yes   |   Yes   |  Yes  |
@@ -91,7 +91,7 @@
 |            Qwen2.5             |   0.5B - 72B    | LLM  |    Yes    |   Yes   |   No    | Yes  |  Yes  |
 |             Qwen3              |   0.6B - 235B   | LLM  |    Yes    |   Yes   |  Yes\*  |  -   |  Yes  |
 |            QWen3.5             |    0.8B-397B    | MLLM |    Yes    |   No    |   No    |  No  |  No   |
-|          Qwen3-Omni            |     30B-A3B     | MLLM |    Yes    |   No    |   No    |  No  |  No   |
+|           Qwen3-Omni           |     30B-A3B     | MLLM |    Yes    |   No    |   No    |  No  |  No   |
 |           QWen3-Next           |       80B       | LLM  |    Yes    |   No    |   No    |  No  |  No   |
 |            QWen2-VL            |     2B, 7B      | MLLM |    Yes    |   Yes   |   No    |  No  |  Yes  |
 |           QWen2.5-VL           |    3B - 72B     | MLLM |    Yes    |   No    |   No    |  No  |  No   |

--- a/docs/zh_cn/supported_models/supported_models.md
+++ b/docs/zh_cn/supported_models/supported_models.md
@@ -47,6 +47,7 @@
 |       MiniCPM-Llama3-V-2_5       |       -        | MLLM |    Yes    |   Yes   |   Yes   |  Yes  |
 |          MiniCPM-V-2_6           |       -        | MLLM |    Yes    |   Yes   |   Yes   |  Yes  |
 |               GLM4               |       9B       | LLM  |    Yes    |   Yes   |   Yes   |  Yes  |
+|         GLM-4.7-Flash            |      30B       | LLM  |    Yes    |   No    |   No    |  No   |
 |            CodeGeeX4             |       9B       | LLM  |    Yes    |   Yes   |   Yes   |   -   |
 |              Molmo               |    7B-D,72B    | MLLM |    Yes    |   Yes   |   Yes   |  No   |
 |             gpt-oss              |    20B,120B    | LLM  |    Yes    |   Yes   |   Yes   |  Yes  |
@@ -75,6 +76,8 @@
 |           InternLM3            |       8B        | LLM  |    Yes    |   Yes   |   Yes   | Yes  |  Yes  |
 |           Intern-S1            |      241B       | MLLM |    Yes    |   Yes   |   Yes   | Yes  |   -   |
 |         Intern-S1-mini         |      8.3B       | MLLM |    Yes    |   Yes   |   Yes   | Yes  |   -   |
+|         Intern-S1-Pro          |       1TB       | MLLM |    Yes    |    -    |    -    |  -   |  No   |
+|       Intern-S2-Preview        |     35B-A3B     | MLLM |    Yes    |   No    |   No    |  No  |  No   |
 |           Baichuan2            |       7B        | LLM  |    Yes    |   Yes   |   Yes   | Yes  |  No   |
 |           Baichuan2            |       13B       | LLM  |    Yes    |   Yes   |   Yes   |  No  |  No   |
 |            ChatGLM2            |       6B        | LLM  |    Yes    |   Yes   |   Yes   |  No  |  No   |
@@ -88,6 +91,7 @@
 |            Qwen2.5             |   0.5B - 72B    | LLM  |    Yes    |   Yes   |   No    | Yes  |  Yes  |
 |             Qwen3              |   0.6B - 235B   | LLM  |    Yes    |   Yes   |  Yes\*  |  -   |  Yes  |
 |            QWen3.5             |    0.8B-397B    | MLLM |    Yes    |   No    |   No    |  No  |  No   |
+|          Qwen3-Omni            |     30B-A3B     | MLLM |    Yes    |   No    |   No    |  No  |  No   |
 |           QWen3-Next           |       80B       | LLM  |    Yes    |   No    |   No    |  No  |  No   |
 |            QWen2-VL            |     2B, 7B      | MLLM |    Yes    |   Yes   |   No    |  No  |  Yes  |
 |           QWen2.5-VL           |    3B - 72B     | MLLM |    Yes    |   No    |   No    |  No  |  No   |

--- a/lmdeploy/vl/__init__.py
+++ b/lmdeploy/vl/__init__.py
@@ -1,8 +1,10 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 from .utils import (
+                    encode_audio_base64,
                     encode_image_base64,
                     encode_time_series_base64,
                     encode_video_base64,
+                    load_audio,
                     load_image,
                     load_time_series,
                     load_video,
@@ -11,8 +13,10 @@ from .utils import (
 __all__ = [
     'load_image',
     'load_video',
+    'load_audio',
     'load_time_series',
     'encode_image_base64',
     'encode_video_base64',
+    'encode_audio_base64',
     'encode_time_series_base64',
 ]

--- a/lmdeploy/vl/engine.py
+++ b/lmdeploy/vl/engine.py
@@ -24,7 +24,13 @@ def _get_hf_config_mm_feature_dtype(hf_config) -> torch.dtype | None:
     if hf_config is None:
         return None
 
-    for config in (hf_config, getattr(hf_config, 'text_config', None), getattr(hf_config, 'llm_config', None)):
+    configs = [hf_config, getattr(hf_config, 'text_config', None), getattr(hf_config, 'llm_config', None)]
+
+    # for qwen3-omni thinker
+    if hasattr(hf_config, 'thinker_config'):
+        configs.append(hf_config.thinker_config)
+
+    for config in configs:
         if config is None:
             continue
         for attr_name in ('dtype', 'torch_dtype'):

--- a/lmdeploy/vl/model/base.py
+++ b/lmdeploy/vl/model/base.py
@@ -213,7 +213,7 @@ class VisionModel(ABC):
                     collected_mm_items[current_modality] = {}
 
                 if attr_name in self.FEATURE_NAMES:
-                    value = self._postprocess_mm_output(value, self.mm_feature_dtype)
+                    value = self._postprocess_mm_output(value, getattr(self, 'mm_feature_dtype', None))
                     processor_outputs[attr_name] = value
                     attr_name = 'feature'
 

--- a/lmdeploy/vl/utils.py
+++ b/lmdeploy/vl/utils.py
@@ -54,7 +54,8 @@ def encode_video_base64(video: str | npt.NDArray, format: str = 'JPEG', **kwargs
 
 
 def encode_audio_base64(audio: str | tuple[npt.NDArray, int], format: str = 'WAV', **kwargs) -> str:
-    """Encode audio (path or audio array with sample rate) to a base64 string."""
+    """Encode audio (path or audio array with sample rate) to a base64
+    string."""
     if isinstance(audio, str):
         audio = load_audio(audio, **kwargs)
     audio_io = AudioMediaIO(**kwargs)

--- a/lmdeploy/vl/utils.py
+++ b/lmdeploy/vl/utils.py
@@ -4,6 +4,7 @@ from typing import Any
 import numpy.typing as npt
 from PIL import Image
 
+from .media.audio import AudioMediaIO
 from .media.connection import load_from_url
 from .media.image import ImageMediaIO
 from .media.time_series import TimeSeriesMediaIO
@@ -21,6 +22,12 @@ def load_video(video_url: str, **kwargs) -> tuple[npt.NDArray, dict[str, Any]]:
     image_io = ImageMediaIO()
     video_io = VideoMediaIO(image_io=image_io, **kwargs)
     return load_from_url(video_url, video_io)
+
+
+def load_audio(audio_url: str, **kwargs) -> tuple[npt.NDArray, int]:
+    """Fetch and decode audio from a URL, path, or base64 string."""
+    audio_io = AudioMediaIO(**kwargs)
+    return load_from_url(audio_url, audio_io)
 
 
 def load_time_series(ts_url: str, **kwargs) -> npt.NDArray:
@@ -44,6 +51,14 @@ def encode_video_base64(video: str | npt.NDArray, format: str = 'JPEG', **kwargs
     image_io = ImageMediaIO()
     video_io = VideoMediaIO(image_io=image_io, **kwargs)
     return video_io.encode_base64(video, video_format=format)
+
+
+def encode_audio_base64(audio: str | tuple[npt.NDArray, int], format: str = 'WAV', **kwargs) -> str:
+    """Encode audio (path or audio array with sample rate) to a base64 string."""
+    if isinstance(audio, str):
+        audio = load_audio(audio, **kwargs)
+    audio_io = AudioMediaIO(**kwargs)
+    return audio_io.encode_base64(audio, audio_format=format)
 
 
 def encode_time_series_base64(data: str | npt.NDArray, **kwargs) -> str:

--- a/tests/test_lmdeploy/test_vl/test_vl_encode.py
+++ b/tests/test_lmdeploy/test_vl/test_vl_encode.py
@@ -3,9 +3,11 @@ import math
 import numpy as np
 
 from lmdeploy.vl import (
+    encode_audio_base64,
     encode_image_base64,
     encode_time_series_base64,
     encode_video_base64,
+    load_audio,
     load_image,
     load_time_series,
     load_video,
@@ -58,6 +60,24 @@ def test_time_series_encode_decode():
 
     assert ts1.shape == ts2.shape
     assert np.allclose(ts1, ts2)
+
+
+def test_audio_encode_decode():
+    import pytest
+    pytest.importorskip('librosa')
+    pytest.importorskip('soundfile')
+
+    sr = 16000
+    seconds = 0.25
+    t = np.linspace(0, seconds, int(sr * seconds), endpoint=False, dtype=np.float32)
+    audio = 0.1 * np.sin(2 * np.pi * 440 * t)
+
+    b64 = encode_audio_base64((audio, sr))
+    audio_out, sr_out = load_audio(f'data:audio/wav;base64,{b64}', sampling_rate=sr)
+
+    assert sr_out == sr
+    assert audio_out.shape == audio.shape
+    assert np.allclose(audio_out, audio, atol=1e-4)
 
 
 def test_image_modes():


### PR DESCRIPTION
## Summary
- add audio base64 helpers and documentation for multimodal inputs
- document Intern-S2-Preview video and mixed image/video support
- update supported model lists for Qwen3-Omni, Intern-S2-Preview, and GLM-4.7-Flash

## Tests
- git diff --check
- python -m py_compile lmdeploy/vl/utils.py lmdeploy/vl/__init__.py tests/test_lmdeploy/test_vl/test_vl_encode.py
- python -m pytest -q tests/test_lmdeploy/test_vl/test_vl_encode.py::test_audio_encode_decode (skipped: optional audio dependencies unavailable)

## Assistance

Assisted with Codex + GPT-5.5 xHigh Fast
