### PR TITLE
[Feature] Support Qwen3-VL AWQ quantization in lite calibration pipeline

### DIFF
--- a/lmdeploy/vl/model/qwen2.py
+++ b/lmdeploy/vl/model/qwen2.py
@@ -10,24 +10,27 @@ def check_qwen_vl_deps_install():
     try:
         import qwen_vl_utils  # noqa: F401
     except ImportError:
-        raise ImportError('please install qwen_vl_utils by `pip install qwen_vl_utils`'  # noqa: E501
-                          )
+        raise ImportError(
+            "please install qwen_vl_utils by `pip install qwen_vl_utils`"  # noqa: E501
+        )
     try:
         from transformers import Qwen2VLForConditionalGeneration  # noqa: F401
     except ImportError:
-        raise ImportError('please install latest transformers by '
-                          'pip install git+https://github.com/huggingface/transformers.git')
+        raise ImportError(
+            "please install latest transformers by pip install git+https://github.com/huggingface/transformers.git"
+        )
 
 
 @VISION_MODELS.register_module()
 class Qwen2VLModel(VisionModel):
     """Qwen2VL model."""
 
-    _arch = ['Qwen2VLForConditionalGeneration', 'Qwen2_5_VLForConditionalGeneration', 'Qwen3VLForConditionalGeneration']
+    _arch = ["Qwen2VLForConditionalGeneration", "Qwen2_5_VLForConditionalGeneration", "Qwen3VLForConditionalGeneration"]
 
     def build_preprocessor(self, trust_remote_code: bool = False):
         check_qwen_vl_deps_install()
         from transformers import AutoProcessor
+
         self.processor = AutoProcessor.from_pretrained(self.model_path, trust_remote_code=trust_remote_code)
         tokenizer = self.processor.tokenizer
         self.image_token = self.processor.image_token
@@ -38,42 +41,44 @@ class Qwen2VLModel(VisionModel):
         from qwen_vl_utils import process_vision_info
 
         images = self.collect_multimodal_items(messages)
-        optional_keys = {'resized_height', 'resized_width', 'min_pixels', 'max_pixels'}
+        optional_keys = {"resized_height", "resized_width", "min_pixels", "max_pixels"}
         outputs = []
         for modality, image, params in images:
-            item = dict(type='image', image=image)
+            item = dict(type="image", image=image)
             item.update({key: params[key] for key in params.keys() if key in optional_keys})
             image_inputs, _ = process_vision_info([dict(content=[item])])
-            result = self.processor.image_processor(images=image_inputs, return_tensors='pt')
+            result = self.processor.image_processor(images=image_inputs, return_tensors="pt")
             merge_length = self.processor.image_processor.merge_size**2
-            image_tokens = result['image_grid_thw'].prod(dim=1) // merge_length
+            image_tokens = result["image_grid_thw"].prod(dim=1) // merge_length
             result.update(dict(image_size=image.size, image_tokens=image_tokens, image_token_id=self.image_token_id))
             outputs.append(result)
-        messages.append(dict(role='preprocess', content=outputs))
+        messages.append(dict(role="preprocess", content=outputs))
         return messages
 
     def build_model(self, trust_remote_code: bool = False):
         check_qwen_vl_deps_install()
         arch = self.hf_config.architectures[0]
-        if arch == 'Qwen2VLForConditionalGeneration':
+        if arch == "Qwen2VLForConditionalGeneration":
             from transformers import Qwen2VLForConditionalGeneration as AutoModelCls
-        elif arch == 'Qwen2_5_VLForConditionalGeneration':
+        elif arch == "Qwen2_5_VLForConditionalGeneration":
             from transformers import Qwen2_5_VLForConditionalGeneration as AutoModelCls
-        elif arch == 'Qwen3VLForConditionalGeneration':
+        elif arch == "Qwen3VLForConditionalGeneration":
             from transformers import Qwen3VLForConditionalGeneration as AutoModelCls
         else:
-            raise ValueError(f'Unsupported arch={arch}')
+            raise ValueError(f"Unsupported arch={arch}")
 
         if self.with_llm:
-            self.vl_model = AutoModelCls.from_pretrained(self.model_path, device_map='cpu',
-                                                         trust_remote_code=trust_remote_code)
+            self.vl_model = AutoModelCls.from_pretrained(
+                self.model_path, device_map="cpu", trust_remote_code=trust_remote_code
+            )
         else:
             from accelerate import init_empty_weights
+
             with init_empty_weights():
                 config = self.hf_config
                 # disable accelerate check_tied_parameters_in_config for Qwen2-VL-2B-Instruct
                 config.tie_word_embeddings = False
-                if hasattr(config, 'text_config'):
+                if hasattr(config, "text_config"):
                     config.text_config.tie_word_embeddings = False
                 model = AutoModelCls._from_config(config, trust_remote_code=trust_remote_code)
                 model.visual = model.model.visual
@@ -82,13 +87,16 @@ class Qwen2VLModel(VisionModel):
                 model.half()
 
             from accelerate import load_checkpoint_and_dispatch
+
             with disable_logging():
-                load_checkpoint_and_dispatch(model=model,
-                                             checkpoint=self.model_path,
-                                             device_map='auto' if not self.with_llm else {'': 'cpu'},
-                                             max_memory=self.max_memory,
-                                             no_split_module_classes=['Qwen2VLVisionBlock', 'Qwen2_5_VLVisionBlock', 'Qwen3VLVisionBlock'],
-                                             dtype=torch.half)
+                load_checkpoint_and_dispatch(
+                    model=model,
+                    checkpoint=self.model_path,
+                    device_map="auto" if not self.with_llm else {"": "cpu"},
+                    max_memory=self.max_memory,
+                    no_split_module_classes=["Qwen2VLVisionBlock", "Qwen2_5_VLVisionBlock", "Qwen3VLVisionBlock"],
+                    dtype=torch.half,
+                )
             self.model = model.eval()
 
     @torch.no_grad()
@@ -103,17 +111,17 @@ class Qwen2VLModel(VisionModel):
         Return:
             the message list with forwarding results included
         """
-        inputs = [x['content'] for x in messages if x['role'] == 'preprocess'][0]
+        inputs = [x["content"] for x in messages if x["role"] == "preprocess"][0]
         dtype = torch.half
         device = next(self.model.visual.parameters()).device
         outputs = []
         for idx in range(0, len(inputs), max_batch_size):
-            pixel_values = [x['pixel_values'].type(dtype) for x in inputs[idx:idx + max_batch_size]]
-            image_grid_thw = [x['image_grid_thw'] for x in inputs[idx:idx + max_batch_size]]
+            pixel_values = [x["pixel_values"].type(dtype) for x in inputs[idx : idx + max_batch_size]]
+            image_grid_thw = [x["image_grid_thw"] for x in inputs[idx : idx + max_batch_size]]
             pixel_values = torch.cat(pixel_values, dim=0).to(device)
             image_grid_thw = torch.cat(image_grid_thw, dim=0).to(device)
             image_embeds = self.model.visual(pixel_values, grid_thw=image_grid_thw)
-            if hasattr(image_embeds, 'pooler_output'):
+            if hasattr(image_embeds, "pooler_output"):
                 # transformers >= 5.0.0, the type if image_embeds is `BaseModelOutputWithPooling`
                 # rather than torch.Tensor
                 image_embeds = image_embeds.pooler_output
@@ -121,49 +129,49 @@ class Qwen2VLModel(VisionModel):
             split_size = image_grid_thw.prod(dim=1) // merge_length
             image_embeds = image_embeds.split(split_size.tolist())
             outputs.extend(image_embeds)
-        messages.append(dict(role='forward', content=outputs))
+        messages.append(dict(role="forward", content=outputs))
         return messages
 
     def proc_messages(self, messages, chat_template, sequence_start, chat_template_kwargs=None):
         """Apply chat template to get the prompt."""
         chat_template_kwargs = chat_template_kwargs or {}
         prompt_messages = []
-        IMAGE_TOKEN = '<IMAGE_TOKEN>'
-        messages = [x for x in messages if x['role'] not in ['preprocess', 'forward']]
+        IMAGE_TOKEN = "<IMAGE_TOKEN>"
+        messages = [x for x in messages if x["role"] not in ["preprocess", "forward"]]
         if VisionModel.IMAGE_TOKEN_included(messages):
             # backward compatibility
             for message in messages:
-                role, content = message['role'], message['content']
-                if role != 'user' or isinstance(content, str):
+                role, content = message["role"], message["content"]
+                if role != "user" or isinstance(content, str):
                     prompt_messages.append(message)
                     continue
-                content = [x['text'] for x in content if x['type'] == 'text']
-                prompt = ''.join(content)
-                prompt = prompt.replace(IMAGE_TOKEN, f'<|vision_start|>{self.image_token}<|vision_end|>')
-                prompt_messages.append(dict(role='user', content=prompt))
+                content = [x["text"] for x in content if x["type"] == "text"]
+                prompt = "".join(content)
+                prompt = prompt.replace(IMAGE_TOKEN, f"<|vision_start|>{self.image_token}<|vision_end|>")
+                prompt_messages.append(dict(role="user", content=prompt))
         else:
             for message in messages:
-                role, content = message['role'], message['content']
-                if role != 'user' or isinstance(content, str):
+                role, content = message["role"], message["content"]
+                if role != "user" or isinstance(content, str):
                     prompt_messages.append(message)
                     continue
                 _content = []
                 for item in content:
-                    if item['type'] == 'text':
-                        _content.append(item['text'])
-                    elif item['type'] in ['image', 'image_url']:
-                        _content.append(f'<|vision_start|>{self.image_token}<|vision_end|>')
+                    if item["type"] == "text":
+                        _content.append(item["text"])
+                    elif item["type"] in ["image", "image_url"]:
+                        _content.append(f"<|vision_start|>{self.image_token}<|vision_end|>")
                     else:
-                        raise ValueError(f'Unsupported message type: {item["type"]}')
-                message = dict(role=role, content=''.join(_content))
+                        raise ValueError(f"Unsupported message type: {item['type']}")
+                message = dict(role=role, content="".join(_content))
                 prompt_messages.append(message)
         prompt = chat_template.messages2prompt(prompt_messages, sequence_start)
         return prompt, self.image_token
 
     @staticmethod
-    def get_mrope_info(seq_len: int,
-                       grid_thws: list[tuple[int, int, int]] = None,
-                       ranges: list[tuple[int, int]] = None):
+    def get_mrope_info(
+        seq_len: int, grid_thws: list[tuple[int, int, int]] = None, ranges: list[tuple[int, int]] = None
+    ):
         mrope_position_ids = [torch.arange(ranges[0][0]).expand(3, -1)]
         st_idx = ranges[0][0]
         for i, (grid_thw, embedding_range) in enumerate(zip(grid_thws, ranges)):
@@ -193,10 +201,10 @@ class Qwen2VLModel(VisionModel):
     def to_turbomind(self, messages, chat_template, tokenizer, sequence_start, chat_template_kwargs=None, **kwargs):
         prompt, IMAGE_TOKEN = self.proc_messages(messages, chat_template, sequence_start, chat_template_kwargs)
         info = super().to_turbomind_aux(messages, prompt, IMAGE_TOKEN, tokenizer, sequence_start)
-        inputs = [x['content'] for x in messages if x['role'] == 'preprocess'][0]
-        grid_thws = [x['image_grid_thw'].tolist()[0] for x in inputs]
-        seq_len = len(info['input_ids'])
-        ranges = info['input_embedding_ranges']
+        inputs = [x["content"] for x in messages if x["role"] == "preprocess"][0]
+        grid_thws = [x["image_grid_thw"].tolist()[0] for x in inputs]
+        seq_len = len(info["input_ids"])
+        ranges = info["input_embedding_ranges"]
         mrope_position_ids, mrope_position_delta = self.get_mrope_info(seq_len, grid_thws, ranges)
         meta = dict(mrope_position_ids=mrope_position_ids, mrope_position_delta=mrope_position_delta)
         info.update(dict(input_meta=meta))

--- a/lmdeploy/vl/model/qwen2.py
+++ b/lmdeploy/vl/model/qwen2.py
@@ -23,7 +23,7 @@ def check_qwen_vl_deps_install():
 class Qwen2VLModel(VisionModel):
     """Qwen2VL model."""
 
-    _arch = ['Qwen2VLForConditionalGeneration', 'Qwen2_5_VLForConditionalGeneration']
+    _arch = ['Qwen2VLForConditionalGeneration', 'Qwen2_5_VLForConditionalGeneration', 'Qwen3VLForConditionalGeneration']
 
     def build_preprocessor(self, trust_remote_code: bool = False):
         check_qwen_vl_deps_install()
@@ -59,6 +59,8 @@ class Qwen2VLModel(VisionModel):
             from transformers import Qwen2VLForConditionalGeneration as AutoModelCls
         elif arch == 'Qwen2_5_VLForConditionalGeneration':
             from transformers import Qwen2_5_VLForConditionalGeneration as AutoModelCls
+        elif arch == 'Qwen3VLForConditionalGeneration':
+            from transformers import Qwen3VLForConditionalGeneration as AutoModelCls
         else:
             raise ValueError(f'Unsupported arch={arch}')
 
@@ -85,7 +87,7 @@ class Qwen2VLModel(VisionModel):
                                              checkpoint=self.model_path,
                                              device_map='auto' if not self.with_llm else {'': 'cpu'},
                                              max_memory=self.max_memory,
-                                             no_split_module_classes=['Qwen2VLVisionBlock', 'Qwen2_5_VLVisionBlock'],
+                                             no_split_module_classes=['Qwen2VLVisionBlock', 'Qwen2_5_VLVisionBlock', 'Qwen3VLVisionBlock'],
                                              dtype=torch.half)
             self.model = model.eval()
 


### PR DESCRIPTION
## Motivation

Qwen3-VL models (2B–235B) are listed as supported in LMDeploy but AWQ quantization via `lmdeploy lite auto_awq` fails with `NotImplementedError` because `build_model()` was not implemented for the `Qwen3VLForConditionalGeneration` architecture.

The model is correctly matched by the registry (log shows: "matching vision model: Qwen3VLModel") but immediately errors out, making AWQ quantization completely unusable for Qwen3-VL.

Fixes #4673

## Modification

Modified `lmdeploy/vl/model/qwen2.py`:

1. Added `Qwen3VLForConditionalGeneration` to the `_arch` list in `Qwen2VLModel`
2. Added an import branch for `Qwen3VLForConditionalGeneration` in `build_model()`
3. Added `Qwen3VLVisionBlock` to `no_split_module_classes` for correct checkpoint dispatch via accelerate

The change follows the identical pattern already used for `Qwen2_5_VLForConditionalGeneration`, keeping the diff minimal and consistent.

## BC-breaking (Optional)

No. This only adds a new architecture branch to an existing method. Existing Qwen2-VL and Qwen2.5-VL behaviour is untouched.

## Use cases (Optional)

Users can now run AWQ quantization on Qwen3-VL models:

```bash
lmdeploy lite auto_awq Qwen/Qwen3-VL-8B \
    --w-bits 4 \
    --w-group-size 128 \
    --work-dir ./Qwen3-VL-8B-AWQ
```

Note: `Qwen3VLMoeForConditionalGeneration` (used by Qwen3-VL MoE variants like 30B-A3B) is not yet covered. Happy to extend this PR to include it if preferred by maintainers.

## Checklist

1. [ ] Pre-commit or other linting tools are used to fix the potential lint issues.
2. [ ] The modification is covered by complete unit tests.
3. [x] No new downstream dependencies introduced.
4. [x] Documentation update not required — this fixes a broken feature, no new API surface introduced.