### PR TITLE
fix prefix caching

### DIFF
--- a/lmdeploy/pytorch/paging/block_trie.py
+++ b/lmdeploy/pytorch/paging/block_trie.py
@@ -1151,6 +1151,8 @@ class BlockTrie:
                 if not self._is_evict_candidate_leaf(leaf):
                     self.leaves.discard(leaf)
                     continue
+                if self._is_pinned_state_checkpoint(leaf):
+                    continue
                 if int(self.allocator.get_ref_count(leaf.block)) != 1:
                     continue
                 break
@@ -1209,6 +1211,8 @@ class BlockTrie:
             if len(parent.children) == 0:
                 __add_leaf(leaves, parent)
 
+        if len(evicted_blocks) == 0:
+            return 0
         self.allocator.free(np.array(evicted_blocks))
 
         return len(evicted_blocks)

--- a/tests/pytorch/paging/test_block_trie.py
+++ b/tests/pytorch/paging/test_block_trie.py
@@ -1414,3 +1414,33 @@ class TestBlockTire:
         block_trie.evict(1)
 
         assert ssm_scheduler.state_manager.get_num_free_checkpoint() == free_states + 1
+
+    def test_evict_ssm_skips_pinned_state_checkpoint(self, ssm_scheduler):
+        block_mgr = ssm_scheduler.block_manager
+        block_trie = ssm_scheduler.block_trie
+        sess = ssm_scheduler.add_session(0)
+        block_size = sess.seq_meta.block_size
+        token_ids = [1] * block_size * 2 + [2]
+
+        seq = sess.add_sequence(token_ids)
+        block_mgr.allocate(seq)
+        block_trie.allocate(seq)
+        node = seq.prefix_cache.last_shared_node
+        assert block_trie.reserve_state_checkpoint_for_seq(seq, step=block_size * 2) >= 0
+        assert block_trie.commit_state_checkpoint_for_seq(seq, acquire_save_ref=True)
+        assert node.state_ready
+        assert node.state_ref_count == 1
+        free_states = ssm_scheduler.state_manager.get_num_free_checkpoint()
+
+        block_mgr.free(seq)
+        seq.set_step(0)
+
+        assert block_trie.evict(1) == 0
+        assert node in block_trie.leaves
+        assert node.state_ready
+        assert node.state_ref_count == 1
+        assert ssm_scheduler.state_manager.get_num_free_checkpoint() == free_states
+
+        assert block_trie.release_state_checkpoint_save_for_seq(seq)
+        assert block_trie.evict(1) == 1
+        assert ssm_scheduler.state_manager.get_num_free_checkpoint() == free_states + 1


### PR DESCRIPTION
Fix SSM prefix-cache KV eviction so it does not release checkpoints that are still pinned by an in-flight save/restore.

Previously, `BlockTrie.evict()` selected leaves only by KV block refcount. For SSM nodes, a leaf could have an idle KV block (`ref_count == 1`) while its state checkpoint was still protected by `state_ref_count > 0`. Evicting that leaf called `release_state_checkpoint()` and hit the invariant error:

```text
Cannot release a pinned SSM prefix-cache checkpoint.
```

The fix makes KV eviction skip pinned SSM checkpoint leaves for the current eviction attempt. The node remains in `self.leaves`, so once the save/restore pin is released, a later eviction can reclaim it normally. It also avoids freeing an empty eviction list when all candidates are skipped.

Added a regression test covering the pinned-checkpoint case: eviction returns `0` while the checkpoint is pinned, keeps the node cached, then successfully evicts it after the producer pin is released.