### PR TITLE
refactor(pytorch): clarify scheduler and input-maker control flow

### DIFF
--- a/lmdeploy/pytorch/engine/inputs_maker.py
+++ b/lmdeploy/pytorch/engine/inputs_maker.py
@@ -8,7 +8,7 @@ metadata, dispatches it to the executor, and updates local running state.
 """
 import logging
 from collections import defaultdict
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -209,6 +209,396 @@ class LongContextChunker:
             self.clear()
 
 
+@dataclass
+class _ForwardInputsState:
+    """Mutable branch state for one ``_ForwardInputsTask.run()`` call.
+
+    ``_ForwardInputsTask`` may try several mutually exclusive work sources
+    before it produces a forward payload: active long-context continuation,
+    waiting prefill, decode, and retry paths after a deferred long chunk. These
+    flags record which branches have already been attempted so the fallback
+    checks can preserve the original scheduling order without threading many
+    local variables through the helper calls.
+
+    Args:
+        prefill: Caller-selected top-level mode from ``do_prefill()``. Decode
+            fallback sets this to ``False`` after a decode turn is chosen.
+        enable_empty: Forwarded from prefetch/send code for parity with the
+            existing call signature. It is currently diagnostic only and does
+            not allow empty payloads.
+        active_chunk_deferred: Whether an active long-context chunk yielded at
+            the start of this task and may be retried after decode or a
+            short-prefill opportunity.
+        tried_long_work: Whether this task has already tried a
+            long-context continuation or a waiting-long-prefill lane.
+        tried_short_prefill: Whether this task has already called
+            ``_try_short_prefill()``. Here "short" means the non-long-prefill
+            lane selected with ``allow_long_prefill=False``.
+        active_chunk_blocked_by_kv: Whether active chunk reservation failed
+            because KV is pinned by running work. In that case the task should
+            let decode drain resources instead of admitting short prefill.
+    """
+
+    prefill: bool
+    enable_empty: bool = False
+    active_chunk_deferred: bool = False
+    tried_long_work: bool = False
+    tried_short_prefill: bool = False
+    active_chunk_blocked_by_kv: bool = False
+
+
+@dataclass
+class _ForwardInputsResult:
+    """Selected work and payload fragments for one executor forward."""
+
+    running: 'SeqList' = field(default_factory=list)
+    inputs: ModelInputs | None = None
+    delta: ModelInputsDelta | None = None
+    extra_inputs: object | None = None
+    swap_in_map: dict = field(default_factory=dict)
+    swap_out_map: dict = field(default_factory=dict)
+
+    def is_empty(self):
+        return self.inputs is None and self.delta is None
+
+    def set_work(self,
+                 running: 'SeqList',
+                 inputs: ModelInputs | None,
+                 delta: ModelInputsDelta | None,
+                 extra_inputs: object | None):
+        """Replace forward work while preserving scheduler swap maps."""
+        self.running = running
+        self.inputs = inputs
+        self.delta = delta
+        self.extra_inputs = extra_inputs
+
+
+class _ForwardInputsTask:
+    """Per-call state machine for selecting the next forward payload."""
+
+    def __init__(self,
+                 maker: 'InputsMakerAsync',
+                 prefill: bool,
+                 enable_empty: bool = False):
+        self.maker = maker
+        self.scheduler = maker.scheduler
+        self.state = _ForwardInputsState(prefill=prefill, enable_empty=enable_empty)
+        self.result = _ForwardInputsResult()
+
+    def run(self):
+        """Select one executor forward while preserving scheduling order.
+
+        The branch order is part of the opt-TTFT long-context policy:
+        1. Pick the primary lane from the active chunker or ``do_prefill()``.
+        2. Let failed waiting-long work fall back to short prefill, while
+           active-chunk KV pressure falls through to decode.
+        3. Try decode when no prefill/chunk payload was selected.
+        4. For deferred active chunks, decode gets the first chance. If decode
+           produces no payload, spend the still-unused short-prefill chance
+           before retrying the chunk.
+        """
+        maker = self.maker
+        state = self.state
+        logger.debug(f'Make forward inputs with prefill={state.prefill}, '
+                     f'enable_empty={state.enable_empty}')
+
+        # 1. Pick the primary lane for this loop. Active chunks are
+        # engine-local runnable work, so they are considered before waiting
+        # scheduler prefill. Without an active chunk, honor do_prefill().
+        maker.long_context_chunker.check_enable()
+        if maker.long_context_chunker.enabled():
+            self._select_active_chunk_work()
+        elif state.prefill:
+            self._select_prefill_work()
+
+        # 2. Waiting-long admission failure can still fall back to short
+        # prefill. Active chunk reservation failure means KV is pinned by
+        # running work; let decode drain blocks instead of admitting more
+        # prefill.
+        if self._can_fallback_to_short_prefill():
+            self._try_short_prefill()
+
+        # 3. If no prefill/chunk payload was selected, run decode so active
+        # requests make progress and can release cache pressure.
+        if self._can_try_decode():
+            self._try_decode()
+
+        # 4. Stage 1 only marked the active chunk as deferred; it did not try
+        # short prefill. Stage 3 gave decode the first chance. If decode
+        # produced no payload and the long-work turn is still not due, spend
+        # the still-unused short/normal-prefill chance before retrying the
+        # deferred chunk.
+        if self._can_try_short_after_defer():
+            self._try_short_prefill()
+
+        if self._can_retry_deferred_chunk():
+            self._try_active_chunk()
+
+        # A non-decode payload satisfies the prefill side of the starvation
+        # guard, so future do_prefill() calls can count decode rounds again.
+        if self.result.inputs is not None and not self.result.inputs.is_decoding:
+            maker._decode_count = 0
+
+        if self.result.is_empty():
+            return None
+        return self._build_payload()
+
+    def _select_active_chunk_work(self):
+        if self._should_defer_active_chunk():
+            self.state.active_chunk_deferred = True
+        elif self._should_try_short_prefill_first():
+            # After a decode turn, keep the short/normal prefill quota in front
+            # of active long chunks; otherwise decode -> long can repeat and
+            # small waiting requests remain gated by the active chunker even
+            # while the long-work turn is not due.
+            self._try_short_prefill()
+            if self.result.is_empty():
+                self._try_active_chunk()
+        else:
+            self._try_active_chunk()
+
+    def _should_defer_active_chunk(self):
+        """Check whether the active long-context chunk should yield this loop."""
+        maker = self.maker
+        if maker.config.role == EngineRole.Prefill:
+            return False
+        if not maker.long_context_chunker.enabled():
+            return False
+        if maker.long_context_chunker.is_last_chunk():
+            if len(maker.running_seqs) == 0:
+                return False
+            return not self.state.prefill
+        return getattr(maker, '_last_forward_kind', None) == 'long_context_chunk'
+
+    def _should_try_short_prefill_first(self):
+        """Allow short/normal prefill quota before an active non-final chunk."""
+        maker = self.maker
+        if maker.long_context_chunker.is_last_chunk():
+            return False
+        if not self.scheduler.has_waiting():
+            return False
+        return not maker._is_long_context_chunk_turn_due()
+
+    def _select_prefill_work(self):
+        maker = self.maker
+        has_waiting_long_prefill = self.scheduler.has_waiting_long_prefill()
+        if has_waiting_long_prefill and not maker._is_long_context_chunk_turn_due():
+            self._try_short_prefill()
+            if self.result.is_empty():
+                self.state.tried_long_work = True
+                self.result = self._schedule_prefill(prefer_long_prefill=True)
+        else:
+            self.result = self._schedule_prefill(prefer_long_prefill=has_waiting_long_prefill)
+            self.state.tried_long_work = has_waiting_long_prefill
+
+    def _can_fallback_to_short_prefill(self):
+        if self.state.active_chunk_blocked_by_kv and not self.state.tried_long_work:
+            logger.warning('Unexpected forward-input state: active long-context chunk is marked '
+                           'KV-blocked before long work was attempted.')
+        if self.state.active_chunk_deferred and self.state.tried_long_work:
+            logger.warning('Unexpected forward-input state: active long-context chunk was both '
+                           'deferred and attempted in the primary lane.')
+        if not self.result.is_empty():
+            return False
+        if not self.state.tried_long_work:
+            return False
+        if self.state.active_chunk_blocked_by_kv:
+            return False
+        if self.state.tried_short_prefill:
+            return False
+        return self.scheduler.has_waiting()
+
+    def _can_try_decode(self):
+        maker = self.maker
+        if self.result.inputs is not None:
+            return False
+        if self.result.delta is not None:
+            logger.warning('Unexpected forward-input state: decode fallback reached after a '
+                           'delta-only payload was already selected.')
+            return False
+        if len(maker.running_seqs) == 0:
+            return False
+        return maker.config.role != EngineRole.Prefill
+
+    def _can_try_short_after_defer(self):
+        if not self.result.is_empty():
+            return False
+        if not self.state.active_chunk_deferred:
+            return False
+        if self.state.tried_short_prefill:
+            logger.warning('Unexpected forward-input state: deferred active chunk is trying '
+                           'short prefill after short/normal prefill was already attempted.')
+            return False
+        if self.state.active_chunk_blocked_by_kv:
+            logger.warning('Unexpected forward-input state: deferred active chunk is also '
+                           'marked KV-blocked.')
+            return False
+        if self.maker._is_long_context_chunk_turn_due():
+            return False
+        return self.scheduler.has_waiting()
+
+    def _can_retry_deferred_chunk(self):
+        if not self.result.is_empty():
+            return False
+        if not self.state.active_chunk_deferred:
+            return False
+        if not self.maker.long_context_chunker.enabled():
+            logger.warning('Unexpected forward-input state: active long-context chunk was '
+                           'deferred but the chunker is no longer enabled.')
+            return False
+        return True
+
+    def _try_short_prefill(self):
+        self.state.tried_short_prefill = True
+        self.result = self._schedule_prefill(allow_long_prefill=False)
+        if not self.result.is_empty():
+            self.maker._short_prefill_turns_since_long_chunk += 1
+
+    def _try_active_chunk(self):
+        self.state.tried_long_work = True
+        result = self._build_active_chunk()
+        self.state.active_chunk_blocked_by_kv = result.is_empty()
+        self.result.set_work(result.running, result.inputs, result.delta, result.extra_inputs)
+
+    def _try_decode(self):
+        maker = self.maker
+        self.state.prefill = False
+        delta, running, invalid_seqs = maker.create_model_inputs_delta()
+        maker.to_evict_seqs = invalid_seqs
+        self.result.set_work(running, None, delta, None)
+
+    def _schedule_prefill(self,
+                          allow_long_prefill: bool = True,
+                          prefer_long_prefill: bool = False):
+        maker = self.maker
+        if maker.config.role == EngineRole.Prefill:
+            prealloc_size = 0
+        else:
+            prealloc_size = maker.engine_strategy.get_prealloc_size(True)
+        scheduler_output = self.scheduler.schedule(is_prefill=True,
+                                                   prealloc_size=prealloc_size,
+                                                   allow_long_prefill=allow_long_prefill,
+                                                   prefer_long_prefill=prefer_long_prefill)
+        running = scheduler_output.running
+        result = _ForwardInputsResult(running=running,
+                                      swap_in_map=scheduler_output.swap_in_map,
+                                      swap_out_map=scheduler_output.swap_out_map)
+
+        if len(running) == 1 and maker.long_context_chunker.is_long_context(running[0]):
+            maker.long_context_chunker.set_seq(running[0])
+            if maker.long_context_chunker.is_last_chunk():
+                # A prefix-cache restore can skip past a large multimodal
+                # span, leaving a tail that fits the multimodal-expanded chunk
+                # limit.  Treat it as normal prefill so the model sees the same
+                # single tail chunk as the no-cache path.  Do not set chunk
+                # flags here: spec decoding uses them as a cross-chunk carry
+                # protocol.
+                maker.long_context_chunker.clear()
+                result.inputs, result.delta, result.extra_inputs = self._build_prefill_inputs(running)
+            else:
+                chunk_size, multimodals = maker.long_context_chunker.next_chunk_size()
+                result.inputs, result.extra_inputs = self._build_chunk_inputs(running, chunk_size, multimodals)
+                result.inputs.is_first_chunk = True
+                result.inputs.is_chunk_multimodal = maker.long_context_chunker.has_multimodal
+                maker._short_prefill_turns_since_long_chunk = 0
+        elif len(running) > 0:
+            result.inputs, result.delta, result.extra_inputs = self._build_prefill_inputs(running)
+        return result
+
+    def _build_active_chunk(self):
+        maker = self.maker
+        seq = maker.long_context_chunker.seq
+        chunk_size, multimodals = maker.long_context_chunker.next_chunk_size()
+        is_last_chunk = maker.long_context_chunker.is_last_chunk()
+        is_chunk_multimodal = maker.long_context_chunker.has_multimodal
+        if not self._reserve_chunk(seq, chunk_size, is_last_chunk):
+            return _ForwardInputsResult()
+
+        running = [seq]
+        if is_last_chunk:
+            inputs, delta, extra_inputs = self._build_prefill_inputs(running)
+            inputs.is_chunk = True
+            inputs.is_last_chunk = True
+            maker.long_context_chunker.clear()
+        else:
+            inputs, extra_inputs = self._build_chunk_inputs(running, chunk_size, multimodals)
+            delta = None
+        inputs.is_first_chunk = False
+        inputs.is_chunk_multimodal = is_chunk_multimodal
+        maker._short_prefill_turns_since_long_chunk = 0
+        return _ForwardInputsResult(running=running,
+                                    inputs=inputs,
+                                    delta=delta,
+                                    extra_inputs=extra_inputs)
+
+    def _reserve_chunk(self,
+                       seq: 'SchedulerSequence',
+                       chunk_size: int,
+                       is_last_chunk: bool):
+        maker = self.maker
+        if maker.config.role == EngineRole.Prefill:
+            prealloc_size = 0
+        elif is_last_chunk:
+            prealloc_size = maker.engine_strategy.get_prealloc_size(True)
+        else:
+            prealloc_size = 0
+        return self.scheduler.reserve_long_context_chunk(seq,
+                                                         chunk_size,
+                                                         prealloc_size=prealloc_size,
+                                                         is_last_chunk=is_last_chunk)
+
+    def _build_prefill_inputs(self, seqs: 'SeqList'):
+        maker = self.maker
+        inputs = maker.create_model_inputs(seqs, True)
+        delta, valid_seqs, _ = maker.create_model_inputs_delta_valid_only()
+        maker.running_seqs = valid_seqs
+        extra_inputs = maker.model_agent_strategy.make_extra_inputs(seqs, inputs)
+        return inputs, delta, extra_inputs
+
+    def _build_chunk_inputs(self,
+                            running: 'SeqList',
+                            chunk_size: int,
+                            multimodals: 'MultiModalInputs|None'):
+        maker = self.maker
+        inputs = maker.create_model_inputs_long_context(running[0], chunk_size, multimodals)
+        extra_inputs = maker.model_agent_strategy.make_extra_inputs(running, inputs)
+        return inputs, extra_inputs
+
+    def _need_logits(self):
+        if self.maker.spec_decoding:
+            return True
+        return any(seq.return_logits for seq in self.result.running)
+
+    def _need_routed_experts(self):
+        return any(seq.return_routed_experts for seq in self.result.running)
+
+    def _need_ce_loss(self):
+        return any(seq.return_ce_loss for seq in self.result.running)
+
+    def _build_payload(self):
+        maker = self.maker
+        result = self.result
+        sampling_inputs = maker.sampling_strategy.make_sampling_inputs(result.running)
+        if result.inputs is not None:
+            stopping_criteria = maker.model_agent_strategy.make_stopping_criteria(result.running)
+        else:
+            stopping_criteria = None
+
+        return dict(
+            running=result.running,
+            inputs=result.inputs,
+            delta=result.delta,
+            swap_in_map=result.swap_in_map,
+            swap_out_map=result.swap_out_map,
+            sampling_inputs=sampling_inputs,
+            stopping_criteria=stopping_criteria,
+            return_logits=self._need_logits(),
+            extra_inputs=result.extra_inputs,
+            return_routed_experts=self._need_routed_experts(),
+            return_ce_loss=self._need_ce_loss(),
+        )
+
+
 class InputsMakerAsync:
     """Coordinate prefill, decode, and long-context input dispatch.
 
@@ -305,19 +695,6 @@ class InputsMakerAsync:
         """Check whether engine-local long-context chunk work can run."""
         self.long_context_chunker.check_enable()
         return self.long_context_chunker.enabled()
-
-    def _should_defer_long_context_chunk(self, prefill: bool):
-        """Check whether the active long-context chunk should yield this
-        loop."""
-        if self.config.role == EngineRole.Prefill:
-            return False
-        if not self.long_context_chunker.enabled():
-            return False
-        if self.long_context_chunker.is_last_chunk():
-            if len(self.running_seqs) == 0:
-                return False
-            return not prefill
-        return getattr(self, '_last_forward_kind', None) == 'long_context_chunk'
 
     def _is_long_context_chunk_turn_due(self):
         """Check if active long chunk should run before another short
@@ -756,298 +1133,7 @@ class InputsMakerAsync:
     @record_function('make_forward_inputs')
     def _make_forward_inputs(self, prefill: bool, enable_empty: bool = False):
         """Make forward inputs for ModelAgent._async_step_background()"""
-
-        def __need_logits(seqs: 'SeqList'):
-            """Need logits."""
-            if self.spec_decoding:
-                return True
-            return any(seq.return_logits for seq in seqs)
-
-        def __need_routed_experts(seqs: 'SeqList'):
-            """Need routed experts."""
-            return any(seq.return_routed_experts for seq in seqs)
-
-        def __need_ce_loss(seqs: 'SeqList'):
-            """Need input cross-entropy loss."""
-            return any(seq.return_ce_loss for seq in seqs)
-
-        def __create_model_inputs(seqs):
-            """Createe model inputs."""
-            inputs = self.create_model_inputs(seqs, True)
-            delta, valid_seqs, _ = self.create_model_inputs_delta_valid_only()
-            self.running_seqs = valid_seqs
-            extra_inputs = self.model_agent_strategy.make_extra_inputs(seqs, inputs)
-            return inputs, delta, extra_inputs
-
-        def __create_inputs_chunk(running: 'SeqList', chunk_size: int, multimodals: 'MultiModalInputs|None'):
-            inputs = self.create_model_inputs_long_context(running[0], chunk_size, multimodals)
-            extra_inputs = self.model_agent_strategy.make_extra_inputs(running, inputs)
-            return inputs, extra_inputs
-
-        def __reserve_long_context_chunk(seq: 'SchedulerSequence', chunk_size: int, is_last_chunk: bool):
-            if self.config.role == EngineRole.Prefill:
-                prealloc_size = 0
-            elif is_last_chunk:
-                prealloc_size = self.engine_strategy.get_prealloc_size(True)
-            else:
-                prealloc_size = 0
-            return scheduler.reserve_long_context_chunk(seq,
-                                                        chunk_size,
-                                                        prealloc_size=prealloc_size,
-                                                        is_last_chunk=is_last_chunk)
-
-        def __create_inputs_long_context_chunk():
-            seq = self.long_context_chunker.seq
-            chunk_size, multimodals = self.long_context_chunker.next_chunk_size()
-            is_last_chunk = self.long_context_chunker.is_last_chunk()
-            is_chunk_multimodal = self.long_context_chunker.has_multimodal
-            if not __reserve_long_context_chunk(seq, chunk_size, is_last_chunk):
-                return [], None, None, None
-            running = [seq]
-            if is_last_chunk:
-                inputs, delta, extra_inputs = __create_model_inputs(running)
-                inputs.is_chunk = True
-                inputs.is_last_chunk = True
-                self.long_context_chunker.clear()
-            else:
-                inputs, extra_inputs = __create_inputs_chunk(running, chunk_size, multimodals)
-                delta = None
-            inputs.is_first_chunk = False
-            inputs.is_chunk_multimodal = is_chunk_multimodal
-            self._short_prefill_turns_since_long_chunk = 0
-            return running, inputs, delta, extra_inputs
-
-        def __create_inputs_prefill(allow_long_prefill: bool = True, prefer_long_prefill: bool = False):
-            if self.config.role == EngineRole.Prefill:
-                prealloc_size = 0
-            else:
-                prealloc_size = self.engine_strategy.get_prealloc_size(True)
-            scheduler_output = scheduler.schedule(is_prefill=True,
-                                                  prealloc_size=prealloc_size,
-                                                  allow_long_prefill=allow_long_prefill,
-                                                  prefer_long_prefill=prefer_long_prefill)
-            running = scheduler_output.running
-            swap_in_map = scheduler_output.swap_in_map
-            swap_out_map = scheduler_output.swap_out_map
-
-            inputs = None
-            delta = None
-            extra_inputs = None
-            if len(running) == 1 and self.long_context_chunker.is_long_context(running[0]):
-                # set long context chunker
-                self.long_context_chunker.set_seq(running[0])
-                if self.long_context_chunker.is_last_chunk():
-                    # A prefix-cache restore can skip past a large multimodal
-                    # span, leaving a tail that fits the multimodal-expanded
-                    # chunk limit.  Treat it as normal prefill so the model sees
-                    # the same single tail chunk as the no-cache path.  Do not
-                    # set chunk flags here: spec decoding uses them as a
-                    # cross-chunk carry protocol.
-                    self.long_context_chunker.clear()
-                    inputs, delta, extra_inputs = __create_model_inputs(running)
-                else:
-                    chunk_size, multimodals = self.long_context_chunker.next_chunk_size()
-                    inputs, extra_inputs = __create_inputs_chunk(running, chunk_size, multimodals)
-                    inputs.is_first_chunk = True
-                    inputs.is_chunk_multimodal = self.long_context_chunker.has_multimodal
-                    self._short_prefill_turns_since_long_chunk = 0
-            elif len(running) > 0:
-                # create inputs
-                inputs, delta, extra_inputs = __create_model_inputs(running)
-            return running, inputs, delta, extra_inputs, swap_in_map, swap_out_map
-
-        def __create_short_or_normal_prefill_turn():
-            nonlocal attempted_short_or_normal_prefill
-            attempted_short_or_normal_prefill = True
-            result = __create_inputs_prefill(allow_long_prefill=False)
-            _, prefill_inputs, prefill_delta, _, _, _ = result
-            if prefill_inputs is not None or prefill_delta is not None:
-                self._short_prefill_turns_since_long_chunk += 1
-            return result
-
-        def __is_empty_forward(forward_inputs: 'ModelInputs|None', forward_delta: 'ModelInputsDelta|None'):
-            return forward_inputs is None and forward_delta is None
-
-        def __try_active_long_context_chunk():
-            nonlocal attempted_long_work
-            nonlocal active_long_chunk_blocked_by_kv
-            attempted_long_work = True
-            result = __create_inputs_long_context_chunk()
-            _, chunk_inputs, chunk_delta, _ = result
-            active_long_chunk_blocked_by_kv = __is_empty_forward(chunk_inputs, chunk_delta)
-            return result
-
-        def __should_try_short_prefill_before_active_chunk():
-            """Allow short/normal prefill quota before an active non-final
-            chunk."""
-            if self.long_context_chunker.is_last_chunk():
-                return False
-            if not scheduler.has_waiting():
-                return False
-            return not self._is_long_context_chunk_turn_due()
-
-        def __has_no_forward():
-            return __is_empty_forward(inputs, delta)
-
-        def __can_fallback_to_short_after_long_work():
-            if not __has_no_forward():
-                return False
-            if not attempted_long_work:
-                return False
-            if active_long_chunk_blocked_by_kv:
-                return False
-            if attempted_short_or_normal_prefill:
-                return False
-            return scheduler.has_waiting()
-
-        def __can_try_short_prefill_after_defer():
-            if not __has_no_forward():
-                return False
-            if not deferred_long_context_chunk:
-                return False
-            if self._is_long_context_chunk_turn_due():
-                return False
-            return scheduler.has_waiting()
-
-        def __can_retry_deferred_active_chunk():
-            return __has_no_forward() and deferred_long_context_chunk and self.long_context_chunker.enabled()
-
-        scheduler = self.scheduler
-        logger.debug(f'Make forward inputs with prefill={prefill}, enable_empty={enable_empty}')
-
-        inputs = None
-        delta = None
-        running = []
-        extra_inputs = None
-        swap_in_map = {}
-        swap_out_map = {}
-        deferred_long_context_chunk = False
-        attempted_long_work = False
-        attempted_short_or_normal_prefill = False
-        active_long_chunk_blocked_by_kv = False
-
-        # Bounded opt-TTFT prefill policy: protect decode before continuing
-        # non-final long chunks, then allow a bounded number of short/normal
-        # prefill turns before forcing one long-work turn. A long-work turn
-        # continues the active chunker first, otherwise it admits one waiting
-        # long prefill through the scheduler.
-        self.long_context_chunker.check_enable()
-        if self.long_context_chunker.enabled():
-            if self._should_defer_long_context_chunk(prefill):
-                deferred_long_context_chunk = True
-            elif __should_try_short_prefill_before_active_chunk():
-                # After a decode turn, keep the short/normal prefill quota in
-                # front of active long chunks; otherwise decode -> long can
-                # repeat and small waiting requests remain gated by the active
-                # chunker even while the long-work turn is not due.
-                (
-                    running,
-                    inputs,
-                    delta,
-                    extra_inputs,
-                    swap_in_map,
-                    swap_out_map,
-                ) = __create_short_or_normal_prefill_turn()
-                if __is_empty_forward(inputs, delta):
-                    running, inputs, delta, extra_inputs = __try_active_long_context_chunk()
-            else:
-                running, inputs, delta, extra_inputs = __try_active_long_context_chunk()
-        elif prefill:
-            # prefill
-            has_waiting_long_prefill = scheduler.has_waiting_long_prefill()
-            if has_waiting_long_prefill and not self._is_long_context_chunk_turn_due():
-                (
-                    running,
-                    inputs,
-                    delta,
-                    extra_inputs,
-                    swap_in_map,
-                    swap_out_map,
-                ) = __create_short_or_normal_prefill_turn()
-                if __has_no_forward():
-                    (
-                        running,
-                        inputs,
-                        delta,
-                        extra_inputs,
-                        swap_in_map,
-                        swap_out_map,
-                    ) = __create_inputs_prefill(prefer_long_prefill=True)
-            else:
-                (
-                    running,
-                    inputs,
-                    delta,
-                    extra_inputs,
-                    swap_in_map,
-                    swap_out_map,
-                ) = __create_inputs_prefill(prefer_long_prefill=has_waiting_long_prefill)
-                attempted_long_work = has_waiting_long_prefill
-
-        # Waiting-long admission failure can still fall back to short prefills.
-        # Active-long reservation failure means KV is pinned by running work;
-        # admit decode only so existing requests can drain blocks.
-        if __can_fallback_to_short_after_long_work():
-            (
-                running,
-                inputs,
-                delta,
-                extra_inputs,
-                swap_in_map,
-                swap_out_map,
-            ) = __create_short_or_normal_prefill_turn()
-
-        # try decoding
-        if inputs is None and len(self.running_seqs) > 0 and self.config.role != EngineRole.Prefill:
-            prefill = False
-            delta, running, invalid_seqs = self.create_model_inputs_delta()
-            self.to_evict_seqs = invalid_seqs
-            extra_inputs = None
-
-        if __can_try_short_prefill_after_defer():
-            (
-                running,
-                inputs,
-                delta,
-                extra_inputs,
-                swap_in_map,
-                swap_out_map,
-            ) = __create_short_or_normal_prefill_turn()
-
-        if __can_retry_deferred_active_chunk():
-            running, inputs, delta, extra_inputs = __try_active_long_context_chunk()
-
-        # reset decode count when non-decoding inputs are produced
-        if inputs is not None and not inputs.is_decoding:
-            self._decode_count = 0
-
-        # skip if enable empty
-        if inputs is None and delta is None:
-            return None
-
-        sampling_inputs = self.sampling_strategy.make_sampling_inputs(running)
-        if inputs is not None:
-            stopping_criteria = self.model_agent_strategy.make_stopping_criteria(running)
-        else:
-            stopping_criteria = None
-
-        return_logits = __need_logits(running)
-        return_routed_experts = __need_routed_experts(running)
-        return_ce_loss = __need_ce_loss(running)
-
-        return dict(
-            running=running,
-            inputs=inputs,
-            delta=delta,
-            swap_in_map=swap_in_map,
-            swap_out_map=swap_out_map,
-            sampling_inputs=sampling_inputs,
-            stopping_criteria=stopping_criteria,
-            return_logits=return_logits,
-            extra_inputs=extra_inputs,
-            return_routed_experts=return_routed_experts,
-            return_ce_loss=return_ce_loss,
-        )
+        return _ForwardInputsTask(self, prefill, enable_empty).run()
 
     def do_prefill_pnode(self):
         return True

--- a/lmdeploy/pytorch/engine/inputs_maker.py
+++ b/lmdeploy/pytorch/engine/inputs_maker.py
@@ -358,7 +358,8 @@ class _ForwardInputsTask:
             self._try_active_chunk()
 
     def _should_defer_active_chunk(self):
-        """Check whether the active long-context chunk should yield this loop."""
+        """Check whether the active long-context chunk should yield this
+        loop."""
         maker = self.maker
         if maker.config.role == EngineRole.Prefill:
             return False
@@ -371,7 +372,8 @@ class _ForwardInputsTask:
         return getattr(maker, '_last_forward_kind', None) == 'long_context_chunk'
 
     def _should_try_short_prefill_first(self):
-        """Allow short/normal prefill quota before an active non-final chunk."""
+        """Allow short/normal prefill quota before an active non-final
+        chunk."""
         maker = self.maker
         if maker.long_context_chunker.is_last_chunk():
             return False

--- a/lmdeploy/pytorch/engine/inputs_maker.py
+++ b/lmdeploy/pytorch/engine/inputs_maker.py
@@ -17,6 +17,12 @@ from torch.profiler import record_function
 
 from lmdeploy.pytorch import envs as _envs
 from lmdeploy.pytorch.disagg.config import EngineRole
+from lmdeploy.pytorch.long_context import (
+    get_long_context_chunk_limit,
+    has_long_context_multimodal,
+    plan_long_context_chunk,
+    sort_long_context_multimodals,
+)
 from lmdeploy.pytorch.messages import MessageStatus
 from lmdeploy.pytorch.model_inputs import ModelInputs, ModelInputsDelta, VisionModelInputs
 from lmdeploy.utils import get_logger
@@ -145,37 +151,11 @@ class LongContextChunker:
         self.seq = seq
         self.next_step = seq.num_history_ids
 
-        max_prefill_num = self.max_prefill_token_num
         input_mm = seq.get_input_multimodals()
-        mm_for_chunk_limit = seq.get_chunk_limit_multimodals()
-        self.multimodals = defaultdict(list)
-
-        for value in mm_for_chunk_limit.values():
-            max_mm_size = max([v.end - v.start for v in value], default=0)
-            max_prefill_num = max(max_prefill_num, max_mm_size)
-
-        has_multimodal = False
-        for key, value in input_mm.items():
-            # Only remaining multimodals are emitted by next_chunk_size().
-            value = sorted(value, key=lambda x: x.start)
-            self.multimodals[key] = value
-
-            has_multimodal = has_multimodal or len(value) > 0
-
-        self.max_prefill_num = max_prefill_num
-        self.has_multimodal = has_multimodal
-
-    def multimodal_iter(self):
-        """Multimodal iterator."""
-        multimodal_data = []
-        for modal_type, modal_datas in self.multimodals.items():
-            if len(modal_datas) == 0:
-                continue
-            multimodal_data += [(modal_type, data) for data in modal_datas]
-
-        multimodal_data = sorted(multimodal_data, key=lambda x: x[1].start)
-        for modal_type, data in multimodal_data:
-            yield modal_type, data
+        # Only remaining multimodals are emitted by next_chunk_size().
+        self.multimodals = sort_long_context_multimodals(input_mm)
+        self.max_prefill_num = get_long_context_chunk_limit(seq, self.max_prefill_token_num)
+        self.has_multimodal = has_long_context_multimodal(self.multimodals)
 
     def next_chunk_size(self):
         """Get the next chunk size and its remaining multimodal payloads."""
@@ -183,33 +163,8 @@ class LongContextChunker:
         if seq is None:
             return 0, None
 
-        llm_chunk_size = min(seq.num_token_ids, self.max_prefill_num)
-
-        if len(self.multimodals) == 0:
-            # no vlm inputs found
-            return llm_chunk_size, None
-
-        start = seq.num_history_ids
-        end = start + llm_chunk_size
-        out_multimodals: MultiModalInputs = defaultdict(list)
-        for modal_type, mm in self.multimodal_iter():
-            assert mm.start >= start, 'multimodal data should be sorted by start'
-            if mm.start >= end:
-                # | start ... end ... mm.start ... mm.end |
-                # if start is beyond threshold, stop
-                break
-
-            if mm.end > end:
-                # | start ... mm.start ... end ... mm.end |
-                # Do not split a multimodal span; recompute from its start in
-                # the next chunk instead.
-                end = mm.start
-                break
-
-            # | start ... mm.start ... mm.end ... end |
-            out_multimodals[modal_type].append(mm)
-
-        return end - start, out_multimodals
+        plan = plan_long_context_chunk(seq, self.max_prefill_num, self.multimodals)
+        return plan.chunk_size, plan.multimodals
 
     def is_last_chunk(self):
         """Is last chunk."""

--- a/lmdeploy/pytorch/long_context.py
+++ b/lmdeploy/pytorch/long_context.py
@@ -1,0 +1,124 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+"""Shared planning helpers for long-context prefill chunks."""
+
+from collections import defaultdict
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from lmdeploy.pytorch.messages import SchedulerSequence
+    from lmdeploy.pytorch.multimodal.data_type import MultiModalInputs
+
+
+@dataclass
+class LongContextChunkPlan:
+    """Boundary and payload decision for one long-context chunk.
+
+    The planner is shared by the scheduler and input maker so both sides make
+    the same chunk-boundary decision.  Scheduler code mostly consumes the
+    absolute ``chunk_end`` as the temporary KV limit for a non-final chunk,
+    while input construction consumes ``chunk_size`` and ``multimodals`` to
+    build the next eager chunk forward.
+
+    Args:
+        chunk_limit: Effective per-chunk token budget.  This starts from
+            ``max_prefill_token_num`` and may be raised to fit an indivisible
+            multimodal span.
+        chunk_start: Absolute prompt position where the next suffix chunk
+            starts.  This is normally ``seq.num_history_ids`` after any
+            accepted prefix-cache hit has advanced the sequence.
+        chunk_end: Exclusive absolute prompt position where the planned chunk
+            ends.  If a multimodal span would cross the budget boundary, this
+            is clamped back to the span start.
+        chunk_size: Number of tokens to send in the next forward,
+            ``chunk_end - chunk_start``.
+        is_last_chunk: Whether the remaining suffix fits in ``chunk_limit``.
+            Last chunks are handled as normal prefill so they can merge into
+            persistent decode state.
+        multimodals: Remaining multimodal payloads wholly contained in this
+            chunk, or ``None`` when the caller does not need payloads or no
+            multimodal data is emitted for this chunk.
+    """
+
+    chunk_limit: int
+    chunk_start: int
+    chunk_end: int
+    chunk_size: int
+    is_last_chunk: bool
+    multimodals: 'MultiModalInputs|None'
+
+
+def sort_long_context_multimodals(multimodals: 'MultiModalInputs') -> 'MultiModalInputs':
+    """Return multimodals sorted by prompt start within each modality."""
+    output = defaultdict(list)
+    for modal_type, modal_datas in multimodals.items():
+        output[modal_type] = sorted(modal_datas, key=lambda data: data.start)
+    return output
+
+
+def has_long_context_multimodal(multimodals: 'MultiModalInputs') -> bool:
+    """Return whether at least one multimodal span remains."""
+    return any(len(modal_datas) > 0 for modal_datas in multimodals.values())
+
+
+def _iter_sorted_multimodals(multimodals: 'MultiModalInputs'):
+    multimodal_data = []
+    for modal_type, modal_datas in multimodals.items():
+        if len(modal_datas) == 0:
+            continue
+        multimodal_data += [(modal_type, data) for data in modal_datas]
+
+    yield from sorted(multimodal_data, key=lambda item: item[1].start)
+
+
+def _max_multimodal_span(multimodals: 'MultiModalInputs') -> int:
+    return max([data.end - data.start for modal_datas in multimodals.values() for data in modal_datas], default=0)
+
+
+def get_long_context_chunk_limit(seq: 'SchedulerSequence', max_prefill_token_num: int) -> int:
+    """Return the token budget for one long-context chunk."""
+    mm_for_chunk_limit = seq.get_chunk_limit_multimodals()
+    return max(max_prefill_token_num, _max_multimodal_span(mm_for_chunk_limit))
+
+
+def plan_long_context_chunk(seq: 'SchedulerSequence',
+                            chunk_limit: int,
+                            multimodals: 'MultiModalInputs|None' = None,
+                            include_multimodals: bool = True) -> LongContextChunkPlan:
+    """Plan the next chunk without splitting multimodal spans."""
+    chunk_size = min(seq.num_token_ids, chunk_limit)
+    start = seq.num_history_ids
+    end = start + chunk_size
+
+    if multimodals is None:
+        multimodals = seq.get_input_multimodals()
+    if len(multimodals) == 0:
+        return LongContextChunkPlan(chunk_limit=chunk_limit,
+                                    chunk_start=start,
+                                    chunk_end=end,
+                                    chunk_size=chunk_size,
+                                    is_last_chunk=seq.num_token_ids <= chunk_limit,
+                                    multimodals=None)
+
+    out_multimodals = defaultdict(list)
+    for modal_type, data in _iter_sorted_multimodals(multimodals):
+        assert data.start >= start, 'multimodal data should be sorted by start'
+        if data.start >= end:
+            break
+        if data.end > end:
+            # Do not split a multimodal span; recompute from its start in the
+            # next chunk instead.
+            end = data.start
+            break
+        if include_multimodals:
+            out_multimodals[modal_type].append(data)
+
+    chunk_size = end - start
+    if not include_multimodals:
+        out_multimodals = None
+    return LongContextChunkPlan(chunk_limit=chunk_limit,
+                                chunk_start=start,
+                                chunk_end=end,
+                                chunk_size=chunk_size,
+                                is_last_chunk=seq.num_token_ids <= chunk_limit,
+                                multimodals=out_multimodals)

--- a/lmdeploy/pytorch/paging/block_trie.py
+++ b/lmdeploy/pytorch/paging/block_trie.py
@@ -112,14 +112,18 @@ class StateCheckpointVerifyStatus(enum.Enum):
 class Node:
     """One full-token-block edge in the prefix-cache trie.
 
-    ``extra_hashes`` augments the token block key with VLM content identity.
-    ``state_idx`` / ``state_ready`` / ``state_ref_count`` are optional SSM
-    state-checkpoint ownership fields; they are meaningful only when the cache
-    config has state shapes.  ``state_ready`` controls whether the checkpoint
-    has been published and may be matched.  ``state_ref_count`` pins a ready
-    checkpoint while a restore copy may still read it or a producer save copy
-    may still write it, so LRU eviction or checkpoint reuse cannot overwrite
-    the slot too early.
+    A non-root node owns one trie KV-block reference.  ``hash_key``,
+    ``tokens``, and ``extra_hashes`` define the block identity; ``extra_hashes``
+    carries VLM content identity for blocks that overlap multimodal spans.
+
+    The same node may also own an optional SSM checkpoint.  ``state_idx`` is
+    the checkpoint slot, ``state_ready`` means the slot has been published and
+    is matchable, and ``state_ref_count`` pins the slot while an async restore
+    may still read it or a producer save may still write it.
+
+    ``parent`` is intentionally stateful: assigning it updates the old and new
+    parent ``children`` maps.  Detached nodes can therefore still exist as
+    stale auxiliary-index entries, but they are no longer trie truth.
     """
 
     def __init__(self,
@@ -183,7 +187,22 @@ class StateCheckpointVerifyResult:
 
 
 class BlockTrie:
-    """Block trie for prefix caching."""
+    """Prefix-cache facade for trie KV reuse and SSM state reuse.
+
+    Public scheduling flow stays small: ``match(seq)`` tentatively reuses a
+    prefix, the scheduler admits resources, then ``allocate(seq)`` attaches the
+    newly computed full blocks.  ``evict()`` frees trie-owned KV leaves under
+    allocator pressure.
+
+    Internally this facade owns several related indexes:
+
+    * adapter-partitioned trie roots and leaf candidates for KV eviction;
+    * multimodal-aware block keys;
+    * optional SSM checkpoint reserve/commit/restore/save lifecycle;
+    * sparse ready-checkpoint lookup for SSM prefix hits;
+    * best-effort routed-expert replay data;
+    * prefix-cache stats used by scheduler rollback.
+    """
 
     def __init__(self, cache_config: CacheConfig, block_manager: BaseBlockManager, state_manager=None):
         self.block_manager = block_manager
@@ -202,6 +221,8 @@ class BlockTrie:
         self._state_checkpoint_index: StateCheckpointIndex = dict()
         self._state_checkpoint_steps: StateCheckpointSteps = dict()
         self.stats = PrefixCacheStats()
+
+    # Prefix-cache stats and tentative-match rollback helpers.
 
     def hit_rate(self):
         """Get hit rate."""
@@ -226,6 +247,13 @@ class BlockTrie:
             return
         self.stats.num_query_tokens += query_tokens
         self.stats.num_hit_tokens += hit_tokens
+
+    @staticmethod
+    def _warn_unexpected_state(message: str):
+        """Warn about contradictory internal trie/checkpoint state."""
+        logger.warning('Unexpected prefix-cache trie state: %s', message)
+
+    # Private recompute-overlap helpers for AR-spec/MTP prefix hits.
 
     @staticmethod
     def _clear_private_recompute_range(seq: SchedulerSequence):
@@ -258,6 +286,8 @@ class BlockTrie:
         start = prefix_cache.private_recompute_start_step
         end = prefix_cache.private_recompute_end_step
         return start >= 0 and start <= step < end
+
+    # Trie keying and raw block matching helpers.
 
     def get_root(self, adapter_name: str):
         """Get root by adapter name."""
@@ -301,6 +331,9 @@ class BlockTrie:
             curr = child
             num_matched += block_size
         return num_matched
+
+    # Routed-expert cache/replay helpers.  Routed experts enrich a hit when
+    # complete block rows are available, but they are not part of cache identity.
 
     @staticmethod
     def _get_routed_experts_for_range(seq: SchedulerSequence, start: int, end: int):
@@ -358,6 +391,9 @@ class BlockTrie:
             return
         for seq in seqs:
             self.cache_routed_experts_for_seq(seq)
+
+    # Sparse SSM checkpoint index helpers.  The lookup key is only a filter;
+    # `_verify_state_checkpoint_node()` remains the correctness check.
 
     def _make_state_checkpoint_lookup_key(self, seq: SchedulerSequence, step: int) -> StateCheckpointKey:
         """Make the sparse SSM checkpoint lookup key for a sequence prefix.
@@ -421,6 +457,8 @@ class BlockTrie:
         for key in list(self._state_checkpoint_index):
             removed = self._remove_state_checkpoint_index_entry(node, key) or removed
         return removed
+
+    # SSM checkpoint reservation and publication lifecycle.
 
     def reserve_state_checkpoint(self, node: Node):
         """Reserve a state-cache slot owned by a trie node.
@@ -486,42 +524,6 @@ class BlockTrie:
             self.release_state_checkpoint(node)
             return True
         return False
-
-    def _get_state_checkpoint_node_for_seq(self, seq: SchedulerSequence, step: int):
-        """Get the trie node that exactly represents a sequence checkpoint
-        step."""
-        node = seq.prefix_cache.last_shared_node
-        while node is not None and node.num_matched > step:
-            node = node.parent
-        if node is None or node.parent is None or node.num_matched != step:
-            return None
-        return node
-
-    @staticmethod
-    def _is_attached_node(node: Node):
-        """Check whether a node is still attached to the trie."""
-        parent = node.parent
-        return parent is not None and parent.children.get(node.hash_key) is node
-
-    @staticmethod
-    def _is_attached_leaf(node: Node):
-        """Check whether a node is a current attached trie leaf."""
-        return BlockTrie._is_attached_node(node) and len(node.children) == 0
-
-    @staticmethod
-    def _is_evict_candidate_leaf(node: Node):
-        """Check whether a leaf-set entry can be considered by KV eviction."""
-        return (node.block >= 0 and len(node.children) == 0
-                and (node.parent is None or BlockTrie._is_attached_node(node)))
-
-    def _is_attached_cursor(self, node: Node):
-        """Check whether a sequence cursor still reaches the adapter root."""
-        if node.parent is None:
-            return node.block < 0 and self._roots.get(node.adapter_name) is node
-        nodes = self._get_node_blocks(node)
-        if len(nodes) * self.block_size != node.num_matched:
-            return False
-        return all(self._is_attached_node(node) for node in nodes)
 
     def reserve_state_checkpoint_for_seq(self,
                                          seq: SchedulerSequence,
@@ -786,6 +788,7 @@ class BlockTrie:
     def _release_state_checkpoint_ref(node: Node | None, state_idx: int, err_msg: str):
         """Release one checkpoint ref held by a sequence."""
         if not BlockTrie._has_state_checkpoint_ref(node, state_idx):
+            BlockTrie._warn_unexpected_state(f'{err_msg} state_idx={state_idx}')
             raise RuntimeError(err_msg)
         node.state_ref_count -= 1
         return node
@@ -844,6 +847,9 @@ class BlockTrie:
             raise RuntimeError('Cannot release a pinned SSM prefix-cache checkpoint.')
         if node.state_idx < 0:
             if node.state_ready:
+                self._warn_unexpected_state(
+                    f'ready SSM checkpoint has no state slot: adapter={node.adapter_name} '
+                    f'step={node.num_matched}')
                 self._unindex_state_checkpoint(node)
                 node.state_ready = False
                 node.state_ref_count = 0
@@ -885,6 +891,44 @@ class BlockTrie:
             self.release_state_checkpoint(node)
             evicted += 1
         return evicted
+
+    # Trie attachment and leaf-index helpers.
+
+    def _get_state_checkpoint_node_for_seq(self, seq: SchedulerSequence, step: int):
+        """Get the trie node that exactly represents a sequence checkpoint
+        step."""
+        node = seq.prefix_cache.last_shared_node
+        while node is not None and node.num_matched > step:
+            node = node.parent
+        if node is None or node.parent is None or node.num_matched != step:
+            return None
+        return node
+
+    @staticmethod
+    def _is_attached_node(node: Node):
+        """Check whether a node is still attached to the trie."""
+        parent = node.parent
+        return parent is not None and parent.children.get(node.hash_key) is node
+
+    @staticmethod
+    def _is_attached_leaf(node: Node):
+        """Check whether a node is a current attached trie leaf."""
+        return BlockTrie._is_attached_node(node) and len(node.children) == 0
+
+    @staticmethod
+    def _is_evict_candidate_leaf(node: Node):
+        """Check whether a leaf-set entry can be considered by KV eviction."""
+        return (node.block >= 0 and len(node.children) == 0
+                and (node.parent is None or BlockTrie._is_attached_node(node)))
+
+    def _is_attached_cursor(self, node: Node):
+        """Check whether a sequence cursor still reaches the adapter root."""
+        if node.parent is None:
+            return node.block < 0 and self._roots.get(node.adapter_name) is node
+        nodes = self._get_node_blocks(node)
+        if len(nodes) * self.block_size != node.num_matched:
+            return False
+        return all(self._is_attached_node(node) for node in nodes)
 
     def _get_node_blocks(self, node: Node):
         """Get trie nodes from root to a target node."""
@@ -1062,10 +1106,17 @@ class BlockTrie:
                          f'max_step={max_step} ready_steps={len(steps)}')
 
     def match(self, seq: SchedulerSequence):
-        """Match reusable prefix blocks for a sequence.
+        """Tentatively match reusable prefix blocks for a sequence.
 
-        Text/VLM models walk the trie block by block.  SSM models delegate to the sparse checkpoint matcher above
-        because a KV block match without an exact recurrent-state snapshot must be treated as a miss.
+        This method mutates sequence state before scheduler admission is final:
+        it may append shared logical blocks, advance ``seq.num_history_ids``,
+        record ``match_start_step``, replay routed experts, update stats, and
+        set SSM restore metadata.  Callers must rollback the sequence if later
+        resource admission rejects the request.
+
+        Text/VLM models walk the trie block by block.  SSM models delegate to
+        sparse checkpoint matching because a KV block match without the exact
+        recurrent-state snapshot is a miss.
         """
         if not self.enable:
             return
@@ -1158,14 +1209,28 @@ class BlockTrie:
                          f'clamped={effective_num_matched != raw_num_matched}')
 
     def allocate(self, seq: SchedulerSequence):
-        """Attach newly allocated full blocks to the prefix-cache trie."""
+        """Attach newly allocated full blocks to the prefix-cache trie.
+
+        Allocation starts from ``seq.prefix_cache.last_shared_node`` when that
+        cursor still reaches the current trie.  Existing identical children are
+        deduplicated back to the trie-owned block, except for the private
+        recompute-overlap window where the sequence must keep fresh writable KV.
+        New nodes take one trie-owned allocator ref.
+        """
         if not self.enable:
             return
 
         block_size = self.block_size
         logical_blocks = seq.logical_blocks
         node: Node = seq.prefix_cache.last_shared_node
-        if node is None or not self._is_attached_cursor(node):
+        if node is None:
+            node = self.get_root(seq.adapter_name)
+            seq.prefix_cache.last_shared_node = node
+        elif not self._is_attached_cursor(node):
+            self._warn_unexpected_state(
+                f'reset detached sequence cursor: session_id={seq.session_id} '
+                f'seq_id={seq.seq_id} adapter={seq.adapter_name} '
+                f'cursor_step={node.num_matched}')
             node = self.get_root(seq.adapter_name)
             seq.prefix_cache.last_shared_node = node
 
@@ -1240,7 +1305,13 @@ class BlockTrie:
         self._clear_private_recompute_range(seq)
 
     def evict(self, max_num_blocks: int):
-        """evict."""
+        """Evict trie-owned KV leaf blocks.
+
+        ``self.leaves`` is an auxiliary candidate index, not the source of
+        truth.  Each candidate is rechecked against the parent/children chain,
+        allocator refcount, and checkpoint pin state before removing it.  When
+        a leaf is removed, its parent can become the next leaf candidate.
+        """
         if not self.enable:
             return 0
 
@@ -1282,22 +1353,26 @@ class BlockTrie:
             return 0
 
         evicted_blocks = []
+        old_leaf_count = len(self.leaves)
         leaves = list(leaf for leaf in self.leaves if self._is_evict_candidate_leaf(leaf))
         if len(leaves) != len(self.leaves):
             self.leaves.intersection_update(leaves)
+            self._warn_unexpected_state(
+                f'dropped stale leaf candidates before eviction: '
+                f'old_count={old_leaf_count} new_count={len(leaves)}')
         if len(leaves) == 0:
             return 0
 
         # filter ref-cnt == 1 (trie own one block ref)
-        leave_blocks = np.array(list(leaf.block for leaf in leaves))
-        ref_cnt = self.allocator.get_ref_count(leave_blocks)
+        leaf_blocks = np.array(list(leaf.block for leaf in leaves))
+        ref_cnt = self.allocator.get_ref_count(leaf_blocks)
         indices = (ref_cnt == 1).nonzero()[0]
         if len(indices) == 0:
             return 0
 
         # make heap
         leaves = list(leaves[i] for i in indices)
-        access_times = self.allocator.get_access_time(leave_blocks)
+        access_times = self.allocator.get_access_time(leaf_blocks)
         access_times = list(access_times[i] for i in indices)
         leaves = list(zip(access_times, leaves))
         heapq.heapify(leaves)

--- a/lmdeploy/pytorch/paging/block_trie.py
+++ b/lmdeploy/pytorch/paging/block_trie.py
@@ -1227,10 +1227,10 @@ class BlockTrie:
             node = self.get_root(seq.adapter_name)
             seq.prefix_cache.last_shared_node = node
         elif not self._is_attached_cursor(node):
-            self._warn_unexpected_state(
-                f'reset detached sequence cursor: session_id={seq.session_id} '
-                f'seq_id={seq.seq_id} adapter={seq.adapter_name} '
-                f'cursor_step={node.num_matched}')
+            if logger.isEnabledFor(logging.DEBUG):
+                logger.debug(f'Reset detached prefix-cache sequence cursor: session_id={seq.session_id} '
+                             f'seq_id={seq.seq_id} adapter={seq.adapter_name} '
+                             f'cursor_step={node.num_matched}')
             node = self.get_root(seq.adapter_name)
             seq.prefix_cache.last_shared_node = node
 
@@ -1357,9 +1357,9 @@ class BlockTrie:
         leaves = list(leaf for leaf in self.leaves if self._is_evict_candidate_leaf(leaf))
         if len(leaves) != len(self.leaves):
             self.leaves.intersection_update(leaves)
-            self._warn_unexpected_state(
-                f'dropped stale leaf candidates before eviction: '
-                f'old_count={old_leaf_count} new_count={len(leaves)}')
+            if logger.isEnabledFor(logging.DEBUG):
+                logger.debug(f'Dropped stale prefix-cache leaf candidates before eviction: '
+                             f'old_count={old_leaf_count} new_count={len(leaves)}')
         if len(leaves) == 0:
             return 0
 

--- a/lmdeploy/pytorch/paging/scheduler.py
+++ b/lmdeploy/pytorch/paging/scheduler.py
@@ -40,7 +40,7 @@ SSM scheduling detail:
 
 import logging
 import time
-from collections import OrderedDict
+from collections import Counter, OrderedDict
 from collections.abc import Callable
 from contextlib import contextmanager
 from dataclasses import dataclass
@@ -104,6 +104,361 @@ class _PrefillReorderInfo:
     prefill_token_count: int
     is_nonfinal_long_prefill: bool
     estimated_long_chunks: int
+
+
+class _PrefillReorderer:
+    """Order waiting prefills without applying scheduler side effects."""
+
+    def __init__(self, scheduler: 'Scheduler'):
+        self.scheduler = scheduler
+        self._info_cache: dict[int, _PrefillReorderInfo] = {}
+
+    def reorder(self,
+                waiting: SeqList,
+                allow_long_prefill: bool,
+                prefer_long_prefill: bool):
+        """Return waiting requests in the order the prefill loop should try."""
+        waiting = sorted(waiting, key=lambda seq: seq.arrive_time)
+        if prefer_long_prefill:
+            # Long-work turns choose one long waiter first. The size policy only
+            # reorders this long lane; it is not global shortest-prefill-first
+            # admission.
+            long_turn_order = self._reorder_for_long_turn(waiting)
+            if long_turn_order is not None:
+                return self._warn_if_not_permutation(waiting, long_turn_order)
+
+        if allow_long_prefill:
+            return self._warn_if_not_permutation(waiting, waiting)
+
+        reordered = self._reorder_for_short_turn(waiting)
+        return self._warn_if_not_permutation(waiting, reordered)
+
+    def _warn_if_not_permutation(self, original: SeqList, reordered: SeqList):
+        """Warn if reorder drops, duplicates, or substitutes waiting sequences."""
+        original_ids = [id(seq) for seq in original]
+        reordered_ids = [id(seq) for seq in reordered]
+        if len(original_ids) == len(reordered_ids) and Counter(original_ids) == Counter(reordered_ids):
+            return reordered
+
+        logger.warning('Unexpected prefill reorder result: original_len=%s reordered_len=%s '
+                       'original_sample=%s reordered_sample=%s',
+                       len(original), len(reordered), self._seq_id_sample(original), self._seq_id_sample(reordered))
+        return reordered
+
+    @staticmethod
+    def _seq_id_sample(seqs: SeqList):
+        return [(seq.session_id, seq.seq_id) for seq in seqs[:5]]
+
+    def _get_reorder_info(self, seq: SchedulerSequence):
+        """Return reorder-only info before prefix-cache side effects.
+
+        Prefix-cache match/rollback mutates the remaining prompt. Keep this
+        cache confined to waiting-list ordering and recompute fresh values in
+        the admission path.
+        """
+        seq_key = id(seq)
+        info = self._info_cache.get(seq_key)
+        if info is not None:
+            return info
+
+        scheduler = self.scheduler
+        chunk_limit = scheduler._long_context_chunk_limit(seq)
+        if seq.num_token_ids <= chunk_limit:
+            info = _PrefillReorderInfo(prefill_token_count=seq.num_token_ids,
+                                       is_nonfinal_long_prefill=False,
+                                       estimated_long_chunks=1)
+        else:
+            kv_token_limit = scheduler._next_long_context_chunk_end(seq, chunk_limit)
+            safe_chunk_limit = max(1, chunk_limit)
+            info = _PrefillReorderInfo(
+                prefill_token_count=max(0, kv_token_limit - seq.num_history_ids),
+                is_nonfinal_long_prefill=True,
+                estimated_long_chunks=max(1, (seq.num_token_ids + safe_chunk_limit - 1) // safe_chunk_limit),
+            )
+        self._info_cache[seq_key] = info
+        return info
+
+    def _long_priority_key(self, seq: SchedulerSequence, now: float):
+        """Prefer smaller long prompts, with age credit to avoid starvation."""
+        scheduler = self.scheduler
+        info = self._get_reorder_info(seq)
+        wait_age = max(0.0, now - seq.arrive_time)
+        age_credit = int(wait_age // scheduler._long_prefill_aging_seconds_per_chunk)
+        age_adjusted_chunks = info.estimated_long_chunks - age_credit
+        return age_adjusted_chunks, info.estimated_long_chunks, seq.arrive_time
+
+    def _split_by_prefill_kind(self, waiting: SeqList):
+        """Split waiting requests into normal/final and non-final long prefill."""
+        normal_waiting: SeqList = []
+        long_waiting: SeqList = []
+        for seq in waiting:
+            if self._get_reorder_info(seq).is_nonfinal_long_prefill:
+                long_waiting.append(seq)
+            else:
+                normal_waiting.append(seq)
+        return normal_waiting, long_waiting
+
+    def _sort_normal_prefills(self, waiting: SeqList):
+        return sorted(waiting,
+                      key=lambda seq: (self._get_reorder_info(seq).prefill_token_count, seq.arrive_time))
+
+    def _sort_long_prefills(self, waiting: SeqList):
+        scheduler = self.scheduler
+        if scheduler._long_prefill_policy != 'size':
+            return waiting
+        now = time.perf_counter()
+        return sorted(waiting, key=lambda seq: self._long_priority_key(seq, now))
+
+    def _reorder_for_long_turn(self, waiting: SeqList):
+        """Choose one long waiter, then fill the turn with normal prefills."""
+        normal_waiting, long_waiting = self._split_by_prefill_kind(waiting)
+        if len(long_waiting) == 0:
+            return None
+
+        long_waiting = self._sort_long_prefills(long_waiting)
+        normal_waiting = self._sort_normal_prefills(normal_waiting)
+        return [long_waiting[0]] + normal_waiting + long_waiting[1:]
+
+    def _reorder_for_short_turn(self, waiting: SeqList):
+        """Prioritize normal/final prefills while preserving long waiters."""
+        normal_waiting, long_waiting = self._split_by_prefill_kind(waiting)
+        return self._sort_normal_prefills(normal_waiting) + long_waiting
+
+
+@dataclass(frozen=True)
+class _PrefillAdmissionResult:
+    """Outcome from trying to admit one waiting prefill request."""
+
+    admitted: bool
+    prefill_token_count: int = 0
+    should_skip: bool = False
+
+    @classmethod
+    def admit(cls, prefill_token_count: int):
+        return cls(admitted=True, prefill_token_count=prefill_token_count)
+
+    @classmethod
+    def skip(cls):
+        return cls(admitted=False, should_skip=True)
+
+    @classmethod
+    def stop(cls):
+        return cls(admitted=False)
+
+    @property
+    def should_stop(self):
+        return not self.admitted and not self.should_skip
+
+
+class _PrefillAdmissionAttempt:
+    """Try to admit one waiting prefill sequence.
+
+    The attempt owns all tentative prefix-cache side effects for the sequence:
+    match, SSM restore pinning, eviction, runtime-state checks, allocation, and
+    rollback. The outer scheduler loop still owns queue traversal and decides
+    whether a rejected candidate is skipped or ends the current prefill turn.
+    """
+
+    def __init__(self,
+                 scheduler: 'Scheduler',
+                 seq: SchedulerSequence,
+                 evictable_waiting: SeqList,
+                 prealloc_size: int,
+                 token_count: int,
+                 has_admitted: bool,
+                 allow_long_prefill: bool):
+        self.scheduler = scheduler
+        self.seq = seq
+        self.evictable_waiting = evictable_waiting
+        self.prealloc_size = prealloc_size
+        self.token_count = token_count
+        self.has_admitted = has_admitted
+        self.allow_long_prefill = allow_long_prefill
+        self._alloc_size = prealloc_size
+
+    def run(self):
+        """Run the admission route for one waiting prefill.
+
+        1. Check prefill gates.
+        2. Return skip/stop if a gate rejects the candidate.
+        3. Try resource admission, including prefix-cache rollback on failure.
+        4. Return skip/stop if resources block the candidate.
+        5. On success, allocate blocks/states and publish any prefix-cache hit.
+        """
+        scheduler = self.scheduler
+        gate_check = scheduler._check_prefill_admission_gates(
+            self.seq,
+            token_count=self.token_count,
+            has_admitted=self.has_admitted,
+            allow_long_prefill=self.allow_long_prefill,
+        )
+
+        if gate_check.reject_action is not None:
+            return self._check_result(
+                self._result_for_gate_action(gate_check.reject_action))
+
+        resource_result = self._admit_resources(gate_check)
+        if resource_result is not None:
+            return self._check_result(resource_result)
+
+        return self._check_result(self._finish_admission())
+
+    def _result_for_gate_action(self, action: str | None):
+        if action == _PREFILL_GATE_SKIP:
+            return _PrefillAdmissionResult.skip()
+        if action == _PREFILL_GATE_BREAK:
+            return _PrefillAdmissionResult.stop()
+        self._warn_unexpected_state(f'unknown prefill gate action: action={action!r}')
+        return _PrefillAdmissionResult.stop()
+
+    def _gate_rollback_result(self, gate_check: _PrefillGateCheck):
+        """Reject a candidate whose gate-only prefix hit was rolled back."""
+        if gate_check.prefix_match is None:
+            return None
+        if gate_check.rollback_action is None:
+            self._warn_unexpected_state('gate-only prefix match rollback has no reject action')
+            return _PrefillAdmissionResult.stop()
+        return self._result_for_gate_action(gate_check.rollback_action)
+
+    def _rollback_gate(self,
+                       stats_snapshot,
+                       gate_check: _PrefillGateCheck,
+                       reason: str):
+        """Rollback a tentative prefix hit and return any gate-only rejection.
+
+        A prefill gate may do a tentative prefix-cache match before resource
+        admission. If that match is rolled back, the candidate should follow
+        the gate's original skip/break action. Matches created after the gate
+        return ``None`` so the resource branch keeps its own retry/stop behavior.
+        """
+        self._rollback_prefix_match(stats_snapshot, reason)
+        return self._gate_rollback_result(gate_check)
+
+    def _check_result(self, result: _PrefillAdmissionResult):
+        if result.admitted and result.should_skip:
+            self._warn_unexpected_state(
+                f'admission result both admits and skips: prefill_token_count={result.prefill_token_count}')
+        if not result.admitted and result.prefill_token_count != 0:
+            self._warn_unexpected_state(
+                f'rejected admission result carries token count: prefill_token_count={result.prefill_token_count}')
+        return result
+
+    def _warn_unexpected_state(self, message: str):
+        seq = self.seq
+        logger.warning('Unexpected prefill admission state: session_id=%s seq_id=%s %s',
+                       seq.session_id, seq.seq_id, message)
+
+    def _admit_resources(self, gate_check: _PrefillGateCheck):
+        if self.scheduler.block_trie.enable:
+            return self._admit_prefix_cache_resources(gate_check)
+        if not self._prepare_and_evict():
+            return _PrefillAdmissionResult.stop()
+        return None
+
+    def _admit_prefix_cache_resources(self, gate_check: _PrefillGateCheck):
+        """Admit resources for prefix-cache scheduling.
+
+        Route map:
+        1. Use or create the tentative prefix-cache match.
+        2. Pin any SSM restore state required by the match.
+        3. Prepare allocation limits and evict KV/state resources.
+        4. For SSM, verify a runtime state slot is still available.
+
+        Any failure rolls the tentative match back. A match created only to pass
+        a prefill gate returns that gate's skip/stop result after rollback;
+        normal resource failures keep their local retry/stop behavior here.
+        """
+        scheduler = self.scheduler
+        seq = self.seq
+        if gate_check.prefix_match is None:
+            stats_snapshot = scheduler.block_trie.snapshot_stats()
+        else:
+            stats_snapshot = gate_check.prefix_match.stats_snapshot
+
+        if gate_check.prefix_match is None:
+            scheduler.block_trie.match(seq)
+
+        had_ssm_restore = scheduler.is_ssm and seq.prefix_cache.restore_state >= 0
+        if not scheduler._acquire_ssm_restore_if_needed(seq):
+            result = self._rollback_gate(stats_snapshot, gate_check,
+                                         'failed to acquire SSM restore checkpoint')
+            if result is not None:
+                return result
+
+        if not self._prepare_and_evict():
+            if not had_ssm_restore:
+                result = self._rollback_gate(stats_snapshot, gate_check, 'eviction failed')
+                if result is not None:
+                    return result
+                return _PrefillAdmissionResult.stop()
+
+            # A matched SSM restore may be pinning the only checkpoint state
+            # that eviction would otherwise free. Roll it back once and retry
+            # eviction before declaring the sequence unschedulable.
+            result = self._rollback_gate(stats_snapshot, gate_check,
+                                         'eviction failed with pinned SSM restore')
+            if result is not None:
+                return result
+            if not self._prepare_and_evict():
+                return _PrefillAdmissionResult.stop()
+
+        if scheduler.is_ssm and not scheduler._ensure_runtime_state_available():
+            result = self._rollback_gate(stats_snapshot, gate_check,
+                                         'no runtime SSM state available')
+            if result is not None:
+                return result
+            if not self._prepare_and_evict():
+                return _PrefillAdmissionResult.stop()
+            if not scheduler._ensure_runtime_state_available():
+                seq.kv_token_limit = None
+                return _PrefillAdmissionResult.stop()
+
+        return None
+
+    def _prepare_and_evict(self):
+        """Apply chunk allocation limits and evict for this prefill."""
+        scheduler = self.scheduler
+        seq = self.seq
+        alloc_size = scheduler._prepare_prefill_allocation(seq, self.prealloc_size)
+        self._alloc_size = alloc_size
+        if self._evict_for_seq(alloc_size):
+            return True
+        seq.kv_token_limit = None
+        return False
+
+    def _evict_for_seq(self, alloc_size: int):
+        """Evict stopped or skipped waiters until this sequence can run."""
+        from itertools import chain
+        scheduler = self.scheduler
+        hanging = reversed(scheduler.hanging)
+        waiting = reversed(self.evictable_waiting)
+        evictable = list(chain(hanging, waiting))
+        return scheduler.eviction_helper.evict_for_seq(self.seq, evictable, alloc_size)
+
+    def _rollback_prefix_match(self, stats_snapshot, reason: str):
+        seq = self.seq
+        if logger.isEnabledFor(logging.DEBUG):
+            logger.debug(f'Rollback tentative prefix-cache match: session_id={seq.session_id} '
+                         f'seq_id={seq.seq_id} reason={reason} num_history_ids={seq.num_history_ids} '
+                         f'restore_state={seq.prefix_cache.restore_state}')
+        self.scheduler._rollback_unscheduled_prefix_match(seq, stats_snapshot)
+
+    def _finish_admission(self):
+        scheduler = self.scheduler
+        seq = self.seq
+        # Prefix-cache matching can advance the sequence step and shrink the
+        # remaining prefill tail. Charge the admitted batch with the
+        # post-match/post-rollback cost, not the conservative pre-match
+        # estimate used to decide whether this sequence is worth trying.
+        prefill_token_count = scheduler._prefill_admission_token_count(seq)
+        scheduler.block_manager.allocate(seq, self._alloc_size)
+        if scheduler.block_trie.enable:
+            scheduler.block_trie.allocate(seq)
+        if scheduler.is_ssm:
+            scheduler.state_manager.allocate(seq)
+        if scheduler.block_trie.enable:
+            scheduler._finish_prefix_cache_schedule(seq)
+        return _PrefillAdmissionResult.admit(prefill_token_count)
 
 
 class Scheduler:
@@ -425,7 +780,7 @@ class Scheduler:
         migrating_token_count = 0
 
         def _to_running(seq: SchedulerSequence):
-            """To running."""
+            """Activate a migrated sequence and count its tokens."""
             seq.state.activate()
             migration_ready.append(seq)
             nonlocal migrating_token_count
@@ -468,7 +823,6 @@ class Scheduler:
         """Schedule for prefilling."""
 
         max_batches = self.scheduler_config.max_batches - self.num_ready() - self.num_running()
-        eviction_helper = self.eviction_helper
         swap_out_map: MapType = dict()
         swap_in_map: MapType = dict()
         copy_map: MapType = dict()
@@ -476,224 +830,40 @@ class Scheduler:
         token_count = 0
 
         def _to_running(seq: SchedulerSequence, prefill_token_count: int):
-            """To running."""
+            """Activate an admitted sequence and count its prefill tokens."""
             seq.state.activate()
             running.append(seq)
             nonlocal token_count
             token_count += prefill_token_count
 
-        def __evict_for_seq(seq: SchedulerSequence, waiting, evict_prealloc_size: int):
-            """Evict until can append."""
-            from itertools import chain
-            hanging = reversed(self.hanging)
-            waiting = reversed(waiting)
-            evictable = list(chain(hanging, waiting))
-            return eviction_helper.evict_for_seq(seq, evictable, evict_prealloc_size)
-
-        def __prepare_and_evict(seq: SchedulerSequence, waiting):
-            """Apply chunk allocation limits and evict for this prefill."""
-            alloc_prealloc_size = self._prepare_prefill_allocation(seq, prealloc_size)
-            if __evict_for_seq(seq, waiting, alloc_prealloc_size):
-                return True, alloc_prealloc_size
-            seq.kv_token_limit = None
-            return False, alloc_prealloc_size
-
-        reorder_info_cache: dict[int, _PrefillReorderInfo] = {}
-
-        def _get_prefill_reorder_info(seq: SchedulerSequence):
-            """Return reorder-only info before prefix-cache side effects.
-
-            Prefix-cache match/rollback mutates the remaining prompt.  Keep this cache confined to waiting-list ordering
-            and recompute fresh values in the admission path below.
-            """
-            seq_key = id(seq)
-            info = reorder_info_cache.get(seq_key)
-            if info is not None:
-                return info
-
-            chunk_limit = self._long_context_chunk_limit(seq)
-            if seq.num_token_ids <= chunk_limit:
-                info = _PrefillReorderInfo(prefill_token_count=seq.num_token_ids,
-                                           is_nonfinal_long_prefill=False,
-                                           estimated_long_chunks=1)
-            else:
-                kv_token_limit = self._next_long_context_chunk_end(seq, chunk_limit)
-                safe_chunk_limit = max(1, chunk_limit)
-                info = _PrefillReorderInfo(
-                    prefill_token_count=max(0, kv_token_limit - seq.num_history_ids),
-                    is_nonfinal_long_prefill=True,
-                    estimated_long_chunks=max(1, (seq.num_token_ids + safe_chunk_limit - 1) // safe_chunk_limit),
-                )
-            reorder_info_cache[seq_key] = info
-            return info
-
-        def _long_prefill_priority_key_for_reorder(seq: SchedulerSequence, now: float):
-            """Prefer smaller long prompts, with age credit to avoid
-            starvation."""
-            info = _get_prefill_reorder_info(seq)
-            wait_age = max(0.0, now - seq.arrive_time)
-            age_credit = int(wait_age // self._long_prefill_aging_seconds_per_chunk)
-            age_adjusted_chunks = info.estimated_long_chunks - age_credit
-            return age_adjusted_chunks, info.estimated_long_chunks, seq.arrive_time
-
-        def _split_waiting_by_prefill_kind(waiting: SeqList):
-            """Split waiting requests into normal/final and non-final long
-            prefill."""
-            normal_waiting: SeqList = []
-            long_waiting: SeqList = []
-            for seq in waiting:
-                if _get_prefill_reorder_info(seq).is_nonfinal_long_prefill:
-                    long_waiting.append(seq)
-                else:
-                    normal_waiting.append(seq)
-            return normal_waiting, long_waiting
-
-        def _sort_normal_prefills(waiting: SeqList):
-            return sorted(waiting, key=lambda seq: (_get_prefill_reorder_info(seq).prefill_token_count,
-                                                   seq.arrive_time))
-
-        def _sort_long_prefills_for_long_turn(waiting: SeqList):
-            if self._long_prefill_policy != 'size':
-                return waiting
-            now = time.perf_counter()
-            return sorted(waiting, key=lambda seq: _long_prefill_priority_key_for_reorder(seq, now))
-
-        def _reorder_waiting_for_long_turn(waiting: SeqList):
-            """Choose one long waiter, then fill the turn with normal
-            prefills."""
-            normal_waiting, long_waiting = _split_waiting_by_prefill_kind(waiting)
-            if len(long_waiting) == 0:
-                return None
-
-            long_waiting = _sort_long_prefills_for_long_turn(long_waiting)
-            normal_waiting = _sort_normal_prefills(normal_waiting)
-            return [long_waiting[0]] + normal_waiting + long_waiting[1:]
-
-        def _reorder_waiting_for_short_turn(waiting: SeqList):
-            """Prioritize normal/final prefills while preserving long
-            waiters."""
-            normal_waiting, long_waiting = _split_waiting_by_prefill_kind(waiting)
-            return _sort_normal_prefills(normal_waiting) + long_waiting
-
-        def _reorder_waiting():
-            """Reorder waiting."""
-            waiting = sorted(self.waiting, key=lambda seq: seq.arrive_time)
-            if prefer_long_prefill:
-                # Long-work turns choose one long waiter first. The size policy
-                # only reorders this long lane; it is not global
-                # shortest-prefill-first admission.
-                long_turn_waiting = _reorder_waiting_for_long_turn(waiting)
-                if long_turn_waiting is not None:
-                    return long_turn_waiting
-
-            if allow_long_prefill:
-                return waiting
-
-            return _reorder_waiting_for_short_turn(waiting)
-
         num_waiting = self.seq_manager.num_sequences(MessageStatus.WAITING)
         if (len(running) >= max_batches or num_waiting == 0):
             return running, swap_in_map, swap_out_map, copy_map
 
-        waiting = _reorder_waiting()
+        waiting = _PrefillReorderer(self).reorder(self.waiting,
+                                                 allow_long_prefill=allow_long_prefill,
+                                                 prefer_long_prefill=prefer_long_prefill)
         skipped_waiting: SeqList = []
         while len(waiting) > 0 and len(running) < max_batches:
             seq = waiting.pop(0)
-            gate_check = self._check_prefill_admission_gates(seq,
-                                                             token_count=token_count,
-                                                             has_admitted=len(running) > 0,
-                                                             allow_long_prefill=allow_long_prefill)
+            evictable_waiting = skipped_waiting + waiting
+            admission = _PrefillAdmissionAttempt(
+                self,
+                seq,
+                evictable_waiting=evictable_waiting,
+                prealloc_size=prealloc_size,
+                token_count=token_count,
+                has_admitted=len(running) > 0,
+                allow_long_prefill=allow_long_prefill,
+            ).run()
 
-            def __reject_after_prefill_gate_match_rollback():
-                """Reject if resource admission rolled back a gate-only hit."""
-                if gate_check.prefix_match is None:
-                    return False
-                if gate_check.rollback_action == _PREFILL_GATE_SKIP:
-                    skipped_waiting.append(seq)
-                    return True
-                return False
-
-            if gate_check.reject_action is not None:
-                if gate_check.reject_action == _PREFILL_GATE_SKIP:
-                    skipped_waiting.append(seq)
-                    continue
+            if admission.should_skip:
+                skipped_waiting.append(seq)
+                continue
+            if admission.should_stop:
                 break
 
-            evictable_waiting = skipped_waiting + waiting
-
-            if self.block_trie.enable:
-                if gate_check.prefix_match is None:
-                    stats_snapshot = self.block_trie.snapshot_stats()
-                else:
-                    stats_snapshot = gate_check.prefix_match.stats_snapshot
-
-                def __rollback_prefix_match(reason: str):
-                    if logger.isEnabledFor(logging.DEBUG):
-                        logger.debug(f'Rollback tentative prefix-cache match: session_id={seq.session_id} '
-                                     f'seq_id={seq.seq_id} reason={reason} num_history_ids={seq.num_history_ids} '
-                                     f'restore_state={seq.prefix_cache.restore_state}')
-                    self._rollback_unscheduled_prefix_match(seq, stats_snapshot)
-
-                if gate_check.prefix_match is None:
-                    self.block_trie.match(seq)
-
-                had_ssm_restore = self.is_ssm and seq.prefix_cache.restore_state >= 0
-                if not self._acquire_ssm_restore_if_needed(seq):
-                    __rollback_prefix_match('failed to acquire SSM restore checkpoint')
-                    if gate_check.prefix_match is not None:
-                        if __reject_after_prefill_gate_match_rollback():
-                            continue
-                        break
-
-                evicted, alloc_prealloc_size = __prepare_and_evict(seq, evictable_waiting)
-                if not evicted:
-                    if not had_ssm_restore:
-                        __rollback_prefix_match('eviction failed')
-                        if __reject_after_prefill_gate_match_rollback():
-                            continue
-                        break
-                    # A matched SSM restore may be pinning the only checkpoint
-                    # state that eviction would otherwise free.  Roll it back once
-                    # and retry eviction before declaring the sequence unschedulable.
-                    __rollback_prefix_match('eviction failed with pinned SSM restore')
-                    if __reject_after_prefill_gate_match_rollback():
-                        continue
-                    if gate_check.prefix_match is not None:
-                        break
-                    evicted, alloc_prealloc_size = __prepare_and_evict(seq, evictable_waiting)
-                    if not evicted:
-                        break
-
-                # allocate session memory
-                if self.is_ssm and not self._ensure_runtime_state_available():
-                    __rollback_prefix_match('no runtime SSM state available')
-                    if __reject_after_prefill_gate_match_rollback():
-                        continue
-                    if gate_check.prefix_match is not None:
-                        break
-                    evicted, alloc_prealloc_size = __prepare_and_evict(seq, evictable_waiting)
-                    if not evicted:
-                        break
-                    if not self._ensure_runtime_state_available():
-                        seq.kv_token_limit = None
-                        break
-            else:
-                evicted, alloc_prealloc_size = __prepare_and_evict(seq, evictable_waiting)
-                if not evicted:
-                    break
-            # Prefix-cache matching can advance the sequence step and shrink
-            # the remaining prefill tail.  Charge the admitted batch with the
-            # post-match/post-rollback cost, not the conservative pre-match
-            # estimate used to decide whether this sequence is worth trying.
-            prefill_token_count = self._prefill_admission_token_count(seq)
-            self.block_manager.allocate(seq, alloc_prealloc_size)
-            if self.block_trie.enable:
-                self.block_trie.allocate(seq)
-            if self.is_ssm:
-                self.state_manager.allocate(seq)
-            if self.block_trie.enable:
-                self._finish_prefix_cache_schedule(seq)
-            _to_running(seq, prefill_token_count)
+            _to_running(seq, admission.prefill_token_count)
 
             seq.record_event(EventType.SCHEDULED)
 

--- a/lmdeploy/pytorch/paging/scheduler.py
+++ b/lmdeploy/pytorch/paging/scheduler.py
@@ -49,6 +49,7 @@ from torch.profiler import record_function
 
 from lmdeploy.messages import EventType, ScheduleMetrics
 from lmdeploy.pytorch import envs as _envs
+from lmdeploy.pytorch.long_context import get_long_context_chunk_limit, plan_long_context_chunk
 from lmdeploy.utils import get_logger
 
 from ..config import CacheConfig, SchedulerConfig
@@ -300,40 +301,14 @@ class Scheduler:
 
     def _long_context_chunk_limit(self, seq: SchedulerSequence):
         """Return the token budget for one long-context chunk."""
-        max_prefill_num = self.cache_config.max_prefill_token_num
-        mm_for_chunk_limit = seq.get_chunk_limit_multimodals()
-        for value in mm_for_chunk_limit.values():
-            max_mm_size = max([v.end - v.start for v in value], default=0)
-            max_prefill_num = max(max_prefill_num, max_mm_size)
-
-        return max_prefill_num
+        return get_long_context_chunk_limit(seq, self.cache_config.max_prefill_token_num)
 
     def _next_long_context_chunk_end(self, seq: SchedulerSequence, max_prefill_num: int | None = None):
         """Return the exclusive absolute token end for the next chunk."""
         if max_prefill_num is None:
             max_prefill_num = self._long_context_chunk_limit(seq)
-        chunk_size = min(seq.num_token_ids, max_prefill_num)
-        start = seq.num_history_ids
-        end = start + chunk_size
-
-        input_mm = seq.get_input_multimodals()
-        if len(input_mm) == 0:
-            return end
-
-        multimodal_data = []
-        for modal_type, modal_datas in input_mm.items():
-            multimodal_data += [(modal_type, data) for data in modal_datas]
-        multimodal_data = sorted(multimodal_data, key=lambda x: x[1].start)
-
-        for _, data in multimodal_data:
-            assert data.start >= start, 'multimodal data should be sorted by start'
-            if data.start >= end:
-                break
-            if data.end > end:
-                end = data.start
-                break
-
-        return end
+        plan = plan_long_context_chunk(seq, max_prefill_num, include_multimodals=False)
+        return plan.chunk_end
 
     def _prefill_kv_token_limit(self, seq: SchedulerSequence):
         """Limit KV allocation for a non-final long-context prefill chunk."""

--- a/lmdeploy/pytorch/paging/scheduler.py
+++ b/lmdeploy/pytorch/paging/scheduler.py
@@ -134,7 +134,8 @@ class _PrefillReorderer:
         return self._warn_if_not_permutation(waiting, reordered)
 
     def _warn_if_not_permutation(self, original: SeqList, reordered: SeqList):
-        """Warn if reorder drops, duplicates, or substitutes waiting sequences."""
+        """Warn if reorder drops, duplicates, or substitutes waiting
+        sequences."""
         original_ids = [id(seq) for seq in original]
         reordered_ids = [id(seq) for seq in reordered]
         if len(original_ids) == len(reordered_ids) and Counter(original_ids) == Counter(reordered_ids):
@@ -152,9 +153,8 @@ class _PrefillReorderer:
     def _get_reorder_info(self, seq: SchedulerSequence):
         """Return reorder-only info before prefix-cache side effects.
 
-        Prefix-cache match/rollback mutates the remaining prompt. Keep this
-        cache confined to waiting-list ordering and recompute fresh values in
-        the admission path.
+        Prefix-cache match/rollback mutates the remaining prompt. Keep this cache confined to waiting-list ordering and
+        recompute fresh values in the admission path.
         """
         seq_key = id(seq)
         info = self._info_cache.get(seq_key)
@@ -188,7 +188,8 @@ class _PrefillReorderer:
         return age_adjusted_chunks, info.estimated_long_chunks, seq.arrive_time
 
     def _split_by_prefill_kind(self, waiting: SeqList):
-        """Split waiting requests into normal/final and non-final long prefill."""
+        """Split waiting requests into normal/final and non-final long
+        prefill."""
         normal_waiting: SeqList = []
         long_waiting: SeqList = []
         for seq in waiting:

--- a/tests/pytorch/engine/test_inputs_maker.py
+++ b/tests/pytorch/engine/test_inputs_maker.py
@@ -520,6 +520,14 @@ def test_long_context_chunk_runs_after_decode_forward():
                                    is_chunk_multimodal=False)
     maker = _make_policy_maker(long_seq, decode_seq)
     maker._last_forward_kind = 'decode'
+    maker.engine_strategy = SimpleNamespace(get_prealloc_size=lambda is_prefill: 99)
+    reserve_calls = []
+
+    def _reserve_long_context_chunk(seq, chunk_size, prealloc_size=0, is_last_chunk=False):
+        reserve_calls.append((seq, chunk_size, prealloc_size, is_last_chunk))
+        return True
+
+    maker.scheduler.reserve_long_context_chunk = _reserve_long_context_chunk
     maker.create_model_inputs_delta = lambda: (_ for _ in ()).throw(AssertionError('decode should not repeat'))
     maker.create_model_inputs_long_context = lambda seq, chunk_size, multimodals: model_inputs
 
@@ -529,6 +537,7 @@ def test_long_context_chunk_runs_after_decode_forward():
     assert forward_inputs['delta'] is None
     assert not model_inputs.is_first_chunk
     assert not model_inputs.is_last_chunk
+    assert reserve_calls == [(long_seq, 512, 0, False)]
 
 
 def test_abandoned_long_context_chunk_is_dropped_without_cleanup_forward():
@@ -1001,6 +1010,14 @@ def test_last_long_context_chunk_runs_as_prefill_on_prefill_turn():
                                    is_chunk_multimodal=False)
     maker = _make_policy_maker(long_seq, decode_seq)
     maker._last_forward_kind = 'long_context_chunk'
+    maker.engine_strategy = SimpleNamespace(get_prealloc_size=lambda is_prefill: 7)
+    reserve_calls = []
+
+    def _reserve_long_context_chunk(seq, chunk_size, prealloc_size=0, is_last_chunk=False):
+        reserve_calls.append((seq, chunk_size, prealloc_size, is_last_chunk))
+        return True
+
+    maker.scheduler.reserve_long_context_chunk = _reserve_long_context_chunk
     maker.create_model_inputs = lambda seqs, is_prefill: model_inputs
     maker.create_model_inputs_delta_valid_only = lambda: (None, [decode_seq], [])
 
@@ -1011,6 +1028,7 @@ def test_last_long_context_chunk_runs_as_prefill_on_prefill_turn():
     assert model_inputs.is_last_chunk
     assert model_inputs.is_chunk_multimodal
     assert not maker.long_context_chunker.enabled()
+    assert reserve_calls == [(long_seq, 256, 7, True)]
 
 
 def test_do_prefill_default_forces_pending_last_chunk_prefill():

--- a/tests/pytorch/paging/test_scheduler.py
+++ b/tests/pytorch/paging/test_scheduler.py
@@ -1238,6 +1238,25 @@ def test_reserve_long_context_chunk_failure_preserves_committed_prefix():
     assert long_seq.num_blocks == 2
 
 
+def test_reserve_last_long_context_chunk_failure_restores_chunk_limit():
+    scheduler, block_size = _make_scheduler_for_long_context_chunks(num_gpu_blocks=3)
+    long_seq = scheduler.add_session(100).add_sequence([1] * (block_size * 4))
+
+    output = scheduler.schedule(is_prefill=True)
+    assert output.running == [long_seq]
+    scheduler.activate_seqs([long_seq])
+    long_seq.set_step(block_size * 2)
+
+    assert not scheduler.reserve_long_context_chunk(long_seq,
+                                                    block_size * 2,
+                                                    prealloc_size=1,
+                                                    is_last_chunk=True)
+    assert long_seq.status == MessageStatus.RUNNING
+    assert long_seq.kv_token_limit == block_size * 2
+    assert long_seq.num_blocks == 2
+    assert scheduler.block_manager.get_num_free_gpu_blocks() == 1
+
+
 def test_scheduler_accepts_prefix_hit_that_starts_middle_long_context_chunk():
     from lmdeploy.pytorch.strategies.ar.sequence import ARSequenceStrategy
     block_size = 16


### PR DESCRIPTION
**Description**
This PR is a readability-focused refactor of the PyTorch scheduler/input-maker path. It keeps scheduling behavior **UNCHANGED** while making long-context chunk planning, forward input selection, prefill admission, and BlockTrie ownership easier to reason about.

**What Changed**
- Added characterization tests for long-context chunk reservation contracts.
- Shared long-context chunk planning between scheduler and input maker.
- Extracted `_ForwardInputsTask` from `InputsMakerAsync._make_forward_inputs()` to separate selection policy from payload construction.
- Split scheduler prefill reorder/admission flow into `_PrefillReorderer` and `_PrefillAdmissionAttempt`.
- Clarified BlockTrie ownership, SSM checkpoint lifecycle, eviction, rollback, and leaf bookkeeping with docstrings/comments.
- Added warning-only diagnostics for impossible internal states.

**Non-Goals**
- No new scheduling feature.
- No intended behavior change.
