### PR TITLE
fix windows ci

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -56,7 +56,7 @@ jobs:
     strategy:
       matrix:
         pyver: ['3.10', '3.11', '3.12', '3.13']
-    runs-on: windows-latest
+    runs-on: windows-2022
     steps:
       - name: Set git for windows
         run: |

--- a/.github/workflows/windows_x64_gpu.yml
+++ b/.github/workflows/windows_x64_gpu.yml
@@ -31,7 +31,7 @@ jobs:
       matrix:
         cudaver: [12.6.2, 12.8.1]
     name: cuda-${{ matrix.cudaver }}
-    runs-on: windows-latest
+    runs-on: windows-2022
     steps:
       - name: Set git for windows
         run: |


### PR DESCRIPTION
## Motivation

Some CI machines are using newer versions of MSVC, while others are using older ones. I recommend temporarily specifying a tag for the machines first. Once all the machines running GitHub Actions with the windows-latest runner have completed their MSVC version upgrades, we can then update the setup_cuda.ps1 script.