### PR TITLE
fix(serve): use unique chatcmpl id for chat completions responses

### DIFF
--- a/lmdeploy/serve/openai/api_server.py
+++ b/lmdeploy/serve/openai/api_server.py
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
 
     from lmdeploy.serve.parsers import ResponseParser
 
+import shortuuid
 import uvicorn
 from fastapi import APIRouter, Depends, FastAPI, HTTPException, Request, status
 from fastapi.encoders import jsonable_encoder
@@ -451,7 +452,7 @@ async def chat_completions_v1(request: ChatCompletionRequest, raw_request: Reque
     adapter_name = None
     if model_name != VariableInterface.async_engine.model_name:
         adapter_name = model_name  # got a adapter name
-    request_id = str(session.session_id)
+    request_id = f'chatcmpl-{shortuuid.random()}'
     created_time = int(time.time())
 
     tokenizer = VariableInterface.async_engine.tokenizer.model.model


### PR DESCRIPTION
## Motivation

`/v1/chat/completions` previously set the response `id` to `str(session.session_id)`, a small numeric value reused across requests. This makes ID collisions likely when clients treat `id` as a per-response identifier.

Downstream gateways that translate OpenAI `chat/completions` into Anthropic-style `messages` APIs (for example, Claude Code) rely on this `id` to distinguish assistant turns. When different assistants receive the same `id`, their outputs can be merged into one assistant history, corrupting conversation traces.

The fix ensures each chat completion response gets a globally unique, OpenAI-compatible `chatcmpl-*` identifier, while `session_id` remains available for explicit session management.

## Modification

- In `lmdeploy/serve/openai/api_server.py`, generate a per-request `request_id` with `f'chatcmpl-{shortuuid.random()}'` instead of reusing `session.session_id`.
- Pass this shared `request_id` to all streaming and non-streaming `ChatCompletionResponse` / `ChatCompletionStreamResponse` objects within the same request, so every SSE chunk keeps a consistent `id`.
- Leave session lifecycle behavior unchanged; only the response envelope `id` field is affected.
