### PR TITLE
[Fix]: Revert the reuse of cudagraph buffer for mtp

### DIFF
--- a/lmdeploy/pytorch/backends/cuda/graph_runner.py
+++ b/lmdeploy/pytorch/backends/cuda/graph_runner.py
@@ -165,7 +165,6 @@ class CUDAGraphRunner(GraphRunner):
                  backend_config: BackendConfig, device: torch.device):
         super().__init__(model, model_config, cache_config, backend_config, device)
         self.max_batches = cache_config.max_batches
-        self.max_tokens = cache_config.max_prefill_token_num
         self.num_blocks = cache_config.num_gpu_blocks
 
         # Speculative decoding on CUDA requires FlashAttention-3 (FA3),
@@ -231,7 +230,6 @@ class CUDAGraphRunner(GraphRunner):
         batch_size = attn_metadata.q_seqlens.size(0)
         meta = self.get_meta()
         enable_microbatch = get_step_ctx_manager().current_context().enable_microbatch
-        # for draft model to distinguish inputs from target model and itself
         query_len = input_ids.size(1) // batch_size
         if meta.padding_batch_size is None:
             batch_size = self._get_capture_tokens(batch_size)

--- a/lmdeploy/pytorch/backends/cuda/graph_runner.py
+++ b/lmdeploy/pytorch/backends/cuda/graph_runner.py
@@ -67,6 +67,7 @@ class CUDASingleGraphRunner:
         max_tokens: int,
         num_blocks: int,
         is_decoding: bool,
+        decode_query_len: int,
         pool: tuple[int, int],
         model_config: ModelConfig,
         device: torch.device,
@@ -92,6 +93,7 @@ class CUDASingleGraphRunner:
             is_ssm=len(model_config.states_shapes) > 0,
             use_mrope=model_config.use_mrope,
             block_size=model_config.block_size,
+            decode_query_len=decode_query_len,
         )
         self.device = device
         self.max_batches = max_batches
@@ -163,6 +165,7 @@ class CUDAGraphRunner(GraphRunner):
                  backend_config: BackendConfig, device: torch.device):
         super().__init__(model, model_config, cache_config, backend_config, device)
         self.max_batches = cache_config.max_batches
+        self.max_tokens = cache_config.max_prefill_token_num
         self.num_blocks = cache_config.num_gpu_blocks
 
         # Speculative decoding on CUDA requires FlashAttention-3 (FA3),
@@ -229,14 +232,12 @@ class CUDAGraphRunner(GraphRunner):
         meta = self.get_meta()
         enable_microbatch = get_step_ctx_manager().current_context().enable_microbatch
         # for draft model to distinguish inputs from target model and itself
-        target_hidden_size = None
-        if context.target_hidden_states is not None:
-            target_hidden_size = context.target_hidden_states.size(-1)
+        query_len = input_ids.size(1) // batch_size
         if meta.padding_batch_size is None:
             batch_size = self._get_capture_tokens(batch_size)
         else:
             batch_size = self._get_capture_tokens(meta.padding_batch_size)
-        return (batch_size, is_decoding, enable_microbatch, target_hidden_size)
+        return (batch_size, is_decoding, enable_microbatch, query_len)
 
     def _prepare_inputs(self, **kwargs):
         """Prepare inputs."""
@@ -271,6 +272,7 @@ class CUDAGraphRunner(GraphRunner):
         graph_key = self.get_graph_key(**kwargs)
         max_batches = graph_key[0]
         is_decoding = graph_key[1]
+        decode_query_len = graph_key[3]
         if graph_key not in self._runner_map:
             max_tokens = self._get_max_tokens(graph_key, kwargs['input_ids'], kwargs['attn_metadata'].q_seqlens)
             runner = CUDASingleGraphRunner(
@@ -279,6 +281,7 @@ class CUDAGraphRunner(GraphRunner):
                 max_tokens=max_tokens,
                 num_blocks=self.num_blocks,
                 is_decoding=is_decoding,
+                decode_query_len=decode_query_len,
                 pool=self.graph_pool_handle,
                 model_config=self.model_config,
                 device=self.device,

--- a/lmdeploy/pytorch/models/utils/cudagraph.py
+++ b/lmdeploy/pytorch/models/utils/cudagraph.py
@@ -78,15 +78,11 @@ class CudaGraphMeta:
     use_mla_fp8_cache: bool = False
     use_flash_mla: bool = False
     mla_index_topk: int | None = None
+    decode_query_len: int = 1
     use_fa3_decoding: bool = False
     is_ssm: bool = False
     use_mrope: bool = False
     block_size: int = 64
-
-
-def get_graph_decode_query_len(graph_meta: CudaGraphMeta) -> int:
-    """Get decode query length from padded graph buffers."""
-    return graph_meta.max_tokens // graph_meta.max_batchs
 
 
 class CudaGraphMixin:
@@ -154,7 +150,7 @@ class CudaGraphMixin:
         max_tokens = graph_meta.max_tokens
         num_blocks = graph_meta.num_blocks
         device = graph_meta.device
-        decode_query_len = get_graph_decode_query_len(graph_meta)
+        decode_query_len = graph_meta.decode_query_len
 
         input_buffers: BuffType = dict()
         input_buffers['input_ids'] = torch.randint(0,
@@ -198,7 +194,7 @@ class CudaGraphMixin:
         elif graph_meta.use_fa3_decoding is True:
             max_seqlen_k = graph_meta.num_blocks * graph_meta.block_size
             input_buffers['scheduler_metadata'] = self.update_meta_flashattn(graph_meta.max_batchs,
-                                                                             decode_query_len,
+                                                                             graph_meta.decode_query_len,
                                                                              block_size=graph_meta.block_size,
                                                                              max_seqlen_k=max_seqlen_k,
                                                                              cache_seqlens=input_buffers['kv_seqlens'])
@@ -228,7 +224,7 @@ class CudaGraphMixin:
 
         batch_size, num_blocks = block_offsets.size()
         num_tokens = input_ids.size(-1)
-        decode_query_len = get_graph_decode_query_len(graph_meta)
+        decode_query_len = graph_meta.decode_query_len
         # fill buffer
         input_buffers['input_ids'].random_(0, graph_meta.vocab_size)
         input_buffers['input_ids'][:, :num_tokens] = input_ids

--- a/lmdeploy/pytorch/strategies/ar_spec/cudagraph.py
+++ b/lmdeploy/pytorch/strategies/ar_spec/cudagraph.py
@@ -11,9 +11,7 @@ class ARSpecCudagraphStrategy(CudagraphStrategy):
 
     def get_max_tokens(self, batch_size: int, origin_batch_size: int, num_tokens: int) -> int:
         """Get max tokens."""
-
-        # only eagle3 has two sets of cudagraph due to different target_hidden_size
-        if num_tokens == origin_batch_size and self.method == 'eagle3':
+        if num_tokens == origin_batch_size:
             return batch_size
 
         return batch_size * (self.num_spec_tokens + 1)

--- a/tests/pytorch/spec_decode/test_cudagraph_strategy.py
+++ b/tests/pytorch/spec_decode/test_cudagraph_strategy.py
@@ -1,10 +1,10 @@
 from lmdeploy.pytorch.strategies.ar_spec.cudagraph import ARSpecCudagraphStrategy
 
 
-def test_arspec_cudagraph_allocates_max_decode_width_for_single_token_capture():
+def test_arspec_cudagraph_uses_single_token_graph_for_all_methods():
     strategy = ARSpecCudagraphStrategy(num_spec_tokens=4, method='qwen3_5_mtp')
 
-    assert strategy.get_max_tokens(batch_size=8, origin_batch_size=8, num_tokens=8) == 40
+    assert strategy.get_max_tokens(batch_size=8, origin_batch_size=8, num_tokens=8) == 8
 
 
 def test_arspec_cudagraph_uses_same_allocation_for_full_spec_capture():
@@ -13,14 +13,14 @@ def test_arspec_cudagraph_uses_same_allocation_for_full_spec_capture():
     assert strategy.get_max_tokens(batch_size=8, origin_batch_size=8, num_tokens=40) == 40
 
 
-def test_arspec_cudagraph_keeps_single_token_graph_for_eagle3():
+def test_arspec_cudagraph_keeps_full_spec_capture_for_eagle3():
     strategy = ARSpecCudagraphStrategy(num_spec_tokens=4, method='eagle3')
 
     assert strategy.get_max_tokens(batch_size=8, origin_batch_size=8, num_tokens=8) == 8
     assert strategy.get_max_tokens(batch_size=8, origin_batch_size=8, num_tokens=40) == 40
 
 
-def test_cudagraph_fa3_metadata_uses_padded_query_len_for_single_token_capture():
+def test_cudagraph_fa3_metadata_uses_single_query_len_for_single_token_capture():
     from types import SimpleNamespace
 
     import torch
@@ -39,13 +39,14 @@ def test_cudagraph_fa3_metadata_uses_padded_query_len_for_single_token_capture()
     model = DummyCudaGraphModel()
     graph_meta = CudaGraphMeta(
         max_batchs=8,
-        max_tokens=32,
+        max_tokens=8,
         num_blocks=1,
         is_decoding=True,
         device=torch.device('cpu'),
         input_buffers={},
         output_buffers={},
         use_fa3_decoding=True,
+        decode_query_len=1,
     )
     input_ids = torch.zeros((1, 8), dtype=torch.long)
     position_ids = torch.zeros_like(input_ids)
@@ -72,4 +73,55 @@ def test_cudagraph_fa3_metadata_uses_padded_query_len_for_single_token_capture()
         inputs_embeds=None,
     )
 
-    assert model.max_seqlen_q_calls == [4, 4]
+    assert model.max_seqlen_q_calls == [1, 1]
+
+
+def test_cuda_graph_key_separates_query_len_without_target_hidden_size(monkeypatch):
+    from types import SimpleNamespace
+
+    import torch
+
+    from lmdeploy.pytorch.backends.cuda import graph_runner as cuda_graph_runner
+
+    context = SimpleNamespace(
+        global_is_decoding=lambda: True,
+        target_hidden_states=torch.zeros((1, 8, 16)),
+    )
+    runner = cuda_graph_runner.CUDAGraphRunner.__new__(cuda_graph_runner.CUDAGraphRunner)
+    runner.ctx_mgr = SimpleNamespace(current_context=lambda: context)
+    runner.get_meta = lambda: SimpleNamespace(padding_batch_size=None)
+    runner._get_capture_tokens = lambda batch_size: batch_size
+
+    step_context = SimpleNamespace(enable_microbatch=False)
+    step_ctx_mgr = SimpleNamespace(current_context=lambda: step_context)
+    monkeypatch.setattr(cuda_graph_runner, 'get_step_ctx_manager', lambda: step_ctx_mgr)
+
+    attn_metadata = SimpleNamespace(q_seqlens=torch.ones(8, dtype=torch.long))
+    input_ids_qlen4 = torch.zeros((1, 32), dtype=torch.long)
+    input_ids_qlen1 = torch.zeros((1, 8), dtype=torch.long)
+
+    key_qlen4 = runner.get_graph_key(
+        input_ids=input_ids_qlen4,
+        position_ids=torch.zeros_like(input_ids_qlen4),
+        past_key_values=[],
+        attn_metadata=attn_metadata,
+        inputs_embeds=None,
+    )
+    key_qlen1 = runner.get_graph_key(
+        input_ids=input_ids_qlen1,
+        position_ids=torch.zeros_like(input_ids_qlen1),
+        past_key_values=[],
+        attn_metadata=attn_metadata,
+        inputs_embeds=None,
+    )
+    assert key_qlen4 != key_qlen1
+
+    context.target_hidden_states = torch.zeros((1, 8, 32))
+    key_hidden32 = runner.get_graph_key(
+        input_ids=input_ids_qlen4,
+        position_ids=torch.zeros_like(input_ids_qlen4),
+        past_key_values=[],
+        attn_metadata=attn_metadata,
+        inputs_embeds=None,
+    )
+    assert key_hidden32 == key_qlen4

--- a/tests/pytorch/spec_decode/test_cudagraph_strategy.py
+++ b/tests/pytorch/spec_decode/test_cudagraph_strategy.py
@@ -96,22 +96,29 @@ def test_cuda_graph_key_separates_query_len_without_target_hidden_size(monkeypat
     step_ctx_mgr = SimpleNamespace(current_context=lambda: step_context)
     monkeypatch.setattr(cuda_graph_runner, 'get_step_ctx_manager', lambda: step_ctx_mgr)
 
-    attn_metadata = SimpleNamespace(q_seqlens=torch.ones(8, dtype=torch.long))
+    def make_attn_metadata(batch_size: int, query_len: int):
+        return SimpleNamespace(
+            q_seqlens=torch.full((batch_size, ), query_len, dtype=torch.long),
+            q_start_loc=torch.arange(batch_size, dtype=torch.long) * query_len,
+        )
+
     input_ids_qlen4 = torch.zeros((1, 32), dtype=torch.long)
     input_ids_qlen1 = torch.zeros((1, 8), dtype=torch.long)
+    attn_metadata_qlen4 = make_attn_metadata(batch_size=8, query_len=4)
+    attn_metadata_qlen1 = make_attn_metadata(batch_size=8, query_len=1)
 
     key_qlen4 = runner.get_graph_key(
         input_ids=input_ids_qlen4,
         position_ids=torch.zeros_like(input_ids_qlen4),
         past_key_values=[],
-        attn_metadata=attn_metadata,
+        attn_metadata=attn_metadata_qlen4,
         inputs_embeds=None,
     )
     key_qlen1 = runner.get_graph_key(
         input_ids=input_ids_qlen1,
         position_ids=torch.zeros_like(input_ids_qlen1),
         past_key_values=[],
-        attn_metadata=attn_metadata,
+        attn_metadata=attn_metadata_qlen1,
         inputs_embeds=None,
     )
     assert key_qlen4 != key_qlen1
@@ -121,7 +128,7 @@ def test_cuda_graph_key_separates_query_len_without_target_hidden_size(monkeypat
         input_ids=input_ids_qlen4,
         position_ids=torch.zeros_like(input_ids_qlen4),
         past_key_values=[],
-        attn_metadata=attn_metadata,
+        attn_metadata=attn_metadata_qlen4,
         inputs_embeds=None,
     )
     assert key_hidden32 == key_qlen4


### PR DESCRIPTION

## Motivation

Revert the reuse of cudagraph buffer for mtp brought by #4611 

## Modification

Please briefly describe what modification is made in this PR.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
