### PR TITLE
fix HCCL port conflict on multi-dp rank startup(single node)

### DIFF
--- a/lmdeploy/pytorch/engine/executor/ray_executor.py
+++ b/lmdeploy/pytorch/engine/executor/ray_executor.py
@@ -687,7 +687,7 @@ class RayExecutor(ExecutorBase):
 
         # Single-node PG below.
         if 'ASCEND_RT_VISIBLE_DEVICES' in os.environ:
-            ray.get([w.set_device.remote(idx) for idx, w in enumerate(self.workers)])
+            ray.get([w.set_device.remote(idx + self.rank_offset) for idx, w in enumerate(self.workers)])
         else:
             local_npu_count = torch.npu.device_count()
             if local_npu_count <= 0:


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily receiving feedbacks. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

使用 Ascend NPU 启动 dp=2, tp=4 服务会报错：
```
RuntimeError: createHCCLCommOrigin:... HCCL function error: HcclGetRootInfo(&hcclID), error code is 7
[ERROR] DIST call hccl api failed.
Communication_Error_Bind_IP_Port(EJ0003): Failed to bind the IP port.
Reason: The IP address and port have been bound already.
```

**分析**：

- `attn_tp = world_size // dp = 4 // 2 = 2`（每个 dp_rank 只有 2 个 workers）
- `rank_offset = dp_rank * attn_tp`
  - `dp_rank=0`: `rank_offset=0`，workers 应使用逻辑设备 0, 1
  - `dp_rank=1`: `rank_offset=2`，workers 应使用逻辑设备 2, 3
- bug 代码中两个 dp_rank 的 workers 都被分配到设备 0, 1
- 两个 TP 组同时在同一 NPU 上初始化 HCCL，争抢同一端口 → 冲突


## Modification


在 `ASCEND_RT_VISIBLE_DEVICES` 分支中加回 `self.rank_offset`，与旧代码行为保持一致：

```python
# 修复后
if 'ASCEND_RT_VISIBLE_DEVICES' in os.environ:
    ray.get([w.set_device.remote(idx + self.rank_offset) for idx, w in enumerate(self.workers)])
```

对应旧代码（commit 之前，无 rank table 情况下）：
```python
ray.get([worker.set_device.remote(idx + self.rank_offset) for idx, worker in enumerate(self.workers)])
```

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
