### PR TITLE
chore: update deepgemm revision

### DIFF
--- a/docker/prepare_3rdparty_wheel.sh
+++ b/docker/prepare_3rdparty_wheel.sh
@@ -14,7 +14,7 @@ fi
 
 GDRCOPY_VERSION=2.5.1
 DEEP_EP_VERSION=9af0e0d  # v1.2.1
-DEEP_GEMM_VERSION=c9f8b34  # v2.1.1.post3
+DEEP_GEMM_VERSION=88965b0
 FLASH_MLA_VERSION=1408756  # no release, pick the latest commit
 
 # DeepEP


### PR DESCRIPTION
## Summary
- Update the DeepGEMM third-party wheel commit to 88965b0.
- Remove the stale release-version comment from the DeepGEMM pin.

## Validation
- Syntax check for the touched shell script.
- Diff whitespace check.
- **Verified with Qwen/Qwen3-235B-A22B and Qwen/Qwen3.5-397B-A17B using DP8/EP8.**

## Assistance

Assisted with Codex + GPT-5.5 xHigh Fast, reviewed manually
