### PR TITLE
Improve engine health monitoring

### DIFF
--- a/lmdeploy/pytorch/engine/engine_loop.py
+++ b/lmdeploy/pytorch/engine/engine_loop.py
@@ -446,7 +446,6 @@ class EngineLoop:
                 running=next_running,
                 forward_inputs=forward_inputs,
             )
-            scheduler.tick()
             self.inputs_maker.deactivate_evict_seqs()
             has_runable_event.set()
 

--- a/lmdeploy/pytorch/engine/inputs_maker.py
+++ b/lmdeploy/pytorch/engine/inputs_maker.py
@@ -796,6 +796,7 @@ class InputsMakerAsync:
             session_ids = [seq.session_id for seq in next_running]
             logger.debug(f'Forward session_ids: {session_ids}')
         await self.executor.forward_async(forward_inputs)
+        self.scheduler.tick()
         self.forward_inputs = forward_inputs
         return forward_inputs, next_running
 

--- a/lmdeploy/pytorch/paging/scheduler.py
+++ b/lmdeploy/pytorch/paging/scheduler.py
@@ -67,7 +67,7 @@ class Scheduler:
         self.scheduler_tick = 0
 
     def tick(self):
-        """Mark one scheduler progress step."""
+        """Mark one scheduler progress step (once per forward dispatch)."""
         self.scheduler_tick += 1
 
     @staticmethod

--- a/lmdeploy/serve/core/async_engine.py
+++ b/lmdeploy/serve/core/async_engine.py
@@ -379,7 +379,7 @@ class AsyncEngine:
         await self.stop_all_session()
         await self.engine.sleep(level)
 
-    async def wakeup(self, tags: list[str] | None = None):
+    def wakeup(self, tags: list[str] | None = None):
         """Wake up the model.
 
         Args:
@@ -393,7 +393,7 @@ class AsyncEngine:
         if any(tag not in self.sleeping_tags for tag in tags):
             logger.warning(f'some tag in {tags} not in sleeping tags {self.sleeping_tags}')
             return
-        await asyncio.to_thread(self.engine.wakeup, tags)
+        self.engine.wakeup(tags)
         # for TM backend, sleep/wakeup will reset gateway, therefore we need to rebuild instances
         if self.backend == 'turbomind' and 'kv_cache' in tags:
             self.session_mgr.build_request_handle_pool(self.engine, self.backend_config.max_batch_size)

--- a/lmdeploy/serve/core/async_engine.py
+++ b/lmdeploy/serve/core/async_engine.py
@@ -280,7 +280,7 @@ class AsyncEngine:
     def _make_health_result(status: str, message: str) -> dict:
         return dict(status=status, message=message)
 
-    async def health_probe(self, timeout: float = 2.0, scheduler_stall_timeout: float = 15.0) -> dict:
+    async def health_probe(self, timeout: float, scheduler_stall_timeout: float) -> dict:
         """Probe backend health with a bounded, non-overlapping call."""
         if self.is_sleeping:
             return self._make_health_result(

--- a/lmdeploy/serve/core/async_engine.py
+++ b/lmdeploy/serve/core/async_engine.py
@@ -291,7 +291,7 @@ class AsyncEngine:
         if self._health_probe_task is not None:
             if not self._health_probe_task.done():
                 return self._make_health_result(
-                    status='unhealthy',
+                    status='pending',
                     message='Previous backend health probe is still pending.',
                 )
             try:
@@ -379,7 +379,7 @@ class AsyncEngine:
         await self.stop_all_session()
         await self.engine.sleep(level)
 
-    def wakeup(self, tags: list[str] | None = None):
+    async def wakeup(self, tags: list[str] | None = None):
         """Wake up the model.
 
         Args:
@@ -393,7 +393,7 @@ class AsyncEngine:
         if any(tag not in self.sleeping_tags for tag in tags):
             logger.warning(f'some tag in {tags} not in sleeping tags {self.sleeping_tags}')
             return
-        self.engine.wakeup(tags)
+        await asyncio.to_thread(self.engine.wakeup, tags)
         # for TM backend, sleep/wakeup will reset gateway, therefore we need to rebuild instances
         if self.backend == 'turbomind' and 'kv_cache' in tags:
             self.session_mgr.build_request_handle_pool(self.engine, self.backend_config.max_batch_size)

--- a/lmdeploy/serve/core/health.py
+++ b/lmdeploy/serve/core/health.py
@@ -2,11 +2,35 @@
 from __future__ import annotations
 
 import asyncio
+import os
 import time
 from typing import TYPE_CHECKING
 
+from lmdeploy.utils import get_logger
+
 if TYPE_CHECKING:
     from .async_engine import AsyncEngine
+
+logger = get_logger('lmdeploy')
+
+HEALTH_POLL_INTERVAL = 'LMDEPLOY_HEALTH_POLL_INTERVAL'
+HEALTH_PROBE_TIMEOUT = 'LMDEPLOY_HEALTH_PROBE_TIMEOUT'
+HEALTH_UNHEALTHY_AFTER = 'LMDEPLOY_HEALTH_UNHEALTHY_AFTER'
+
+DEFAULT_PROBE_TIMEOUT = 10.0
+DEFAULT_POLL_INTERVAL = 12.0
+DEFAULT_UNHEALTHY_AFTER = 90.0
+
+
+def _env_override_float(env_var: str, value: float) -> float:
+    """Return ``value`` unless ``env_var`` is set, then parse and return it."""
+    env_value = os.getenv(env_var)
+    if env_value is None:
+        return value
+    try:
+        return float(env_value)
+    except ValueError:
+        return value
 
 
 class EngineHealthMonitor:
@@ -14,13 +38,37 @@ class EngineHealthMonitor:
 
     def __init__(self,
                  async_engine: AsyncEngine | None,
-                 poll_interval: float = 5.0,
-                 probe_timeout: float = 2.0,
-                 unhealthy_after: float = 15.0):
+                 poll_interval: float = DEFAULT_POLL_INTERVAL,
+                 probe_timeout: float = DEFAULT_PROBE_TIMEOUT,
+                 unhealthy_after: float = DEFAULT_UNHEALTHY_AFTER):
+        """Initialize the background health monitor.
+
+        Args:
+            async_engine: Engine instance to probe; ``None`` marks the service
+                unhealthy until an engine is attached.
+            poll_interval: Seconds between consecutive ``probe_once()`` calls in
+                the background loop (default 12.0). Should be greater than
+                ``probe_timeout`` to reduce overlapping probes. Overridden by
+                ``LMDEPLOY_HEALTH_POLL_INTERVAL`` when that variable is set.
+            probe_timeout: Maximum seconds to wait for a single
+                ``health_probe()`` (backend ``get_health_status()``) before
+                reporting that probe as unhealthy (default 10.0). Overridden by
+                ``LMDEPLOY_HEALTH_PROBE_TIMEOUT`` when that variable is set.
+            unhealthy_after: Seconds without a successful probe or scheduler
+                progress before the service is considered unhealthy (default
+                90.0). Overridden by ``LMDEPLOY_HEALTH_UNHEALTHY_AFTER`` when
+                that variable is set. Passed to ``health_probe()`` as
+                ``scheduler_stall_timeout``, and also used in ``snapshot()``
+                to expire stale healthy status or stuck ``initializing`` state.
+        """
         self.async_engine = async_engine
-        self.poll_interval = poll_interval
-        self.probe_timeout = probe_timeout
-        self.unhealthy_after = unhealthy_after
+        self.poll_interval = _env_override_float(HEALTH_POLL_INTERVAL, poll_interval)
+        self.probe_timeout = _env_override_float(HEALTH_PROBE_TIMEOUT, probe_timeout)
+        self.unhealthy_after = _env_override_float(HEALTH_UNHEALTHY_AFTER, unhealthy_after)
+        if self.poll_interval <= self.probe_timeout:
+            logger.warning('Engine health poll_interval (%.1fs) should be greater than probe_timeout (%.1fs) '
+                             'to avoid overlapping probes.',
+                             self.poll_interval, self.probe_timeout)
         self._task: asyncio.Task | None = None
         self._started_time = time.monotonic()
         self._last_success_time: float | None = None
@@ -61,6 +109,9 @@ class EngineHealthMonitor:
                               message=f'Engine health probe failed: {e}')
 
         status = result['status']
+        if status == 'pending':
+            logger.info('Engine health probe skipped: previous backend health probe is still pending.')
+            return
         if status in ('healthy', 'sleeping'):
             self._last_success_time = probe_time
         self._snapshot = dict(status=status, message=result['message'])
@@ -68,7 +119,7 @@ class EngineHealthMonitor:
     def snapshot(self) -> dict:
         snapshot = dict(self._snapshot)
         now = time.monotonic()
-        if snapshot['status'] in ('healthy', 'sleeping') and self._last_success_time is not None:
+        if snapshot['status'] == 'healthy' and self._last_success_time is not None:
             if now - self._last_success_time > self.unhealthy_after:
                 snapshot['status'] = 'unhealthy'
                 snapshot['message'] = f'No successful health probe for {now - self._last_success_time:.1f}s.'

--- a/lmdeploy/serve/openai/api_server.py
+++ b/lmdeploy/serve/openai/api_server.py
@@ -1223,7 +1223,7 @@ async def sleep(raw_request: Request = None):
 async def wakeup(raw_request: Request = None):
     tags = raw_request.query_params.getlist('tags')
     tags = tags or None
-    await VariableInterface.async_engine.wakeup(tags)
+    VariableInterface.async_engine.wakeup(tags)
     return Response(status_code=200)
 
 

--- a/lmdeploy/serve/openai/api_server.py
+++ b/lmdeploy/serve/openai/api_server.py
@@ -1223,7 +1223,7 @@ async def sleep(raw_request: Request = None):
 async def wakeup(raw_request: Request = None):
     tags = raw_request.query_params.getlist('tags')
     tags = tags or None
-    VariableInterface.async_engine.wakeup(tags)
+    await VariableInterface.async_engine.wakeup(tags)
     return Response(status_code=200)
 
 


### PR DESCRIPTION
## Motivation

- Health checks were too aggressive for PyTorch MP/Ray deployments: short probe timeouts and overlapping polls caused false unhealthy results while the engine was busy or recovering from sleep/wakeup. 
- Synchronous POST /wakeup also blocked the FastAPI event loop during long warmup, starving background health probes. 
- Scheduler tick advanced only after a full forward completed, so long prefills looked stalled to health logic. 

## Modification

**lmdeploy/serve/core/health.py**

- Add env overrides: `LMDEPLOY_HEALTH_POLL_INTERVAL`, `LMDEPLOY_HEALTH_PROBE_TIMEOUT`, `LMDEPLOY_HEALTH_UNHEALTHY_AFTER`.
- Change defaults to 12s poll interval, 10s probe timeout, 90s unhealthy/stale threshold.
- Warn` if poll_interval <= probe_timeout`.
- On `pending` probe result: log and skip snapshot update (keep last successful state).
- Expire stale probes only when last snapshot was healthy (not sleeping).

**lmdeploy/serve/core/async_engine.py**

- Return status='pending' instead of unhealthy when a previous health probe is still running.
- Make `wakeup()` async and run` engine.wakeup()` via `asyncio.to_thread()` to avoid blocking the API event loop.

**lmdeploy/serve/openai/api_server.py**

- `await async wakeup()` in the `/wakeup` handler.

**lmdeploy/pytorch/engine/inputs_maker.py**
**lmdeploy/pytorch/engine/engine_loop.py**
**lmdeploy/pytorch/paging/scheduler.py**
- Call `scheduler.tick() `after each `forward_async()` (one tick per forward dispatch).
