### PR TITLE
[Bugfix] Fix ImportError in get_chat_template for builtin chat-template names

### DIFF
--- a/lmdeploy/cli/utils.py
+++ b/lmdeploy/cli/utils.py
@@ -7,10 +7,6 @@ import sys
 from collections import defaultdict
 from typing import Any
 
-from lmdeploy.utils import get_logger
-
-logger = get_logger('lmdeploy')
-
 
 class DefaultsAndTypesHelpFormatter(argparse.HelpFormatter):
     """Formatter to output default value and type in help information."""
@@ -73,7 +69,7 @@ def get_chat_template(chat_template: str, model_path: str = None):
 
     Args:
         chat_template(str): it could be a builtin chat template name, or a chat template json file
-        model_path(str): the model path, used to check deprecated chat template names
+        model_path(str): the model path, passed through to the chat template config
     """
     import os
 
@@ -82,14 +78,7 @@ def get_chat_template(chat_template: str, model_path: str = None):
         if os.path.isfile(chat_template):
             return ChatTemplateConfig.from_json(chat_template)
         else:
-            from lmdeploy.model import DEPRECATED_CHAT_TEMPLATE_NAMES, MODELS, REMOVED_CHAT_TEMPLATE_NAMES
-            if chat_template in REMOVED_CHAT_TEMPLATE_NAMES:
-                raise ValueError(f"The chat template '{chat_template}' has been removed. "
-                                 f'Please refer to the latest chat templates in '
-                                 f'https://lmdeploy.readthedocs.io/en/latest/advance/chat_template.html')
-            if chat_template in DEPRECATED_CHAT_TEMPLATE_NAMES:
-                logger.warning(f"The chat template '{chat_template}' is deprecated and fallback to hf chat template.")
-                chat_template = 'hf'
+            from lmdeploy.model import MODELS
             assert chat_template in MODELS.module_dict.keys(), \
                 f"chat template '{chat_template}' is not " \
                 f'registered. The builtin chat templates are: ' \

--- a/lmdeploy/cli/utils.py
+++ b/lmdeploy/cli/utils.py
@@ -64,12 +64,12 @@ def get_lora_adapters(adapters: list[str]):
     return output
 
 
-def get_chat_template(chat_template: str, model_path: str = None):
+def get_chat_template(chat_template: str | None, model_path: str | None = None):
     """Get chat template config.
 
     Args:
-        chat_template(str): it could be a builtin chat template name, or a chat template json file
-        model_path(str): the model path, passed through to the chat template config
+        chat_template(str | None): it could be a builtin chat template name, or a chat template json file
+        model_path(str | None): the model path, passed through to the chat template config
     """
     import os
 

--- a/tests/test_lmdeploy/test_utils.py
+++ b/tests/test_lmdeploy/test_utils.py
@@ -1,3 +1,4 @@
+import pytest
 import torch
 from transformers import AutoConfig
 
@@ -106,12 +107,8 @@ def test_get_chat_template_unregistered_name():
     """An unregistered name is rejected by the registry check, not by an
     ImportError."""
     from lmdeploy.cli.utils import get_chat_template
-    raised = False
-    try:
+    with pytest.raises(AssertionError):
         get_chat_template('not-a-registered-template')
-    except AssertionError:
-        raised = True
-    assert raised, 'an unregistered chat template name should raise AssertionError'
 
 
 def test_get_chat_template_none():

--- a/tests/test_lmdeploy/test_utils.py
+++ b/tests/test_lmdeploy/test_utils.py
@@ -87,3 +87,34 @@ def test_get_and_verify_max_len():
     assert (_get_and_verify_max_len(config, None) == 32768)
     assert (_get_and_verify_max_len(config, 1024) == 1024)
     assert (_get_and_verify_max_len(config, 102400) == 102400)
+
+
+def test_get_chat_template_builtin_name():
+    """A builtin chat-template name must resolve without crashing.
+
+    Regression for #4533: get_chat_template imported DEPRECATED_CHAT_TEMPLATE_NAMES / REMOVED_CHAT_TEMPLATE_NAMES from
+    lmdeploy.model, which were removed in #4252, so any non-file --chat-template value raised ImportError before
+    reaching the registry check.
+    """
+    from lmdeploy.cli.utils import get_chat_template
+    cfg = get_chat_template('llama2')
+    assert cfg is not None
+    assert cfg.model_name == 'llama2'
+
+
+def test_get_chat_template_unregistered_name():
+    """An unregistered name is rejected by the registry check, not by an
+    ImportError."""
+    from lmdeploy.cli.utils import get_chat_template
+    raised = False
+    try:
+        get_chat_template('not-a-registered-template')
+    except AssertionError:
+        raised = True
+    assert raised, 'an unregistered chat template name should raise AssertionError'
+
+
+def test_get_chat_template_none():
+    """Passing no chat template returns None."""
+    from lmdeploy.cli.utils import get_chat_template
+    assert get_chat_template(None) is None


### PR DESCRIPTION
## Motivation

`lmdeploy serve api_server ... --chat-template <name>` and `lmdeploy chat ... --chat-template <name>` crash with `ImportError` whenever `<name>` is a builtin chat-template name (anything that is not a `.json` file path):

```
ImportError: cannot import name 'DEPRECATED_CHAT_TEMPLATE_NAMES' from 'lmdeploy.model'
```

Fixes #4533.

## Root cause

`get_chat_template` (`lmdeploy/cli/utils.py`) imports `DEPRECATED_CHAT_TEMPLATE_NAMES` and `REMOVED_CHAT_TEMPLATE_NAMES` from `lmdeploy.model`. Those lists were removed in #4252 (*[AsyncEngine Refactor 2/N] Remove deprecates from chat template*), which cleaned up `model.py`, `cli.py`, `async_engine.py` and the tests but left the import — and its two guard blocks — dangling in `cli/utils.py`. The two names now exist nowhere in the repo, so the import raises before reaching the registry validation.

The crash only fires on the `else` branch (a builtin name that is not a file), which is why it went unnoticed: passing no `--chat-template`, or a `.json` file path, both return earlier. It is reachable from both `lmdeploy/cli/serve.py` (`serve api_server`) and `lmdeploy/cli/chat.py` (`chat`).

## Modification

Complete the #4252 refactor in `get_chat_template`: drop the dead import and the removed-/deprecated-name guard blocks, keep the existing `MODELS` registry check, and remove the now-unused module-level `logger`. Unknown names are still rejected — by the registry `assert`, which lists the builtin templates.

## BC-breaking (Optional)

No. Builtin names that previously crashed now work; unknown names still raise (an `AssertionError` from the registry check instead of an `ImportError`).

## Use cases (Optional)

```
lmdeploy chat <model_path> --chat-template internlm2
lmdeploy serve api_server <model_path> --chat-template qwen
```

## Checklist

1. Added regression tests in `tests/test_lmdeploy/test_utils.py` (GPU-free, no model load):
   - `test_get_chat_template_builtin_name` — `get_chat_template('llama2')` returns a `ChatTemplateConfig`. **Fails with `ImportError` on current `main`, passes with this fix.**
   - `test_get_chat_template_unregistered_name` — an unregistered name raises `AssertionError` (registry check), not `ImportError`.
   - `test_get_chat_template_none` — `None` in → `None` out.
2. Verified locally: reverting only the `cli/utils.py` change makes `test_get_chat_template_builtin_name` fail at `cli/utils.py:85: ImportError`; with the fix all three pass. `pre-commit` (ruff-check / docformatter / copyright) is clean.

 Generated with [Claude Code](https://claude.com/claude-code)
