### PR TITLE
Fix scheduler for ssm

### DIFF
--- a/lmdeploy/pytorch/config.py
+++ b/lmdeploy/pytorch/config.py
@@ -457,7 +457,7 @@ class ModelConfig:
         fp32_lm_head = False
         if hf_overrides is not None:
             logger.warning(f'Overriding HF config with {hf_overrides}')
-            fp32_lm_head = hf_overrides.pop('fp32_lm_head', False)
+            fp32_lm_head = hf_overrides.get('fp32_lm_head', False)
             override_hf_config(model_config.hf_config, hf_overrides)
 
         # for fp32 head

--- a/lmdeploy/pytorch/engine/executor/base.py
+++ b/lmdeploy/pytorch/engine/executor/base.py
@@ -258,10 +258,10 @@ class ExecutorBase:
         num_state_caches = cache_config.num_state_caches
         if num_state_caches is None:
             # One state slot is reserved for system use. Active sequences need
-            # max_batches runtime slots; prefix-cache checkpoints use an
-            # explicitly configured extra budget.
+            # max_batches runtime slots plus one spare for rolling prefill;
+            # prefix-cache checkpoints use an explicitly configured extra budget.
             # TODO: Share memory between state cache and pageable cache
-            num_state_caches = int(cache_config.max_batches + 1 + cache_config.prefix_cache_state_budget)
+            num_state_caches = int(cache_config.max_batches + 2 + cache_config.prefix_cache_state_budget)
             cache_config.num_state_caches = num_state_caches
 
         mems = StateCacheEngine.get_cache_state_size(cache_config.states_shapes)

--- a/lmdeploy/pytorch/paging/eviction_helper/recompute_eviction_helper.py
+++ b/lmdeploy/pytorch/paging/eviction_helper/recompute_eviction_helper.py
@@ -67,7 +67,9 @@ class RecomputeEvictionHelper(BaseEvictionHelper):
         state_manager = self.state_manager
         block_trie = self.block_trie
         num_required_blocks = block_manager.num_required_blocks(seq, prealloc_size)
-        has_free_state = state_manager.get_num_free_runtime() > 0
+        # avoid requiring free state when already allocated.
+        has_runtime_state = state_manager.is_allocated(seq)
+        has_free_state = has_runtime_state or state_manager.get_num_free_runtime() > 0
         if block_trie.enable and not has_free_state:
             block_trie.evict_state_checkpoints(1)
             has_free_state = state_manager.get_num_free_runtime() > 0
@@ -87,7 +89,7 @@ class RecomputeEvictionHelper(BaseEvictionHelper):
             if block_trie.enable:
                 evict_seq.prefix_cache.suppress_match_stats = True
             evict_seq.state.free()
-            has_free_state = state_manager.get_num_free_runtime() > 0
+            has_free_state = has_runtime_state or state_manager.get_num_free_runtime() > 0
             if block_trie.enable and not has_free_state:
                 block_trie.evict_state_checkpoints(1)
                 has_free_state = state_manager.get_num_free_runtime() > 0

--- a/lmdeploy/pytorch/paging/state_manager.py
+++ b/lmdeploy/pytorch/paging/state_manager.py
@@ -140,6 +140,10 @@ def build_state_manager(cache_config: CacheConfig) -> StateManager:
     # `num_state_caches` is the number of allocated cache rows, including
     # reserved rows. StateManager subtracts reserved rows internally, so pass
     # the total row count to keep allocatable state ids below num_state_caches.
+    # Rows left after reserved rows and explicit checkpoint budget are runtime
+    # rows. With ExecutorBase's default sizing this gives max_batches plus one
+    # spare runtime row.
+    num_runtime_states = num_state_caches - num_reserved - cache_config.prefix_cache_state_budget
     return StateManager(num_state_caches,
                         num_reserved,
-                        num_runtime_states=cache_config.max_batches)
+                        num_runtime_states=num_runtime_states)

--- a/tests/pytorch/config/test_hf_overrides.py
+++ b/tests/pytorch/config/test_hf_overrides.py
@@ -1,4 +1,8 @@
 import pytest
+import torch
+
+from lmdeploy.pytorch.config import CacheConfig, DistConfig, ModelConfig, SpecDecodeConfig
+from lmdeploy.pytorch.model_inputs import BuildModelContext
 
 
 class TestHFOverrides:
@@ -31,3 +35,53 @@ class TestHFOverrides:
         assert hf_config.model_type == 'llava_custom2'
         assert hf_config.text_config.model_type == 'llama'
         assert hf_config.text_config.rope_parameters['rope_type'] == 'yarn2'
+
+
+def test_fp32_lm_head_hf_override_survives_mtp_draft_config(monkeypatch):
+    from transformers import PretrainedConfig
+
+    from lmdeploy.pytorch import transformers as pytorch_transformers
+    from lmdeploy.pytorch.configurations import AutoModelConfigBuilder
+
+    def fake_config_from_pretrained(pretrained_model_name_or_path, **kwargs):
+        return PretrainedConfig(model_type='fake', torch_dtype='float16', tie_word_embeddings=False)
+
+    def fake_build(cls, hf_config, model_path=None, **kwargs):
+        return ModelConfig(hidden_size=16,
+                           num_layers=1,
+                           num_attention_heads=2,
+                           num_key_value_heads=2,
+                           bos_token_id=1,
+                           eos_token_id=[2],
+                           head_dim=8,
+                           dtype=torch.float16,
+                           vocab_size=32,
+                           hf_config=hf_config,
+                           llm_config=hf_config)
+
+    monkeypatch.setattr(pytorch_transformers, 'config_from_pretrained', fake_config_from_pretrained)
+    monkeypatch.setattr(AutoModelConfigBuilder, 'build', classmethod(fake_build))
+
+    hf_overrides = {'fp32_lm_head': True}
+    target_cache_cfg = CacheConfig(max_batches=1,
+                                   block_size=64,
+                                   num_cpu_blocks=0,
+                                   num_gpu_blocks=0)
+
+    specdecode_config = SpecDecodeConfig.from_config(method='qwen3_5_mtp',
+                                                     num_speculative_tokens=1,
+                                                     model=None,
+                                                     target_model='fake-model',
+                                                     target_cache_cfg=target_cache_cfg,
+                                                     hf_overrides=hf_overrides,
+                                                     dist_config=DistConfig())
+    main_model_config = ModelConfig.from_pretrained('fake-model',
+                                                   hf_overrides=hf_overrides,
+                                                   spec_method=specdecode_config.method,
+                                                   num_spec_tokens=specdecode_config.num_speculative_tokens)
+
+    assert specdecode_config.model_config.fp32_lm_head
+    assert main_model_config.fp32_lm_head
+    assert BuildModelContext(fp32_lm_head=specdecode_config.model_config.fp32_lm_head).fp32_lm_head
+    assert BuildModelContext(fp32_lm_head=main_model_config.fp32_lm_head).fp32_lm_head
+    assert hf_overrides['fp32_lm_head']

--- a/tests/pytorch/engine/test_executor_base.py
+++ b/tests/pytorch/engine/test_executor_base.py
@@ -219,7 +219,7 @@ def test_get_state_cache_mem_uses_prefix_cache_state_budget():
 
     mem = executor._get_state_cache_mem()
 
-    expected_num_state_caches = 4 + 1 + 3
+    expected_num_state_caches = 4 + 2 + 3
     expected_mem = StateCacheEngine.get_cache_state_size(state_shapes) * expected_num_state_caches
     assert executor.cache_config.num_state_caches == expected_num_state_caches
     assert mem == expected_mem
@@ -238,7 +238,7 @@ def test_get_state_cache_mem_keeps_ssm_prefix_cache_enabled_without_extra_budget
 
     executor._get_state_cache_mem()
 
-    assert executor.cache_config.num_state_caches == 4 + 1
+    assert executor.cache_config.num_state_caches == 4 + 2
     assert executor.cache_config.enable_prefix_caching
 
 
@@ -255,7 +255,7 @@ def test_get_state_cache_mem_keeps_budgeted_ssm_prefix_cache_enabled():
 
     executor._get_state_cache_mem()
 
-    assert executor.cache_config.num_state_caches == 4 + 1 + 2
+    assert executor.cache_config.num_state_caches == 4 + 2 + 2
     assert executor.cache_config.enable_prefix_caching
 
 

--- a/tests/pytorch/paging/test_scheduler.py
+++ b/tests/pytorch/paging/test_scheduler.py
@@ -285,6 +285,27 @@ def test_ssm_long_chunked_request_schedules_with_only_runtime_state_slot():
     assert scheduler.block_trie.reserve_state_checkpoint_for_seq(seq, step=block_size * 2) == -1
 
 
+def test_ssm_running_request_reuses_own_runtime_state_without_spare_slot():
+    scheduler = _make_ssm_scheduler(max_batch_size=1, prefix_cache_state_budget=0)
+    block_size = scheduler.seq_meta.block_size
+    seq = scheduler.add_session(100).add_sequence([1] * block_size)
+
+    output = scheduler.schedule(is_prefill=True)
+    assert output.running == [seq]
+    assert scheduler.state_manager.get_num_free_runtime() == 0
+    seq.state.activate()
+
+    seq.update_token_ids([2] * block_size, mode=UpdateTokenMode.DECODE)
+    valid_mask = scheduler.schedule_running([seq], num_required_tokens=0, prealloc_size=0)
+
+    assert valid_mask == [True]
+    assert seq.status == MessageStatus.RUNNING
+    assert seq.logical_state >= 0
+    assert seq.num_blocks == 2
+    assert scheduler.state_manager.get_num_runtime_states() == 1
+    assert scheduler.state_manager.get_num_free_runtime() == 0
+
+
 def test_ssm_runtime_state_waits_when_only_checkpoint_slot_is_pinned():
     scheduler = _make_ssm_scheduler(max_batch_size=1, prefix_cache_state_budget=0)
     block_size = scheduler.seq_meta.block_size

--- a/tests/pytorch/paging/test_state_manager.py
+++ b/tests/pytorch/paging/test_state_manager.py
@@ -29,6 +29,49 @@ def test_reserved_state_cache_is_not_allocatable():
         state_manager.allocate(SimpleNamespace(logical_state=-1))
 
 
+def test_spare_state_cache_is_allocatable_for_runtime():
+    cache_config = CacheConfig(max_batches=128,
+                               block_size=64,
+                               num_cpu_blocks=0,
+                               num_gpu_blocks=0,
+                               num_state_caches=130,
+                               states_shapes=[((1,), torch.float16)])
+    state_manager = build_state_manager(cache_config)
+
+    seqs = [SimpleNamespace(logical_state=-1) for _ in range(129)]
+    for seq in seqs:
+        state_manager.allocate(seq)
+
+    state_ids = [seq.logical_state for seq in seqs]
+    assert state_ids == list(range(1, 130))
+    assert state_manager.get_num_free_runtime() == 0
+    assert state_manager.get_num_free() == 0
+
+    with pytest.raises(RuntimeError, match='No free states.'):
+        state_manager.allocate(SimpleNamespace(logical_state=-1))
+
+
+def test_prefix_cache_budget_is_not_counted_as_runtime_spare():
+    cache_config = CacheConfig(max_batches=1,
+                               block_size=64,
+                               num_cpu_blocks=0,
+                               num_gpu_blocks=0,
+                               num_state_caches=3,
+                               prefix_cache_state_budget=1,
+                               states_shapes=[((1,), torch.float16)])
+    state_manager = build_state_manager(cache_config)
+
+    seq = SimpleNamespace(logical_state=-1)
+    state_manager.allocate(seq)
+
+    assert state_manager.get_num_runtime_states() == 1
+    assert state_manager.get_num_free_runtime() == 0
+    assert state_manager.get_num_free_checkpoint() == 1
+
+    with pytest.raises(RuntimeError, match='No free states.'):
+        state_manager.allocate(SimpleNamespace(logical_state=-1))
+
+
 def test_non_ssm_state_manager_without_state_caches():
     cache_config = CacheConfig(max_batches=128,
                                block_size=64,


### PR DESCRIPTION

## Motivation

- Fix SSM scheduler admission by treating a sequence with an existing runtime state as state-ready, so decode/continued scheduling does not require an extra free state slot.
- Add one spare SSM runtime state via default state-cache sizing, avoiding stalls when rolling prefill overlaps active requests.
- Fix hf_overrides so fp32_lm_head is not consumed during MTP draft config creation and remains available for the main model/build context.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
