### PR TITLE
fix: fail fast on invalid serve parsers

### DIFF
--- a/lmdeploy/cli/utils.py
+++ b/lmdeploy/cli/utils.py
@@ -477,14 +477,13 @@ class ArgumentHelper:
     @staticmethod
     def reasoning_parser(parser):
         """Add reasoning parser to parser."""
-        legacy_names = ['qwen-qwq', 'intern-s1', 'deepseek-r1']
-        from lmdeploy.serve.parsers.reasoning_parser import ReasoningParserManager
+        from lmdeploy.serve.parsers.reasoning_parser import LEGACY_REASONING_PARSER_NAMES, ReasoningParserManager
         return parser.add_argument(
             '--reasoning-parser',
             type=str,
             default=None,
             help=f'The registered reasoning parser name: {ReasoningParserManager.module_dict.keys()}. '
-            f'Legacy names: {legacy_names}. '
+            f'Legacy names: {list(LEGACY_REASONING_PARSER_NAMES)}. '
             'Default to None.')
 
     @staticmethod

--- a/lmdeploy/serve/openai/api_server.py
+++ b/lmdeploy/serve/openai/api_server.py
@@ -1605,6 +1605,8 @@ def serve(model_path: str,
 
     VariableInterface.allow_terminate_by_client = allow_terminate_by_client
     VariableInterface.enable_abort_handling = enable_abort_handling
+    from lmdeploy.serve.parsers import validate_parser_names
+    reasoning_parser, tool_call_parser = validate_parser_names(reasoning_parser, tool_call_parser)
 
     ssl_keyfile, ssl_certfile, http_or_https = None, None, 'http'
     if ssl:

--- a/lmdeploy/serve/openai/launch_server.py
+++ b/lmdeploy/serve/openai/launch_server.py
@@ -166,5 +166,5 @@ def launch_server(num_nodes: int,
             alive_processes.remove(process)
             if process.exitcode != 0:
                 logger.error(f'Server process {process.pid} exited with code {process.exitcode}')
-                terminate_processes(alive_processes)
+                terminate_processes([process, *alive_processes])
                 raise RuntimeError(f'Server process {process.pid} exited with code {process.exitcode}')

--- a/lmdeploy/serve/openai/launch_server.py
+++ b/lmdeploy/serve/openai/launch_server.py
@@ -52,11 +52,18 @@ def _run_server(gpu_ids: list[int], model_path: str, **kwargs):
     os.setpgrp()
     if len(gpu_ids) > 0:
         os.environ['CUDA_VISIBLE_DEVICES'] = cuda_visible_devices
-    serve(model_path, **kwargs)
+    try:
+        serve(model_path, **kwargs)
+    except Exception:
+        logger.exception('Server process failed during startup or serving.')
+        # Avoid Python multiprocessing atexit cleanup blocking forever while
+        # non-daemon engine/Ray children are still alive. The launcher will
+        # observe the non-zero exit code and terminate this process group.
+        os._exit(1)
 
 
-def cleanup_processes(processes: list[mp.Process]):
-    """Clean up server process."""
+def terminate_processes(processes: list[mp.Process]):
+    """Terminate child server process groups."""
     for process in processes:
         logger.info(f'Terminating process group {process.pid}')
         try:
@@ -76,6 +83,11 @@ def cleanup_processes(processes: list[mp.Process]):
                 pass
 
     logger.info('All processes terminated')
+
+
+def cleanup_processes(processes: list[mp.Process]):
+    """Clean up server process."""
+    terminate_processes(processes)
     sys.exit(0)
 
 
@@ -142,5 +154,17 @@ def launch_server(num_nodes: int,
     signal.signal(signal.SIGTERM, lambda sig, frame: cleanup_processes(processes))
     signal.signal(signal.SIGQUIT, lambda sig, frame: cleanup_processes(processes))
 
-    for p in processes:
-        p.join()
+    # Poll all DP server processes so one failed child cannot be hidden behind
+    # another healthy long-running server blocked in join().
+    alive_processes = list(processes)
+    while alive_processes:
+        for process in list(alive_processes):
+            process.join(timeout=1)
+            if process.exitcode is None:
+                continue
+
+            alive_processes.remove(process)
+            if process.exitcode != 0:
+                logger.error(f'Server process {process.pid} exited with code {process.exitcode}')
+                terminate_processes(alive_processes)
+                raise RuntimeError(f'Server process {process.pid} exited with code {process.exitcode}')

--- a/lmdeploy/serve/parsers/__init__.py
+++ b/lmdeploy/serve/parsers/__init__.py
@@ -1,6 +1,6 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 # registers ResponseParser 'gpt-oss', None if openai_harmony unavailable
 from .gpt_oss_response_parser import GptOssResponseParser
-from .response_parser import ResponseParser, ResponseParserManager
+from .response_parser import ResponseParser, ResponseParserManager, validate_parser_names
 
-__all__ = ['ResponseParser', 'ResponseParserManager', 'GptOssResponseParser']
+__all__ = ['ResponseParser', 'ResponseParserManager', 'GptOssResponseParser', 'validate_parser_names']

--- a/lmdeploy/serve/parsers/reasoning_parser/__init__.py
+++ b/lmdeploy/serve/parsers/reasoning_parser/__init__.py
@@ -1,8 +1,9 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 from .deepseek_v3_reasoning_parser import DeepSeekV3ReasoningParser
-from .reasoning_parser import ReasoningParser, ReasoningParserManager
+from .reasoning_parser import LEGACY_REASONING_PARSER_NAMES, ReasoningParser, ReasoningParserManager
 
 __all__ = [
+    'LEGACY_REASONING_PARSER_NAMES',
     'ReasoningParser',
     'ReasoningParserManager',
     'DeepSeekV3ReasoningParser',

--- a/lmdeploy/serve/parsers/reasoning_parser/reasoning_parser.py
+++ b/lmdeploy/serve/parsers/reasoning_parser/reasoning_parser.py
@@ -10,6 +10,8 @@ if TYPE_CHECKING:
 
 ReasoningParserManager = Registry('reasoning_parser', locations=['lmdeploy.serve.parsers.reasoning_parser'])
 
+LEGACY_REASONING_PARSER_NAMES = ('qwen-qwq', 'intern-s1', 'deepseek-r1')
+
 
 @ReasoningParserManager.register_module(name='default')
 class ReasoningParser:

--- a/lmdeploy/serve/parsers/response_parser.py
+++ b/lmdeploy/serve/parsers/response_parser.py
@@ -24,6 +24,35 @@ logger = get_logger('lmdeploy')
 
 ResponseParserManager = Registry('response_parser', locations=['lmdeploy.serve.parsers.response_parser'])
 
+LEGACY_REASONING_PARSER_NAMES = ('qwen-qwq', 'intern-s1', 'deepseek-r1')
+
+
+def validate_parser_names(
+    reasoning_parser_name: str | None = None,
+    tool_parser_name: str | None = None,
+    *,
+    warn_legacy: bool = True,
+) -> tuple[str | None, str | None]:
+    """Validate parser registry names before expensive engine startup."""
+    from .reasoning_parser import ReasoningParserManager
+    from .tool_parser import ToolParserManager
+
+    if reasoning_parser_name in LEGACY_REASONING_PARSER_NAMES:
+        if warn_legacy:
+            logger.warning(f'The reasoning parser {reasoning_parser_name} is deprecated, '
+                           'please use the default reasoning parser instead.')
+        reasoning_parser_name = 'default'
+
+    if reasoning_parser_name is not None and reasoning_parser_name not in ReasoningParserManager.module_dict:
+        raise ValueError(f'The reasoning parser {reasoning_parser_name} is not in the parser list: '
+                         f'{ReasoningParserManager.module_dict.keys()}')
+
+    if tool_parser_name is not None and tool_parser_name not in ToolParserManager.module_dict:
+        raise ValueError(f'The tool parser {tool_parser_name} is not in the parser list: '
+                         f'{ToolParserManager.module_dict.keys()}')
+
+    return reasoning_parser_name, tool_parser_name
+
 
 def _parse_tool_call_arguments_dict(arguments: Any) -> dict[str, Any] | None:
     """Return dict-like tool arguments for request message normalization.
@@ -221,27 +250,15 @@ class BaseResponseParser(ResponseParser):
         from .reasoning_parser import ReasoningParserManager
         from .tool_parser import ToolParserManager
 
-        legacy_reasoning_parser_names = ['qwen-qwq', 'intern-s1', 'deepseek-r1']
-        if reasoning_parser_name in legacy_reasoning_parser_names:
-            logger.warning(f'The reasoning parser {reasoning_parser_name} is deprecated, '
-                           'please use the default reasoning parser instead.')
-            reasoning_parser_name = 'default'
+        reasoning_parser_name, tool_parser_name = validate_parser_names(reasoning_parser_name, tool_parser_name)
 
         if reasoning_parser_name is not None:
-            if reasoning_parser_name in ReasoningParserManager.module_dict:
-                cls.reasoning_parser_cls = ReasoningParserManager.get(reasoning_parser_name)
-                if tokenizer is not None:
-                    cls.reasoning_parser_cls.validate_tokenizer(tokenizer)
-            else:
-                raise ValueError(f'The reasoning parser {reasoning_parser_name} is not in the parser list: '
-                                 f'{ReasoningParserManager.module_dict.keys()}')
+            cls.reasoning_parser_cls = ReasoningParserManager.get(reasoning_parser_name)
+            if tokenizer is not None:
+                cls.reasoning_parser_cls.validate_tokenizer(tokenizer)
 
         if tool_parser_name is not None:
-            if tool_parser_name in ToolParserManager.module_dict:
-                cls.tool_parser_cls = ToolParserManager.get(tool_parser_name)
-            else:
-                raise ValueError(f'The tool parser {tool_parser_name} is not in the parser list: '
-                                 f'{ToolParserManager.module_dict.keys()}')
+            cls.tool_parser_cls = ToolParserManager.get(tool_parser_name)
 
     @classmethod
     def chat_template_kwargs_from_request(cls, request: ChatCompletionRequest) -> dict:

--- a/lmdeploy/serve/parsers/response_parser.py
+++ b/lmdeploy/serve/parsers/response_parser.py
@@ -24,9 +24,6 @@ logger = get_logger('lmdeploy')
 
 ResponseParserManager = Registry('response_parser', locations=['lmdeploy.serve.parsers.response_parser'])
 
-LEGACY_REASONING_PARSER_NAMES = ('qwen-qwq', 'intern-s1', 'deepseek-r1')
-
-
 def validate_parser_names(
     reasoning_parser_name: str | None = None,
     tool_parser_name: str | None = None,
@@ -34,7 +31,7 @@ def validate_parser_names(
     warn_legacy: bool = True,
 ) -> tuple[str | None, str | None]:
     """Validate parser registry names before expensive engine startup."""
-    from .reasoning_parser import ReasoningParserManager
+    from .reasoning_parser import LEGACY_REASONING_PARSER_NAMES, ReasoningParserManager
     from .tool_parser import ToolParserManager
 
     if reasoning_parser_name in LEGACY_REASONING_PARSER_NAMES:

--- a/tests/test_lmdeploy/serve/parsers/test_parser_config.py
+++ b/tests/test_lmdeploy/serve/parsers/test_parser_config.py
@@ -1,0 +1,50 @@
+import pytest
+
+from lmdeploy.serve.parsers import ResponseParserManager, validate_parser_names
+from lmdeploy.serve.parsers.reasoning_parser import ReasoningParserManager
+from lmdeploy.serve.parsers.tool_parser import ToolParserManager
+
+
+@pytest.fixture
+def default_response_parser_cls():
+    cls = ResponseParserManager.get('default')
+    reasoning_parser_cls = cls.reasoning_parser_cls
+    tool_parser_cls = cls.tool_parser_cls
+    try:
+        cls.reasoning_parser_cls = None
+        cls.tool_parser_cls = None
+        yield cls
+    finally:
+        cls.reasoning_parser_cls = reasoning_parser_cls
+        cls.tool_parser_cls = tool_parser_cls
+
+
+def test_validate_parser_names_rejects_unknown_tool_parser_before_tokenizer():
+    with pytest.raises(ValueError, match='The tool parser default is not in the parser list'):
+        validate_parser_names(reasoning_parser_name='qwen-qwq', tool_parser_name='default')
+
+
+def test_validate_parser_names_maps_legacy_reasoning_parser():
+    reasoning_parser_name, tool_parser_name = validate_parser_names(
+        reasoning_parser_name='qwen-qwq',
+        tool_parser_name='interns2-preview',
+        warn_legacy=False,
+    )
+
+    assert reasoning_parser_name == 'default'
+    assert tool_parser_name == 'interns2-preview'
+
+
+def test_response_parser_set_parsers_rejects_unknown_tool_parser(default_response_parser_cls):
+    with pytest.raises(ValueError, match='The tool parser default is not in the parser list'):
+        default_response_parser_cls.set_parsers(reasoning_parser_name='default', tool_parser_name='default')
+
+    assert default_response_parser_cls.reasoning_parser_cls is None
+    assert default_response_parser_cls.tool_parser_cls is None
+
+
+def test_response_parser_set_parsers_accepts_registered_names(default_response_parser_cls):
+    default_response_parser_cls.set_parsers(reasoning_parser_name='default', tool_parser_name='interns2-preview')
+
+    assert default_response_parser_cls.reasoning_parser_cls is ReasoningParserManager.get('default')
+    assert default_response_parser_cls.tool_parser_cls is ToolParserManager.get('interns2-preview')


### PR DESCRIPTION
## Summary

- Validate serve parser names before expensive engine startup so invalid parser configs fail fast.
- Reuse the same parser validation in response parser setup while preserving legacy reasoning parser aliases.
- Surface DP child startup failures to the launcher and terminate sibling process groups instead of blocking behind a long-running join.

## Tests

- `python -m py_compile lmdeploy/serve/parsers/response_parser.py lmdeploy/serve/parsers/__init__.py lmdeploy/serve/openai/api_server.py lmdeploy/serve/openai/launch_server.py tests/test_lmdeploy/serve/parsers/test_parser_config.py`
- `pytest tests/test_lmdeploy/serve/parsers/test_parser_config.py -q`
- Bad-parser serve reproduction fails fast before model loading with a clear parser validation error.

## Assistance

Assisted with Codex + GPT-5.5 xHigh Fast, reviewed manually
