### PR TITLE
[Bugfix] Fix InternVL/InternVL3 LoRA loading TypeError in adapter fallback

### DIFF
--- a/lmdeploy/pytorch/models/internvl.py
+++ b/lmdeploy/pytorch/models/internvl.py
@@ -930,7 +930,7 @@ class InternVLChatModel(nn.Module, DeployModelMixinV1, CudaGraphMixin):
         else:
             from lmdeploy.pytorch.adapter.adapter import load_lora_weights
 
-            return load_lora_weights(weights, adapter_id)
+            return load_lora_weights(self, weights, adapter_id)
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]):
         """Load weights."""

--- a/lmdeploy/pytorch/models/internvl3_hf.py
+++ b/lmdeploy/pytorch/models/internvl3_hf.py
@@ -657,12 +657,12 @@ class InternVLForConditionalGeneration(nn.Module, DeployModelMixinV1, CudaGraphM
     def load_lora_weights(self, weights: Iterable[tuple[str, torch.Tensor]], adapter_id: int):
         """Load lora weights."""
 
-        if hasattr(self.model.language_model, 'load_lora_weights'):
-            return self.model.language_model.load_lora_weights(weights, adapter_id)
+        if hasattr(self.language_model, 'load_lora_weights'):
+            return self.language_model.load_lora_weights(weights, adapter_id)
         else:
             from lmdeploy.pytorch.adapter.adapter import load_lora_weights
 
-            return load_lora_weights(weights, adapter_id)
+            return load_lora_weights(self, weights, adapter_id)
 
     @classmethod
     def rename_weight(cls, name: str) -> str:

--- a/tests/pytorch/test_internvl_lora.py
+++ b/tests/pytorch/test_internvl_lora.py
@@ -1,0 +1,54 @@
+from unittest.mock import MagicMock, patch
+
+import lmdeploy.pytorch.adapter.adapter as adapter_module
+from lmdeploy.pytorch.models.internvl import InternVLChatModel
+from lmdeploy.pytorch.models.internvl3_hf import InternVLForConditionalGeneration
+
+_LORA_WEIGHTS = [('base_model.model.language_model.model.layers.0.mlp.down_proj.lora_A.weight', None)]
+
+
+class _LanguageModelWithoutLora:
+    """Inner language model that does not implement ``load_lora_weights`` so
+    the VLM wrapper falls back to the standalone adapter loader."""
+
+
+def _assert_fallback_passes_model(model_cls):
+    model = model_cls.__new__(model_cls)
+    model.language_model = _LanguageModelWithoutLora()
+
+    with patch.object(adapter_module, 'load_lora_weights') as mock_loader:
+        model.load_lora_weights(_LORA_WEIGHTS, adapter_id=7)
+
+    # The fallback must call the standalone loader as
+    # load_lora_weights(model, weights, adapter_id). The top-level model is
+    # required because its named_parameters() carry the ``language_model.``
+    # prefix the loader maps against. It was previously called as
+    # load_lora_weights(weights, adapter_id), raising
+    # ``TypeError: load_lora_weights() missing 1 required positional argument:
+    # 'adapter_id'``.
+    mock_loader.assert_called_once_with(model, _LORA_WEIGHTS, 7)
+
+
+def test_internvl_chat_model_lora_fallback_passes_model():
+    _assert_fallback_passes_model(InternVLChatModel)
+
+
+def test_internvl_hf_lora_fallback_passes_model():
+    # Regression: InternVLForConditionalGeneration referenced
+    # ``self.model.language_model``, but the constructor stores
+    # ``self.language_model``. ``self.model`` did not exist, so hasattr swallowed
+    # the AttributeError and the fallback fired unconditionally with wrong arity.
+    _assert_fallback_passes_model(InternVLForConditionalGeneration)
+
+
+def test_internvl_hf_lora_delegates_to_language_model():
+    # When the inner language model implements load_lora_weights, the wrapper
+    # must delegate to it -- which only works once the hasattr check looks at
+    # self.language_model instead of the non-existent self.model.
+    model = InternVLForConditionalGeneration.__new__(InternVLForConditionalGeneration)
+    inner = MagicMock()
+    model.language_model = inner
+
+    model.load_lora_weights(_LORA_WEIGHTS, adapter_id=9)
+
+    inner.load_lora_weights.assert_called_once_with(_LORA_WEIGHTS, 9)


### PR DESCRIPTION
## Summary
Fixes #4105. Serving `OpenGVLab/InternVL3-14B` (or any InternVL) with a LoRA adapter on the PyTorch backend crashes with:
```
TypeError: load_lora_weights() missing 1 required positional argument: 'adapter_id'
```

## Root cause
Both `InternVLChatModel.load_lora_weights` (internvl.py) and `InternVLForConditionalGeneration.load_lora_weights` (internvl3_hf.py) fall back to the standalone `lmdeploy.pytorch.adapter.adapter.load_lora_weights` when the inner language model does not define `load_lora_weights`. Its signature is:
```python
def load_lora_weights(model: nn.Module, weights, adapter_id): ...
```
but both call it as `load_lora_weights(weights, adapter_id)` — `weights` binds to `model`, `adapter_id` binds to `weights`, and `adapter_id` is unbound → `TypeError`.

`internvl3_hf.py` has a second bug that makes the broken branch fire **unconditionally**: it gates on `hasattr(self.model.language_model, 'load_lora_weights')`, but the constructor stores `self.language_model` (there is no `self.model`). `hasattr` swallows the `AttributeError` and always takes the `else` branch.

## Fix
Pass the **top-level model** (`self`) to the standalone loader, and use `self.language_model` for the `hasattr`/delegate path in `internvl3_hf.py`.

`self` is correct because the loader does `dict(model.named_parameters())` and maps de-prefixed adapter keys like `language_model.model.layers.0.mlp.down_proj.lora_adapters.down_proj.lora_A` — i.e. names that start with `language_model.`. Only the top-level VLM (which has `language_model` as a child) produces that namespace. This mirrors the canonical caller `internlm2.py`:
```python
load_lora_weights(self, weights_iter, adapter_id)
```

## Relation to #4106
The earlier (closed) #4106 passed `self.language_model` (internvl.py) / `self.model.language_model` (internvl3_hf.py). `self.language_model.named_parameters()` yields `model.layers...` (no `language_model.` prefix), so the loader's `params_dict[param_name]` lookup misses — which is the `KeyError`/param-name mismatch the reporter hit after trying #4106. Passing `self` gives the loader the namespace it actually maps against, and also fixes the non-existent `self.model` reference.

## Test
Added `tests/pytorch/test_internvl_lora.py` (GPU-free; mocks the standalone loader):
```
pytest tests/pytorch/test_internvl_lora.py
```
- **WITH** fix: `3 passed` — both classes pass `(model, weights, adapter_id)` to the loader, and `internvl3_hf` delegates correctly when the language model implements `load_lora_weights`.
- **WITHOUT** fix: `3 failed` (loader called with the wrong `(weights, adapter_id)` arity; delegation never happens).

`ruff check` clean on all three files.

## Honesty / scope
The `TypeError` and `self.model` bugs are verified by code analysis + the GPU-free unit tests above. I do not have the `InternVL3-14B` + LoRA serving setup to run the full end-to-end here; the parameter-namespace analysis indicates passing `self` also resolves the downstream `KeyError` from #4106, but an e2e confirmation by someone with that model/adapter would be welcome. cc @windreamer (you triaged the original issue).

---
AI-assisted (Claude); every line human-reviewed.
