### PR TITLE
Fix stale prefix cache hit rate metric

### DIFF
--- a/lmdeploy/messages.py
+++ b/lmdeploy/messages.py
@@ -662,7 +662,6 @@ class ScheduleMetrics:
     active_blocks: int = 0
     cached_blocks: int = 0
     free_blocks: int = 0
-    prefix_cache_hit_rate: float = 0
     num_prefix_cache_query_tokens: int = 0
     num_prefix_cache_hit_tokens: int = 0
     scheduler_tick: int = 0

--- a/lmdeploy/messages.py
+++ b/lmdeploy/messages.py
@@ -663,6 +663,8 @@ class ScheduleMetrics:
     cached_blocks: int = 0
     free_blocks: int = 0
     prefix_cache_hit_rate: float = 0
+    num_prefix_cache_query_tokens: int = 0
+    num_prefix_cache_hit_tokens: int = 0
     scheduler_tick: int = 0
 
 

--- a/lmdeploy/metrics/loggers.py
+++ b/lmdeploy/metrics/loggers.py
@@ -35,13 +35,16 @@ class LoggingStatLogger(StatLoggerBase):
 
     def __init__(self, dp_rank: int = 0):
         self.dp_rank = dp_rank
-        self._reset(time.perf_counter())
         self.last_scheduler_stats = SchedulerStats()
+        self._reset(time.perf_counter())
 
     def _reset(self, now):
         self.last_log_time = now
         self.total_prompt_tokens = 0
         self.total_generation_tokens = 0
+        # prefix cache token counts at the start of this interval
+        self.last_prefix_cache_query_tokens = self.last_scheduler_stats.num_prefix_cache_query_tokens
+        self.last_prefix_cache_hit_tokens = self.last_scheduler_stats.num_prefix_cache_hit_tokens
         # spec decode
         self.num_drafts: int = 0
         self.num_draft_tokens: int = 0
@@ -118,8 +121,10 @@ class LoggingStatLogger(StatLoggerBase):
                    f'{scheduler_stats.num_running_reqs} / {scheduler_stats.num_waiting_reqs}, '
                    f'KV cache: {scheduler_stats.gpu_cache_usage * 100 :.1f}%, ')
 
-        if scheduler_stats.prefix_cache_hit_rate != 0:
-            log_msg += f'Prefix cache hit rate: {scheduler_stats.prefix_cache_hit_rate * 100 :.1f}%, '
+        if scheduler_stats.num_prefix_cache_query_tokens > self.last_prefix_cache_query_tokens:
+            query_delta = scheduler_stats.num_prefix_cache_query_tokens - self.last_prefix_cache_query_tokens
+            hit_delta = scheduler_stats.num_prefix_cache_hit_tokens - self.last_prefix_cache_hit_tokens
+            log_msg += f'Prefix cache hit rate: {hit_delta / query_delta * 100 :.1f}%, '
 
         if spec_msg is not None:
             log_msg += spec_msg
@@ -191,11 +196,6 @@ class PrometheusStatLogger(StatLoggerBase):
             documentation='GPU KV-cache usage. 1 means 100 percent usage.',
             labelnames=labelnames).labels(*labelvalues)
 
-        self.gauge_prefix_cache_hit_rate = prometheus_client.Gauge(
-            name='lmdeploy:prefix_cache_hit_rate',
-            documentation='Prefix-cache hit rate. 1 means 100 percent of queried prefix tokens hit.',
-            labelnames=labelnames).labels(*labelvalues)
-
         #
         # Counters
         #
@@ -207,22 +207,6 @@ class PrometheusStatLogger(StatLoggerBase):
             name='lmdeploy:generation_tokens_total',
             documentation='Number of generation tokens processed.',
             labelnames=labelnames).labels(*labelvalues)
-
-        # Prefix cache hit rate is derived in PromQL from these raw counters:
-        #   rate(prefix_cache_hits_total) / rate(prefix_cache_queries_total)
-        self.counter_prefix_cache_queries = prometheus_client.Counter(
-            name='lmdeploy:prefix_cache_queries_total',
-            documentation='Number of tokens queried against the prefix cache.',
-            labelnames=labelnames).labels(*labelvalues)
-
-        self.counter_prefix_cache_hits = prometheus_client.Counter(
-            name='lmdeploy:prefix_cache_hits_total',
-            documentation='Number of tokens served from the prefix cache.',
-            labelnames=labelnames).labels(*labelvalues)
-
-        # engine-side stats are cumulative; track last seen values to emit deltas
-        self._last_prefix_cache_query_tokens = 0
-        self._last_prefix_cache_hit_tokens = 0
 
         # Speculative decoding counters. Acceptance rate and mean acceptance
         # length are derived in PromQL from these raw counters.
@@ -400,16 +384,6 @@ class PrometheusStatLogger(StatLoggerBase):
         self.gauge_scheduler_running.set(stats.num_running_reqs)
         self.gauge_scheduler_waiting.set(stats.num_waiting_reqs)
         self.gauge_gpu_cache_usage.set(stats.gpu_cache_usage)
-        self.gauge_prefix_cache_hit_rate.set(stats.prefix_cache_hit_rate)
-
-        query_delta = stats.num_prefix_cache_query_tokens - self._last_prefix_cache_query_tokens
-        hit_delta = stats.num_prefix_cache_hit_tokens - self._last_prefix_cache_hit_tokens
-        if query_delta > 0:
-            self.counter_prefix_cache_queries.inc(query_delta)
-        if hit_delta > 0:
-            self.counter_prefix_cache_hits.inc(hit_delta)
-        self._last_prefix_cache_query_tokens = stats.num_prefix_cache_query_tokens
-        self._last_prefix_cache_hit_tokens = stats.num_prefix_cache_hit_tokens
 
     def record_iteration(self, stats: IterationStats) -> None:
         """Report token-related metrics to prometheus."""

--- a/lmdeploy/metrics/loggers.py
+++ b/lmdeploy/metrics/loggers.py
@@ -208,6 +208,22 @@ class PrometheusStatLogger(StatLoggerBase):
             documentation='Number of generation tokens processed.',
             labelnames=labelnames).labels(*labelvalues)
 
+        # Prefix cache hit rate is derived in PromQL from these raw counters:
+        #   rate(prefix_cache_hits_total) / rate(prefix_cache_queries_total)
+        self.counter_prefix_cache_queries = prometheus_client.Counter(
+            name='lmdeploy:prefix_cache_queries_total',
+            documentation='Number of tokens queried against the prefix cache.',
+            labelnames=labelnames).labels(*labelvalues)
+
+        self.counter_prefix_cache_hits = prometheus_client.Counter(
+            name='lmdeploy:prefix_cache_hits_total',
+            documentation='Number of tokens served from the prefix cache.',
+            labelnames=labelnames).labels(*labelvalues)
+
+        # engine-side stats are cumulative; track last seen values to emit deltas
+        self._last_prefix_cache_query_tokens = 0
+        self._last_prefix_cache_hit_tokens = 0
+
         # Speculative decoding counters. Acceptance rate and mean acceptance
         # length are derived in PromQL from these raw counters.
         #   rate(accepted_tokens) / rate(draft_tokens)
@@ -385,6 +401,15 @@ class PrometheusStatLogger(StatLoggerBase):
         self.gauge_scheduler_waiting.set(stats.num_waiting_reqs)
         self.gauge_gpu_cache_usage.set(stats.gpu_cache_usage)
         self.gauge_prefix_cache_hit_rate.set(stats.prefix_cache_hit_rate)
+
+        query_delta = stats.num_prefix_cache_query_tokens - self._last_prefix_cache_query_tokens
+        hit_delta = stats.num_prefix_cache_hit_tokens - self._last_prefix_cache_hit_tokens
+        if query_delta > 0:
+            self.counter_prefix_cache_queries.inc(query_delta)
+        if hit_delta > 0:
+            self.counter_prefix_cache_hits.inc(hit_delta)
+        self._last_prefix_cache_query_tokens = stats.num_prefix_cache_query_tokens
+        self._last_prefix_cache_hit_tokens = stats.num_prefix_cache_hit_tokens
 
     def record_iteration(self, stats: IterationStats) -> None:
         """Report token-related metrics to prometheus."""

--- a/lmdeploy/metrics/stats.py
+++ b/lmdeploy/metrics/stats.py
@@ -38,7 +38,6 @@ class SchedulerStats:
         num_running_reqs: Engine core, currently executing requests.
         num_waiting_reqs: Engine core, requests queued waiting for execution.
         gpu_cache_usage: Fraction of GPU KV blocks utilized (0.0 to 1.0).
-        prefix_cache_hit_rate: Prefix caching hit rate.
         num_prefix_cache_query_tokens: Cumulative number of tokens queried against the prefix cache.
         num_prefix_cache_hit_tokens: Cumulative number of tokens served from the prefix cache.
     """
@@ -55,7 +54,6 @@ class SchedulerStats:
     num_running_reqs: int = 0
     num_waiting_reqs: int = 0
     gpu_cache_usage: float = 0.0
-    prefix_cache_hit_rate: float = 0.0
     num_prefix_cache_query_tokens: int = 0
     num_prefix_cache_hit_tokens: int = 0
 
@@ -88,7 +86,6 @@ class SchedulerStats:
                 f'  num_running_reqs={self.num_running_reqs},\n'
                 f'  num_waiting_reqs={self.num_waiting_reqs},\n'
                 f'  gpu_cache_usage={self.gpu_cache_usage:.6f},\n'
-                f'  prefix_cache_hit_rate={self.prefix_cache_hit_rate:.6f},\n'
                 f'  num_prefix_cache_query_tokens={self.num_prefix_cache_query_tokens},\n'
                 f'  num_prefix_cache_hit_tokens={self.num_prefix_cache_hit_tokens},\n'
                 ')')
@@ -97,7 +94,6 @@ class SchedulerStats:
         self.num_running_reqs = scheduled_metrics.active_seqs
         self.num_waiting_reqs = scheduled_metrics.waiting_seqs
         self.gpu_cache_usage = 1.0 - (scheduled_metrics.free_blocks / scheduled_metrics.total_blocks)
-        self.prefix_cache_hit_rate = scheduled_metrics.prefix_cache_hit_rate
         self.num_prefix_cache_query_tokens = scheduled_metrics.num_prefix_cache_query_tokens
         self.num_prefix_cache_hit_tokens = scheduled_metrics.num_prefix_cache_hit_tokens
 

--- a/lmdeploy/metrics/stats.py
+++ b/lmdeploy/metrics/stats.py
@@ -39,6 +39,8 @@ class SchedulerStats:
         num_waiting_reqs: Engine core, requests queued waiting for execution.
         gpu_cache_usage: Fraction of GPU KV blocks utilized (0.0 to 1.0).
         prefix_cache_hit_rate: Prefix caching hit rate.
+        num_prefix_cache_query_tokens: Cumulative number of tokens queried against the prefix cache.
+        num_prefix_cache_hit_tokens: Cumulative number of tokens served from the prefix cache.
     """
 
     # api server
@@ -54,6 +56,8 @@ class SchedulerStats:
     num_waiting_reqs: int = 0
     gpu_cache_usage: float = 0.0
     prefix_cache_hit_rate: float = 0.0
+    num_prefix_cache_query_tokens: int = 0
+    num_prefix_cache_hit_tokens: int = 0
 
     @property
     def num_failed_reqs(self) -> int:
@@ -85,6 +89,8 @@ class SchedulerStats:
                 f'  num_waiting_reqs={self.num_waiting_reqs},\n'
                 f'  gpu_cache_usage={self.gpu_cache_usage:.6f},\n'
                 f'  prefix_cache_hit_rate={self.prefix_cache_hit_rate:.6f},\n'
+                f'  num_prefix_cache_query_tokens={self.num_prefix_cache_query_tokens},\n'
+                f'  num_prefix_cache_hit_tokens={self.num_prefix_cache_hit_tokens},\n'
                 ')')
 
     def update_from_schedule_metrics(self, scheduled_metrics: ScheduleMetrics):
@@ -92,6 +98,8 @@ class SchedulerStats:
         self.num_waiting_reqs = scheduled_metrics.waiting_seqs
         self.gpu_cache_usage = 1.0 - (scheduled_metrics.free_blocks / scheduled_metrics.total_blocks)
         self.prefix_cache_hit_rate = scheduled_metrics.prefix_cache_hit_rate
+        self.num_prefix_cache_query_tokens = scheduled_metrics.num_prefix_cache_query_tokens
+        self.num_prefix_cache_hit_tokens = scheduled_metrics.num_prefix_cache_hit_tokens
 
 
 class RequestStats:

--- a/lmdeploy/pytorch/paging/scheduler.py
+++ b/lmdeploy/pytorch/paging/scheduler.py
@@ -567,7 +567,6 @@ class Scheduler:
             waiting_seqs=self.num_waiting() + self.num_ready(),
             total_blocks=self.block_manager.num_gpu_blocks,
             free_blocks=self.block_manager.get_num_free_gpu_blocks(),
-            prefix_cache_hit_rate=self.block_trie.hit_rate(),
             num_prefix_cache_query_tokens=prefix_cache_stats.num_query_tokens,
             num_prefix_cache_hit_tokens=prefix_cache_stats.num_hit_tokens,
             scheduler_tick=self.scheduler_tick,

--- a/lmdeploy/pytorch/paging/scheduler.py
+++ b/lmdeploy/pytorch/paging/scheduler.py
@@ -561,11 +561,14 @@ class Scheduler:
 
     @property
     def schedule_metrics(self):
+        prefix_cache_stats = self.block_trie.stats
         return ScheduleMetrics(
             active_seqs=self.num_running(),
             waiting_seqs=self.num_waiting() + self.num_ready(),
             total_blocks=self.block_manager.num_gpu_blocks,
             free_blocks=self.block_manager.get_num_free_gpu_blocks(),
             prefix_cache_hit_rate=self.block_trie.hit_rate(),
+            num_prefix_cache_query_tokens=prefix_cache_stats.num_query_tokens,
+            num_prefix_cache_hit_tokens=prefix_cache_stats.num_hit_tokens,
             scheduler_tick=self.scheduler_tick,
         )

--- a/tests/test_lmdeploy/test_metrics_loggers.py
+++ b/tests/test_lmdeploy/test_metrics_loggers.py
@@ -2,8 +2,8 @@
 
 import pytest
 
-from lmdeploy.metrics.loggers import PrometheusStatLogger
-from lmdeploy.metrics.stats import SchedulerStats, SpeculativeDecodingStats
+from lmdeploy.metrics.loggers import LoggingStatLogger, PrometheusStatLogger
+from lmdeploy.metrics.stats import IterationStats, SchedulerStats, SpeculativeDecodingStats
 
 prometheus_client = pytest.importorskip('prometheus_client')
 
@@ -44,15 +44,30 @@ def test_prometheus_stat_logger_records_specdecode_metrics():
     assert _get_sample_value('lmdeploy:spec_decode_per_position_accept_rate', position_labels) == 0
 
 
-def test_prometheus_stat_logger_records_prefix_cache_counters():
-    logger = PrometheusStatLogger('test-prefix-model', max_model_len=16, dp_rank=0)
-    labels = {'model_name': 'test-prefix-model', 'engine': '0'}
+def _iteration_stats(prompt_tokens: int) -> IterationStats:
+    stats = IterationStats()
+    stats.prompt_tokens = prompt_tokens
+    return stats
 
-    # engine-side stats are cumulative, so the logger must emit per-interval deltas
+
+def test_logging_stat_logger_reports_interval_prefix_cache_hit_rate(capsys):
+    logger = LoggingStatLogger(dp_rank=0)
+
+    # cumulative engine-side counts; the log line must report the interval hit
+    # rate over the last logging window, not the lifetime average.
+    logger.record_iteration(_iteration_stats(100))
     logger.record_schedule(SchedulerStats(num_prefix_cache_query_tokens=100, num_prefix_cache_hit_tokens=30))
-    assert _get_sample_value('lmdeploy:prefix_cache_queries_total', labels) == 100
-    assert _get_sample_value('lmdeploy:prefix_cache_hits_total', labels) == 30
+    logger.log()
+    assert 'Prefix cache hit rate: 30.0%' in capsys.readouterr().out
 
+    # interval (80-30)/(250-100) = 50/150 = 33.3%, not the lifetime 80/250 = 32%
+    logger.record_iteration(_iteration_stats(150))
     logger.record_schedule(SchedulerStats(num_prefix_cache_query_tokens=250, num_prefix_cache_hit_tokens=80))
-    assert _get_sample_value('lmdeploy:prefix_cache_queries_total', labels) == 250
-    assert _get_sample_value('lmdeploy:prefix_cache_hits_total', labels) == 80
+    logger.log()
+    assert 'Prefix cache hit rate: 33.3%' in capsys.readouterr().out
+
+    # no new queries in the interval -> the line is omitted, no div-by-zero
+    logger.record_iteration(_iteration_stats(10))
+    logger.record_schedule(SchedulerStats(num_prefix_cache_query_tokens=250, num_prefix_cache_hit_tokens=80))
+    logger.log()
+    assert 'Prefix cache hit rate' not in capsys.readouterr().out

--- a/tests/test_lmdeploy/test_metrics_loggers.py
+++ b/tests/test_lmdeploy/test_metrics_loggers.py
@@ -3,7 +3,7 @@
 import pytest
 
 from lmdeploy.metrics.loggers import PrometheusStatLogger
-from lmdeploy.metrics.stats import SpeculativeDecodingStats
+from lmdeploy.metrics.stats import SchedulerStats, SpeculativeDecodingStats
 
 prometheus_client = pytest.importorskip('prometheus_client')
 
@@ -42,3 +42,17 @@ def test_prometheus_stat_logger_records_specdecode_metrics():
     position_labels = labels | {'position': '2'}
     assert _get_sample_value('lmdeploy:spec_decode_num_accepted_tokens_per_pos_total', position_labels) == 0
     assert _get_sample_value('lmdeploy:spec_decode_per_position_accept_rate', position_labels) == 0
+
+
+def test_prometheus_stat_logger_records_prefix_cache_counters():
+    logger = PrometheusStatLogger('test-prefix-model', max_model_len=16, dp_rank=0)
+    labels = {'model_name': 'test-prefix-model', 'engine': '0'}
+
+    # engine-side stats are cumulative, so the logger must emit per-interval deltas
+    logger.record_schedule(SchedulerStats(num_prefix_cache_query_tokens=100, num_prefix_cache_hit_tokens=30))
+    assert _get_sample_value('lmdeploy:prefix_cache_queries_total', labels) == 100
+    assert _get_sample_value('lmdeploy:prefix_cache_hits_total', labels) == 30
+
+    logger.record_schedule(SchedulerStats(num_prefix_cache_query_tokens=250, num_prefix_cache_hit_tokens=80))
+    assert _get_sample_value('lmdeploy:prefix_cache_queries_total', labels) == 250
+    assert _get_sample_value('lmdeploy:prefix_cache_hits_total', labels) == 80


### PR DESCRIPTION
## Motivation

`lmdeploy:prefix_cache_hit_rate` is exposed as a gauge fed by `BlockTrie.stats`, whose `num_query_tokens` / `num_hit_tokens` are accumulated since startup and never reset. The gauge therefore reports a lifetime average: after the server has been running for a while the denominator grows so large that the value flattens out and no longer reflects recent cache behavior.

As @lvhan028  pointed out, the windowed hit rate is already obtainable from the counters added in #4670:

rate(lmdeploy:cached_tokens_total[5m]) / rate(lmdeploy:prompt_tokens_total[5m])

So a second set of BlockTrie-derived counters would just duplicate that. This PR instead fixes the stale gauge directly.

## Modification

- Remove the lifetime-averaged `lmdeploy:prefix_cache_hit_rate` gauge and its data-source plumbing (the `prefix_cache_hit_rate` field on  `ScheduleMetrics` / `SchedulerStats` and the `block_trie.hit_rate()` call in the scheduler).
- The terminal log line now reports the prefix cache hit rate **over the last logging interval**, derived from the raw query/hit token counts, consistent with the throughput numbers printed alongside it.
- For Prometheus, the recommended way to obtain a windowed hit rate is the existing counters from #4670 `rate(cached_tokens_total) / rate(prompt_tokens_total)`.
- Update the unit test accordingly.

## BC-breaking (Optional)

**YES**, The `lmdeploy:prefix_cache_hit_rate` Prometheus gauge is removed. Dashboards relying on it should switch to `rate(lmdeploy:cached_tokens_total[5m]) / rate(lmdeploy:prompt_tokens_total[5m])`, which gives a more meaningful windowed hit rate. The terminal log line is preserved (now interval-based instead of lifetime-averaged).

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
