### PR TITLE
fix: release multimodal payload after mp handoff

### DIFF
--- a/lmdeploy/pytorch/engine/mp_engine/base.py
+++ b/lmdeploy/pytorch/engine/mp_engine/base.py
@@ -153,6 +153,8 @@ class MPEngineInstance(EngineInstanceBase):
                                                                 state.init_done,
                                                                 *args,
                                                                 **kwargs)
+        # The RPC generator captured the request; release this wrapper's multimodal reference.
+        kwargs.pop('multimodal', None)
 
         try:
             async for result in generator:

--- a/lmdeploy/pytorch/engine/mp_engine/ray_engine.py
+++ b/lmdeploy/pytorch/engine/mp_engine/ray_engine.py
@@ -201,6 +201,8 @@ class RayMPEngine(MPEngine):
         """Collective rpc call."""
         # ray generator would try cache every result, which is too verbose.
         stream_task = asyncio.create_task(self._collective_rpc_async('create_stream_task', func, *args, **kwargs))
+        # The startup task captured kwargs; avoid retaining tensors in this streaming wrapper.
+        kwargs.pop('multimodal', None)
 
         def _mark_init_done(task: asyncio.Task):
             init_done.set()

--- a/lmdeploy/pytorch/engine/mp_engine/zmq_engine.py
+++ b/lmdeploy/pytorch/engine/mp_engine/zmq_engine.py
@@ -191,13 +191,14 @@ class ZMQMPEngine(MPEngine):
     async def _collective_rpc_streaming_async(self, func: str, sess_event: asyncio.Event,  *args, **kwargs):
         """Collective rpc call."""
         startup_notify_kwarg = 'notify_add_msg_func' if func == 'instance_async_stream_infer' else None
-        async for out in self.rpc_client.async_stream_call(
-                func,
-                sess_event,
-                *args,
-                streaming_startup_notify_kwarg=startup_notify_kwarg,
-                **kwargs,
-        ):
+        generator = self.rpc_client.async_stream_call(func,
+                                                      sess_event,
+                                                      *args,
+                                                      streaming_startup_notify_kwarg=startup_notify_kwarg,
+                                                      **kwargs)
+        # async_stream_call captured kwargs in its task; this frame no longer needs multimodal data.
+        kwargs.pop('multimodal', None)
+        async for out in generator:
             yield out
 
     async def get_health_status(self):

--- a/lmdeploy/pytorch/engine/mp_engine/zmq_rpc.py
+++ b/lmdeploy/pytorch/engine/mp_engine/zmq_rpc.py
@@ -487,6 +487,8 @@ class AsyncRPCClient:
                 streaming=streaming,
                 streaming_startup_notify_kwarg=_streaming_startup_notify_kwarg,
             ))
+        # The socket payload has been built; do not also keep original tensor refs in kwargs.
+        kwargs.pop('multimodal', None)
 
         try:
             await self.async_socket.send(data)
@@ -519,6 +521,8 @@ class AsyncRPCClient:
                 _streaming_startup_notify_kwarg=streaming_startup_notify_kwarg,
                 **kwargs,
             ))
+        # The startup task captured kwargs; avoid retaining tensors in this streaming wrapper.
+        kwargs.pop('multimodal', None)
         stream_id = None
         stopped = False
 

--- a/lmdeploy/serve/core/async_engine.py
+++ b/lmdeploy/serve/core/async_engine.py
@@ -428,6 +428,8 @@ class AsyncEngine:
     @asynccontextmanager
     async def safe_run(self, handle, session, **kwargs):
         generator = handle.async_stream_infer(session.session_id, **kwargs)
+        # async_stream_infer captured its own kwargs; do not retain large multimodal data here.
+        kwargs.pop('multimodal', None)
 
         async def cleanup_after_exception():
             # Use asyncio.shield to protect cleanup coroutines from being cancelled.
@@ -660,6 +662,8 @@ class AsyncEngine:
                                      sequence_start=sequence_start,
                                      sequence_end=sequence_end,
                                      step=history_len) as gen:
+                # The engine has accepted multimodal data; avoid retaining preprocessed tensors here.
+                prompt_input.pop('multimodal', None)
                 logger.debug(f'[generate] session {session_id} started')
                 hit_stop_token = 0
                 req_stats = RequestStats(prompt_tokens=input_len)  # per-request stats


### PR DESCRIPTION
## Motivation

Large multimodal requests can keep API-server CPU RSS growing under high concurrency. In the Qwen3.5 image backpressure workload, the API process retained large preprocessed multimodal payloads after the request had already been handed off to the PyTorch MP engine path.

## Result

In the 128-concurrency Qwen3.5 image backpressure workload:

| Version | API RSS Behavior |
| --- | --- |
| Baseline `main` | Continued growing under load, observed above 200 GiB in long runs |
| This PR: AsyncEngine + MP streaming-wrapper cleanup | Plateaued around ~38 GiB |

Ablation also confirmed that partial cleanup is insufficient:

| Variant | API RSS Behavior |
| --- | --- |
| AsyncEngine cleanup only | Still grew to ~92 GiB before early stop |
| MP/ZMQ cleanup only | Still grew to ~94 GiB before early stop |
| AsyncEngine + MP/ZMQ cleanup | Plateaued around ~38 GiB |

## Root Cause

The large `multimodal` payload is passed through several async generator / task wrappers:

- `AsyncEngine.generate`
- `AsyncEngine.safe_run`
- `MPEngineInstance.async_stream_infer`
- MP backend streaming wrappers, such as `ZMQMPEngine._collective_rpc_streaming_async`, `RayMPEngine._collective_rpc_streaming_async`, and `AsyncRPCClient.async_stream_call`

Even after the next stage has captured the request, the caller-side `prompt_input` / `kwargs` dictionaries can stay alive in suspended async frames for the lifetime of the streamed response. Those stale references keep large preprocessed image tensors alive in the API process.

Clearing only one side is insufficient: the API-side and MP wrapper-side references both need to be released after handoff.

## Changes

- Release `multimodal` from `AsyncEngine` after inference handoff.
- Release `multimodal` from MP streaming wrapper frames after the RPC generator/task is created.

## Validation

- Compile check for touched runtime files.
- Real Qwen3.5 multimodal backpressure reproduction confirmed API RSS plateau with the combined fix.

## Assistance

Assisted with Codex + GPT-5.5 xHigh Fast, reviewed manually
