### PR TITLE
fix: enable graph capture during DP warmup decoding

### DIFF
--- a/lmdeploy/pytorch/engine/model_agent/agent.py
+++ b/lmdeploy/pytorch/engine/model_agent/agent.py
@@ -413,6 +413,7 @@ class BaseModelAgent:
             if dp > 1:
                 num_tokens = inputs.input_ids.numel()
                 inputs.build_dp_meta([num_tokens] * world_size)
+                inputs.dp_meta.dp_is_decoding = False
             logger.debug('Warmup prefill start.')
             self._forward_impl(inputs)
             torch.cuda.synchronize()
@@ -433,6 +434,7 @@ class BaseModelAgent:
                 if dp > 1:
                     num_tokens = inputs.input_ids.numel()
                     inputs.build_dp_meta([num_tokens] * world_size)
+                    inputs.dp_meta.dp_is_decoding = True
                 logger.debug(f'Warmup decoding num_tokens={num_tokens} start.')
                 self._forward_impl(inputs)
                 torch.cuda.synchronize()

--- a/lmdeploy/pytorch/spec_decode/spec_agent.py
+++ b/lmdeploy/pytorch/spec_decode/spec_agent.py
@@ -541,10 +541,8 @@ class SpecModelAgent(BaseSpecModelAgent):
     def _build_warmup_dp_meta(self, inputs: ModelInputs):
         """Build dp_meta for warmup dummy inputs.
 
-        During warmup all ranks use the same dummy batch size, so the local
-        token count can be broadcast to every rank entry in num_tokens.
-        Must be called inside draft_context so DPMeta.build uses the correct
-        dist groups.
+        During warmup all ranks use the same dummy batch size, so the local token count can be broadcast to every rank
+        entry in num_tokens. Must be called inside draft_context so DPMeta.build uses the correct dist groups.
         """
         draft_dist_config = self.draft_dist_ctx.dist_config
         if draft_dist_config.dp > 1:

--- a/lmdeploy/pytorch/spec_decode/spec_agent.py
+++ b/lmdeploy/pytorch/spec_decode/spec_agent.py
@@ -538,6 +538,21 @@ class SpecModelAgent(BaseSpecModelAgent):
         draft_model_inputs, draft_extra_inputs = self._prepare_inputs_from_main(model_inputs, extra_inputs)
         return await self._async_model_forward(draft_model_inputs, draft_extra_inputs, sampling_inputs)
 
+    def _build_warmup_dp_meta(self, inputs: ModelInputs):
+        """Build dp_meta for warmup dummy inputs.
+
+        During warmup all ranks use the same dummy batch size, so the local
+        token count can be broadcast to every rank entry in num_tokens.
+        Must be called inside draft_context so DPMeta.build uses the correct
+        dist groups.
+        """
+        draft_dist_config = self.draft_dist_ctx.dist_config
+        if draft_dist_config.dp > 1:
+            num_tokens = inputs.input_ids.numel()
+            with self.draft_context():
+                inputs.build_dp_meta([num_tokens] * draft_dist_config.world_size)
+            inputs.dp_meta.dp_is_decoding = inputs.is_decoding
+
     def warmup(self, max_batches: int, target_model_config: ModelConfig):
         """warmup."""
         target_hidden_size = self.proposer.get_target_hidden_size(target_model_config)
@@ -551,7 +566,7 @@ class SpecModelAgent(BaseSpecModelAgent):
                                                  target_dtype=self.model_config.dtype,
                                                  meta=self.make_dummy_meta)
 
-        # warmup prefill
+        self._build_warmup_dp_meta(inputs)
         self._forward_impl(inputs)
 
         capture_batch_sizes = self.proposer.model.get_capture_batch_sizes()
@@ -568,6 +583,7 @@ class SpecModelAgent(BaseSpecModelAgent):
                                                     target_hidden_size=target_hidden_size,
                                                     target_dtype=self.model_config.dtype,
                                                     meta=self.make_dummy_meta)
+            self._build_warmup_dp_meta(inputs)
             self._forward_impl(inputs)
             # decode 1 tokens per sequence
             inputs = self.inputs_strategy.make_dummy(batch_size,
@@ -578,6 +594,7 @@ class SpecModelAgent(BaseSpecModelAgent):
                                                     target_hidden_size=self.model_config.hidden_size,
                                                     target_dtype=self.model_config.dtype,
                                                     meta=self.make_dummy_meta)
+            self._build_warmup_dp_meta(inputs)
             self._forward_impl(inputs)
 
     def reset_graph_runner(self):


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily receiving feedbacks. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

When DP is enabled, the decoding graph could not be captured correctly during warmup, because `dp_meta.dp_is_decoding` was not set (or was inconsistent) for the warmup dummy inputs. In addition, the draft model in speculative decoding was missing `dp_meta` entirely during warmup, so its warmup forwards ran without the proper DP metadata and its decoding graph could not be captured.

## Modification

- **Main model** (`lmdeploy/pytorch/engine/model_agent/agent.py`): set `dp_meta.dp_is_decoding` explicitly for the warmup dummy inputs — `False` for warmup prefill and `True` for warmup decoding — so the decoding graph is captured correctly under DP.

- **Draft model** (`lmdeploy/pytorch/spec_decode/spec_agent.py`): add a `_build_warmup_dp_meta` helper that builds the previously-missing `dp_meta` for the warmup dummy inputs. Since all ranks use the same dummy batch size during warmup, the local token count is broadcast to every rank entry in `num_tokens`. It is built inside `draft_context()` so `DPMeta.build` uses the correct dist groups, and `dp_is_decoding` is set from the input's `is_decoding` flag. This helper is applied to all warmup forwards (prefill and decoding).

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
