### PR TITLE
refactor: simplify multimodal preprocessing expansion

### DIFF
--- a/lmdeploy/vl/model/preprocess_utils.py
+++ b/lmdeploy/vl/model/preprocess_utils.py
@@ -78,6 +78,10 @@ def _expand_bundled_image_items(item: dict, token_id: int) -> list[dict]:
     expanded_mm_items = []
     image_grid_thw = item['image_grid_thw']
     num_items = len(item['offset'])
+    num_images = len(image_grid_thw)
+
+    if num_items != num_images:
+        raise ValueError(f'Image offsets must match image grids: got {num_items} offsets for {num_images} images.')
 
     patches_per_item = []
     for grid in image_grid_thw:
@@ -106,7 +110,7 @@ def _expand_bundled_video_items(item: dict, token_id: int) -> list[dict]:
     num_items = len(item['offset'])
     num_videos = video_grid_thw.shape[0]
 
-    # calculate patches for each video (i.e. feature len): T * H * W
+    # calculate patches for each video (i.e. feature rows): T * H * W
     patches_per_video = []
     for i in range(num_videos):
         grid = video_grid_thw[i]
@@ -144,6 +148,11 @@ def _expand_bundled_video_items(item: dict, token_id: int) -> list[dict]:
                     video_token_id=token_id,
                 ))
         return expanded_mm_items
+
+    total_frames = sum(frames_per_video)
+    if num_items != total_frames:
+        raise ValueError('Video offsets must be per-video or per-frame: '
+                         f'got {num_items} offsets for {num_videos} videos and {total_frames} frames.')
 
     # qwen3-vl emits one offset per frame: split into [1, H, W] items.
     # because MultiModalData carries one prompt span per item

--- a/lmdeploy/vl/model/preprocess_utils.py
+++ b/lmdeploy/vl/model/preprocess_utils.py
@@ -205,9 +205,9 @@ def _expand_bundled_audio_items(item: dict, token_id: int) -> list[dict]:
 
 # adapted from https://github.com/sgl-project/sglang/blob/main/python/sglang/srt/managers/mm_utils.py
 def get_expanded_mm_items(collected_mm_items, mm_tokens: 'MultimodalSpecialTokens'):
-    """When multiple multimodal items of the same modality are present, Hugging
-    Face (HF) processors return them in a bundled format (e.g., all images
-    combined into a single tensor).
+    """When multiple mm items of the same modality present, HF processors
+    return them in a bundled format (e.g., all images are combined into a
+    single tensor).
 
     This function expands such bundled HF processor outputs into per-image / video entries for better cache locality.
     """

--- a/lmdeploy/vl/model/preprocess_utils.py
+++ b/lmdeploy/vl/model/preprocess_utils.py
@@ -74,10 +74,135 @@ def get_expanded_input_ids(input_prompt, collected_mm_items, processor,
     return torch.tensor(input_ids)
 
 
+def _expand_bundled_image_items(item: dict, token_id: int) -> list[dict]:
+    expanded_mm_items = []
+    image_grid_thw = item['image_grid_thw']
+    num_items = len(item['offset'])
+
+    patches_per_item = []
+    for grid in image_grid_thw:
+        grid_tensor = torch.as_tensor(grid, dtype=torch.long)
+        patches_per_item.append(int(torch.prod(grid_tensor).item()))
+
+    cumulative = torch.cumsum(torch.tensor(patches_per_item, dtype=torch.long), dim=0)
+    slice_indices = [0] + cumulative.tolist()
+
+    for i in range(num_items):
+        start_idx, end_idx = slice_indices[i], slice_indices[i + 1]
+        expanded_mm_items.append(
+            dict(
+                modality=Modality.IMAGE,
+                pixel_values=item['feature'][start_idx:end_idx].clone(),
+                image_grid_thw=image_grid_thw[i],
+                offset=item['offset'][i],
+                image_token_id=token_id,
+            ))
+    return expanded_mm_items
+
+
+def _expand_bundled_video_items(item: dict, token_id: int) -> list[dict]:
+    expanded_mm_items = []
+    video_grid_thw = item['video_grid_thw']
+    num_items = len(item['offset'])
+    num_videos = video_grid_thw.shape[0]
+
+    # calculate patches for each video (i.e. feature len): T * H * W
+    patches_per_video = []
+    for i in range(num_videos):
+        grid = video_grid_thw[i]
+        patches_per_video.append(
+            int(torch.prod(grid).item()) if isinstance(grid, torch.Tensor) else int(
+                torch.prod(torch.as_tensor(grid, dtype=torch.long)).item()))
+
+    # get frames for each video: T
+    frames_per_video = []
+    for i in range(num_videos):
+        grid = video_grid_thw[i]
+        frames = int(grid[0].item()) if isinstance(grid, torch.Tensor) else int(
+            torch.as_tensor(grid, dtype=torch.long)[0].item())
+        frames_per_video.append(frames)
+
+    cumulative = torch.cumsum(torch.tensor(patches_per_video, dtype=torch.long), dim=0)
+    slice_indices = [0] + cumulative.tolist()
+
+    # qwen3-omni emits one offset per video: keep each [T, H, W] grid intact.
+    if num_items == num_videos:
+        for video_idx in range(num_videos):
+            feature_start, feature_end = slice_indices[video_idx], slice_indices[video_idx + 1]
+
+            second_per_grid = item.get('video_second_per_grid')
+            if second_per_grid is not None:
+                second_per_grid = second_per_grid[video_idx].item()
+
+            expanded_mm_items.append(
+                dict(
+                    modality=Modality.VIDEO,
+                    pixel_values_videos=item['feature'][feature_start:feature_end].clone(),
+                    video_grid_thw=video_grid_thw[video_idx],
+                    offset=item['offset'][video_idx],
+                    second_per_grid=second_per_grid,
+                    video_token_id=token_id,
+                ))
+        return expanded_mm_items
+
+    # qwen3-vl emits one offset per frame: split into [1, H, W] items.
+    # because MultiModalData carries one prompt span per item
+    frame_start_indices = [0]
+    for i in range(num_videos):
+        frame_start_indices.append(frame_start_indices[-1] + frames_per_video[i])
+
+    for video_idx in range(num_videos):
+        feature_start, feature_end = slice_indices[video_idx], slice_indices[video_idx + 1]
+        frame_start, frame_end = frame_start_indices[video_idx], frame_start_indices[video_idx + 1]
+        video_feature = item['feature'][feature_start:feature_end]
+        frame_offsets = item['offset'][frame_start:frame_end]
+
+        second_per_grid = item.get('video_second_per_grid')
+        if second_per_grid is not None:
+            second_per_grid = second_per_grid[video_idx].item()
+
+        t, h, w = video_grid_thw[video_idx].tolist()
+        for frame_idx in range(t):
+            grid_start = frame_idx * h * w
+            grid_end = (frame_idx + 1) * h * w
+            expanded_mm_items.append(
+                dict(
+                    modality=Modality.VIDEO,
+                    pixel_values_videos=video_feature[grid_start:grid_end].clone(),
+                    video_grid_thw=torch.tensor([1, h, w]),
+                    offset=frame_offsets[frame_idx],
+                    second_per_grid=second_per_grid,
+                    video_token_id=token_id,
+                ))
+    return expanded_mm_items
+
+
+def _expand_bundled_audio_items(item: dict, token_id: int) -> list[dict]:
+    expanded_mm_items = []
+    for i in range(len(item['offset'])):
+        feature_attention_mask = item.get('feature_attention_mask')
+        if feature_attention_mask is not None:
+            feature_attention_mask = feature_attention_mask[i:i + 1].clone()
+        expanded_mm_items.append(
+            dict(
+                modality=Modality.AUDIO,
+                input_features=item['feature'][i:i + 1].clone(),
+                feature_attention_mask=feature_attention_mask,
+                offset=item['offset'][i],
+                audio_token_id=token_id,
+            ))
+    return expanded_mm_items
+
+
 # adapted from https://github.com/sgl-project/sglang/blob/main/python/sglang/srt/managers/mm_utils.py
 def get_expanded_mm_items(collected_mm_items, mm_tokens: 'MultimodalSpecialTokens'):
-    """Expand bundled hf processor outputs into per-image/video entries for
-    cache locality and scheduling."""
+    """When multiple multimodal items of the same modality are present, Hugging
+    Face (HF) processors return them in a bundled format (e.g., all images
+    combined into a single tensor).
+
+    This function expands such bundled HF processor outputs into per-image / video entries for better cache locality.
+    """
+
     expanded_mm_items = []
     for modality, item in collected_mm_items.items():
         token_id = mm_tokens.get_token_id_by_modality(modality)
@@ -97,9 +222,7 @@ def get_expanded_mm_items(collected_mm_items, mm_tokens: 'MultimodalSpecialToken
             elif modality == Modality.VIDEO:
                 second_per_grid = item.get('video_second_per_grid')
                 if second_per_grid is not None:
-                    second_per_grid = second_per_grid[0]
-                    if isinstance(second_per_grid, torch.Tensor) and second_per_grid.numel() == 1:
-                        second_per_grid = second_per_grid.item()
+                    second_per_grid = second_per_grid[0].item()
                 expanded_mm_items.append(
                     dict(
                         modality=modality,
@@ -130,113 +253,13 @@ def get_expanded_mm_items(collected_mm_items, mm_tokens: 'MultimodalSpecialToken
                     ))
             continue
 
-        # bundled case
-        num_items = len(item['offset'])
+        # bundled case, expand into per-item entries
         if modality == Modality.IMAGE:
-            image_grid_thw = item['image_grid_thw']
-
-            patches_per_item = []
-            for grid in image_grid_thw:
-                grid_tensor = torch.as_tensor(grid, dtype=torch.long)
-                patches_per_item.append(int(torch.prod(grid_tensor).item()))
-
-            cumulative = torch.cumsum(torch.tensor(patches_per_item, dtype=torch.long), dim=0)
-            slice_indices = [0] + cumulative.tolist()
-
-            for i in range(num_items):
-                start_idx, end_idx = slice_indices[i], slice_indices[i + 1]
-                # TODO: zhouxinyu, compute mask and avoid passing token id
-                expanded_mm_items.append(
-                    dict(
-                        modality=modality,
-                        pixel_values=item['feature'][start_idx:end_idx].clone(),
-                        image_grid_thw=image_grid_thw[i],
-                        offset=item['offset'][i],
-                        image_token_id=token_id,
-                    ))
+            expanded_mm_items.extend(_expand_bundled_image_items(item, token_id))
         elif modality == Modality.VIDEO:
-            video_grid_thw = item['video_grid_thw']
-            num_videos = video_grid_thw.shape[0]
-
-            frames_per_video = []
-            total_frames = 0
-            for i in range(num_videos):
-                grid = video_grid_thw[i]
-                T = int(grid[0].item()) if isinstance(grid, torch.Tensor) else int(
-                    torch.as_tensor(grid, dtype=torch.long)[0].item())
-                frames_per_video.append(T)
-                total_frames += T
-
-            patches_per_video = []
-            for i in range(num_videos):
-                grid = video_grid_thw[i]
-                patches_per_video.append(
-                    int(torch.prod(grid).item()) if isinstance(grid, torch.Tensor) else int(
-                        torch.prod(torch.as_tensor(grid, dtype=torch.long)).item()))
-
-            cumulative = torch.cumsum(torch.tensor(patches_per_video, dtype=torch.long), dim=0)
-            slice_indices = [0] + cumulative.tolist()
-
-            if num_items != total_frames:
-                for video_idx in range(num_videos):
-                    start, end = slice_indices[video_idx], slice_indices[video_idx + 1]
-                    second_per_grid = item.get('video_second_per_grid')
-                    if second_per_grid is not None:
-                        second_per_grid = second_per_grid[video_idx]
-                        if isinstance(second_per_grid, torch.Tensor) and second_per_grid.numel() == 1:
-                            second_per_grid = second_per_grid.item()
-                    expanded_mm_items.append(
-                        dict(
-                            modality=modality,
-                            pixel_values_videos=item['feature'][start:end].clone(),
-                            video_grid_thw=video_grid_thw[video_idx],
-                            offset=item['offset'][video_idx],
-                            second_per_grid=second_per_grid,
-                            video_token_id=token_id,
-                        ))
-                continue
-
-            frame_start_indices = [0]
-            for i in range(num_videos):
-                frame_start_indices.append(frame_start_indices[-1] + frames_per_video[i])
-
-            for video_idx in range(num_videos):
-                start, end = slice_indices[video_idx], slice_indices[video_idx + 1]
-                frame_start, frame_end = frame_start_indices[video_idx], frame_start_indices[video_idx + 1]
-                second_per_grid = item.get('video_second_per_grid')
-                if second_per_grid is not None:
-                    second_per_grid = second_per_grid[video_idx]
-                    if isinstance(second_per_grid, torch.Tensor) and second_per_grid.numel() == 1:
-                        second_per_grid = second_per_grid.item()
-
-                # TODO: zhouxinyu, not sure per-frame split is good or not
-                # TODO: zhouxinyu, grid_thw [1, h, w] is only for qwen3vl
-                t, h, w = video_grid_thw[video_idx].tolist()
-                for frame_idx in range(t):
-                    video_feature = item['feature'][start:end]
-                    offset = item['offset'][frame_start:frame_end][frame_idx]
-                    expanded_mm_items.append(
-                        dict(
-                            modality=modality,
-                            pixel_values_videos=video_feature[frame_idx * h * w:(frame_idx + 1) * h * w].clone(),
-                            video_grid_thw=torch.tensor([1, h, w]),
-                            offset=offset,
-                            second_per_grid=second_per_grid,
-                            video_token_id=token_id,
-                        ))
+            expanded_mm_items.extend(_expand_bundled_video_items(item, token_id))
         elif modality == Modality.AUDIO:
-            for i in range(num_items):
-                feature_attention_mask = item.get('feature_attention_mask')
-                if feature_attention_mask is not None:
-                    feature_attention_mask = feature_attention_mask[i:i + 1].clone()
-                expanded_mm_items.append(
-                    dict(
-                        modality=modality,
-                        input_features=item['feature'][i:i + 1].clone(),
-                        feature_attention_mask=feature_attention_mask,
-                        offset=item['offset'][i],
-                        audio_token_id=token_id,
-                    ))
+            expanded_mm_items.extend(_expand_bundled_audio_items(item, token_id))
 
     # HF processors return features grouped by modality; offsets restore prompt order for mixed inputs.
     expanded_mm_items.sort(key=lambda item: item['offset'][0])


### PR DESCRIPTION
## Summary

- Split bundled multimodal expansion into image, video, and audio helpers.
- Make bundled video expansion explicit for per-video and per-frame offset layouts.
- Keep Qwen3 Omni whole-video items and Qwen3VL/Qwen3.5 per-frame items aligned with the one-span MultiModalData contract.

## Validation

- Focused VLM preprocessing tests passed.
- Qwen3 Omni processor tests passed.
- Qwen3.5 single-video pipeline smoke passed with a local cached model/media setup.
- Pre-commit hooks passed for the touched file.

## Assistance

Assisted with Codex + GPT-5.5 xHigh Fast
