### PR TITLE
fix: proper XGrammar integration for guided decoding

### DIFF
--- a/lmdeploy/pytorch/engine/guided_process.py
+++ b/lmdeploy/pytorch/engine/guided_process.py
@@ -17,6 +17,15 @@ class GuidedDecodingManager:
         if vocab_size is None:
             vocab_size = tokenizer.vocab_size
 
+        # vocab_size must include all token IDs the model can produce (EOS, special tokens).
+        # Some models have vocab_size < len(tokenizer), causing EOS to be out of bitmask range.
+        tokenizer_vocab_len = len(tokenizer)
+        if tokenizer_vocab_len > vocab_size:
+            logger.info(f'GuidedDecodingManager: expanding vocab_size from {vocab_size} '
+                        f'to {tokenizer_vocab_len}')
+            vocab_size = tokenizer_vocab_len
+
+        # XGrammar will automatically detect stop tokens from the tokenizer
         tokenizer_info = xgr.TokenizerInfo.from_huggingface(tokenizer, vocab_size=vocab_size)
         self.compiler = xgr.GrammarCompiler(tokenizer_info)
         self.vocab_size = vocab_size
@@ -72,7 +81,7 @@ class GuidedDecodingManager:
         else:
             assert False, f'Do not support schema type {type}'
 
-        processor = xgr.GrammarMatcher(compiled, terminate_without_stop_token=True)
+        processor = xgr.GrammarMatcher(compiled)
         self.processors.setdefault(session_id, {})[seq_id] = processor
         logger.info(f'create guided processor for session_id={session_id}, seq_id={seq_id}, and '
                     f'total_processors={len(self.processors)}')
@@ -92,6 +101,9 @@ class GuidedDecodingManager:
 
     def accept_token(self, processor: xgr.GrammarMatcher, token: int) -> None:
         processor.accept_token(token)
+
+    def is_terminated(self, processor: xgr.GrammarMatcher) -> bool:
+        return processor.is_terminated()
 
     def apply_batched_bitmap(self, logits: torch.Tensor, guided_bitmask: torch.Tensor) -> None:
         device = logits.device

--- a/lmdeploy/pytorch/engine/logits_process.py
+++ b/lmdeploy/pytorch/engine/logits_process.py
@@ -352,12 +352,16 @@ class FusedLogitsProcessor:
             await asyncio.sleep(0)
 
     def _fill_guided_bitmask(self, guided_bitmask: torch.Tensor):
+        guided_bitmask.data.fill_(-1)
         for i, processor in self.guided_processors.items():
-            self.guided_decoding_manager.fill_bitmap(processor, guided_bitmask, i)
+            if not self.guided_decoding_manager.is_terminated(processor):
+                self.guided_decoding_manager.fill_bitmap(processor, guided_bitmask, i)
 
     def _accept_guided_tokens(self, next_token_ids: torch.Tensor):
         cpu_result = next_token_ids.tolist()
         for i, processor in self.guided_processors.items():
+            if self.guided_decoding_manager.is_terminated(processor):
+                continue
             self.guided_decoding_manager.accept_token(processor, cpu_result[i])
 
     async def accept_guided_tokens(self, next_token_ids: torch.Tensor):

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -20,4 +20,4 @@ shortuuid
 tiktoken
 transformers >= 4.56.0, != 5.0.*, != 5.1.*, != 5.2.*, != 5.3.*, != 5.4.*, != 5.5.0, !=5.7.*, !=5.8.*, !=5.9.*
 uvicorn
-xgrammar
+xgrammar >= 0.1.33


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily receiving feedbacks. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Due to xgrammar upgrade, lmdeploy unit tests are failing. This PR fixes the XGrammar integration issues to ensure compatibility with the latest xgrammar version.

## Modification

This PR makes the following modifications to properly integrate with XGrammar:

### 1. vocab_size expansion
- Expand `vocab_size` to `len(tokenizer)` to include all token IDs (EOS, special tokens)
- Some models have `vocab_size < len(tokenizer)`, causing EOS tokens to be out of bitmask range
- Added logic to detect and expand vocab_size when necessary

### 2. Remove terminate_without_stop_token parameter
- Removed `terminate_without_stop_token=True` parameter from GrammarMatcher initialization
- XGrammar now automatically detects stop tokens from the tokenizer

### 3. Add is_terminated checks
- Added `is_terminated()` method to GuidedDecodingManager
- Added `is_terminated()` check before `fill_bitmap()` to prevent operations on terminated processors
- Added `is_terminated()` check before `accept_token()` to safely handle terminated processors

## BC-breaking (Optional)

None. This change maintains backward compatibility while fixing integration issues with the latest xgrammar version.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues. ✓
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness. (Tests exist in test_grammar.py)
3. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.

**Note**: This fix is cherry-picked from commit 2b118c5858fee3af0ccc999bd25bad44d425c0e4 on the mtp-guided branch, adapted for the main branch.