### PR TITLE
fix: parse multimodal tool messages

### DIFF
--- a/lmdeploy/serve/processors/multimodal.py
+++ b/lmdeploy/serve/processors/multimodal.py
@@ -16,6 +16,18 @@ from lmdeploy.vl.media.video import VideoMediaIO
 
 logger = get_logger('lmdeploy')
 
+MULTIMODAL_TYPES = (
+    'image_url',
+    'image_data',
+    'image',
+    'video_url',
+    'video',
+    'audio_url',
+    'audio',
+    'time_series_url',
+    'time_series',
+)
+
 
 class MultimodalProcessor:
     """Processor for handling prompt preprocessing, message content merging,
@@ -97,12 +109,13 @@ class MultimodalProcessor:
         role = in_messages[i]['role']
         content = in_messages[i]['content']
 
-        if role != 'user' or isinstance(content, str):
+        if role not in ('user', 'tool') or isinstance(content, str):
             out_messages[i] = in_messages[i]
             return
 
         assert isinstance(content, list)
-        out_message = dict(role=role, content=[])
+        out_message = dict(in_messages[i])
+        out_message['content'] = []
 
         for item in content:
             item_type = item.get('type')
@@ -332,13 +345,14 @@ class MultimodalProcessor:
     def _has_multimodal_input(self, messages: list[dict]) -> bool:
         """Check if messages contain multimodal input such as images, videos,
         audios, or time series."""
-        multimodal_types = [
-            'image_url', 'image_data', 'image', 'video_url', 'video', 'audio_url', 'audio', 'time_series_url',
-            'time_series'
-        ]
-        return any(
-            isinstance(message.get('content'), list) and any(
-                item.get('type') in multimodal_types for item in message['content']) for message in messages)
+        for message in messages:
+            content = message.get('content')
+            if not isinstance(content, list):
+                continue
+            for item in content:
+                if isinstance(item, dict) and item.get('type') in MULTIMODAL_TYPES:
+                    return True
+        return False
 
     async def _get_text_prompt_input(self,
                                      prompt: str | list[dict],

--- a/tests/test_lmdeploy/test_content_merge.py
+++ b/tests/test_lmdeploy/test_content_merge.py
@@ -6,7 +6,6 @@ from PIL import Image
 
 from lmdeploy.serve.processors import MultimodalProcessor
 from lmdeploy.vl.constants import Modality
-from lmdeploy.vl.model.base import VisionModel
 
 multimodal_module = sys.modules[MultimodalProcessor.__module__]
 
@@ -395,8 +394,6 @@ def test_async_parse_multimodal_item_preserves_tool_image_content(monkeypatch):
     assert parsed[2]['content'][1]['type'] == Modality.IMAGE
     assert parsed[2]['content'][1]['data'] == f'loaded:{image_data_url}'
     assert parsed[2]['content'][1]['detail'] == 'auto'
-    mm_items = VisionModel.collect_multimodal_items(parsed)
-    assert [(modality, data) for modality, data, _ in mm_items] == [(Modality.IMAGE, f'loaded:{image_data_url}')]
     assert load_calls == [(image_data_url, 'ImageMediaIO')]
 
 

--- a/tests/test_lmdeploy/test_content_merge.py
+++ b/tests/test_lmdeploy/test_content_merge.py
@@ -6,6 +6,7 @@ from PIL import Image
 
 from lmdeploy.serve.processors import MultimodalProcessor
 from lmdeploy.vl.constants import Modality
+from lmdeploy.vl.model.base import VisionModel
 
 multimodal_module = sys.modules[MultimodalProcessor.__module__]
 
@@ -333,6 +334,72 @@ def test_async_parse_multimodal_item_supports_new_value_encodings(monkeypatch):
     ]
 
 
+def test_async_parse_multimodal_item_preserves_tool_image_content(monkeypatch):
+    """Tool result images should be parsed in place like vLLM."""
+    load_calls = []
+
+    def fake_load_from_url(data_src, media_io):
+        load_calls.append((data_src, type(media_io).__name__))
+        return f'loaded:{data_src}'
+
+    monkeypatch.setattr(multimodal_module, 'load_from_url', fake_load_from_url)
+
+    image_data_url = 'data:image/png;base64,abc'
+    messages = [
+        {
+            'role': 'user',
+            'content': 'describe the image from the tool result',
+        },
+        {
+            'role': 'assistant',
+            'content': '',
+            'tool_calls': [{
+                'id': 'call_read',
+                'type': 'function',
+                'function': {
+                    'name': 'file_read',
+                    'arguments': '{}',
+                },
+            }],
+        },
+        {
+            'role':
+            'tool',
+            'tool_call_id':
+            'call_read',
+            'content': [
+                {
+                    'type': 'text',
+                    'text': 'Image file read successfully: file-read-demo.png',
+                },
+                {
+                    'type': 'image_url',
+                    'image_url': {
+                        'url': image_data_url,
+                        'detail': 'auto',
+                    },
+                },
+            ],
+        },
+    ]
+
+    parsed = asyncio.run(MultimodalProcessor.async_parse_multimodal_item(messages))
+
+    assert len(parsed) == 3
+    assert parsed[2]['role'] == 'tool'
+    assert parsed[2]['tool_call_id'] == 'call_read'
+    assert parsed[2]['content'][0] == {
+        'type': 'text',
+        'text': 'Image file read successfully: file-read-demo.png',
+    }
+    assert parsed[2]['content'][1]['type'] == Modality.IMAGE
+    assert parsed[2]['content'][1]['data'] == f'loaded:{image_data_url}'
+    assert parsed[2]['content'][1]['detail'] == 'auto'
+    mm_items = VisionModel.collect_multimodal_items(parsed)
+    assert [(modality, data) for modality, data, _ in mm_items] == [(Modality.IMAGE, f'loaded:{image_data_url}')]
+    assert load_calls == [(image_data_url, 'ImageMediaIO')]
+
+
 @pytest.mark.parametrize('item', [{'type': 'image_url'}, {'type': 'image', 'image': {}},
                                   {'type': 'time_series', 'time_series': {'sr': 16000}}])
 def test_async_parse_multimodal_item_rejects_missing_payload(item):
@@ -360,6 +427,7 @@ def test_has_multimodal_input_detects_all_supported_types():
             'time_series'
     ]:
         assert processor._has_multimodal_input([{'role': 'user', 'content': [{'type': item_type}]}])
+    assert processor._has_multimodal_input([{'role': 'tool', 'content': [{'type': 'image_url'}]}])
     assert not processor._has_multimodal_input([{'role': 'user', 'content': [{'type': 'text', 'text': 'hello'}]}])
 
 


### PR DESCRIPTION
## Summary

- Parse multimodal content in `tool` messages instead of only `user` messages.
- Preserve tool-message metadata such as `tool_call_id` while converting multimodal parts.
- Add regression coverage for a tool-result image payload and multimodal input detection.

## Validation

- Diff whitespace check passed.
- Syntax compilation passed for touched Python files.
- Replayed the original multimodal tool-result chat-completions payload against a real Qwen3.5 LMDeploy server and confirmed it completes normally instead of returning a prompt-processing error.

## Assistance

Assisted with Codex + GPT-5.5 xHigh Fast
