### PR TITLE
feat(serve): add --generation-config CLI for server sampling defaults

### DIFF
--- a/autotest/interface/restful/test_restful_generate.py
+++ b/autotest/interface/restful/test_restful_generate.py
@@ -881,9 +881,10 @@ class TestGenerateComprehensive:
     def test_repetition_penalty(self):
         print(f'\n[Model: {self.model_name}] Running repetition penalty test')
         prompt = 'Repeat repeat repeat repeat'
+        base = {'prompt': prompt, 'max_tokens': 10, 'top_k': 0, 'stream': False}
 
-        resp_no_penalty = self._post({'prompt': prompt, 'max_tokens': 10, 'repetition_penalty': 1.0, 'stream': False})
-        resp_penalty = self._post({'prompt': prompt, 'max_tokens': 10, 'repetition_penalty': 1.5, 'stream': False})
+        resp_no_penalty = self._post({**base, 'repetition_penalty': 1.0})
+        resp_penalty = self._post({**base, 'repetition_penalty': 1.5})
 
         text_no_penalty = resp_no_penalty.json()['text']
         text_penalty = resp_penalty.json()['text']

--- a/lmdeploy/cli/serve.py
+++ b/lmdeploy/cli/serve.py
@@ -97,6 +97,7 @@ class SubCliServe:
         # model args
         ArgumentHelper.revision(parser)
         ArgumentHelper.download_dir(parser)
+        ArgumentHelper.generation_config(parser)
 
         # pytorch engine args
         pt_group = parser.add_argument_group('PyTorch engine arguments')
@@ -323,6 +324,7 @@ class SubCliServe:
                 reasoning_parser=args.reasoning_parser,
                 tool_call_parser=args.tool_call_parser,
                 speculative_config=speculative_config,
+                generation_config=args.generation_config,
             )
         else:
             from lmdeploy.serve.openai.launch_server import launch_server
@@ -355,6 +357,7 @@ class SubCliServe:
                 reasoning_parser=args.reasoning_parser,
                 tool_call_parser=args.tool_call_parser,
                 speculative_config=speculative_config,
+                generation_config=args.generation_config,
             )
 
     @staticmethod

--- a/lmdeploy/cli/utils.py
+++ b/lmdeploy/cli/utils.py
@@ -291,6 +291,18 @@ class ArgumentHelper:
                                    help='Extra arguments to be forwarded to the HuggingFace config.')
 
     @staticmethod
+    def generation_config(parser):
+        """Add argument generation_config to parser."""
+        return parser.add_argument(
+            '--generation-config',
+            type=str,
+            default='auto',
+            help='The folder path to the generation config. Defaults to "auto", the '
+            'generation config will be loaded from model path. If set to "lmdeploy", no '
+            'generation config is loaded, lmdeploy defaults will be used. If set to a folder '
+            'path, the generation config will be loaded from the specified folder path.')
+
+    @staticmethod
     def use_logn_attn(parser):
         """Add argument use_logn_attn to parser."""
 

--- a/lmdeploy/serve/anthropic/adapter.py
+++ b/lmdeploy/serve/anthropic/adapter.py
@@ -9,6 +9,7 @@ from typing import Any
 import shortuuid
 
 from lmdeploy.messages import GenerationConfig
+from lmdeploy.serve.core.generation_config import build_generation_config
 from lmdeploy.serve.openai.protocol import Tool, ToolChoice, ToolChoiceFuncName
 
 from .protocol import (
@@ -341,15 +342,15 @@ def to_lmdeploy_messages(request: MessagesRequest | CountTokensRequest) -> list[
     return lm_messages
 
 
-def to_generation_config(request: MessagesRequest) -> GenerationConfig:
+def to_generation_config(
+    request: MessagesRequest,
+    default_gen_config: dict | None = None,
+) -> GenerationConfig:
     """Map Anthropic messages request to LMDeploy generation config."""
-
-    return GenerationConfig(
+    return build_generation_config(
+        request,
+        default_gen_config or {},
         max_new_tokens=request.max_tokens,
-        do_sample=True,
-        top_k=40 if request.top_k is None else request.top_k,
-        top_p=1.0 if request.top_p is None else request.top_p,
-        temperature=1.0 if request.temperature is None else request.temperature,
         stop_words=request.stop_sequences,
         include_stop_str_in_output=request.include_stop_str_in_output or False,
         skip_special_tokens=True,

--- a/lmdeploy/serve/anthropic/endpoints/messages.py
+++ b/lmdeploy/serve/anthropic/endpoints/messages.py
@@ -174,7 +174,10 @@ def register(router: APIRouter, server_context) -> None:
         result_generator = server_context.async_engine.generate(
             engine_messages,
             session,
-            gen_config=to_generation_config(request),
+            gen_config=to_generation_config(
+                request,
+                default_gen_config=server_context.default_gen_config,
+            ),
             tools=parsed_request.tools,
             stream_response=True,
             sequence_start=True,

--- a/lmdeploy/serve/anthropic/protocol.py
+++ b/lmdeploy/serve/anthropic/protocol.py
@@ -104,7 +104,7 @@ class MessagesRequest(BaseModel):
     system: str | list[ContentBlockParam] | None = None
     stop_sequences: list[str] | None = None
     stream: bool = False
-    temperature: float | None = 1.0
+    temperature: float | None = None
     top_p: float | None = None
     top_k: int | None = None
     metadata: dict[str, Any] | None = None

--- a/lmdeploy/serve/core/generation_config.py
+++ b/lmdeploy/serve/core/generation_config.py
@@ -73,10 +73,11 @@ def extract_request_gen_config(request: BaseModel) -> dict[str, Any]:
     """Extract explicit non-None GenerationConfig fields from a request."""
     # exclude_unset keeps client-supplied fields plus parser-updated fields,
     # while leaving plain Pydantic defaults available for server defaults.
+    allowed_fields = set(type(request).model_fields)
     return {
         key: value
         for key, value in request.model_dump(exclude_unset=True).items()
-        if key in _GENERATION_CONFIG_FIELDS and value is not None
+        if key in allowed_fields and key in _GENERATION_CONFIG_FIELDS and value is not None
     }
 
 

--- a/lmdeploy/serve/core/generation_config.py
+++ b/lmdeploy/serve/core/generation_config.py
@@ -1,0 +1,103 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+"""Server-side generation config resolution and sampling parameter merge
+helpers."""
+
+from __future__ import annotations
+
+import dataclasses
+from typing import Any
+
+from pydantic import BaseModel
+
+from lmdeploy.messages import GenerationConfig
+from lmdeploy.utils import get_logger
+
+logger = get_logger('lmdeploy')
+_GENERATION_CONFIG_FIELDS = {field.name for field in dataclasses.fields(GenerationConfig)}
+
+
+def _filter_gen_config(config: dict[str, Any]) -> dict[str, Any]:
+    return {key: value for key, value in config.items() if key in _GENERATION_CONFIG_FIELDS}
+
+
+def _load_hf_generation_config(path: str, trust_remote_code: bool) -> dict[str, Any]:
+    from transformers import GenerationConfig
+
+    try:
+        cfg = GenerationConfig.from_pretrained(path, trust_remote_code=trust_remote_code)
+        return cfg.to_diff_dict()
+    except OSError:
+        return {}
+
+
+def resolve_default_gen_config(
+    generation_config: str,
+    model_path: str,
+    trust_remote_code: bool,
+) -> dict[str, Any]:
+    """Resolve server-side default generation config from CLI flags."""
+    src = generation_config
+
+    if src == 'lmdeploy':
+        config: dict[str, Any] = {}
+    elif src == 'auto':
+        config = _load_hf_generation_config(model_path, trust_remote_code)
+    else:
+        config = _load_hf_generation_config(src, trust_remote_code)
+    config = _filter_gen_config(config)
+
+    if config and src != 'lmdeploy':
+        source = "the model's `generation_config.json`" if src == 'auto' else src
+        logger.info(
+            f'Using default generation config from {source}: {config}. '
+            'Use `--generation-config lmdeploy` to disable.')
+
+    return config
+
+
+def merge_gen_config(
+    request_gen_config: dict[str, Any],
+    default_gen_config: dict[str, Any],
+) -> dict[str, Any]:
+    """Merge generation config with request > default_gen_config priority."""
+    merged: dict[str, Any] = {}
+    for key in set(default_gen_config) | set(request_gen_config):
+        if key in request_gen_config:
+            merged[key] = request_gen_config[key]
+        else:
+            merged[key] = default_gen_config[key]
+    return merged
+
+
+def extract_request_gen_config(request: BaseModel) -> dict[str, Any]:
+    """Extract explicit non-None GenerationConfig fields from a request."""
+    # exclude_unset keeps client-supplied fields plus parser-updated fields,
+    # while leaving plain Pydantic defaults available for server defaults.
+    return {
+        key: value
+        for key, value in request.model_dump(exclude_unset=True).items()
+        if key in _GENERATION_CONFIG_FIELDS and value is not None
+    }
+
+
+def build_generation_config(
+    request: BaseModel,
+    default_gen_config: dict[str, Any],
+    *,
+    max_new_tokens: int | None = None,
+    **extra_kwargs: Any,
+) -> GenerationConfig:
+    """Build ``GenerationConfig`` from merged sampling defaults and request
+    values."""
+    request_gen_config = extract_request_gen_config(request)
+    for key in extra_kwargs:
+        request_gen_config.pop(key, None)
+    merged = merge_gen_config(request_gen_config, _filter_gen_config(default_gen_config))
+    merged.pop('max_new_tokens', None)
+    merged.pop('do_sample', None)
+    return GenerationConfig(
+        max_new_tokens=max_new_tokens,
+        do_sample=True,
+        **merged,
+        **extra_kwargs,
+    )

--- a/lmdeploy/serve/openai/api_server.py
+++ b/lmdeploy/serve/openai/api_server.py
@@ -48,6 +48,10 @@ from lmdeploy.pytorch.disagg.conn.protocol import (
 )
 from lmdeploy.serve.anthropic import create_anthropic_router
 from lmdeploy.serve.core import AsyncEngine, EngineHealthMonitor
+from lmdeploy.serve.core.generation_config import (
+    build_generation_config,
+    resolve_default_gen_config,
+)
 from lmdeploy.serve.openai.protocol import (
     AbortRequest,
     ChatCompletionRequest,
@@ -111,6 +115,7 @@ class VariableInterface:
     allow_terminate_by_client: bool = False
     enable_abort_handling: bool = False
     response_parser_cls: type[ResponseParser] | None = None
+    default_gen_config: dict = {}
 
     @classmethod
     def create_session(cls, user_session_id: int | None = None) -> Session:
@@ -146,6 +151,23 @@ class VariableInterface:
     @classmethod
     def get_engine_config(cls):
         return cls.async_engine.backend_config
+
+
+def _build_serving_generation_config(request, **extra_kwargs) -> GenerationConfig:
+    """Build ``GenerationConfig`` with server and request sampling merge.
+
+    Same-name request fields are extracted automatically; ``extra_kwargs`` is
+    for renamed, computed, or raw-json fields only.
+    """
+    max_new_tokens = getattr(request, 'max_completion_tokens', None)
+    if max_new_tokens is None:
+        max_new_tokens = getattr(request, 'max_tokens', None)
+    return build_generation_config(
+        request,
+        VariableInterface.default_gen_config,
+        max_new_tokens=max_new_tokens,
+        **extra_kwargs,
+    )
 
 
 async def _with_request_cleanup(generator, result_generators, sessions):
@@ -476,8 +498,6 @@ async def chat_completions_v1(request: ChatCompletionRequest, raw_request: Reque
                 HTTPStatus.BAD_REQUEST,
                 'Please launch the api_server with --tool-call-parser if you want to use tool.')
 
-    random_seed = request.seed if request.seed is not None else None
-
     parser_cls = VariableInterface.response_parser_cls
     try:
         response_parser = parser_cls(request)
@@ -487,30 +507,15 @@ async def chat_completions_v1(request: ChatCompletionRequest, raw_request: Reque
     # (e.g. GPT-OSS clears response_format and injects the schema into messages)
     request = response_parser.request
 
-    gen_config = GenerationConfig(
-        max_new_tokens=request.max_completion_tokens,
-        do_sample=True,
+    gen_config = _build_serving_generation_config(
+        request,
         logprobs=gen_logprobs,
-        top_k=request.top_k,
-        top_p=request.top_p,
-        temperature=request.temperature,
-        repetition_penalty=request.repetition_penalty,
-        ignore_eos=request.ignore_eos,
         stop_words=request.stop,
-        include_stop_str_in_output=request.include_stop_str_in_output,
-        skip_special_tokens=request.skip_special_tokens,
-        response_format=request.response_format,
         logits_processors=logits_processors,
-        min_new_tokens=request.min_new_tokens,
-        min_p=request.min_p,
-        random_seed=random_seed,
-        spaces_between_special_tokens=request.spaces_between_special_tokens,
+        random_seed=request.seed,
         migration_request=migration_request,
         with_cache=with_cache,
         preserve_cache=preserve_cache,
-        repetition_ngram_size=request.repetition_ngram_size,
-        repetition_ngram_threshold=request.repetition_ngram_threshold,
-        return_routed_experts=request.return_routed_experts,
     )
 
     # text completion for string input or input_ids
@@ -828,28 +833,14 @@ async def completions_v1(request: CompletionRequest, raw_request: Request = None
             sessions.append(VariableInterface.create_session(i + 1))
     if isinstance(request.stop, str):
         request.stop = [request.stop]
-    random_seed = request.seed if request.seed is not None else None
-    max_new_tokens = (request.max_completion_tokens if request.max_completion_tokens else request.max_tokens)
 
-    gen_config = GenerationConfig(
-        max_new_tokens=max_new_tokens,
-        do_sample=True,
-        logprobs=request.logprobs,
-        top_k=request.top_k,
-        top_p=request.top_p,
-        temperature=request.temperature,
-        repetition_penalty=request.repetition_penalty,
-        ignore_eos=request.ignore_eos,
+    gen_config = _build_serving_generation_config(
+        request,
         stop_words=request.stop,
-        skip_special_tokens=request.skip_special_tokens,
-        min_p=request.min_p,
-        random_seed=random_seed,
-        spaces_between_special_tokens=request.spaces_between_special_tokens,
+        random_seed=request.seed,
         migration_request=migration_request,
         with_cache=with_cache,
         preserve_cache=preserve_cache,
-        repetition_ngram_size=request.repetition_ngram_size,
-        repetition_ngram_threshold=request.repetition_ngram_threshold,
     )
     generators = []
     for prompt, session in zip(request.prompt, sessions):
@@ -1013,24 +1004,10 @@ async def generate(request: GenerateReqInput, raw_request: Request = None):
         prompt = [dict(role='user', content=[text_input] + image_input)]
         input_ids = None
 
-    gen_config = GenerationConfig(
-        max_new_tokens=request.max_tokens,
-        do_sample=True,
+    gen_config = _build_serving_generation_config(
+        request,
         logprobs=1 if request.return_logprob else None,
-        top_k=request.top_k,
-        top_p=request.top_p,
-        min_p=request.min_p,
-        temperature=request.temperature,
-        repetition_penalty=request.repetition_penalty,
-        ignore_eos=request.ignore_eos,
         stop_words=request.stop,
-        stop_token_ids=request.stop_token_ids,
-        skip_special_tokens=request.skip_special_tokens,
-        spaces_between_special_tokens=request.spaces_between_special_tokens,
-        include_stop_str_in_output=request.include_stop_str_in_output,
-        return_routed_experts=request.return_routed_experts,
-        repetition_ngram_size=request.repetition_ngram_size,
-        repetition_ngram_threshold=request.repetition_ngram_threshold,
     )
 
     result_generator = VariableInterface.async_engine.generate(
@@ -1547,6 +1524,7 @@ def serve(model_path: str,
           allow_terminate_by_client: bool = False,
           enable_abort_handling: bool = False,
           speculative_config: SpeculativeConfig | None = None,
+          generation_config: str = 'auto',
           **kwargs):
     """An example to perform model inference through the command line
     interface.
@@ -1608,6 +1586,12 @@ def serve(model_path: str,
     VariableInterface.enable_abort_handling = enable_abort_handling
     from lmdeploy.serve.parsers import validate_parser_names
     reasoning_parser, tool_call_parser = validate_parser_names(reasoning_parser, tool_call_parser)
+
+    VariableInterface.default_gen_config = resolve_default_gen_config(
+        generation_config,
+        model_path,
+        trust_remote_code,
+    )
 
     ssl_keyfile, ssl_certfile, http_or_https = None, None, 'http'
     if ssl:

--- a/lmdeploy/serve/openai/protocol.py
+++ b/lmdeploy/serve/openai/protocol.py
@@ -144,8 +144,8 @@ class ChatCompletionRequest(BaseModel):
     model: str
 
     messages: str | list[dict[str, Any]] = Field(examples=[[{'role': 'user', 'content': 'hi'}]])
-    temperature: float | None = 0.7
-    top_p: float | None = 1.0
+    temperature: float | None = None
+    top_p: float | None = None
     tools: list[Tool] | None = Field(default=None, examples=[None])
     tool_choice: ToolChoice | AllowedToolChoice | Literal[
         'auto', 'required', 'none'] = Field(default='auto', examples=['none'])
@@ -176,17 +176,17 @@ class ChatCompletionRequest(BaseModel):
     response_format: ResponseFormat | None = Field(default=None, examples=[None])
     # additional argument of lmdeploy
     do_preprocess: bool | None = True
-    repetition_penalty: float | None = 1.0
+    repetition_penalty: float | None = None
     repetition_ngram_size: int = Field(default=0, ge=0)
     repetition_ngram_threshold: int = Field(default=0, ge=0)
     session_id: int | None = -1
     ignore_eos: bool | None = False
     skip_special_tokens: bool | None = True
     spaces_between_special_tokens: bool | None = True
-    top_k: int | None = 40
+    top_k: int | None = None
     seed: int | None = None
     min_new_tokens: int | None = Field(default=None, examples=[None])
-    min_p: float = 0.0
+    min_p: float | None = None
     enable_thinking: bool | None = None  # will be deprecated in the future
     return_token_ids: bool | None = False
     return_logprob: bool | None = False
@@ -352,7 +352,7 @@ class CompletionRequest(BaseModel):
     model: str
     prompt: str | list[Any]
     suffix: str | None = None
-    temperature: float | None = 0.7
+    temperature: float | None = None
     n: int | None = 1
     logprobs: int | None = None
     max_completion_tokens: int | None = Field(
@@ -362,29 +362,29 @@ class CompletionRequest(BaseModel):
                      'including visible output tokens and reasoning tokens'),
     )
     max_tokens: int | None = Field(
-        default=16,
-        examples=[16],
+        default=None,
+        examples=[None],
         deprecated='max_tokens is deprecated in favor of the max_completion_tokens field',
     )
     stop: str | list[str] | None = Field(default=None, examples=[None])
     stream: bool | None = False
     stream_options: StreamOptions | None = Field(default=None, examples=[None])
-    top_p: float | None = 1.0
+    top_p: float | None = None
     echo: bool | None = False
     presence_penalty: float | None = 0.0
     frequency_penalty: float | None = 0.0
     user: str | None = None
     # additional argument of lmdeploy
-    repetition_penalty: float | None = 1.0
+    repetition_penalty: float | None = None
     repetition_ngram_size: int = Field(default=0, ge=0)
     repetition_ngram_threshold: int = Field(default=0, ge=0)
     session_id: int | None = -1
     ignore_eos: bool | None = False
     skip_special_tokens: bool | None = True
     spaces_between_special_tokens: bool | None = True
-    top_k: int | None = 40  # for opencompass
+    top_k: int | None = None  # for opencompass
     seed: int | None = None
-    min_p: float = 0.0
+    min_p: float | None = None
 
 
 class CompletionResponseChoice(BaseModel):
@@ -549,12 +549,12 @@ class GenerateReqInput(BaseModel):
     stop: str | list[str] | None = None
     stop_token_ids: list[int] | None = None
     stream: bool | None = False
-    temperature: float = 1.0
-    repetition_penalty: float | None = 1.0
+    temperature: float | None = None
+    repetition_penalty: float | None = None
     ignore_eos: bool | None = False
-    top_p: float = 1.0
-    top_k: int = 0
-    min_p: float = 0.0
+    top_p: float | None = None
+    top_k: int | None = None
+    min_p: float | None = None
     skip_special_tokens: bool | None = True
     spaces_between_special_tokens: bool | None = True
     include_stop_str_in_output: bool | None = False

--- a/lmdeploy/serve/openai/responses/protocol.py
+++ b/lmdeploy/serve/openai/responses/protocol.py
@@ -82,10 +82,10 @@ class ResponsesRequest(BaseModel):
     presence_penalty: float | None = None
     frequency_penalty: float | None = None
     repetition_penalty: float | None = None
-    top_k: int | None = 40
+    top_k: int | None = None
     stop: str | list[str] | None = None
     seed: int | None = None
-    min_p: float = 0.0
+    min_p: float | None = None
     ignore_eos: bool | None = False
     skip_special_tokens: bool | None = True
     include_stop_str_in_output: bool | None = False

--- a/lmdeploy/serve/openai/responses/protocol.py
+++ b/lmdeploy/serve/openai/responses/protocol.py
@@ -20,7 +20,7 @@ from openai.types.responses.response import ToolChoice as ResponseToolChoice
 from openai.types.responses.response_create_params import StreamOptions as ResponseStreamOptions
 from openai.types.responses.tool import Tool as ResponseTool
 from openai.types.shared import Metadata, Reasoning
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, Field
 
 ResponseInputOutputItem: TypeAlias = ResponseInputItemParam | ResponseOutputItem
 
@@ -32,8 +32,6 @@ class ResponsesRequest(BaseModel):
     after the official fields.
     Reference: https://developers.openai.com/api/reference/resources/responses/methods/create
     """
-
-    model_config = ConfigDict(extra='allow')
 
     background: bool | None = False
     context_management: list[dict[str, Any]] | None = None

--- a/lmdeploy/serve/openai/responses/request.py
+++ b/lmdeploy/serve/openai/responses/request.py
@@ -9,6 +9,7 @@ from typing import Any, Literal
 from fastapi.responses import JSONResponse
 
 from lmdeploy.messages import GenerationConfig
+from lmdeploy.serve.core.generation_config import build_generation_config
 from lmdeploy.serve.openai.protocol import Tool, ToolChoice, ToolChoiceFuncName
 from lmdeploy.serve.openai.responses.protocol import ResponsesRequest
 from lmdeploy.utils import get_logger
@@ -264,20 +265,16 @@ def _response_format_from_text(text: Any) -> dict[str, Any] | None:
     raise ValueError(f'Unsupported text.format type: {format_type!r}.')
 
 
-def to_generation_config(request: ResponsesRequest) -> GenerationConfig:
+def to_generation_config(
+    request: ResponsesRequest,
+    default_gen_config: dict | None = None,
+) -> GenerationConfig:
     stop_words = [request.stop] if isinstance(request.stop, str) else request.stop
-    return GenerationConfig(
+    return build_generation_config(
+        request,
+        default_gen_config or {},
         max_new_tokens=request.max_output_tokens,
-        do_sample=True,
-        top_k=40 if request.top_k is None else request.top_k,
-        top_p=1.0 if request.top_p is None else request.top_p,
-        temperature=1.0 if request.temperature is None else request.temperature,
         stop_words=stop_words,
-        ignore_eos=request.ignore_eos,
-        skip_special_tokens=request.skip_special_tokens,
-        include_stop_str_in_output=request.include_stop_str_in_output,
         response_format=_response_format_from_text(request.text),
-        min_p=request.min_p,
         random_seed=request.seed,
-        repetition_penalty=1.0 if request.repetition_penalty is None else request.repetition_penalty,
     )

--- a/lmdeploy/serve/openai/responses/serving.py
+++ b/lmdeploy/serve/openai/responses/serving.py
@@ -97,7 +97,10 @@ class OpenAIServingResponses:
         except ValueError as err:
             return error_response(HTTPStatus.BAD_REQUEST, str(err), param='input')
         try:
-            gen_config = to_generation_config(request)
+            gen_config = to_generation_config(
+                request,
+                default_gen_config=self.server_context.default_gen_config,
+            )
         except ValueError as err:
             return error_response(HTTPStatus.BAD_REQUEST, str(err), param='text')
         try:

--- a/lmdeploy/serve/openai/serving_chat_completion.py
+++ b/lmdeploy/serve/openai/serving_chat_completion.py
@@ -35,11 +35,11 @@ def check_request(request: ChatCompletionRequest, server_context: 'VariableInter
     # check sampling settings
     if request.n <= 0:
         return f'The n {request.n!r} must be a positive int.'
-    if not (0 < request.top_p <= 1):
+    if request.top_p is not None and not (0 < request.top_p <= 1):
         return f'The top_p {request.top_p!r} must be in (0, 1].'
-    if request.top_k < 0:
+    if request.top_k is not None and request.top_k < 0:
         return f'The top_k {request.top_k!r} cannot be a negative integer.'
-    if not (0 <= request.temperature <= 2):
+    if request.temperature is not None and not (0 <= request.temperature <= 2):
         return f'The temperature {request.temperature!r} must be in [0, 2]'
 
     # Validate input_ids and image_data constraints.

--- a/lmdeploy/serve/openai/serving_completion.py
+++ b/lmdeploy/serve/openai/serving_completion.py
@@ -27,11 +27,11 @@ def check_request(request: CompletionRequest, server_context: 'VariableInterface
     # check sampling settings
     if request.n <= 0:
         return f'The n {request.n!r} must be a positive int.'
-    if not (0 < request.top_p <= 1):
+    if request.top_p is not None and not (0 < request.top_p <= 1):
         return f'The top_p {request.top_p!r} must be in (0, 1].'
-    if request.top_k < 0:
+    if request.top_k is not None and request.top_k < 0:
         return f'The top_k {request.top_k!r} cannot be a negative integer.'
-    if not (0 <= request.temperature <= 2):
+    if request.temperature is not None and not (0 <= request.temperature <= 2):
         return f'The temperature {request.temperature!r} must be in [0, 2]'
 
     return ''

--- a/lmdeploy/serve/openai/serving_generate.py
+++ b/lmdeploy/serve/openai/serving_generate.py
@@ -35,11 +35,11 @@ def check_request(request: GenerateReqInput, server_context: 'VariableInterface'
         return f'The session_id {request.session_id!r} is occupied.'
 
     # check sampling settings
-    if not (0 < request.top_p <= 1):
+    if request.top_p is not None and not (0 < request.top_p <= 1):
         return f'The top_p {request.top_p!r} must be in (0, 1].'
-    if request.top_k < 0:
+    if request.top_k is not None and request.top_k < 0:
         return f'The top_k {request.top_k!r} cannot be a negative integer.'
-    if not (0 <= request.temperature <= 2):
+    if request.temperature is not None and not (0 <= request.temperature <= 2):
         return f'The temperature {request.temperature!r} must be in [0, 2]'
 
     return ''

--- a/tests/test_lmdeploy/serve/anthropic/test_endpoints.py
+++ b/tests/test_lmdeploy/serve/anthropic/test_endpoints.py
@@ -5,9 +5,10 @@ import json
 from types import SimpleNamespace
 
 import pytest
-from fastapi import FastAPI
-from fastapi.testclient import TestClient
+from fastapi.encoders import jsonable_encoder
+from fastapi.responses import JSONResponse, StreamingResponse
 
+from lmdeploy.serve.anthropic.protocol import MessagesRequest
 from lmdeploy.serve.anthropic.router import create_anthropic_router
 from lmdeploy.serve.anthropic.streaming import stream_messages_response
 from lmdeploy.serve.openai.protocol import DeltaFunctionCall, DeltaMessage, DeltaToolCall, FunctionCall, ToolCall
@@ -141,6 +142,7 @@ class _FakeServerContext:
             logprobs_mode=logprobs_mode,
             enable_return_routed_experts=enable_return_routed_experts,
         )
+        self.default_gen_config = {}
         self.response_parser_cls = response_parser_cls
 
     def create_session(self, _session_id: int | None = None):
@@ -151,6 +153,79 @@ class _FakeServerContext:
 
     def get_engine_config(self):
         return self.async_engine.backend_config
+
+
+class _FakeRawRequest:
+
+    def __init__(self, headers):
+        self.headers = headers
+
+    async def is_disconnected(self):
+        return False
+
+
+class _TestResponse:
+
+    def __init__(self, status_code: int, payload=None, body: str = ''):
+        self.status_code = status_code
+        self._payload = jsonable_encoder(payload)
+        self._body = body
+
+    def json(self):
+        return self._payload
+
+    def iter_lines(self):
+        return self._body.splitlines()
+
+
+class _StreamContext:
+
+    def __init__(self, response: _TestResponse):
+        self.response = response
+
+    def __enter__(self):
+        return self.response
+
+    def __exit__(self, *args):
+        return False
+
+
+class _AnthropicTestClient:
+
+    def __init__(self, server_context):
+        router = create_anthropic_router(server_context)
+        self._routes = {route.path: route.endpoint for route in router.routes}
+
+    def post(self, path: str, *, headers, json):
+        return asyncio.run(self._post(path, headers=headers, json=json))
+
+    def stream(self, method: str, path: str, *, headers, json):
+        assert method == 'POST'
+        return _StreamContext(self.post(path, headers=headers, json=json))
+
+    def get(self, path: str):
+        return asyncio.run(self._get(path))
+
+    async def _post(self, path: str, *, headers, json):
+        endpoint = self._routes[path.split('?', 1)[0]]
+        result = await endpoint(MessagesRequest(**json), _FakeRawRequest(headers))
+        return await self._response_from_result(result)
+
+    async def _get(self, path: str):
+        endpoint = self._routes[path.split('?', 1)[0]]
+        return await self._response_from_result(await endpoint())
+
+    async def _response_from_result(self, result):
+        if isinstance(result, JSONResponse):
+            return _TestResponse(result.status_code, json.loads(result.body))
+        if isinstance(result, StreamingResponse):
+            chunks = []
+            async for chunk in result.body_iterator:
+                if isinstance(chunk, bytes):
+                    chunk = chunk.decode()
+                chunks.append(chunk)
+            return _TestResponse(result.status_code, body=''.join(chunks))
+        return _TestResponse(200, result)
 
 
 class _ToolAndReasoningParser:
@@ -217,11 +292,9 @@ def _make_client(response_parser_cls=_BasicParser,
                  server_context=None,
                  logprobs_mode='raw_logprobs',
                  return_context=False):
-    app = FastAPI()
     context = server_context or _FakeServerContext(response_parser_cls=response_parser_cls,
                                                   logprobs_mode=logprobs_mode)
-    app.include_router(create_anthropic_router(context))
-    client = TestClient(app)
+    client = _AnthropicTestClient(context)
     if return_context:
         return client, context
     return client
@@ -252,11 +325,11 @@ def test_messages_non_stream():
     assert len(context.session_mgr.removed) == 1
 
 
-def _post_messages(client: TestClient, **overrides):
+def _post_messages(client: _AnthropicTestClient, **overrides):
     return client.post('/v1/messages', headers=ANTHROPIC_HEADERS, json=_messages_payload(**overrides))
 
 
-def _stream_messages_body(client: TestClient, **overrides):
+def _stream_messages_body(client: _AnthropicTestClient, **overrides):
     payload = _messages_payload(**overrides)
     payload['stream'] = True
     with client.stream('POST', '/v1/messages', headers=ANTHROPIC_HEADERS, json=payload) as response:

--- a/tests/test_lmdeploy/serve/openai/responses/conftest.py
+++ b/tests/test_lmdeploy/serve/openai/responses/conftest.py
@@ -64,6 +64,7 @@ class FakeServerContext:
 
     def __init__(self):
         self.async_engine = FakeAsyncEngine()
+        self.default_gen_config = {}
         self.sessions = []
 
     def create_session(self, session_id):

--- a/tests/test_lmdeploy/serve/test_generation_config.py
+++ b/tests/test_lmdeploy/serve/test_generation_config.py
@@ -2,6 +2,8 @@
 import warnings
 from unittest.mock import patch
 
+from pydantic import BaseModel, ConfigDict
+
 from lmdeploy.messages import GenerationConfig
 from lmdeploy.serve.core.generation_config import (
     build_generation_config,
@@ -10,6 +12,7 @@ from lmdeploy.serve.core.generation_config import (
     resolve_default_gen_config,
 )
 from lmdeploy.serve.openai.protocol import ChatCompletionRequest, CompletionRequest, GenerateReqInput
+from lmdeploy.serve.openai.responses import ResponsesRequest
 from lmdeploy.serve.openai.serving_generate import check_request as check_generate_request
 
 _DEFAULTS = GenerationConfig()
@@ -51,6 +54,24 @@ def test_extract_request_gen_config_only_explicit_fields():
     request = ChatCompletionRequest(model='test', messages='hi', temperature=0.3)
     values = extract_request_gen_config(request)
     assert values == {'temperature': 0.3}
+
+
+class _RequestWithExtraAllow(BaseModel):
+    model_config = ConfigDict(extra='allow')
+
+    temperature: float | None = None
+
+
+def test_extract_request_gen_config_ignores_undeclared_fields():
+    request = _RequestWithExtraAllow(temperature=0.3, return_ppl=True)
+    assert extract_request_gen_config(request) == {'temperature': 0.3}
+
+
+def test_responses_request_ignores_unknown_generation_fields():
+    request = ResponsesRequest(model='fake-model', input='hi', return_ppl=True)
+    assert 'return_ppl' not in request.model_dump()
+    gen_config = build_generation_config(request, {})
+    assert gen_config.return_ppl is False
 
 
 def test_build_generation_config_from_merged_values():

--- a/tests/test_lmdeploy/serve/test_generation_config.py
+++ b/tests/test_lmdeploy/serve/test_generation_config.py
@@ -1,0 +1,160 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+import warnings
+from unittest.mock import patch
+
+from lmdeploy.messages import GenerationConfig
+from lmdeploy.serve.core.generation_config import (
+    build_generation_config,
+    extract_request_gen_config,
+    merge_gen_config,
+    resolve_default_gen_config,
+)
+from lmdeploy.serve.openai.protocol import ChatCompletionRequest, CompletionRequest, GenerateReqInput
+from lmdeploy.serve.openai.serving_generate import check_request as check_generate_request
+
+_DEFAULTS = GenerationConfig()
+
+
+class _FakeEngineConfig:
+    logprobs_mode = None
+
+
+class _FakeSessionManager:
+
+    def has(self, session_id):
+        return False
+
+
+class _FakeServerContext:
+
+    def get_engine_config(self):
+        return _FakeEngineConfig()
+
+    def get_session_manager(self):
+        return _FakeSessionManager()
+
+
+def test_merge_gen_config_priority():
+    merged = merge_gen_config(
+        {'temperature': 0.2},
+        {'temperature': 0.5, 'top_k': 10},
+    )
+    assert merged == {'temperature': 0.2, 'top_k': 10}
+
+
+def test_merge_gen_config_uses_server_defaults():
+    merged = merge_gen_config({}, {'temperature': 0.5})
+    assert merged == {'temperature': 0.5}
+
+
+def test_extract_request_gen_config_only_explicit_fields():
+    request = ChatCompletionRequest(model='test', messages='hi', temperature=0.3)
+    values = extract_request_gen_config(request)
+    assert values == {'temperature': 0.3}
+
+
+def test_build_generation_config_from_merged_values():
+    request = ChatCompletionRequest(model='test', messages='hi', temperature=0.2)
+    gen_config = build_generation_config(
+        request,
+        {'top_k': 5},
+        max_new_tokens=32,
+    )
+    assert gen_config.temperature == 0.2
+    assert gen_config.top_k == 5
+    assert gen_config.max_new_tokens == 32
+    assert gen_config.do_sample is True
+
+
+def test_build_generation_config_max_new_tokens_defaults_to_none():
+    request = CompletionRequest(model='test', prompt='hello')
+    gen_config = build_generation_config(request, {})
+    assert gen_config.max_new_tokens is None
+
+
+def test_build_generation_config_uses_generation_config_defaults():
+    request = CompletionRequest(model='test', prompt='hello')
+    gen_config = build_generation_config(request, {})
+    assert gen_config.temperature == _DEFAULTS.temperature
+    assert gen_config.top_k == _DEFAULTS.top_k
+
+
+def test_build_generation_config_ignores_unsupported_defaults():
+    request = CompletionRequest(model='test', prompt='hello')
+    gen_config = build_generation_config(
+        request,
+        {
+            'temperature': 0.6,
+            'eos_token_id': 2,
+            'pad_token_id': 0,
+            'transformers_version': '5.12.1',
+        },
+    )
+    assert gen_config.temperature == 0.6
+
+
+def test_completion_request_max_tokens_is_optional():
+    request = CompletionRequest(model='test', prompt='hello')
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore', DeprecationWarning)
+        assert request.max_tokens is None
+
+
+def test_generate_request_sampling_defaults_match_chat_request():
+    chat_request = ChatCompletionRequest(model='test', messages='hello')
+    generate_request = GenerateReqInput(prompt='hello')
+    for name in ('temperature', 'top_p', 'top_k', 'min_p'):
+        assert getattr(generate_request, name) == getattr(chat_request, name)
+
+
+def test_generate_request_accepts_none_sampling_defaults():
+    request = GenerateReqInput(prompt='hello')
+    assert check_generate_request(request, _FakeServerContext()) == ''
+
+
+def test_generate_request_sampling_merge_uses_server_defaults():
+    request = GenerateReqInput(prompt='hello')
+    gen_config = build_generation_config(
+        request,
+        {
+            'temperature': 0.2,
+            'top_p': 0.3,
+            'top_k': 7,
+            'min_p': 0.1,
+        },
+        max_new_tokens=request.max_tokens,
+    )
+    assert gen_config.temperature == 0.2
+    assert gen_config.top_p == 0.3
+    assert gen_config.top_k == 7
+    assert gen_config.min_p == 0.1
+
+
+@patch('lmdeploy.serve.core.generation_config._load_hf_generation_config')
+def test_resolve_default_gen_config_auto(mock_load):
+    mock_load.return_value = {
+        'temperature': 0.6,
+        'top_p': 0.8,
+        'max_new_tokens': 2048,
+        'eos_token_id': 2,
+        'transformers_version': '5.12.1',
+    }
+    config = resolve_default_gen_config('auto', '/fake/model', False)
+    assert config == {
+        'temperature': 0.6,
+        'top_p': 0.8,
+        'max_new_tokens': 2048,
+    }
+    mock_load.assert_called_once_with('/fake/model', False)
+
+
+def test_resolve_default_gen_config_lmdeploy():
+    config = resolve_default_gen_config('lmdeploy', '/fake/model', False)
+    assert config == {}
+
+
+def test_completion_request_sampling_merge():
+    request = CompletionRequest(model='test', prompt='hello')
+    gen_config = build_generation_config(request, {'temperature': 0.9})
+    assert gen_config.temperature == 0.9
+    assert gen_config.top_k == _DEFAULTS.top_k


### PR DESCRIPTION
## Motivation

LMDeploy's OpenAI-compatible API server previously relied on hard-coded protocol defaults for sampling parameters (e.g. `temperature=0.7`, `top_k=40`). This made it difficult to align server behavior with a model's own HuggingFace `generation_config.json`, which many models ship with recommended decoding settings.

vLLM exposes a similar `--generation-config` flag to load HF generation defaults at startup. This PR brings comparable behavior to LMDeploy:

- Load a model's HF `generation_config.json` as server-side defaults when users omit sampling fields in requests.
- Allow opting out via `--generation-config lmdeploy` to keep LMDeploy/`GenerationConfig` defaults.
- Support loading from a custom folder path when needed.

To support proper merge semantics, protocol sampling fields are changed to default to `None` (meaning "not specified by the user") instead of fixed values. Unspecified fields fall back to HF defaults (if loaded) and then to `GenerationConfig` dataclass defaults.

## Modification

### CLI

- Add `--generation-config` to `lmdeploy serve api_server` (default: `auto`).
  - `auto`: load `generation_config.json` from the model path via HuggingFace `GenerationConfig.from_pretrained()`.
  - `lmdeploy`: do not load HF config; use LMDeploy defaults only.
  - `<path>`: load from a custom directory.

### Core module (`lmdeploy/serve/core/generation_config.py`)

Introduce a small helper module

### API server integration

- Parse `--generation-config` once at startup and store the result in `VariableInterface.default_gen_config`.
- Route chat completions, completions, generate, Responses API, and Anthropic endpoints through `build_generation_config()` for consistent merge behavior.
- Remove redundant same-name pass-through kwargs at call sites; keep only renamed (`stop` → `stop_words`, `seed` → `random_seed`), computed (`logprobs`), or raw-json fields (`migration_request`, `with_cache`, `preserve_cache`) in `extra_kwargs`.

### Protocol changes

- Set sampling-related fields in OpenAI/Responses/Anthropic protocols to `None` defaults (e.g. `temperature`, `top_p`, `top_k`, `repetition_penalty`, `min_p`) so "user did not send" can be distinguished from an explicit value.

## Behavior notes

- When `--generation-config lmdeploy` and the user omits sampling params, defaults come from `GenerationConfig` (`temperature=0.8`, `top_k=50`, etc.), not the old protocol defaults (`0.7` / `40`).
- `max_new_tokens` is not taken from HF config; it is resolved from `max_completion_tokens` / `max_tokens` on the request, with engine-level fallback when unset.
- `do_sample=True` is always set for serving requests.
