### PR TITLE
Force blksize=128 when head_dim=256 on ascend

### DIFF
--- a/lmdeploy/pytorch/engine/executor/base.py
+++ b/lmdeploy/pytorch/engine/executor/base.py
@@ -239,16 +239,15 @@ class ExecutorBase:
             if self.cache_config.block_size != 64:
                 raise ValueError('Please set block_size to 64 for flash_mla.')
             return
-        # Linear attention requires a kv block size of 128 on ascend.
+        # head_dim=256 requires block_size=128 on ascend.
         # Other models keep the user-provided block size.
-        is_ssm = len(self.model_config.states_shapes) > 0
-        if (self.cache_config.device_type == 'ascend' and is_ssm and
+        if (self.cache_config.device_type == 'ascend' and self.model_config.k_head_dim == 256 and
                 (self.cache_config.block_size != 128 or self.cache_config.kernel_block_size != 128)):
             logger.warning(
                 'Force `block_size=128` and `kernel_block_size=128` '
                 f'(was block_size={self.cache_config.block_size}, '
                 f'kernel_block_size={self.cache_config.kernel_block_size}) '
-                'for linear attention on ascend.')
+                'for head_dim=256 on ascend.')
             self.cache_config.block_size = 128
             self.cache_config.kernel_block_size = 128
             return


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily receiving feedbacks. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

On ascend, when head_dim=256, block size must be 256. Otherwise, it will meet error:

```
  File "/afs-weights/wangqing/qwen35_dev/code_mtp_ppl/dlinfer/dlinfer/ops/llm.py", line 310, in paged_decode_attention
    return vendor_ops_registry["paged_decode_attention"](
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/afs-weights/wangqing/qwen35_dev/code_mtp_ppl/dlinfer/dlinfer/vendor/ascend/torch_npu_ops.py", line 399, in paged_decode_attention
    return decode_attention(
           ^^^^^^^^^^^^^^^^^
  File "/afs-weights/wangqing/qwen35_dev/code_mtp_ppl/dlinfer/dlinfer/vendor/ascend/attention.py", line 70, in decode_attention
    attn_output, _ = torch.ops.npu.npu_fused_infer_attention_score(
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/python3.11.14/lib/python3.11/site-packages/torch/_ops.py", line 1255, in __call__
    return self._op(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
RuntimeError: npu_fused_infer_attention_score_symint:build/CMakeFiles/torch_npu.dir/compiler_depend.ts:415 NPU function error: call aclnnFusedInferAttentionScoreV3 failed, error code is 561002
[ERROR] 2026-06-30-08:24:00 (PID:1722292, Device:0, RankID:0) ERR00100 PTA call acl api failed.
E89999: Inner Error!
E89999[PID: 1722292] 2026-06-30-08:24:00.248.443 (E89999):  When layout is TND, queryD(256), keyD(256) and valueD(256) must be same equal 192/128/64, or queryD and keyD equal 192 and valueD equal 128.[FUNC:CheckInputShapeWhenLayoutIsTND][FILE:prompt_flash_attention_tiling.cpp][LINE:3682]
        TraceBack (most recent call last):
       tiling process for pfa failed[FUNC:TilingFusedInferAttentionScore][FILE:fused_infer_attention_score_tiling.cpp][LINE:1804]
       FusedInferAttentionScore do tiling failed, ret is -1.
       Check NnopbaseExecutorDoTiling(executor) failed
       Check NnopbaseExecutorTilingAndUpdateBinInfo(executor) failed
       Check NnopbaseExecutorMatchCache(executor) failed
       Check NnopbaseRunForWorkspace(*executor, workspaceSize) failed
```

## Modification

Please briefly describe what modification is made in this PR.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
