### PR TITLE
Stream tool parameters during response parsing

### DIFF
--- a/lmdeploy/serve/openai/api_server.py
+++ b/lmdeploy/serve/openai/api_server.py
@@ -270,7 +270,10 @@ def _should_suppress_empty_stream_delta(response_parser, delta_message: DeltaMes
     """Return whether an empty parser result is hidden from chat SSE output."""
     if not (
         getattr(response_parser, 'tool_parser', None) is not None
-        and getattr(response_parser, '_mode', None) == getattr(response_parser, 'MODE_TOOL', None)
+        and (
+            getattr(response_parser, '_mode', None) == getattr(response_parser, 'MODE_TOOL', None)
+            or getattr(response_parser, '_last_stream_consumed_tool', False)
+        )
     ):
         return False
     if delta_message is None:

--- a/lmdeploy/serve/openai/api_server.py
+++ b/lmdeploy/serve/openai/api_server.py
@@ -266,12 +266,16 @@ def _create_output_token_logprobs(token_ids: list[int] | None = None,
     return output_token_logprobs or None
 
 
-def _should_suppress_empty_stream_delta(response_parser) -> bool:
+def _should_suppress_empty_stream_delta(response_parser, delta_message: DeltaMessage | None = None) -> bool:
     """Return whether an empty parser result is hidden from chat SSE output."""
-    return (
+    if not (
         getattr(response_parser, 'tool_parser', None) is not None
         and getattr(response_parser, '_mode', None) == getattr(response_parser, 'MODE_TOOL', None)
-    )
+    ):
+        return False
+    if delta_message is None:
+        return True
+    return delta_message.content == '' and delta_message.reasoning_content is None and not delta_message.tool_calls
 
 
 @router.get('/health')
@@ -608,6 +612,16 @@ async def chat_completions_v1(request: ChatCompletionRequest, raw_request: Reque
                 res.response,
                 delta_token_ids
             )
+            if res.finish_reason is None and stream_deltas and _should_suppress_empty_stream_delta(response_parser):
+                stream_deltas = [
+                    (delta_message, tool_emitted)
+                    for delta_message, tool_emitted in stream_deltas
+                    if not _should_suppress_empty_stream_delta(response_parser, delta_message)
+                ]
+                if not stream_deltas:
+                    if request.return_token_ids and delta_token_ids:
+                        pending_output_ids.extend(delta_token_ids)
+                    continue
             if not stream_deltas:
                 # Parser may buffer partial protocol tags and emit no visible delta
                 # while the engine still produced new tokens (e.g. MTP batch). Do not

--- a/lmdeploy/serve/openai/api_server.py
+++ b/lmdeploy/serve/openai/api_server.py
@@ -266,6 +266,14 @@ def _create_output_token_logprobs(token_ids: list[int] | None = None,
     return output_token_logprobs or None
 
 
+def _should_suppress_empty_stream_delta(response_parser) -> bool:
+    """Return whether an empty parser result is hidden from chat SSE output."""
+    return (
+        getattr(response_parser, 'tool_parser', None) is not None
+        and getattr(response_parser, '_mode', None) == getattr(response_parser, 'MODE_TOOL', None)
+    )
+
+
 @router.get('/health')
 async def health() -> JSONResponse:
     """Health check."""
@@ -581,6 +589,7 @@ async def chat_completions_v1(request: ChatCompletionRequest, raw_request: Reque
     async def completion_stream_generator() -> AsyncGenerator[str, None]:
         streaming_tools = False
         final_usage = None
+        pending_output_ids: list[int] = []
         async for res in result_generator:
             logprobs = None
             output_token_logprobs = None
@@ -603,6 +612,10 @@ async def chat_completions_v1(request: ChatCompletionRequest, raw_request: Reque
                 # Parser may buffer partial protocol tags and emit no visible delta
                 # while the engine still produced new tokens (e.g. MTP batch). Do not
                 # drop those token ids; emit them once on a placeholder delta.
+                if res.finish_reason is None and _should_suppress_empty_stream_delta(response_parser):
+                    if request.return_token_ids and delta_token_ids:
+                        pending_output_ids.extend(delta_token_ids)
+                    continue
                 if res.finish_reason is None and not delta_token_ids:
                     continue
                 stream_deltas = [(DeltaMessage(role='assistant', content=''), False)]
@@ -632,7 +645,10 @@ async def chat_completions_v1(request: ChatCompletionRequest, raw_request: Reque
                 routed_experts = res.routed_experts if finish_reason is not None else None
                 # Emit token ids once per engine yield on the last parsed delta, when
                 # accumulated delta text and token ids for this step are aligned.
-                stream_output_ids = delta_token_ids if (request.return_token_ids and is_last_delta) else None
+                stream_output_ids = None
+                if request.return_token_ids and is_last_delta:
+                    stream_output_ids = pending_output_ids + delta_token_ids
+                    pending_output_ids = []
 
                 response_json = create_stream_response_json(index=0,
                                                             delta_message=delta_message,

--- a/lmdeploy/serve/parsers/response_parser.py
+++ b/lmdeploy/serve/parsers/response_parser.py
@@ -285,6 +285,7 @@ class BaseResponseParser(ResponseParser):
         else:
             self._mode = self.MODE_PLAIN
         self._pending = ''
+        self._last_stream_consumed_tool = False
 
     def stream_chunk(
         self,
@@ -322,6 +323,7 @@ class BaseResponseParser(ResponseParser):
 
         self._accumulated_text += delta_text
         self._pending += delta_text
+        self._last_stream_consumed_tool = False
         produced_any = False
         deltas: list[tuple[DeltaMessage, bool]] = []
 
@@ -344,6 +346,8 @@ class BaseResponseParser(ResponseParser):
                 # self._consume_plain() might change the mode to MODE_TOOL
                 # so we need to check the mode again
                 new_calls, progressed = self._consume_tool()
+                if progressed:
+                    self._last_stream_consumed_tool = True
                 if new_calls:
                     deltas.append((DeltaMessage(role='assistant', tool_calls=new_calls), True))
                     produced_any = True

--- a/lmdeploy/serve/parsers/tool_parser/glm47_tool_parser.py
+++ b/lmdeploy/serve/parsers/tool_parser/glm47_tool_parser.py
@@ -164,6 +164,16 @@ class Glm47ToolParser(XmlToolParser):
 
     def _extract_streaming_param(self, payload: str) -> tuple[str | None, str, bool]:
         payload = payload.strip()
+        args_start_idx = payload.find(self.arg_key_start_token)
+        args_text = payload[args_start_idx:] if args_start_idx >= 0 else ''
+        if self._open_arg_key is not None and self._value_start >= 0:
+            value_end = args_text.find(self.arg_value_end_token, self._value_start)
+            if value_end < 0:
+                raw_value = self._strip_partial_xml_close_suffix(args_text[self._value_start:],
+                                                                 self.arg_value_end_token)
+                return self._open_arg_key, raw_value, False
+            return self._open_arg_key, args_text[self._value_start:value_end], True
+
         key_start = payload.rfind(self.arg_key_start_token)
         if key_start < 0:
             return None, '', False

--- a/lmdeploy/serve/parsers/tool_parser/glm47_tool_parser.py
+++ b/lmdeploy/serve/parsers/tool_parser/glm47_tool_parser.py
@@ -162,6 +162,29 @@ class Glm47ToolParser(XmlToolParser):
             self._scan_pos = next_pos
             self._in_progress_value = False
 
+    def _extract_streaming_param(self, payload: str) -> tuple[str | None, str, bool]:
+        payload = payload.strip()
+        key_start = payload.rfind(self.arg_key_start_token)
+        if key_start < 0:
+            return None, '', False
+
+        key_content_start = key_start + len(self.arg_key_start_token)
+        key_end = payload.find(self.arg_key_end_token, key_content_start)
+        if key_end < 0:
+            return None, '', False
+
+        key = payload[key_content_start:key_end].strip()
+        value_start = payload.find(self.arg_value_start_token, key_end + len(self.arg_key_end_token))
+        if value_start < 0:
+            return None, '', False
+
+        value_content_start = value_start + len(self.arg_value_start_token)
+        value_end = payload.find(self.arg_value_end_token, value_content_start)
+        if value_end < 0:
+            raw_value = self._strip_partial_xml_close_suffix(payload[value_content_start:], self.arg_value_end_token)
+            return key, raw_value, False
+        return key, payload[value_content_start:value_end], True
+
     def _parse_payload(self, payload: str, *, final: bool = False) -> tuple[str | None, dict[str, str]]:
         payload = payload.strip()
         if not payload:

--- a/lmdeploy/serve/parsers/tool_parser/qwen3coder_tool_parser.py
+++ b/lmdeploy/serve/parsers/tool_parser/qwen3coder_tool_parser.py
@@ -163,6 +163,13 @@ class Qwen3CoderToolParser(XmlToolParser):
 
     def _extract_streaming_param(self, payload: str) -> tuple[str | None, str, bool]:
         content = payload.strip()
+        if self._open_param_name is not None and self._value_start >= 0:
+            value_end = content.find(self.param_suffix, self._value_start)
+            if value_end == -1:
+                raw_value = self._strip_partial_xml_close_suffix(content[self._value_start:], self.param_suffix)
+                return self._open_param_name, raw_value.strip(), False
+            return self._open_param_name, content[self._value_start:value_end].strip(), True
+
         param_start = content.rfind(self.param_prefix)
         if param_start == -1:
             return None, '', False

--- a/lmdeploy/serve/parsers/tool_parser/qwen3coder_tool_parser.py
+++ b/lmdeploy/serve/parsers/tool_parser/qwen3coder_tool_parser.py
@@ -161,6 +161,25 @@ class Qwen3CoderToolParser(XmlToolParser):
             self._scan_pos = next_pos
             self._in_progress_value = False
 
+    def _extract_streaming_param(self, payload: str) -> tuple[str | None, str, bool]:
+        content = payload.strip()
+        param_start = content.rfind(self.param_prefix)
+        if param_start == -1:
+            return None, '', False
+
+        name_start = param_start + len(self.param_prefix)
+        name_end = content.find('>', name_start)
+        if name_end == -1:
+            return None, '', False
+
+        param_name = content[name_start:name_end].strip()
+        value_start = name_end + 1
+        value_end = content.find(self.param_suffix, value_start)
+        if value_end == -1:
+            raw_value = self._strip_partial_xml_close_suffix(content[value_start:], self.param_suffix)
+            return param_name, raw_value.strip(), False
+        return param_name, content[value_start:value_end].strip(), True
+
     @staticmethod
     def _parse_param_value(param_val_str: str) -> Any:
         try:

--- a/lmdeploy/serve/parsers/tool_parser/qwen3coder_tool_parser.py
+++ b/lmdeploy/serve/parsers/tool_parser/qwen3coder_tool_parser.py
@@ -45,6 +45,9 @@ class Qwen3CoderToolParser(XmlToolParser):
     def _close_json_on_final(self) -> bool:
         return False
 
+    def _stream_quoted_string_without_schema(self) -> bool:
+        return True
+
     @classmethod
     def get_tool_open_tag(cls) -> str | None:
         return '<tool_call>'

--- a/lmdeploy/serve/parsers/tool_parser/qwen3coder_tool_parser.py
+++ b/lmdeploy/serve/parsers/tool_parser/qwen3coder_tool_parser.py
@@ -45,9 +45,6 @@ class Qwen3CoderToolParser(XmlToolParser):
     def _close_json_on_final(self) -> bool:
         return False
 
-    def _stream_quoted_string_without_schema(self) -> bool:
-        return True
-
     @classmethod
     def get_tool_open_tag(cls) -> str | None:
         return '<tool_call>'

--- a/lmdeploy/serve/parsers/tool_parser/tool_parser.py
+++ b/lmdeploy/serve/parsers/tool_parser/tool_parser.py
@@ -147,11 +147,11 @@ class ToolParser:
                     ))
                 self._name_emitted = True
 
-        if 'arguments' in obj:
+        if self._args_payload_key:
+            args_key = self._args_payload_key
+        elif 'arguments' in obj:
             args_key = 'arguments'
         elif 'parameters' in obj:
-            if not final:
-                return out
             args_key = 'parameters'
         else:
             return out

--- a/lmdeploy/serve/parsers/tool_parser/tool_parser.py
+++ b/lmdeploy/serve/parsers/tool_parser/tool_parser.py
@@ -34,6 +34,7 @@ class ToolParser:
         self._active_tool_index: int = -1
         self._name_emitted: bool = False
         self._args_emitted_len: int = 0
+        self._args_payload_start: int = -1
 
     def adjust_request(self, request: ChatCompletionRequest) -> ChatCompletionRequest:
         """Adjust request payload before rendering, if needed."""
@@ -60,6 +61,7 @@ class ToolParser:
         self._active_tool_call_id = f'chatcmpl-tool-{shortuuid.random()}'
         self._name_emitted = False
         self._args_emitted_len = 0
+        self._args_payload_start = -1
         self._tool_payload = ''
 
     def finish_tool_call(self) -> None:
@@ -67,6 +69,7 @@ class ToolParser:
         self._active_tool_call_id = ''
         self._name_emitted = False
         self._args_emitted_len = 0
+        self._args_payload_start = -1
         self._tool_payload = ''
 
     def decode_tool_incremental(self, added_text: str, *, final: bool) -> list[DeltaToolCall]:
@@ -115,7 +118,8 @@ class ToolParser:
 
     def _decode_tool_incremental_json(self, added_text: str, *, final: bool) -> list[DeltaToolCall]:
         self._tool_payload += added_text
-        payload = self._tool_payload.strip()
+        raw_payload = self._tool_payload.lstrip()
+        payload = raw_payload.strip()
         if not payload:
             return []
 
@@ -148,11 +152,19 @@ class ToolParser:
         if args_json in ('{}', '[]'):
             return out
 
-        # Emit argument text only when the tool payload is complete. This keeps
-        # streamed argument chunks valid JSON and avoids malformed intermediate
-        # fragments when partial parsers expose transient dict states.
-        if final and len(args_json) > self._args_emitted_len:
-            diff = args_json[self._args_emitted_len:]
+        if self._args_payload_start < 0:
+            args_key = 'arguments' if 'arguments' in obj else 'parameters'
+            self._args_payload_start = self._find_json_key_value_start(raw_payload, args_key)
+        if self._args_payload_start < 0:
+            return out
+
+        args_payload_end = self._find_json_value_end(raw_payload, self._args_payload_start)
+        if args_payload_end < 0:
+            args_payload_end = len(raw_payload)
+
+        args_payload = raw_payload[self._args_payload_start:args_payload_end]
+        if len(args_payload) > self._args_emitted_len:
+            diff = args_payload[self._args_emitted_len:]
             out.append(
                 DeltaToolCall(
                     id=None,
@@ -160,8 +172,79 @@ class ToolParser:
                     type=None,
                     function=DeltaFunctionCall(arguments=diff),
                 ))
-            self._args_emitted_len = len(args_json)
+            self._args_emitted_len = len(args_payload)
         return out
+
+    @staticmethod
+    def _find_json_key_value_start(payload: str, key: str) -> int:
+        depth = 0
+        i = 0
+        while i < len(payload):
+            ch = payload[i]
+            if ch == '"':
+                value, end = ToolParser._read_json_string(payload, i)
+                if end < 0:
+                    return -1
+                j = end
+                while j < len(payload) and payload[j].isspace():
+                    j += 1
+                if depth == 1 and value == key and j < len(payload) and payload[j] == ':':
+                    j += 1
+                    while j < len(payload) and payload[j].isspace():
+                        j += 1
+                    return j if j < len(payload) else -1
+                i = end
+                continue
+            if ch in '{[':
+                depth += 1
+            elif ch in '}]':
+                depth -= 1
+            i += 1
+        return -1
+
+    @staticmethod
+    def _find_json_value_end(payload: str, start: int) -> int:
+        depth = 0
+        i = start
+        while i < len(payload):
+            ch = payload[i]
+            if ch == '"':
+                _, end = ToolParser._read_json_string(payload, i)
+                if end < 0:
+                    return -1
+                i = end
+                continue
+            if ch in '{[':
+                depth += 1
+            elif ch in '}]':
+                if depth == 0:
+                    return i
+                depth -= 1
+                if depth == 0:
+                    return i + 1
+            elif depth == 0 and ch in ',':
+                return i
+            i += 1
+        return -1
+
+    @staticmethod
+    def _read_json_string(payload: str, start: int) -> tuple[str, int]:
+        chars: list[str] = []
+        escaped = False
+        i = start + 1
+        while i < len(payload):
+            ch = payload[i]
+            if escaped:
+                chars.append(ch)
+                escaped = False
+            elif ch == '\\':
+                escaped = True
+            elif ch == '"':
+                return ''.join(chars), i + 1
+            else:
+                chars.append(ch)
+            i += 1
+        return '', -1
 
     @staticmethod
     def _parse_tool_call_complete_json(payload: str) -> ToolCall | None:

--- a/lmdeploy/serve/parsers/tool_parser/tool_parser.py
+++ b/lmdeploy/serve/parsers/tool_parser/tool_parser.py
@@ -147,13 +147,8 @@ class ToolParser:
                     ))
                 self._name_emitted = True
 
-        if self._args_payload_key:
-            args_key = self._args_payload_key
-        elif 'arguments' in obj:
-            args_key = 'arguments'
-        elif 'parameters' in obj:
-            args_key = 'parameters'
-        else:
+        args_key = self._args_payload_key or self._select_json_args_key(raw_payload, obj)
+        if args_key is None:
             return out
 
         if args_key != self._args_payload_key:
@@ -182,6 +177,19 @@ class ToolParser:
                 ))
             self._args_emitted_len = len(args_payload)
         return out
+
+    @staticmethod
+    def _select_json_args_key(payload: str, obj: dict) -> str | None:
+        found_keys: list[tuple[int, str]] = []
+        for key in ('arguments', 'parameters'):
+            if key not in obj:
+                continue
+            value_start = ToolParser._find_json_key_value_start(payload, key)
+            if value_start >= 0:
+                found_keys.append((value_start, key))
+        if found_keys:
+            return min(found_keys)[1]
+        return None
 
     @staticmethod
     def _find_json_key_value_start(payload: str, key: str) -> int:
@@ -248,7 +256,11 @@ class ToolParser:
             elif ch == '\\':
                 escaped = True
             elif ch == '"':
-                return ''.join(chars), i + 1
+                end = i + 1
+                try:
+                    return json.loads(payload[start:end]), end
+                except json.JSONDecodeError:
+                    return ''.join(chars), end
             else:
                 chars.append(ch)
             i += 1
@@ -267,6 +279,7 @@ class ToolParser:
         name = obj.get('name')
         if not isinstance(name, str) or not name:
             return None
-        args_obj = obj.get('arguments', obj.get('parameters', {}))
+        args_key = ToolParser._select_json_args_key(payload.lstrip(), obj)
+        args_obj = obj[args_key] if args_key is not None else {}
         args_json = json.dumps(args_obj, ensure_ascii=False)
         return ToolCall(function=FunctionCall(name=name, arguments=args_json))

--- a/lmdeploy/serve/parsers/tool_parser/tool_parser.py
+++ b/lmdeploy/serve/parsers/tool_parser/tool_parser.py
@@ -147,8 +147,13 @@ class ToolParser:
                     ))
                 self._name_emitted = True
 
-        args_key = self._args_payload_key or self._select_json_args_key(raw_payload, obj)
-        if args_key is None:
+        if self._args_payload_key:
+            args_key = self._args_payload_key
+        elif 'arguments' in obj:
+            args_key = 'arguments'
+        elif 'parameters' in obj:
+            args_key = 'parameters'
+        else:
             return out
 
         if args_key != self._args_payload_key:
@@ -177,19 +182,6 @@ class ToolParser:
                 ))
             self._args_emitted_len = len(args_payload)
         return out
-
-    @staticmethod
-    def _select_json_args_key(payload: str, obj: dict) -> str | None:
-        found_keys: list[tuple[int, str]] = []
-        for key in ('arguments', 'parameters'):
-            if key not in obj:
-                continue
-            value_start = ToolParser._find_json_key_value_start(payload, key)
-            if value_start >= 0:
-                found_keys.append((value_start, key))
-        if found_keys:
-            return min(found_keys)[1]
-        return None
 
     @staticmethod
     def _find_json_key_value_start(payload: str, key: str) -> int:
@@ -256,11 +248,7 @@ class ToolParser:
             elif ch == '\\':
                 escaped = True
             elif ch == '"':
-                end = i + 1
-                try:
-                    return json.loads(payload[start:end]), end
-                except json.JSONDecodeError:
-                    return ''.join(chars), end
+                return ''.join(chars), i + 1
             else:
                 chars.append(ch)
             i += 1
@@ -279,7 +267,6 @@ class ToolParser:
         name = obj.get('name')
         if not isinstance(name, str) or not name:
             return None
-        args_key = ToolParser._select_json_args_key(payload.lstrip(), obj)
-        args_obj = obj[args_key] if args_key is not None else {}
+        args_obj = obj.get('arguments', obj.get('parameters', {}))
         args_json = json.dumps(args_obj, ensure_ascii=False)
         return ToolCall(function=FunctionCall(name=name, arguments=args_json))

--- a/lmdeploy/serve/parsers/tool_parser/tool_parser.py
+++ b/lmdeploy/serve/parsers/tool_parser/tool_parser.py
@@ -148,10 +148,6 @@ class ToolParser:
         if args_obj is None:
             return out
 
-        args_json = json.dumps(args_obj, ensure_ascii=False)
-        if args_json in ('{}', '[]'):
-            return out
-
         if self._args_payload_start < 0:
             args_key = 'arguments' if 'arguments' in obj else 'parameters'
             self._args_payload_start = self._find_json_key_value_start(raw_payload, args_key)

--- a/lmdeploy/serve/parsers/tool_parser/tool_parser.py
+++ b/lmdeploy/serve/parsers/tool_parser/tool_parser.py
@@ -34,6 +34,7 @@ class ToolParser:
         self._active_tool_index: int = -1
         self._name_emitted: bool = False
         self._args_emitted_len: int = 0
+        self._args_payload_key: str = ''
         self._args_payload_start: int = -1
 
     def adjust_request(self, request: ChatCompletionRequest) -> ChatCompletionRequest:
@@ -61,6 +62,7 @@ class ToolParser:
         self._active_tool_call_id = f'chatcmpl-tool-{shortuuid.random()}'
         self._name_emitted = False
         self._args_emitted_len = 0
+        self._args_payload_key = ''
         self._args_payload_start = -1
         self._tool_payload = ''
 
@@ -69,6 +71,7 @@ class ToolParser:
         self._active_tool_call_id = ''
         self._name_emitted = False
         self._args_emitted_len = 0
+        self._args_payload_key = ''
         self._args_payload_start = -1
         self._tool_payload = ''
 
@@ -147,9 +150,16 @@ class ToolParser:
         if 'arguments' in obj:
             args_key = 'arguments'
         elif 'parameters' in obj:
+            if not final:
+                return out
             args_key = 'parameters'
         else:
             return out
+
+        if args_key != self._args_payload_key:
+            self._args_payload_key = args_key
+            self._args_payload_start = -1
+            self._args_emitted_len = 0
 
         if self._args_payload_start < 0:
             self._args_payload_start = self._find_json_key_value_start(raw_payload, args_key)

--- a/lmdeploy/serve/parsers/tool_parser/tool_parser.py
+++ b/lmdeploy/serve/parsers/tool_parser/tool_parser.py
@@ -144,12 +144,14 @@ class ToolParser:
                     ))
                 self._name_emitted = True
 
-        args_obj = obj.get('arguments', obj.get('parameters', None))
-        if args_obj is None:
+        if 'arguments' in obj:
+            args_key = 'arguments'
+        elif 'parameters' in obj:
+            args_key = 'parameters'
+        else:
             return out
 
         if self._args_payload_start < 0:
-            args_key = 'arguments' if 'arguments' in obj else 'parameters'
             self._args_payload_start = self._find_json_key_value_start(raw_payload, args_key)
         if self._args_payload_start < 0:
             return out

--- a/lmdeploy/serve/parsers/tool_parser/xml_tool_parser.py
+++ b/lmdeploy/serve/parsers/tool_parser/xml_tool_parser.py
@@ -124,11 +124,13 @@ class XmlToolParser(ToolParser):
             return
         value = args_dict[param_name]
         if self._xml_streaming_param_quote_opened:
-            value_text = json.dumps(value, ensure_ascii=False)[1:-1] if isinstance(value, str) else ''
+            if isinstance(value, str) and len(value) > self._xml_streaming_param_emitted_raw_len:
+                diff = value[self._xml_streaming_param_emitted_raw_len:]
+                json_fragments.append(json.dumps(diff, ensure_ascii=False)[1:-1])
         else:
             value_text = json.dumps(value, ensure_ascii=False)
-        if len(value_text) > self._xml_streaming_param_emitted_raw_len:
-            json_fragments.append(value_text[self._xml_streaming_param_emitted_raw_len:])
+            if len(value_text) > self._xml_streaming_param_emitted_raw_len:
+                json_fragments.append(value_text[self._xml_streaming_param_emitted_raw_len:])
         if self._xml_streaming_param_quote_opened:
             json_fragments.append('"')
         self._reset_streaming_param()

--- a/lmdeploy/serve/parsers/tool_parser/xml_tool_parser.py
+++ b/lmdeploy/serve/parsers/tool_parser/xml_tool_parser.py
@@ -81,6 +81,7 @@ class XmlToolParser(ToolParser):
         should_close = is_closed or (final and self._close_json_on_final())
 
         json_fragments: list[str] = []
+        self._append_completed_streaming_param_close(json_fragments, args_dict)
         has_streaming_param = self._prepare_streaming_param(
             func_name,
             streaming_param_name,
@@ -116,6 +117,14 @@ class XmlToolParser(ToolParser):
                     function=DeltaFunctionCall(arguments=''.join(json_fragments)),
                 ))
         return out
+
+    def _append_completed_streaming_param_close(self, json_fragments: list[str], args_dict: dict[str, Any]) -> None:
+        param_name = self._xml_streaming_param_name
+        if param_name is None or param_name not in args_dict or param_name not in self._xml_emitted_param_names:
+            return
+        if self._xml_streaming_param_quote_opened:
+            json_fragments.append('"')
+        self._reset_streaming_param()
 
     def _prepare_streaming_param(self,
                                  func_name: str | None,

--- a/lmdeploy/serve/parsers/tool_parser/xml_tool_parser.py
+++ b/lmdeploy/serve/parsers/tool_parser/xml_tool_parser.py
@@ -122,6 +122,10 @@ class XmlToolParser(ToolParser):
         param_name = self._xml_streaming_param_name
         if param_name is None or param_name not in args_dict or param_name not in self._xml_emitted_param_names:
             return
+        value = args_dict[param_name]
+        if isinstance(value, str) and len(value) > self._xml_streaming_param_emitted_raw_len:
+            diff = value[self._xml_streaming_param_emitted_raw_len:]
+            json_fragments.append(json.dumps(diff, ensure_ascii=False)[1:-1])
         if self._xml_streaming_param_quote_opened:
             json_fragments.append('"')
         self._reset_streaming_param()

--- a/lmdeploy/serve/parsers/tool_parser/xml_tool_parser.py
+++ b/lmdeploy/serve/parsers/tool_parser/xml_tool_parser.py
@@ -157,10 +157,12 @@ class XmlToolParser(ToolParser):
         if param_name is None:
             return False
         value_text = self._streaming_value_text(raw_value)
-        if value_text is None:
+        if value_text is None and self._streaming_param_emits_json_string():
             return False
         if param_name not in self._xml_emitted_param_names:
-            return bool(value_text) or is_param_closed
+            return bool(value_text) or not self._streaming_param_emits_json_string() or is_param_closed
+        if value_text is None:
+            return False
         return len(value_text) > self._xml_streaming_param_emitted_raw_len or is_param_closed
 
     def _streaming_value_text(self, raw_value: str) -> str | None:
@@ -187,10 +189,10 @@ class XmlToolParser(ToolParser):
             return
 
         value_text = self._streaming_value_text(raw_value)
-        if value_text is None:
+        is_string = self._streaming_param_emits_json_string()
+        if value_text is None and is_string:
             return
 
-        is_string = self._streaming_param_emits_json_string()
         if param_name not in self._xml_emitted_param_names:
             prefix = ', ' if len(self._xml_emitted_param_names) > 0 else ''
             json_fragments.append(f'{prefix}\"{param_name}\": ')
@@ -199,7 +201,7 @@ class XmlToolParser(ToolParser):
                 self._xml_streaming_param_quote_opened = True
             self._xml_emitted_param_names.add(param_name)
 
-        if len(value_text) > self._xml_streaming_param_emitted_raw_len:
+        if value_text is not None and len(value_text) > self._xml_streaming_param_emitted_raw_len:
             diff = value_text[self._xml_streaming_param_emitted_raw_len:]
             if is_string:
                 diff = json.dumps(diff, ensure_ascii=False)[1:-1]

--- a/lmdeploy/serve/parsers/tool_parser/xml_tool_parser.py
+++ b/lmdeploy/serve/parsers/tool_parser/xml_tool_parser.py
@@ -169,6 +169,8 @@ class XmlToolParser(ToolParser):
             return None
         if stripped_value.startswith('"'):
             return None
+        if self._xml_streaming_param_schema_type == 'string' and raw_value != raw_value.strip():
+            return None
         if self._xml_streaming_param_schema_type in (None, 'string'):
             return raw_value
         return None

--- a/lmdeploy/serve/parsers/tool_parser/xml_tool_parser.py
+++ b/lmdeploy/serve/parsers/tool_parser/xml_tool_parser.py
@@ -166,22 +166,13 @@ class XmlToolParser(ToolParser):
         if not stripped_value:
             return None
         if stripped_value.startswith('"'):
-            if self._xml_streaming_param_schema_type != 'string' and not self._stream_quoted_string_without_schema():
-                return None
-            return self._strip_json_string_framing(stripped_value)
+            return None
         if self._xml_streaming_param_schema_type in (None, 'string'):
             return raw_value
-        if self._xml_streaming_param_schema_type == 'integer':
-            return raw_value if self._looks_like_integer(raw_value) else None
-        if self._xml_streaming_param_schema_type == 'number':
-            return raw_value if self._looks_like_number(raw_value) else None
         return None
 
     def _streaming_param_emits_json_string(self) -> bool:
         return self._xml_streaming_param_schema_type in (None, 'string')
-
-    def _stream_quoted_string_without_schema(self) -> bool:
-        return False
 
     def _append_streaming_param_fragments(self,
                                           json_fragments: list[str],
@@ -237,29 +228,6 @@ class XmlToolParser(ToolParser):
             if close_tag.startswith(raw_value[-suffix_len:]):
                 return raw_value[:-suffix_len]
         return raw_value
-
-    @staticmethod
-    def _strip_json_string_framing(raw_value: str) -> str:
-        value = raw_value[1:]
-        if value.endswith('"') and not value.endswith(r'\"'):
-            return value[:-1]
-        return value
-
-    @staticmethod
-    def _looks_like_integer(raw_value: str) -> bool:
-        value = raw_value.strip()
-        return bool(value) and (value.isdigit() or (value.startswith('-') and value[1:].isdigit()))
-
-    @staticmethod
-    def _looks_like_number(raw_value: str) -> bool:
-        value = raw_value.strip()
-        if not value:
-            return False
-        try:
-            parsed_value = json.loads(value)
-        except json.JSONDecodeError:
-            return False
-        return isinstance(parsed_value, (int, float)) and not isinstance(parsed_value, bool)
 
     def _build_function_param_schemas(self, request: ChatCompletionRequest) -> dict[str, dict[str, dict[str, Any]]]:
         """Build function->parameter schema map from request tools."""

--- a/lmdeploy/serve/parsers/tool_parser/xml_tool_parser.py
+++ b/lmdeploy/serve/parsers/tool_parser/xml_tool_parser.py
@@ -54,10 +54,7 @@ class XmlToolParser(ToolParser):
         self._payload_parts.clear()
         self._coerced_args.clear()
         self._in_progress_value = False
-        self._xml_streaming_param_name = None
-        self._xml_streaming_param_emitted_raw_len = 0
-        self._xml_streaming_param_schema_type = None
-        self._xml_streaming_param_quote_opened = False
+        self._reset_streaming_param()
         self._reset_incremental_state()
 
     def _reset_incremental_state(self) -> None:
@@ -100,6 +97,8 @@ class XmlToolParser(ToolParser):
             prefix = ', ' if len(self._xml_emitted_param_names) > 0 else ''
             json_fragments.append(f'{prefix}\"{key}\": {json.dumps(value, ensure_ascii=False)}')
             self._xml_emitted_param_names.add(key)
+            if key == self._xml_streaming_param_name:
+                self._reset_streaming_param()
 
         if has_streaming_param and has_streaming_update:
             self._append_streaming_param_fragments(json_fragments, streaming_raw_value, is_param_closed)
@@ -139,9 +138,17 @@ class XmlToolParser(ToolParser):
         param_name = self._xml_streaming_param_name
         if param_name is None:
             return False
+        if not self._can_stream_raw_param_value(raw_value):
+            return False
         if param_name not in self._xml_emitted_param_names:
             return bool(raw_value) or is_param_closed
         return len(raw_value) > self._xml_streaming_param_emitted_raw_len or is_param_closed
+
+    def _can_stream_raw_param_value(self, raw_value: str) -> bool:
+        if self._xml_streaming_param_schema_type not in (None, 'string'):
+            return False
+        stripped_value = raw_value.lstrip()
+        return bool(stripped_value) and not stripped_value.startswith('"')
 
     def _append_streaming_param_fragments(self,
                                           json_fragments: list[str],
@@ -170,10 +177,13 @@ class XmlToolParser(ToolParser):
         if is_param_closed:
             if is_string and self._xml_streaming_param_quote_opened:
                 json_fragments.append('"')
-            self._xml_streaming_param_name = None
-            self._xml_streaming_param_emitted_raw_len = 0
-            self._xml_streaming_param_schema_type = None
-            self._xml_streaming_param_quote_opened = False
+            self._reset_streaming_param()
+
+    def _reset_streaming_param(self) -> None:
+        self._xml_streaming_param_name = None
+        self._xml_streaming_param_emitted_raw_len = 0
+        self._xml_streaming_param_schema_type = None
+        self._xml_streaming_param_quote_opened = False
 
     def _get_param_schema_type(self, func_name: str | None, param_name: str) -> str | None:
         if func_name is None:

--- a/lmdeploy/serve/parsers/tool_parser/xml_tool_parser.py
+++ b/lmdeploy/serve/parsers/tool_parser/xml_tool_parser.py
@@ -123,9 +123,12 @@ class XmlToolParser(ToolParser):
         if param_name is None or param_name not in args_dict or param_name not in self._xml_emitted_param_names:
             return
         value = args_dict[param_name]
-        if isinstance(value, str) and len(value) > self._xml_streaming_param_emitted_raw_len:
-            diff = value[self._xml_streaming_param_emitted_raw_len:]
-            json_fragments.append(json.dumps(diff, ensure_ascii=False)[1:-1])
+        if self._xml_streaming_param_quote_opened:
+            value_text = json.dumps(value, ensure_ascii=False)[1:-1] if isinstance(value, str) else ''
+        else:
+            value_text = json.dumps(value, ensure_ascii=False)
+        if len(value_text) > self._xml_streaming_param_emitted_raw_len:
+            json_fragments.append(value_text[self._xml_streaming_param_emitted_raw_len:])
         if self._xml_streaming_param_quote_opened:
             json_fragments.append('"')
         self._reset_streaming_param()
@@ -151,17 +154,34 @@ class XmlToolParser(ToolParser):
         param_name = self._xml_streaming_param_name
         if param_name is None:
             return False
-        if not self._can_stream_raw_param_value(raw_value):
+        value_text = self._streaming_value_text(raw_value)
+        if value_text is None:
             return False
         if param_name not in self._xml_emitted_param_names:
-            return bool(raw_value) or is_param_closed
-        return len(raw_value) > self._xml_streaming_param_emitted_raw_len or is_param_closed
+            return bool(value_text) or is_param_closed
+        return len(value_text) > self._xml_streaming_param_emitted_raw_len or is_param_closed
 
-    def _can_stream_raw_param_value(self, raw_value: str) -> bool:
-        if self._xml_streaming_param_schema_type not in (None, 'string'):
-            return False
+    def _streaming_value_text(self, raw_value: str) -> str | None:
         stripped_value = raw_value.lstrip()
-        return bool(stripped_value) and not stripped_value.startswith('"')
+        if not stripped_value:
+            return None
+        if stripped_value.startswith('"'):
+            if self._xml_streaming_param_schema_type != 'string' and not self._stream_quoted_string_without_schema():
+                return None
+            return self._strip_json_string_framing(stripped_value)
+        if self._xml_streaming_param_schema_type in (None, 'string'):
+            return raw_value
+        if self._xml_streaming_param_schema_type == 'integer':
+            return raw_value if self._looks_like_integer(raw_value) else None
+        if self._xml_streaming_param_schema_type == 'number':
+            return raw_value if self._looks_like_number(raw_value) else None
+        return None
+
+    def _streaming_param_emits_json_string(self) -> bool:
+        return self._xml_streaming_param_schema_type in (None, 'string')
+
+    def _stream_quoted_string_without_schema(self) -> bool:
+        return False
 
     def _append_streaming_param_fragments(self,
                                           json_fragments: list[str],
@@ -171,7 +191,11 @@ class XmlToolParser(ToolParser):
         if param_name is None:
             return
 
-        is_string = self._xml_streaming_param_schema_type in (None, 'string')
+        value_text = self._streaming_value_text(raw_value)
+        if value_text is None:
+            return
+
+        is_string = self._streaming_param_emits_json_string()
         if param_name not in self._xml_emitted_param_names:
             prefix = ', ' if len(self._xml_emitted_param_names) > 0 else ''
             json_fragments.append(f'{prefix}\"{param_name}\": ')
@@ -180,12 +204,12 @@ class XmlToolParser(ToolParser):
                 self._xml_streaming_param_quote_opened = True
             self._xml_emitted_param_names.add(param_name)
 
-        if len(raw_value) > self._xml_streaming_param_emitted_raw_len:
-            diff = raw_value[self._xml_streaming_param_emitted_raw_len:]
+        if len(value_text) > self._xml_streaming_param_emitted_raw_len:
+            diff = value_text[self._xml_streaming_param_emitted_raw_len:]
             if is_string:
                 diff = json.dumps(diff, ensure_ascii=False)[1:-1]
             json_fragments.append(diff)
-            self._xml_streaming_param_emitted_raw_len = len(raw_value)
+            self._xml_streaming_param_emitted_raw_len = len(value_text)
 
         if is_param_closed:
             if is_string and self._xml_streaming_param_quote_opened:
@@ -213,6 +237,29 @@ class XmlToolParser(ToolParser):
             if close_tag.startswith(raw_value[-suffix_len:]):
                 return raw_value[:-suffix_len]
         return raw_value
+
+    @staticmethod
+    def _strip_json_string_framing(raw_value: str) -> str:
+        value = raw_value[1:]
+        if value.endswith('"') and not value.endswith(r'\"'):
+            return value[:-1]
+        return value
+
+    @staticmethod
+    def _looks_like_integer(raw_value: str) -> bool:
+        value = raw_value.strip()
+        return bool(value) and (value.isdigit() or (value.startswith('-') and value[1:].isdigit()))
+
+    @staticmethod
+    def _looks_like_number(raw_value: str) -> bool:
+        value = raw_value.strip()
+        if not value:
+            return False
+        try:
+            parsed_value = json.loads(value)
+        except json.JSONDecodeError:
+            return False
+        return isinstance(parsed_value, (int, float)) and not isinstance(parsed_value, bool)
 
     def _build_function_param_schemas(self, request: ChatCompletionRequest) -> dict[str, dict[str, dict[str, Any]]]:
         """Build function->parameter schema map from request tools."""

--- a/lmdeploy/serve/parsers/tool_parser/xml_tool_parser.py
+++ b/lmdeploy/serve/parsers/tool_parser/xml_tool_parser.py
@@ -30,6 +30,10 @@ class XmlToolParser(ToolParser):
         self._payload_parts: list[str] = []
         self._coerced_args: dict[str, Any] = {}
         self._in_progress_value = False
+        self._xml_streaming_param_name: str | None = None
+        self._xml_streaming_param_emitted_raw_len = 0
+        self._xml_streaming_param_schema_type: str | None = None
+        self._xml_streaming_param_quote_opened = False
 
     def adjust_request(self, request: ChatCompletionRequest) -> ChatCompletionRequest:
         self._function_param_schemas = self._build_function_param_schemas(request)
@@ -50,27 +54,21 @@ class XmlToolParser(ToolParser):
         self._payload_parts.clear()
         self._coerced_args.clear()
         self._in_progress_value = False
+        self._xml_streaming_param_name = None
+        self._xml_streaming_param_emitted_raw_len = 0
+        self._xml_streaming_param_schema_type = None
+        self._xml_streaming_param_quote_opened = False
         self._reset_incremental_state()
 
     def _reset_incremental_state(self) -> None:
         """Reset subclass-specific incremental parse state."""
 
-    def _should_buffer_value_chunk(self, added_text: str, final: bool) -> bool:
-        """Fast-path plain value fragments that cannot close an XML tag."""
-        if final or not self._in_progress_value:
-            return False
-        return not any(ch in added_text for ch in '<>/')
-
     def decode_tool_incremental(self, added_text: str, *, final: bool) -> list[DeltaToolCall]:
         self._payload_parts.append(added_text)
-        if self._should_buffer_value_chunk(added_text, final):
-            return []
-
-        func_name, raw_args_dict, is_closed = self._extract_incremental_state(
-            ''.join(self._payload_parts),
-            final=final,
-        )
+        payload = ''.join(self._payload_parts)
+        func_name, raw_args_dict, is_closed = self._extract_incremental_state(payload, final=final)
         args_dict = self._get_coerced_args(func_name, raw_args_dict)
+        streaming_param_name, streaming_raw_value, is_param_closed = self._extract_streaming_param(payload)
 
         out: list[DeltaToolCall] = []
         if func_name and not self._name_emitted:
@@ -86,7 +84,13 @@ class XmlToolParser(ToolParser):
         should_close = is_closed or (final and self._close_json_on_final())
 
         json_fragments: list[str] = []
-        if not self._xml_has_emitted_json_start and (args_dict or should_close):
+        has_streaming_param = self._prepare_streaming_param(
+            func_name,
+            streaming_param_name,
+            is_param_closed,
+        )
+        has_streaming_update = self._has_streaming_param_update(streaming_raw_value, is_param_closed)
+        if not self._xml_has_emitted_json_start and (args_dict or has_streaming_update or should_close):
             json_fragments.append('{')
             self._xml_has_emitted_json_start = True
 
@@ -96,6 +100,9 @@ class XmlToolParser(ToolParser):
             prefix = ', ' if len(self._xml_emitted_param_names) > 0 else ''
             json_fragments.append(f'{prefix}\"{key}\": {json.dumps(value, ensure_ascii=False)}')
             self._xml_emitted_param_names.add(key)
+
+        if has_streaming_param and has_streaming_update:
+            self._append_streaming_param_fragments(json_fragments, streaming_raw_value, is_param_closed)
 
         if should_close and self._xml_has_emitted_json_start and not self._xml_json_closed:
             json_fragments.append('}')
@@ -110,6 +117,79 @@ class XmlToolParser(ToolParser):
                     function=DeltaFunctionCall(arguments=''.join(json_fragments)),
                 ))
         return out
+
+    def _prepare_streaming_param(self,
+                                 func_name: str | None,
+                                 param_name: str | None,
+                                 is_param_closed: bool) -> bool:
+        if param_name is None:
+            return self._xml_streaming_param_name is not None
+        if self._xml_streaming_param_name == param_name:
+            return True
+        if is_param_closed or param_name in self._xml_emitted_param_names:
+            return False
+
+        self._xml_streaming_param_name = param_name
+        self._xml_streaming_param_emitted_raw_len = 0
+        self._xml_streaming_param_schema_type = self._get_param_schema_type(func_name, param_name)
+        self._xml_streaming_param_quote_opened = False
+        return True
+
+    def _has_streaming_param_update(self, raw_value: str, is_param_closed: bool) -> bool:
+        param_name = self._xml_streaming_param_name
+        if param_name is None:
+            return False
+        if param_name not in self._xml_emitted_param_names:
+            return bool(raw_value) or is_param_closed
+        return len(raw_value) > self._xml_streaming_param_emitted_raw_len or is_param_closed
+
+    def _append_streaming_param_fragments(self,
+                                          json_fragments: list[str],
+                                          raw_value: str,
+                                          is_param_closed: bool) -> None:
+        param_name = self._xml_streaming_param_name
+        if param_name is None:
+            return
+
+        is_string = self._xml_streaming_param_schema_type in (None, 'string')
+        if param_name not in self._xml_emitted_param_names:
+            prefix = ', ' if len(self._xml_emitted_param_names) > 0 else ''
+            json_fragments.append(f'{prefix}\"{param_name}\": ')
+            if is_string:
+                json_fragments.append('"')
+                self._xml_streaming_param_quote_opened = True
+            self._xml_emitted_param_names.add(param_name)
+
+        if len(raw_value) > self._xml_streaming_param_emitted_raw_len:
+            diff = raw_value[self._xml_streaming_param_emitted_raw_len:]
+            if is_string:
+                diff = json.dumps(diff, ensure_ascii=False)[1:-1]
+            json_fragments.append(diff)
+            self._xml_streaming_param_emitted_raw_len = len(raw_value)
+
+        if is_param_closed:
+            if is_string and self._xml_streaming_param_quote_opened:
+                json_fragments.append('"')
+            self._xml_streaming_param_name = None
+            self._xml_streaming_param_emitted_raw_len = 0
+            self._xml_streaming_param_schema_type = None
+            self._xml_streaming_param_quote_opened = False
+
+    def _get_param_schema_type(self, func_name: str | None, param_name: str) -> str | None:
+        if func_name is None:
+            return None
+        param_schema = self._function_param_schemas.get(func_name, {}).get(param_name)
+        if not isinstance(param_schema, dict):
+            return None
+        return self._resolve_schema_type(param_schema)
+
+    @staticmethod
+    def _strip_partial_xml_close_suffix(raw_value: str, close_tag: str) -> str:
+        max_len = min(len(raw_value), len(close_tag) - 1)
+        for suffix_len in range(max_len, 0, -1):
+            if close_tag.startswith(raw_value[-suffix_len:]):
+                return raw_value[:-suffix_len]
+        return raw_value
 
     def _build_function_param_schemas(self, request: ChatCompletionRequest) -> dict[str, dict[str, dict[str, Any]]]:
         """Build function->parameter schema map from request tools."""
@@ -236,6 +316,9 @@ class XmlToolParser(ToolParser):
 
     def _close_json_on_final(self) -> bool:
         return True
+
+    def _extract_streaming_param(self, payload: str) -> tuple[str | None, str, bool]:
+        return None, '', False
 
     def _extract_incremental_state(self,
                                  payload: str,

--- a/tests/test_lmdeploy/serve/openai/chat_completions/test_delta_tool_call_id.py
+++ b/tests/test_lmdeploy/serve/openai/chat_completions/test_delta_tool_call_id.py
@@ -2,7 +2,7 @@
 
 def test_decode_tool_incremental_json_id_only_on_first_chunk():
     """When streaming a tool call, id should appear only on the name-delta
-    chunk, not on subsequent argument-delta chunks."""
+    chunk, not on subsequent argument chunks."""
     from lmdeploy.serve.parsers.tool_parser.tool_parser import ToolParser
 
     class TestToolParser(ToolParser):
@@ -24,11 +24,12 @@ def test_decode_tool_incremental_json_id_only_on_first_chunk():
     assert name_delta.id.startswith('chatcmpl-tool-')
     assert name_delta.type == 'function'
 
-    # Step 2: feed final chunk with arguments
-    deltas = parser._decode_tool_incremental_json('"arguments": {"city": "NYC"}}', final=True)
+    deltas = parser._decode_tool_incremental_json('"arguments": {"city": "NY', final=False)
     assert len(deltas) == 1
     args_delta = deltas[0]
-    assert args_delta.function.arguments is not None
+    assert args_delta.id is None
+    assert args_delta.type is None
+    assert args_delta.function.arguments
 
 
 def test_stream_delta_tool_call_omits_null_id_and_type_in_json():

--- a/tests/test_lmdeploy/serve/openai/chat_completions/test_delta_tool_call_id.py
+++ b/tests/test_lmdeploy/serve/openai/chat_completions/test_delta_tool_call_id.py
@@ -106,40 +106,6 @@ def test_decode_tool_incremental_json_streams_parameters_fallback_before_payload
     assert json.loads(''.join(fragments)) == _complete_arguments(payload)
 
 
-def test_decode_tool_incremental_json_uses_first_argument_alias_consistently():
-    payload = '{"name":"f","parameters":{"p":1},"arguments":{"a":2}}'
-    fragments = _stream_argument_fragments(
-        [
-            '{"name":"f","parameters":{"p":1},',
-            '"arguments":{"a":2}}',
-        ],
-        final_on_last=True,
-    )
-
-    assert fragments
-    assert json.loads(''.join(fragments)) == _complete_arguments(payload)
-
-    payload = '{"name":"f","arguments":{"a":2},"parameters":{"p":1}}'
-    fragments = _stream_argument_fragments(
-        [
-            '{"name":"f","arguments":{"a":2},',
-            '"parameters":{"p":1}}',
-        ],
-        final_on_last=True,
-    )
-
-    assert fragments
-    assert json.loads(''.join(fragments)) == _complete_arguments(payload)
-
-
-def test_decode_tool_incremental_json_streams_escaped_arguments_key():
-    payload = '{"name":"f","\\u0061rguments":{"x":1}}'
-    fragments = _stream_argument_fragments([payload], final_on_last=True)
-
-    assert fragments
-    assert json.loads(''.join(fragments)) == _complete_arguments(payload)
-
-
 def test_chat_stream_suppresses_empty_delta_while_tool_payload_is_buffering():
     from lmdeploy.serve.openai.api_server import _should_suppress_empty_stream_delta
     from lmdeploy.serve.openai.protocol import ChatCompletionRequest
@@ -164,6 +130,11 @@ def test_chat_stream_suppresses_empty_delta_while_tool_payload_is_buffering():
         assert tool_emitted is False
         assert delta_msg.content == ''
         assert _should_suppress_empty_stream_delta(parser, delta_msg) is True
+
+        parser.stream_chunk('{"name":"f","arguments":{}}', [])
+        assert _should_suppress_empty_stream_delta(parser) is True
+        assert parser.stream_chunk('</tool_call>', [1]) == []
+        assert _should_suppress_empty_stream_delta(parser) is True
     finally:
         cls.reasoning_parser_cls = old_reasoning_cls
         cls.tool_parser_cls = old_tool_cls

--- a/tests/test_lmdeploy/serve/openai/chat_completions/test_delta_tool_call_id.py
+++ b/tests/test_lmdeploy/serve/openai/chat_completions/test_delta_tool_call_id.py
@@ -106,7 +106,8 @@ def test_decode_tool_incremental_json_streams_parameters_fallback_before_payload
     assert json.loads(''.join(fragments)) == _complete_arguments(payload)
 
 
-def test_decode_tool_incremental_json_keeps_streamed_parameters_when_arguments_arrive_later():
+def test_decode_tool_incremental_json_uses_first_argument_alias_consistently():
+    payload = '{"name":"f","parameters":{"p":1},"arguments":{"a":2}}'
     fragments = _stream_argument_fragments(
         [
             '{"name":"f","parameters":{"p":1},',
@@ -116,7 +117,27 @@ def test_decode_tool_incremental_json_keeps_streamed_parameters_when_arguments_a
     )
 
     assert fragments
-    assert json.loads(''.join(fragments)) == {'p': 1}
+    assert json.loads(''.join(fragments)) == _complete_arguments(payload)
+
+    payload = '{"name":"f","arguments":{"a":2},"parameters":{"p":1}}'
+    fragments = _stream_argument_fragments(
+        [
+            '{"name":"f","arguments":{"a":2},',
+            '"parameters":{"p":1}}',
+        ],
+        final_on_last=True,
+    )
+
+    assert fragments
+    assert json.loads(''.join(fragments)) == _complete_arguments(payload)
+
+
+def test_decode_tool_incremental_json_streams_escaped_arguments_key():
+    payload = '{"name":"f","\\u0061rguments":{"x":1}}'
+    fragments = _stream_argument_fragments([payload], final_on_last=True)
+
+    assert fragments
+    assert json.loads(''.join(fragments)) == _complete_arguments(payload)
 
 
 def test_chat_stream_suppresses_empty_delta_while_tool_payload_is_buffering():
@@ -136,6 +157,13 @@ def test_chat_stream_suppresses_empty_delta_while_tool_payload_is_buffering():
         assert _should_suppress_empty_stream_delta(parser) is False
         assert parser.stream_chunk('<tool_call>', []) == []
         assert _should_suppress_empty_stream_delta(parser) is True
+
+        deltas = parser.stream_chunk('', [])
+        assert len(deltas) == 1
+        delta_msg, tool_emitted = deltas[0]
+        assert tool_emitted is False
+        assert delta_msg.content == ''
+        assert _should_suppress_empty_stream_delta(parser, delta_msg) is True
     finally:
         cls.reasoning_parser_cls = old_reasoning_cls
         cls.tool_parser_cls = old_tool_cls

--- a/tests/test_lmdeploy/serve/openai/chat_completions/test_delta_tool_call_id.py
+++ b/tests/test_lmdeploy/serve/openai/chat_completions/test_delta_tool_call_id.py
@@ -1,18 +1,37 @@
 # Copyright (c) OpenMMLab. All rights reserved.
+import json
+
+from lmdeploy.serve.parsers.tool_parser.tool_parser import ToolParser
+
+
+class _TestToolParser(ToolParser):
+    def get_tool_open_tag(self): return None
+    def get_tool_close_tag(self): return None
+    def get_tool_payload_format(self): return 'json'
+    def decode_tool_incremental(self, added_text, *, final): return []
+    def parse_tool_call_complete(self, payload): return self._parse_tool_call_complete_json(payload)
+
+
+def _stream_argument_fragments(chunks, *, final_on_last):
+    parser = _TestToolParser()
+    parser.start_tool_call()
+    fragments = []
+    for idx, chunk in enumerate(chunks):
+        deltas = parser._decode_tool_incremental_json(chunk, final=final_on_last and idx == len(chunks) - 1)
+        fragments.extend(delta.function.arguments for delta in deltas if delta.function and delta.function.arguments)
+    return fragments
+
+
+def _complete_arguments(payload):
+    call = _TestToolParser._parse_tool_call_complete_json(payload)
+    return json.loads(call.function.arguments)
+
 
 def test_decode_tool_incremental_json_id_only_on_first_chunk():
     """When streaming a tool call, id should appear only on the name-delta
     chunk, not on subsequent argument chunks."""
-    from lmdeploy.serve.parsers.tool_parser.tool_parser import ToolParser
 
-    class TestToolParser(ToolParser):
-        def get_tool_open_tag(self): return None
-        def get_tool_close_tag(self): return None
-        def get_tool_payload_format(self): return 'json'
-        def decode_tool_incremental(self, added_text, *, final): return []
-        def parse_tool_call_complete(self, payload): return None
-
-    parser = TestToolParser()
+    parser = _TestToolParser()
     parser.start_tool_call()
 
     # Step 1: feed partial JSON with name
@@ -33,35 +52,77 @@ def test_decode_tool_incremental_json_id_only_on_first_chunk():
 
 
 def test_decode_tool_incremental_json_streams_empty_arguments():
-    from lmdeploy.serve.parsers.tool_parser.tool_parser import ToolParser
-
-    class TestToolParser(ToolParser):
-        def get_tool_open_tag(self): return None
-        def get_tool_close_tag(self): return None
-        def get_tool_payload_format(self): return 'json'
-        def decode_tool_incremental(self, added_text, *, final): return []
-        def parse_tool_call_complete(self, payload): return None
-
     for arguments in ('{}', '[]', 'null'):
-        parser = TestToolParser()
-        parser.start_tool_call()
-
-        deltas = parser._decode_tool_incremental_json(
-            '{"name":"f","arguments":' + arguments + '}',
-            final=True,
+        argument_fragments = _stream_argument_fragments(
+            ['{"name":"f","arguments":' + arguments + '}'],
+            final_on_last=True,
         )
-        argument_fragments = [
-            delta.function.arguments for delta in deltas if delta.function and delta.function.arguments
-        ]
 
         assert argument_fragments == [arguments]
+
+
+def test_decode_tool_incremental_json_streams_arguments_before_payload_complete():
+    payload = '{"name":"f","arguments":{"city":"New York","units":"c"}}'
+    fragments = _stream_argument_fragments(
+        [
+            '{"name":"f","arguments":{"city":"Ne',
+            'w York","units":"c"}',
+        ],
+        final_on_last=False,
+    )
+
+    assert fragments
+    assert json.loads(''.join(fragments)) == _complete_arguments(payload)
+
+
+def test_decode_tool_incremental_json_streams_nested_and_escaped_arguments():
+    args = {'outer': {'items': [1, {'text': 'a"b'}], 'path': 'C:\\tmp'}}
+    payload = '{"name":"f","arguments":' + json.dumps(args) + '}'
+    body_without_outer_close = payload[:-1]
+    split_at = body_without_outer_close.find('a\\"b')
+    fragments = _stream_argument_fragments(
+        [
+            body_without_outer_close[:split_at + 2],
+            body_without_outer_close[split_at + 2:],
+        ],
+        final_on_last=False,
+    )
+
+    assert fragments
+    assert json.loads(''.join(fragments)) == _complete_arguments(payload)
+
+
+def test_decode_tool_incremental_json_streams_parameters_fallback_when_final():
+    payload = '{"name":"f","parameters":{"p":1}}'
+    fragments = _stream_argument_fragments(
+        [
+            '{"name":"f","parameters":{"p":',
+            '1}}',
+        ],
+        final_on_last=True,
+    )
+
+    assert fragments
+    assert json.loads(''.join(fragments)) == _complete_arguments(payload)
+
+
+def test_decode_tool_incremental_json_prefers_arguments_over_parameters():
+    payload = '{"name":"f","parameters":{"p":1},"arguments":{"a":2}}'
+    fragments = _stream_argument_fragments(
+        [
+            '{"name":"f","parameters":{"p":1},',
+            '"arguments":{"a":2}}',
+        ],
+        final_on_last=True,
+    )
+
+    assert fragments
+    assert json.loads(''.join(fragments)) == _complete_arguments(payload)
 
 
 def test_stream_delta_tool_call_omits_null_id_and_type_in_json():
     """Serialized stream chunks should omit null id/type, not emit them as JSON
     null."""
-    import json
-
     from lmdeploy.serve.openai.protocol import (
         ChatCompletionResponseStreamChoice,
         ChatCompletionStreamResponse,

--- a/tests/test_lmdeploy/serve/openai/chat_completions/test_delta_tool_call_id.py
+++ b/tests/test_lmdeploy/serve/openai/chat_completions/test_delta_tool_call_id.py
@@ -92,22 +92,21 @@ def test_decode_tool_incremental_json_streams_nested_and_escaped_arguments():
     assert json.loads(''.join(fragments)) == _complete_arguments(payload)
 
 
-def test_decode_tool_incremental_json_streams_parameters_fallback_when_final():
+def test_decode_tool_incremental_json_streams_parameters_fallback_before_payload_complete():
     payload = '{"name":"f","parameters":{"p":1}}'
     fragments = _stream_argument_fragments(
         [
             '{"name":"f","parameters":{"p":',
-            '1}}',
+            '1}',
         ],
-        final_on_last=True,
+        final_on_last=False,
     )
 
     assert fragments
     assert json.loads(''.join(fragments)) == _complete_arguments(payload)
 
 
-def test_decode_tool_incremental_json_prefers_arguments_over_parameters():
-    payload = '{"name":"f","parameters":{"p":1},"arguments":{"a":2}}'
+def test_decode_tool_incremental_json_keeps_streamed_parameters_when_arguments_arrive_later():
     fragments = _stream_argument_fragments(
         [
             '{"name":"f","parameters":{"p":1},',
@@ -117,7 +116,7 @@ def test_decode_tool_incremental_json_prefers_arguments_over_parameters():
     )
 
     assert fragments
-    assert json.loads(''.join(fragments)) == _complete_arguments(payload)
+    assert json.loads(''.join(fragments)) == {'p': 1}
 
 
 def test_stream_delta_tool_call_omits_null_id_and_type_in_json():

--- a/tests/test_lmdeploy/serve/openai/chat_completions/test_delta_tool_call_id.py
+++ b/tests/test_lmdeploy/serve/openai/chat_completions/test_delta_tool_call_id.py
@@ -119,6 +119,28 @@ def test_decode_tool_incremental_json_keeps_streamed_parameters_when_arguments_a
     assert json.loads(''.join(fragments)) == {'p': 1}
 
 
+def test_chat_stream_suppresses_empty_delta_while_tool_payload_is_buffering():
+    from lmdeploy.serve.openai.api_server import _should_suppress_empty_stream_delta
+    from lmdeploy.serve.openai.protocol import ChatCompletionRequest
+    from lmdeploy.serve.parsers import ResponseParserManager
+    from lmdeploy.serve.parsers.tool_parser import ToolParserManager
+
+    cls = ResponseParserManager.get('default')
+    old_reasoning_cls = cls.reasoning_parser_cls
+    old_tool_cls = cls.tool_parser_cls
+    try:
+        cls.reasoning_parser_cls = None
+        cls.tool_parser_cls = ToolParserManager.get('qwen3')
+        parser = cls(ChatCompletionRequest(model='test', messages=[], stream=True, tool_choice='auto'))
+
+        assert _should_suppress_empty_stream_delta(parser) is False
+        assert parser.stream_chunk('<tool_call>', []) == []
+        assert _should_suppress_empty_stream_delta(parser) is True
+    finally:
+        cls.reasoning_parser_cls = old_reasoning_cls
+        cls.tool_parser_cls = old_tool_cls
+
+
 def test_stream_delta_tool_call_omits_null_id_and_type_in_json():
     """Serialized stream chunks should omit null id/type, not emit them as JSON
     null."""

--- a/tests/test_lmdeploy/serve/openai/chat_completions/test_delta_tool_call_id.py
+++ b/tests/test_lmdeploy/serve/openai/chat_completions/test_delta_tool_call_id.py
@@ -42,7 +42,7 @@ def test_decode_tool_incremental_json_streams_empty_arguments():
         def decode_tool_incremental(self, added_text, *, final): return []
         def parse_tool_call_complete(self, payload): return None
 
-    for arguments in ('{}', '[]'):
+    for arguments in ('{}', '[]', 'null'):
         parser = TestToolParser()
         parser.start_tool_call()
 

--- a/tests/test_lmdeploy/serve/openai/chat_completions/test_delta_tool_call_id.py
+++ b/tests/test_lmdeploy/serve/openai/chat_completions/test_delta_tool_call_id.py
@@ -32,6 +32,31 @@ def test_decode_tool_incremental_json_id_only_on_first_chunk():
     assert args_delta.function.arguments
 
 
+def test_decode_tool_incremental_json_streams_empty_arguments():
+    from lmdeploy.serve.parsers.tool_parser.tool_parser import ToolParser
+
+    class TestToolParser(ToolParser):
+        def get_tool_open_tag(self): return None
+        def get_tool_close_tag(self): return None
+        def get_tool_payload_format(self): return 'json'
+        def decode_tool_incremental(self, added_text, *, final): return []
+        def parse_tool_call_complete(self, payload): return None
+
+    for arguments in ('{}', '[]'):
+        parser = TestToolParser()
+        parser.start_tool_call()
+
+        deltas = parser._decode_tool_incremental_json(
+            '{"name":"f","arguments":' + arguments + '}',
+            final=True,
+        )
+        argument_fragments = [
+            delta.function.arguments for delta in deltas if delta.function and delta.function.arguments
+        ]
+
+        assert argument_fragments == [arguments]
+
+
 def test_stream_delta_tool_call_omits_null_id_and_type_in_json():
     """Serialized stream chunks should omit null id/type, not emit them as JSON
     null."""

--- a/tests/test_lmdeploy/serve/parsers/test_glm47_parser.py
+++ b/tests/test_lmdeploy/serve/parsers/test_glm47_parser.py
@@ -70,6 +70,21 @@ def _stream_tool_arguments(parser, chunks):
     return ''.join(argument_fragments)
 
 
+def _stream_tool_arguments_by_chunk(parser, chunks):
+    parser.start_tool_call()
+    argument_fragments = []
+    per_chunk = []
+    for chunk, final in chunks:
+        chunk_fragments = []
+        for call in parser.decode_tool_incremental(chunk, final=final):
+            if call.function and call.function.arguments is not None:
+                argument_fragments.append(call.function.arguments)
+                chunk_fragments.append(call.function.arguments)
+        per_chunk.append(''.join(chunk_fragments))
+    parser.finish_tool_call()
+    return ''.join(argument_fragments), per_chunk
+
+
 REFERENCE_CHUNKS = [
     ('prefix ', [{'content': 'prefix ', 'tool_emitted': False}]),
     ('<tool_call>', []),
@@ -354,6 +369,48 @@ class TestGlm47ToolParserComplete:
         assert complete_tool_call is not None
         assert streamed_arguments == complete_tool_call.function.arguments
 
+    def test_stream_chunk_emits_quoted_string_value_before_arg_value_close(self):
+        parser = Glm47ToolParser()
+        request = ChatCompletionRequest(
+            model=MODEL_ID,
+            messages=[],
+            tools=[{
+                'type': 'function',
+                'function': {
+                    'name': 'typed_tool',
+                    'parameters': {
+                        'type': 'object',
+                        'properties': {
+                            'name': {
+                                'type': 'string'
+                            },
+                        },
+                    },
+                },
+            }],
+            tool_choice='auto',
+        )
+        parser.adjust_request(request)
+        payload = 'typed_tool<arg_key>name</arg_key><arg_value>"Chen"</arg_value>'
+
+        streamed_arguments, per_chunk = _stream_tool_arguments_by_chunk(
+            parser,
+            [
+                ('typed_tool', False),
+                ('<arg_key>name</arg_key><arg_value>', False),
+                ('"Ch', False),
+                ('en"', False),
+                ('</arg_value>', False),
+                ('', True),
+            ],
+        )
+        complete_tool_call = parser.parse_tool_call_complete(payload)
+
+        assert per_chunk[2]
+        assert per_chunk[3]
+        assert complete_tool_call is not None
+        assert streamed_arguments == complete_tool_call.function.arguments
+
     def test_streamed_arguments_match_complete_parse_for_invalid_integer_value(self):
         parser = Glm47ToolParser()
         request = ChatCompletionRequest(
@@ -391,6 +448,48 @@ class TestGlm47ToolParserComplete:
         )
         complete_tool_call = parser.parse_tool_call_complete(payload)
 
+        assert complete_tool_call is not None
+        assert streamed_arguments == complete_tool_call.function.arguments
+
+    def test_stream_chunk_emits_valid_integer_value_before_arg_value_close(self):
+        parser = Glm47ToolParser()
+        request = ChatCompletionRequest(
+            model=MODEL_ID,
+            messages=[],
+            tools=[{
+                'type': 'function',
+                'function': {
+                    'name': 'typed_tool',
+                    'parameters': {
+                        'type': 'object',
+                        'properties': {
+                            'age': {
+                                'type': 'integer'
+                            },
+                        },
+                    },
+                },
+            }],
+            tool_choice='auto',
+        )
+        parser.adjust_request(request)
+        payload = 'typed_tool<arg_key>age</arg_key><arg_value>29</arg_value>'
+
+        streamed_arguments, per_chunk = _stream_tool_arguments_by_chunk(
+            parser,
+            [
+                ('typed_tool', False),
+                ('<arg_key>age</arg_key><arg_value>', False),
+                ('2', False),
+                ('9', False),
+                ('</arg_value>', False),
+                ('', True),
+            ],
+        )
+        complete_tool_call = parser.parse_tool_call_complete(payload)
+
+        assert per_chunk[2]
+        assert per_chunk[3]
         assert complete_tool_call is not None
         assert streamed_arguments == complete_tool_call.function.arguments
 

--- a/tests/test_lmdeploy/serve/parsers/test_glm47_parser.py
+++ b/tests/test_lmdeploy/serve/parsers/test_glm47_parser.py
@@ -607,3 +607,22 @@ class TestGlm47ToolParserComplete:
 
         assert complete_tool_call is not None
         assert streamed_arguments == complete_tool_call.function.arguments
+
+    def test_streamed_arguments_match_complete_parse_when_value_contains_arg_like_text(self):
+        parser = Glm47ToolParser()
+        payload = 'f<arg_key>a</arg_key><arg_value>foo <arg_key>bar</arg_key><arg_value> baz</arg_value>'
+
+        streamed_arguments = _stream_tool_arguments(
+            parser,
+            [
+                ('f', False),
+                ('<arg_key>a</arg_key><arg_value>foo ', False),
+                ('<arg_key>bar</arg_key><arg_value> baz', False),
+                ('</arg_value>', False),
+                ('', True),
+            ],
+        )
+        complete_tool_call = parser.parse_tool_call_complete(payload)
+
+        assert complete_tool_call is not None
+        assert streamed_arguments == complete_tool_call.function.arguments

--- a/tests/test_lmdeploy/serve/parsers/test_glm47_parser.py
+++ b/tests/test_lmdeploy/serve/parsers/test_glm47_parser.py
@@ -407,6 +407,48 @@ class TestGlm47ToolParserComplete:
         assert complete_tool_call is not None
         assert streamed_arguments == complete_tool_call.function.arguments
 
+    def test_streamed_arguments_emit_typed_arg_before_arg_value_close(self):
+        parser = Glm47ToolParser()
+        request = ChatCompletionRequest(
+            model=MODEL_ID,
+            messages=[],
+            tools=[{
+                'type': 'function',
+                'function': {
+                    'name': 'typed_tool',
+                    'parameters': {
+                        'type': 'object',
+                        'properties': {
+                            'age': {
+                                'type': 'integer'
+                            },
+                        },
+                    },
+                },
+            }],
+            tool_choice='auto',
+        )
+        parser.adjust_request(request)
+        payload = 'typed_tool<arg_key>age</arg_key><arg_value>12</arg_value>'
+
+        streamed_arguments, per_chunk = _stream_tool_arguments_by_chunk(
+            parser,
+            [
+                ('typed_tool', False),
+                ('<arg_key>age</arg_key><arg_value>', False),
+                ('12', False),
+                ('</arg_value>', False),
+                ('', True),
+            ],
+        )
+        complete_tool_call = parser.parse_tool_call_complete(payload)
+
+        assert per_chunk[1] == '{"age": '
+        assert per_chunk[2] == ''
+        assert complete_tool_call is not None
+        assert streamed_arguments == complete_tool_call.function.arguments
+        assert json.loads(streamed_arguments) == {'age': 12}
+
     def test_streamed_arguments_match_complete_parse_for_newline_escaped_quoted_string_value(self):
         parser = Glm47ToolParser()
         request = ChatCompletionRequest(

--- a/tests/test_lmdeploy/serve/parsers/test_glm47_parser.py
+++ b/tests/test_lmdeploy/serve/parsers/test_glm47_parser.py
@@ -571,3 +571,39 @@ class TestGlm47ToolParserComplete:
 
         assert complete_tool_call is not None
         assert streamed_arguments == complete_tool_call.function.arguments
+
+    def test_streamed_arguments_match_complete_parse_for_unquoted_newline_value(self):
+        parser = Glm47ToolParser()
+        payload = 'f<arg_key>a</arg_key><arg_value>A\nB</arg_value>'
+
+        streamed_arguments = _stream_tool_arguments(
+            parser,
+            [
+                ('f', False),
+                ('<arg_key>a</arg_key><arg_value>A\n', False),
+                ('B</arg_value>', False),
+                ('', True),
+            ],
+        )
+        complete_tool_call = parser.parse_tool_call_complete(payload)
+
+        assert complete_tool_call is not None
+        assert streamed_arguments == complete_tool_call.function.arguments
+
+    def test_streamed_arguments_match_complete_parse_for_unquoted_quote_value(self):
+        parser = Glm47ToolParser()
+        payload = 'f<arg_key>a</arg_key><arg_value>A"B</arg_value>'
+
+        streamed_arguments = _stream_tool_arguments(
+            parser,
+            [
+                ('f', False),
+                ('<arg_key>a</arg_key><arg_value>A"', False),
+                ('B</arg_value>', False),
+                ('', True),
+            ],
+        )
+        complete_tool_call = parser.parse_tool_call_complete(payload)
+
+        assert complete_tool_call is not None
+        assert streamed_arguments == complete_tool_call.function.arguments

--- a/tests/test_lmdeploy/serve/parsers/test_glm47_parser.py
+++ b/tests/test_lmdeploy/serve/parsers/test_glm47_parser.py
@@ -393,3 +393,23 @@ class TestGlm47ToolParserComplete:
 
         assert complete_tool_call is not None
         assert streamed_arguments == complete_tool_call.function.arguments
+
+    def test_streamed_arguments_match_complete_parse_when_next_arg_starts_with_previous_close(self):
+        parser = Glm47ToolParser()
+        payload = 'two_args<arg_key>a</arg_key><arg_value>one</arg_value><arg_key>b</arg_key><arg_value>two</arg_value>'
+
+        streamed_arguments = _stream_tool_arguments(
+            parser,
+            [
+                ('two_args', False),
+                ('<arg_key>a</arg_key>', False),
+                ('<arg_value>one', False),
+                ('</arg_value><arg_key>b</arg_key><arg_value>two', False),
+                ('</arg_value>', False),
+                ('', True),
+            ],
+        )
+        complete_tool_call = parser.parse_tool_call_complete(payload)
+
+        assert complete_tool_call is not None
+        assert streamed_arguments == complete_tool_call.function.arguments

--- a/tests/test_lmdeploy/serve/parsers/test_glm47_parser.py
+++ b/tests/test_lmdeploy/serve/parsers/test_glm47_parser.py
@@ -413,3 +413,21 @@ class TestGlm47ToolParserComplete:
 
         assert complete_tool_call is not None
         assert streamed_arguments == complete_tool_call.function.arguments
+
+    def test_streamed_arguments_match_complete_parse_when_close_chunk_has_value_tail(self):
+        parser = Glm47ToolParser()
+        payload = 'f<arg_key>a</arg_key><arg_value>San Francisco</arg_value>'
+
+        streamed_arguments = _stream_tool_arguments(
+            parser,
+            [
+                ('f', False),
+                ('<arg_key>a</arg_key><arg_value>San ', False),
+                ('Francisco</arg_value>', False),
+                ('', True),
+            ],
+        )
+        complete_tool_call = parser.parse_tool_call_complete(payload)
+
+        assert complete_tool_call is not None
+        assert streamed_arguments == complete_tool_call.function.arguments

--- a/tests/test_lmdeploy/serve/parsers/test_glm47_parser.py
+++ b/tests/test_lmdeploy/serve/parsers/test_glm47_parser.py
@@ -369,6 +369,44 @@ class TestGlm47ToolParserComplete:
         assert complete_tool_call is not None
         assert streamed_arguments == complete_tool_call.function.arguments
 
+    def test_streamed_arguments_match_complete_parse_for_string_schema_value_with_whitespace(self):
+        parser = Glm47ToolParser()
+        request = ChatCompletionRequest(
+            model=MODEL_ID,
+            messages=[],
+            tools=[{
+                'type': 'function',
+                'function': {
+                    'name': 'typed_tool',
+                    'parameters': {
+                        'type': 'object',
+                        'properties': {
+                            'name': {
+                                'type': 'string'
+                            },
+                        },
+                    },
+                },
+            }],
+            tool_choice='auto',
+        )
+        parser.adjust_request(request)
+        payload = 'typed_tool<arg_key>name</arg_key><arg_value>  abc  </arg_value>'
+
+        streamed_arguments = _stream_tool_arguments(
+            parser,
+            [
+                ('typed_tool', False),
+                ('<arg_key>name</arg_key><arg_value>  a', False),
+                ('bc  </arg_value>', False),
+                ('', True),
+            ],
+        )
+        complete_tool_call = parser.parse_tool_call_complete(payload)
+
+        assert complete_tool_call is not None
+        assert streamed_arguments == complete_tool_call.function.arguments
+
     def test_streamed_arguments_match_complete_parse_for_newline_escaped_quoted_string_value(self):
         parser = Glm47ToolParser()
         request = ChatCompletionRequest(

--- a/tests/test_lmdeploy/serve/parsers/test_glm47_parser.py
+++ b/tests/test_lmdeploy/serve/parsers/test_glm47_parser.py
@@ -369,7 +369,7 @@ class TestGlm47ToolParserComplete:
         assert complete_tool_call is not None
         assert streamed_arguments == complete_tool_call.function.arguments
 
-    def test_stream_chunk_emits_quoted_string_value_before_arg_value_close(self):
+    def test_streamed_arguments_match_complete_parse_for_newline_escaped_quoted_string_value(self):
         parser = Glm47ToolParser()
         request = ChatCompletionRequest(
             model=MODEL_ID,
@@ -391,23 +391,63 @@ class TestGlm47ToolParserComplete:
             tool_choice='auto',
         )
         parser.adjust_request(request)
-        payload = 'typed_tool<arg_key>name</arg_key><arg_value>"Chen"</arg_value>'
+        payload = r'typed_tool<arg_key>name</arg_key><arg_value>"A\nB"</arg_value>'
 
         streamed_arguments, per_chunk = _stream_tool_arguments_by_chunk(
             parser,
             [
                 ('typed_tool', False),
                 ('<arg_key>name</arg_key><arg_value>', False),
-                ('"Ch', False),
-                ('en"', False),
+                ('"A\\', False),
+                ('nB"', False),
                 ('</arg_value>', False),
                 ('', True),
             ],
         )
         complete_tool_call = parser.parse_tool_call_complete(payload)
 
-        assert per_chunk[2]
-        assert per_chunk[3]
+        assert per_chunk[2] == ''
+        assert per_chunk[3] == ''
+        assert complete_tool_call is not None
+        assert streamed_arguments == complete_tool_call.function.arguments
+
+    def test_streamed_arguments_match_complete_parse_for_quote_escaped_quoted_string_value(self):
+        parser = Glm47ToolParser()
+        request = ChatCompletionRequest(
+            model=MODEL_ID,
+            messages=[],
+            tools=[{
+                'type': 'function',
+                'function': {
+                    'name': 'typed_tool',
+                    'parameters': {
+                        'type': 'object',
+                        'properties': {
+                            'name': {
+                                'type': 'string'
+                            },
+                        },
+                    },
+                },
+            }],
+            tool_choice='auto',
+        )
+        parser.adjust_request(request)
+        payload = r'typed_tool<arg_key>name</arg_key><arg_value>"A\"B"</arg_value>'
+
+        streamed_arguments = _stream_tool_arguments(
+            parser,
+            [
+                ('typed_tool', False),
+                ('<arg_key>name</arg_key><arg_value>', False),
+                ('"A\\', False),
+                ('"B"', False),
+                ('</arg_value>', False),
+                ('', True),
+            ],
+        )
+        complete_tool_call = parser.parse_tool_call_complete(payload)
+
         assert complete_tool_call is not None
         assert streamed_arguments == complete_tool_call.function.arguments
 
@@ -451,7 +491,7 @@ class TestGlm47ToolParserComplete:
         assert complete_tool_call is not None
         assert streamed_arguments == complete_tool_call.function.arguments
 
-    def test_stream_chunk_emits_valid_integer_value_before_arg_value_close(self):
+    def test_streamed_arguments_match_complete_parse_for_invalid_integer_after_numeric_prefix(self):
         parser = Glm47ToolParser()
         request = ChatCompletionRequest(
             model=MODEL_ID,
@@ -473,7 +513,7 @@ class TestGlm47ToolParserComplete:
             tool_choice='auto',
         )
         parser.adjust_request(request)
-        payload = 'typed_tool<arg_key>age</arg_key><arg_value>29</arg_value>'
+        payload = 'typed_tool<arg_key>age</arg_key><arg_value>2a</arg_value>'
 
         streamed_arguments, per_chunk = _stream_tool_arguments_by_chunk(
             parser,
@@ -481,17 +521,18 @@ class TestGlm47ToolParserComplete:
                 ('typed_tool', False),
                 ('<arg_key>age</arg_key><arg_value>', False),
                 ('2', False),
-                ('9', False),
+                ('a', False),
                 ('</arg_value>', False),
                 ('', True),
             ],
         )
         complete_tool_call = parser.parse_tool_call_complete(payload)
 
-        assert per_chunk[2]
-        assert per_chunk[3]
+        assert per_chunk[2] == ''
+        assert per_chunk[3] == ''
         assert complete_tool_call is not None
         assert streamed_arguments == complete_tool_call.function.arguments
+        assert json.loads(streamed_arguments) == {'age': '2a'}
 
     def test_streamed_arguments_match_complete_parse_when_next_arg_starts_with_previous_close(self):
         parser = Glm47ToolParser()

--- a/tests/test_lmdeploy/serve/parsers/test_glm47_parser.py
+++ b/tests/test_lmdeploy/serve/parsers/test_glm47_parser.py
@@ -59,6 +59,17 @@ def _flatten_stream_deltas(deltas):
     return events
 
 
+def _stream_tool_arguments(parser, chunks):
+    parser.start_tool_call()
+    argument_fragments = []
+    for chunk, final in chunks:
+        for call in parser.decode_tool_incremental(chunk, final=final):
+            if call.function and call.function.arguments is not None:
+                argument_fragments.append(call.function.arguments)
+    parser.finish_tool_call()
+    return ''.join(argument_fragments)
+
+
 REFERENCE_CHUNKS = [
     ('prefix ', [{'content': 'prefix ', 'tool_emitted': False}]),
     ('<tool_call>', []),
@@ -302,3 +313,83 @@ class TestGlm47ToolParserComplete:
             'active': 'true',
             'meta': '{"city":"Houston"}',
         }
+
+    def test_streamed_arguments_match_complete_parse_for_quoted_string_value(self):
+        parser = Glm47ToolParser()
+        request = ChatCompletionRequest(
+            model=MODEL_ID,
+            messages=[],
+            tools=[{
+                'type': 'function',
+                'function': {
+                    'name': 'typed_tool',
+                    'parameters': {
+                        'type': 'object',
+                        'properties': {
+                            'name': {
+                                'type': 'string'
+                            },
+                        },
+                    },
+                },
+            }],
+            tool_choice='auto',
+        )
+        parser.adjust_request(request)
+        payload = 'typed_tool<arg_key>name</arg_key><arg_value>"Chen"</arg_value>'
+
+        streamed_arguments = _stream_tool_arguments(
+            parser,
+            [
+                ('typed_tool', False),
+                ('<arg_key>name</arg_key>', False),
+                ('<arg_value>', False),
+                ('"Chen"', False),
+                ('</arg_value>', False),
+                ('', True),
+            ],
+        )
+        complete_tool_call = parser.parse_tool_call_complete(payload)
+
+        assert complete_tool_call is not None
+        assert streamed_arguments == complete_tool_call.function.arguments
+
+    def test_streamed_arguments_match_complete_parse_for_invalid_integer_value(self):
+        parser = Glm47ToolParser()
+        request = ChatCompletionRequest(
+            model=MODEL_ID,
+            messages=[],
+            tools=[{
+                'type': 'function',
+                'function': {
+                    'name': 'typed_tool',
+                    'parameters': {
+                        'type': 'object',
+                        'properties': {
+                            'age': {
+                                'type': 'integer'
+                            },
+                        },
+                    },
+                },
+            }],
+            tool_choice='auto',
+        )
+        parser.adjust_request(request)
+        payload = 'typed_tool<arg_key>age</arg_key><arg_value>abc</arg_value>'
+
+        streamed_arguments = _stream_tool_arguments(
+            parser,
+            [
+                ('typed_tool', False),
+                ('<arg_key>age</arg_key>', False),
+                ('<arg_value>', False),
+                ('abc', False),
+                ('</arg_value>', False),
+                ('', True),
+            ],
+        )
+        complete_tool_call = parser.parse_tool_call_complete(payload)
+
+        assert complete_tool_call is not None
+        assert streamed_arguments == complete_tool_call.function.arguments

--- a/tests/test_lmdeploy/serve/parsers/test_glm47_parser.py
+++ b/tests/test_lmdeploy/serve/parsers/test_glm47_parser.py
@@ -7,8 +7,6 @@ from lmdeploy.serve.parsers import ResponseParserManager
 from lmdeploy.serve.parsers.reasoning_parser import ReasoningParserManager
 from lmdeploy.serve.parsers.tool_parser import Glm47ToolParser, ToolParserManager
 
-from .helpers import first_stream_delta
-
 MODEL_ID = 'zai-org/GLM-4.7'
 
 
@@ -41,15 +39,36 @@ def response_parser_with_reasoning():
     return cls(request=request)
 
 
+def _flatten_stream_deltas(deltas):
+    events = []
+    for delta_msg, tool_emitted in deltas:
+        if delta_msg is None:
+            continue
+        if delta_msg.reasoning_content is not None:
+            events.append({'reasoning_content': delta_msg.reasoning_content, 'tool_emitted': tool_emitted})
+        if delta_msg.content is not None:
+            events.append({'content': delta_msg.content, 'tool_emitted': tool_emitted})
+        if delta_msg.tool_calls:
+            for call in delta_msg.tool_calls:
+                events.append({
+                    'tool_emitted': tool_emitted,
+                    'type': call.type,
+                    'name': call.function.name if call.function else None,
+                    'arguments': call.function.arguments if call.function else None,
+                })
+    return events
+
+
 REFERENCE_CHUNKS = [
-    # (delta_text, emitted_delta_msg, content, tool_emitted, function_name, function_arguments, tool_call_type)
-    ('prefix ', True, 'prefix ', False, None, None, None),
-    ('<tool_call>', False, None, False, None, None, None),
-    # Name is deferred until the first ``<arg_key>`` appears in the payload.
-    ('get_weather', False, None, False, None, None, None),
-    ('<arg_key>location</arg_key>', True, None, True, 'get_weather', None, 'function'),
-    ('<arg_value>Beijing</arg_value>', True, None, True, None, '{"location": "Beijing"', None),
-    ('</tool_call>', True, None, True, None, '}', None),
+    ('prefix ', [{'content': 'prefix ', 'tool_emitted': False}]),
+    ('<tool_call>', []),
+    ('get_weather', []),
+    ('<arg_key>location</arg_key>',
+     [{'tool_emitted': True, 'type': 'function', 'name': 'get_weather', 'arguments': None}]),
+    ('<arg_value>Bei', [{'tool_emitted': True, 'type': None, 'name': None, 'arguments': '{"location": "Bei'}]),
+    ('jing', [{'tool_emitted': True, 'type': None, 'name': None, 'arguments': 'jing'}]),
+    ('</arg_value>', [{'tool_emitted': True, 'type': None, 'name': None, 'arguments': '"'}]),
+    ('</tool_call>', [{'tool_emitted': True, 'type': None, 'name': None, 'arguments': '}'}]),
 ]
 
 
@@ -58,24 +77,35 @@ class TestGlm47ResponseParserStreaming:
     parser."""
 
     def test_stream_chunk_matches_reference(self, response_parser):
-        for (delta_text, exp_delta_msg, exp_content, exp_tool_emitted,
-             exp_function_name, exp_function_arguments, exp_type) in REFERENCE_CHUNKS:
-            delta_msg, tool_emitted = first_stream_delta(response_parser.stream_chunk(
-                delta_text=delta_text, delta_token_ids=[]))
-            if not exp_delta_msg:
-                assert delta_msg is None
-                continue
-            assert delta_msg is not None
-            assert delta_msg.content == exp_content
-            assert tool_emitted == exp_tool_emitted
-            if tool_emitted:
-                assert delta_msg.tool_calls is not None
-                assert len(delta_msg.tool_calls) == 1
-                call = delta_msg.tool_calls[0]
-                assert call.type == exp_type
-                assert call.function is not None
-                assert call.function.name == exp_function_name
-                assert call.function.arguments == exp_function_arguments
+        actual = []
+        expected = []
+        for delta_text, expected_events in REFERENCE_CHUNKS:
+            actual.extend(
+                _flatten_stream_deltas(response_parser.stream_chunk(delta_text=delta_text, delta_token_ids=[])))
+            expected.extend(expected_events)
+        assert actual == expected
+
+    def test_stream_chunk_emits_arg_value_before_arg_value_close(self, response_parser):
+        chunks = [
+            '<tool_call>',
+            'get_weather',
+            '<arg_key>location</arg_key>',
+            '<arg_value>San',
+            ' Francisco',
+            ', CA',
+        ]
+
+        argument_fragments = []
+        emitted_before_close = False
+        for chunk in chunks:
+            for event in _flatten_stream_deltas(response_parser.stream_chunk(delta_text=chunk, delta_token_ids=[])):
+                fragment = event.get('arguments')
+                if fragment:
+                    argument_fragments.append(fragment)
+                    emitted_before_close = True
+
+        assert emitted_before_close is True
+        assert ''.join(argument_fragments) == '{"location": "San Francisco, CA'
 
     def test_stream_chunk_function_name_split_before_arg_key(self, response_parser):
         """Callee name streamed in many deltas before ``<arg_key>`` must not
@@ -91,14 +121,13 @@ class TestGlm47ResponseParserStreaming:
         emitted_name = None
         emitted_args = ''
         for chunk in chunks:
-            delta, tool_emitted = first_stream_delta(response_parser.stream_chunk(delta_text=chunk, delta_token_ids=[]))
-            if not tool_emitted or delta is None or not delta.tool_calls:
-                continue
-            for call in delta.tool_calls:
-                if call.function and call.function.name:
-                    emitted_name = call.function.name
-                if call.function and call.function.arguments:
-                    emitted_args += call.function.arguments
+            for event in _flatten_stream_deltas(response_parser.stream_chunk(delta_text=chunk, delta_token_ids=[])):
+                if not event.get('tool_emitted'):
+                    continue
+                if event.get('name'):
+                    emitted_name = event['name']
+                if event.get('arguments'):
+                    emitted_args += event['arguments']
         assert emitted_name == 'get_current_temperature'
         assert json.loads(emitted_args) == {'location': '北京'}
 
@@ -117,34 +146,28 @@ class TestGlm47ResponseParserStreaming:
         emitted_args = ''
 
         for chunk in chunks:
-            delta, tool_emitted = first_stream_delta(response_parser_with_reasoning.stream_chunk(
-                delta_text=chunk, delta_token_ids=[]))
-            if delta is not None:
-                if delta.reasoning_content:
-                    reasoning_seen.append(delta.reasoning_content)
-                if delta.content:
-                    content_seen.append(delta.content)
-            if tool_emitted and delta and delta.tool_calls:
-                for call in delta.tool_calls:
-                    if call.function and call.function.name:
-                        emitted_name = call.function.name
-                    if call.function and call.function.arguments:
-                        emitted_args += call.function.arguments
+            for event in _flatten_stream_deltas(
+                    response_parser_with_reasoning.stream_chunk(delta_text=chunk, delta_token_ids=[])):
+                if event.get('reasoning_content'):
+                    reasoning_seen.append(event['reasoning_content'])
+                if event.get('content'):
+                    content_seen.append(event['content'])
+                if event.get('tool_emitted') and event.get('name'):
+                    emitted_name = event['name']
+                if event.get('tool_emitted') and event.get('arguments'):
+                    emitted_args += event['arguments']
 
         for _ in range(3):
-            delta, tool_emitted = first_stream_delta(response_parser_with_reasoning.stream_chunk(
-                delta_text='', delta_token_ids=[]))
-            if delta is not None:
-                if delta.reasoning_content:
-                    reasoning_seen.append(delta.reasoning_content)
-                if delta.content:
-                    content_seen.append(delta.content)
-            if tool_emitted and delta and delta.tool_calls:
-                for call in delta.tool_calls:
-                    if call.function and call.function.name:
-                        emitted_name = call.function.name
-                    if call.function and call.function.arguments:
-                        emitted_args += call.function.arguments
+            for event in _flatten_stream_deltas(
+                    response_parser_with_reasoning.stream_chunk(delta_text='', delta_token_ids=[])):
+                if event.get('reasoning_content'):
+                    reasoning_seen.append(event['reasoning_content'])
+                if event.get('content'):
+                    content_seen.append(event['content'])
+                if event.get('tool_emitted') and event.get('name'):
+                    emitted_name = event['name']
+                if event.get('tool_emitted') and event.get('arguments'):
+                    emitted_args += event['arguments']
 
         assert ''.join(reasoning_seen) == 'first reason'
         assert ''.join(content_seen) == '\nAnswer: '
@@ -162,14 +185,13 @@ class TestGlm47ResponseParserStreaming:
         emitted_name = None
         emitted_args = ''
         for chunk in chunks:
-            delta, tool_emitted = first_stream_delta(response_parser.stream_chunk(delta_text=chunk, delta_token_ids=[]))
-            if not tool_emitted or delta is None or not delta.tool_calls:
-                continue
-            for call in delta.tool_calls:
-                if call.function and call.function.name:
-                    emitted_name = call.function.name
-                if call.function and call.function.arguments:
-                    emitted_args += call.function.arguments
+            for event in _flatten_stream_deltas(response_parser.stream_chunk(delta_text=chunk, delta_token_ids=[])):
+                if not event.get('tool_emitted'):
+                    continue
+                if event.get('name'):
+                    emitted_name = event['name']
+                if event.get('arguments'):
+                    emitted_args += event['arguments']
         assert emitted_name == 'no_schema_tool'
         assert emitted_args == '{"zip": "77004", "active": "true"}'
 

--- a/tests/test_lmdeploy/serve/parsers/test_llama3_parser.py
+++ b/tests/test_lmdeploy/serve/parsers/test_llama3_parser.py
@@ -69,7 +69,7 @@ def test_llama3_streaming_emits_arguments_before_json_payload_complete():
 
     parser.stream_chunk('<|python_tag|>', [])
     chunks = [
-        '{"name":"find_user_id_by_name_zip","parameters":{"first_name":"Ch',
+        '{"name":"find_user_id_by_name_zip","arguments":{"first_name":"Ch',
         'en","last_name":"Johnson","zip":77004',
     ]
 

--- a/tests/test_lmdeploy/serve/parsers/test_llama3_parser.py
+++ b/tests/test_lmdeploy/serve/parsers/test_llama3_parser.py
@@ -64,6 +64,30 @@ def test_llama3_streaming_without_close_tag():
     }
 
 
+def test_llama3_streaming_emits_arguments_before_json_payload_complete():
+    parser = _build_parser()
+
+    parser.stream_chunk('<|python_tag|>', [])
+    chunks = [
+        '{"name":"find_user_id_by_name_zip","parameters":{"first_name":"Ch',
+        'en","last_name":"Johnson","zip":77004',
+    ]
+
+    argument_fragments = []
+    for chunk in chunks:
+        for delta_msg, tool_emitted in parser.stream_chunk(chunk, []):
+            if not tool_emitted or delta_msg is None or not delta_msg.tool_calls:
+                continue
+            for call in delta_msg.tool_calls:
+                if call.function and call.function.arguments:
+                    argument_fragments.append(call.function.arguments)
+
+    assert argument_fragments
+    joined = ''.join(argument_fragments)
+    assert 'Chen' in joined
+    assert joined != '{"first_name":"Chen","last_name":"Johnson","zip":77004}'
+
+
 def test_llama3_parse_complete_without_close_tag():
     parser = _build_parser()
     text = ('<|python_tag|>{"name":"find_user_id_by_name_zip","parameters":{"first_name":"Chen",'

--- a/tests/test_lmdeploy/serve/parsers/test_llama3_parser.py
+++ b/tests/test_lmdeploy/serve/parsers/test_llama3_parser.py
@@ -69,7 +69,7 @@ def test_llama3_streaming_emits_arguments_before_json_payload_complete():
 
     parser.stream_chunk('<|python_tag|>', [])
     chunks = [
-        '{"name":"find_user_id_by_name_zip","arguments":{"first_name":"Ch',
+        '{"name":"find_user_id_by_name_zip","parameters":{"first_name":"Ch',
         'en","last_name":"Johnson","zip":77004',
     ]
 

--- a/tests/test_lmdeploy/serve/parsers/test_qwen3_5_parser.py
+++ b/tests/test_lmdeploy/serve/parsers/test_qwen3_5_parser.py
@@ -460,3 +460,16 @@ null
 
         assert complete_tool_call is not None
         assert streamed_arguments == complete_tool_call.function.arguments
+
+    def test_streamed_arguments_match_complete_parse_when_value_contains_parameter_like_text(self):
+        parser = Qwen3CoderToolParser()
+        payload = '<function=f><parameter=a>foo <parameter=bar> baz</parameter></function>'
+
+        streamed_arguments = _stream_tool_arguments(
+            parser,
+            ['<function=f>', '<parameter=a>foo ', '<parameter=bar> baz', '</parameter></function>'],
+        )
+        complete_tool_call = parser.parse_tool_call_complete(payload)
+
+        assert complete_tool_call is not None
+        assert streamed_arguments == complete_tool_call.function.arguments

--- a/tests/test_lmdeploy/serve/parsers/test_qwen3_5_parser.py
+++ b/tests/test_lmdeploy/serve/parsers/test_qwen3_5_parser.py
@@ -55,6 +55,21 @@ def _stream_tool_arguments(parser, chunks):
     return ''.join(argument_fragments)
 
 
+def _stream_tool_arguments_by_chunk(parser, chunks):
+    parser.start_tool_call()
+    argument_fragments = []
+    per_chunk = []
+    for chunk in chunks:
+        chunk_fragments = []
+        for call in parser.decode_tool_incremental(chunk, final=False):
+            if call.function and call.function.arguments is not None:
+                argument_fragments.append(call.function.arguments)
+                chunk_fragments.append(call.function.arguments)
+        per_chunk.append(''.join(chunk_fragments))
+    parser.finish_tool_call()
+    return ''.join(argument_fragments), per_chunk
+
+
 REFERENCE_CHUNKS = [
     ('计划', [{'reasoning_content': '计划', 'tool_emitted': False}]),
     ('调用', [{'reasoning_content': '调用', 'tool_emitted': False}]),
@@ -291,6 +306,21 @@ null
         assert complete_tool_call is not None
         assert streamed_arguments == complete_tool_call.function.arguments
 
+    def test_stream_chunk_emits_quoted_string_value_before_parameter_close(self):
+        parser = Qwen3CoderToolParser()
+        payload = '<function=find_user><parameter=name>"Chen"</parameter></function>'
+
+        streamed_arguments, per_chunk = _stream_tool_arguments_by_chunk(
+            parser,
+            ['<function=find_user>', '<parameter=name>', '"Ch', 'en"', '</parameter></function>'],
+        )
+        complete_tool_call = parser.parse_tool_call_complete(payload)
+
+        assert per_chunk[2]
+        assert per_chunk[3]
+        assert complete_tool_call is not None
+        assert streamed_arguments == complete_tool_call.function.arguments
+
     def test_streamed_arguments_match_complete_parse_for_invalid_integer_value(self):
         parser = Qwen3CoderToolParser()
         request = ChatCompletionRequest(
@@ -321,6 +351,41 @@ null
         )
         complete_tool_call = parser.parse_tool_call_complete(payload)
 
+        assert complete_tool_call is not None
+        assert streamed_arguments == complete_tool_call.function.arguments
+
+    def test_stream_chunk_emits_valid_integer_value_before_parameter_close(self):
+        parser = Qwen3CoderToolParser()
+        request = ChatCompletionRequest(
+            model=MODEL_ID,
+            messages=[],
+            tools=[{
+                'type': 'function',
+                'function': {
+                    'name': 'typed_tool',
+                    'parameters': {
+                        'type': 'object',
+                        'properties': {
+                            'age': {
+                                'type': 'integer'
+                            },
+                        },
+                    },
+                },
+            }],
+            tool_choice='auto',
+        )
+        parser.adjust_request(request)
+        payload = '<function=typed_tool><parameter=age>29</parameter></function>'
+
+        streamed_arguments, per_chunk = _stream_tool_arguments_by_chunk(
+            parser,
+            ['<function=typed_tool>', '<parameter=age>', '2', '9', '</parameter></function>'],
+        )
+        complete_tool_call = parser.parse_tool_call_complete(payload)
+
+        assert per_chunk[2]
+        assert per_chunk[3]
         assert complete_tool_call is not None
         assert streamed_arguments == complete_tool_call.function.arguments
 

--- a/tests/test_lmdeploy/serve/parsers/test_qwen3_5_parser.py
+++ b/tests/test_lmdeploy/serve/parsers/test_qwen3_5_parser.py
@@ -44,6 +44,17 @@ def _flatten_stream_deltas(deltas):
     return events
 
 
+def _stream_tool_arguments(parser, chunks):
+    parser.start_tool_call()
+    argument_fragments = []
+    for chunk in chunks:
+        for call in parser.decode_tool_incremental(chunk, final=False):
+            if call.function and call.function.arguments is not None:
+                argument_fragments.append(call.function.arguments)
+    parser.finish_tool_call()
+    return ''.join(argument_fragments)
+
+
 REFERENCE_CHUNKS = [
     ('计划', [{'reasoning_content': '计划', 'tool_emitted': False}]),
     ('调用', [{'reasoning_content': '调用', 'tool_emitted': False}]),
@@ -266,3 +277,49 @@ null
             'scores': [98, 87],
             'misc': None,
         }
+
+    def test_streamed_arguments_match_complete_parse_for_quoted_string_value(self):
+        parser = Qwen3CoderToolParser()
+        payload = '<function=find_user><parameter=name>"Chen"</parameter></function>'
+
+        streamed_arguments = _stream_tool_arguments(
+            parser,
+            ['<function=find_user>', '<parameter=name>', '"Chen"', '</parameter>', '</function>'],
+        )
+        complete_tool_call = parser.parse_tool_call_complete(payload)
+
+        assert complete_tool_call is not None
+        assert streamed_arguments == complete_tool_call.function.arguments
+
+    def test_streamed_arguments_match_complete_parse_for_invalid_integer_value(self):
+        parser = Qwen3CoderToolParser()
+        request = ChatCompletionRequest(
+            model=MODEL_ID,
+            messages=[],
+            tools=[{
+                'type': 'function',
+                'function': {
+                    'name': 'typed_tool',
+                    'parameters': {
+                        'type': 'object',
+                        'properties': {
+                            'age': {
+                                'type': 'integer'
+                            },
+                        },
+                    },
+                },
+            }],
+            tool_choice='auto',
+        )
+        parser.adjust_request(request)
+        payload = '<function=typed_tool><parameter=age>abc</parameter></function>'
+
+        streamed_arguments = _stream_tool_arguments(
+            parser,
+            ['<function=typed_tool>', '<parameter=age>', 'abc', '</parameter>', '</function>'],
+        )
+        complete_tool_call = parser.parse_tool_call_complete(payload)
+
+        assert complete_tool_call is not None
+        assert streamed_arguments == complete_tool_call.function.arguments

--- a/tests/test_lmdeploy/serve/parsers/test_qwen3_5_parser.py
+++ b/tests/test_lmdeploy/serve/parsers/test_qwen3_5_parser.py
@@ -339,6 +339,42 @@ null
         assert complete_tool_call is not None
         assert streamed_arguments == complete_tool_call.function.arguments
 
+    def test_streamed_arguments_emit_typed_parameter_before_parameter_close(self):
+        parser = Qwen3CoderToolParser()
+        request = ChatCompletionRequest(
+            model=MODEL_ID,
+            messages=[],
+            tools=[{
+                'type': 'function',
+                'function': {
+                    'name': 'typed_tool',
+                    'parameters': {
+                        'type': 'object',
+                        'properties': {
+                            'age': {
+                                'type': 'integer'
+                            },
+                        },
+                    },
+                },
+            }],
+            tool_choice='auto',
+        )
+        parser.adjust_request(request)
+        payload = '<function=typed_tool><parameter=age>12</parameter></function>'
+
+        streamed_arguments, per_chunk = _stream_tool_arguments_by_chunk(
+            parser,
+            ['<function=typed_tool>', '<parameter=age>', '12', '</parameter></function>'],
+        )
+        complete_tool_call = parser.parse_tool_call_complete(payload)
+
+        assert per_chunk[1] == '{"age": '
+        assert per_chunk[2] == ''
+        assert complete_tool_call is not None
+        assert streamed_arguments == complete_tool_call.function.arguments
+        assert json.loads(streamed_arguments) == {'age': 12}
+
     def test_streamed_arguments_match_complete_parse_for_newline_escaped_quoted_string_value(self):
         parser = Qwen3CoderToolParser()
         payload = r'<function=find_user><parameter=name>"A\nB"</parameter></function>'

--- a/tests/test_lmdeploy/serve/parsers/test_qwen3_5_parser.py
+++ b/tests/test_lmdeploy/serve/parsers/test_qwen3_5_parser.py
@@ -306,18 +306,31 @@ null
         assert complete_tool_call is not None
         assert streamed_arguments == complete_tool_call.function.arguments
 
-    def test_stream_chunk_emits_quoted_string_value_before_parameter_close(self):
+    def test_streamed_arguments_match_complete_parse_for_newline_escaped_quoted_string_value(self):
         parser = Qwen3CoderToolParser()
-        payload = '<function=find_user><parameter=name>"Chen"</parameter></function>'
+        payload = r'<function=find_user><parameter=name>"A\nB"</parameter></function>'
 
         streamed_arguments, per_chunk = _stream_tool_arguments_by_chunk(
             parser,
-            ['<function=find_user>', '<parameter=name>', '"Ch', 'en"', '</parameter></function>'],
+            ['<function=find_user>', '<parameter=name>', '"A\\', 'nB"', '</parameter></function>'],
         )
         complete_tool_call = parser.parse_tool_call_complete(payload)
 
-        assert per_chunk[2]
-        assert per_chunk[3]
+        assert per_chunk[2] == ''
+        assert per_chunk[3] == ''
+        assert complete_tool_call is not None
+        assert streamed_arguments == complete_tool_call.function.arguments
+
+    def test_streamed_arguments_match_complete_parse_for_quote_escaped_quoted_string_value(self):
+        parser = Qwen3CoderToolParser()
+        payload = r'<function=find_user><parameter=name>"A\"B"</parameter></function>'
+
+        streamed_arguments = _stream_tool_arguments(
+            parser,
+            ['<function=find_user>', '<parameter=name>', '"A\\', '"B"', '</parameter></function>'],
+        )
+        complete_tool_call = parser.parse_tool_call_complete(payload)
+
         assert complete_tool_call is not None
         assert streamed_arguments == complete_tool_call.function.arguments
 
@@ -354,7 +367,7 @@ null
         assert complete_tool_call is not None
         assert streamed_arguments == complete_tool_call.function.arguments
 
-    def test_stream_chunk_emits_valid_integer_value_before_parameter_close(self):
+    def test_streamed_arguments_match_complete_parse_for_invalid_integer_after_numeric_prefix(self):
         parser = Qwen3CoderToolParser()
         request = ChatCompletionRequest(
             model=MODEL_ID,
@@ -376,18 +389,19 @@ null
             tool_choice='auto',
         )
         parser.adjust_request(request)
-        payload = '<function=typed_tool><parameter=age>29</parameter></function>'
+        payload = '<function=typed_tool><parameter=age>2a</parameter></function>'
 
         streamed_arguments, per_chunk = _stream_tool_arguments_by_chunk(
             parser,
-            ['<function=typed_tool>', '<parameter=age>', '2', '9', '</parameter></function>'],
+            ['<function=typed_tool>', '<parameter=age>', '2', 'a', '</parameter></function>'],
         )
         complete_tool_call = parser.parse_tool_call_complete(payload)
 
-        assert per_chunk[2]
-        assert per_chunk[3]
+        assert per_chunk[2] == ''
+        assert per_chunk[3] == ''
         assert complete_tool_call is not None
         assert streamed_arguments == complete_tool_call.function.arguments
+        assert json.loads(streamed_arguments) == {'age': '2a'}
 
     def test_streamed_arguments_match_complete_parse_when_next_param_starts_with_previous_close(self):
         parser = Qwen3CoderToolParser()

--- a/tests/test_lmdeploy/serve/parsers/test_qwen3_5_parser.py
+++ b/tests/test_lmdeploy/serve/parsers/test_qwen3_5_parser.py
@@ -434,3 +434,29 @@ null
 
         assert complete_tool_call is not None
         assert streamed_arguments == complete_tool_call.function.arguments
+
+    def test_streamed_arguments_match_complete_parse_for_unquoted_newline_value(self):
+        parser = Qwen3CoderToolParser()
+        payload = '<function=f><parameter=a>A\nB</parameter></function>'
+
+        streamed_arguments = _stream_tool_arguments(
+            parser,
+            ['<function=f>', '<parameter=a>A\n', 'B</parameter></function>'],
+        )
+        complete_tool_call = parser.parse_tool_call_complete(payload)
+
+        assert complete_tool_call is not None
+        assert streamed_arguments == complete_tool_call.function.arguments
+
+    def test_streamed_arguments_match_complete_parse_for_unquoted_quote_value(self):
+        parser = Qwen3CoderToolParser()
+        payload = '<function=f><parameter=a>A"B</parameter></function>'
+
+        streamed_arguments = _stream_tool_arguments(
+            parser,
+            ['<function=f>', '<parameter=a>A"', 'B</parameter></function>'],
+        )
+        complete_tool_call = parser.parse_tool_call_complete(payload)
+
+        assert complete_tool_call is not None
+        assert streamed_arguments == complete_tool_call.function.arguments

--- a/tests/test_lmdeploy/serve/parsers/test_qwen3_5_parser.py
+++ b/tests/test_lmdeploy/serve/parsers/test_qwen3_5_parser.py
@@ -1,12 +1,10 @@
 import json
 
-from lmdeploy.serve.openai.protocol import ChatCompletionRequest, DeltaToolCall
+from lmdeploy.serve.openai.protocol import ChatCompletionRequest
 from lmdeploy.serve.parsers import ResponseParserManager
 from lmdeploy.serve.parsers.reasoning_parser import ReasoningParserManager
 from lmdeploy.serve.parsers.tool_parser import ToolParserManager
 from lmdeploy.serve.parsers.tool_parser.qwen3coder_tool_parser import Qwen3CoderToolParser
-
-from .helpers import first_stream_delta
 
 MODEL_ID = 'Qwen/Qwen3.5-35B-A3B'
 
@@ -26,54 +24,69 @@ def _build_response_parser():
     return cls(request=request)
 
 
+def _flatten_stream_deltas(deltas):
+    events = []
+    for delta_msg, tool_emitted in deltas:
+        if delta_msg is None:
+            continue
+        if delta_msg.reasoning_content is not None:
+            events.append({'reasoning_content': delta_msg.reasoning_content, 'tool_emitted': tool_emitted})
+        if delta_msg.content is not None:
+            events.append({'content': delta_msg.content, 'tool_emitted': tool_emitted})
+        if delta_msg.tool_calls:
+            for call in delta_msg.tool_calls:
+                events.append({
+                    'tool_emitted': tool_emitted,
+                    'type': call.type,
+                    'name': call.function.name if call.function else None,
+                    'arguments': call.function.arguments if call.function else None,
+                })
+    return events
+
+
 REFERENCE_CHUNKS = [
-    # (delta_text, emitted_delta_msg, reasoning_content, content,
-    # tool_emitted, function_name, function_arguments, tool_call_type)
-    # Short representative reasoning stream; literal text is irrelevant.
-    ('计划', True, '计划', None, False, None, None, None),
-    ('调用', True, '调用', None, False, None, None, None),
-    ('get', True, 'get', None, False, None, None, None),
-    ('_current', True, '_current', None, False, None, None, None),
-    ('_temperature', True, '_temperature', None, False, None, None, None),
-    ('函数', True, '函数', None, False, None, None, None),
-    ('并提供', True, '并提供', None, False, None, None, None),
-    ('location', True, 'location', None, False, None, None, None),
-    ('参数', True, '参数', None, False, None, None, None),
-    ('。', True, '。', None, False, None, None, None),
-    ('\n', True, '\n', None, False, None, None, None),
-    ('</think>', False, None, None, False, None, None, None),
-    ('\n\n', True, None, '\n\n', False, None, None, None),
-    # Tool call section: placeholder; will be updated to match Qwen3.5 XML-style.
-    ('<tool_call>', False, None, None, False, None, None, None),
-    ('\n', False, None, None, False, None, None, None),
-    ('<', False, None, None, False, None, None, None),
-    ('function', False, None, None, False, None, None, None),
-    ('=get', False, None, None, False, None, None, None),
-    ('_current', False, None, None, False, None, None, None),
-    ('_temperature', False, None, None, False, None, None, None),
-    ('>', True, None, None, True, 'get_current_temperature', None, 'function'),
-    ('\n', False, None, None, False, None, None, None),
-    ('<', False, None, None, False, None, None, None),
-    ('parameter', False, None, None, False, None, None, None),
-    ('=location', False, None, None, False, None, None, None),
-    ('>', False, None, None, False, None, None, None),
-    ('\n', False, None, None, False, None, None, None),
-    ('Be', False, None, None, False, None, None, None),
-    ('ijing', False, None, None, False, None, None, None),
-    (',', False, None, None, False, None, None, None),
-    (' China', False, None, None, False, None, None, None),
-    ('\n', False, None, None, False, None, None, None),
-    ('</', False, None, None, False, None, None, None),
-    ('parameter', False, None, None, False, None, None, None),
-    # Tokenizer maps this `>` to a single id; Qwen3Coder may emit accumulated JSON args in one delta.
-    ('>', True, None, None, True, None, '{"location": "Beijing, China"', None),
-    ('\n', False, None, None, False, None, None, None),
-    ('</', False, None, None, False, None, None, None),
-    ('function', False, None, None, False, None, None, None),
-    ('>', True, None, None, True, None, '}', None),
-    ('\n', False, None, None, False, None, None, None),
-    ('</tool_call>', False, None, None, False, None, None, None),
-    ('', True, None, '', False, None, None, None),
+    ('计划', [{'reasoning_content': '计划', 'tool_emitted': False}]),
+    ('调用', [{'reasoning_content': '调用', 'tool_emitted': False}]),
+    ('get', [{'reasoning_content': 'get', 'tool_emitted': False}]),
+    ('_current', [{'reasoning_content': '_current', 'tool_emitted': False}]),
+    ('_temperature', [{'reasoning_content': '_temperature', 'tool_emitted': False}]),
+    ('函数', [{'reasoning_content': '函数', 'tool_emitted': False}]),
+    ('并提供', [{'reasoning_content': '并提供', 'tool_emitted': False}]),
+    ('location', [{'reasoning_content': 'location', 'tool_emitted': False}]),
+    ('参数', [{'reasoning_content': '参数', 'tool_emitted': False}]),
+    ('。', [{'reasoning_content': '。', 'tool_emitted': False}]),
+    ('\n', [{'reasoning_content': '\n', 'tool_emitted': False}]),
+    ('</think>', []),
+    ('\n\n', [{'content': '\n\n', 'tool_emitted': False}]),
+    ('<tool_call>', []),
+    ('\n', []),
+    ('<', []),
+    ('function', []),
+    ('=get', []),
+    ('_current', []),
+    ('_temperature', []),
+    ('>', [{'tool_emitted': True, 'type': 'function', 'name': 'get_current_temperature', 'arguments': None}]),
+    ('\n', []),
+    ('<', []),
+    ('parameter', []),
+    ('=location', []),
+    ('>', []),
+    ('\n', []),
+    ('Be', [{'tool_emitted': True, 'type': None, 'name': None, 'arguments': '{"location": "Be'}]),
+    ('ijing', [{'tool_emitted': True, 'type': None, 'name': None, 'arguments': 'ijing'}]),
+    (',', [{'tool_emitted': True, 'type': None, 'name': None, 'arguments': ','}]),
+    (' China', [{'tool_emitted': True, 'type': None, 'name': None, 'arguments': ' China'}]),
+    ('\n', []),
+    ('</', []),
+    ('parameter', []),
+    ('>', [{'tool_emitted': True, 'type': None, 'name': None, 'arguments': '"'}]),
+    ('\n', []),
+    ('</', []),
+    ('function', []),
+    ('>', [{'tool_emitted': True, 'type': None, 'name': None, 'arguments': '}'}]),
+    ('\n', []),
+    ('</tool_call>', []),
+    ('', [{'content': '', 'tool_emitted': False}]),
 ]
 
 
@@ -82,50 +95,38 @@ class TestQwen3_5ResponseParserStreaming:
     parsers."""
 
     def test_stream_chunk_matches_reference(self):
-        """Feed the real streaming sequence into ResponseParser.stream_chunk
-        and verify each parsed chunk.
-
-        Expectations for tool_calls will be refined once the Qwen3.5 ground-truth stream is finalized.
-        """
-
         response_parser = _build_response_parser()
-        for (delta_text, exp_delta_msg, exp_reasoning, exp_content, exp_tool_emitted,
-             exp_function_name, exp_function_arguments,
-             exp_type) in REFERENCE_CHUNKS:
-            delta_msg, tool_emitted = first_stream_delta(response_parser.stream_chunk(
-                delta_text=delta_text,
-                delta_token_ids=[],
-            ))
-            if exp_delta_msg is False:
-                assert delta_msg is None
-                continue
+        actual = []
+        expected = []
+        for delta_text, expected_events in REFERENCE_CHUNKS:
+            actual.extend(
+                _flatten_stream_deltas(response_parser.stream_chunk(delta_text=delta_text, delta_token_ids=[])))
+            expected.extend(expected_events)
+        assert actual == expected
 
-            assert delta_msg.reasoning_content == exp_reasoning
-            assert delta_msg.content == exp_content
+    def test_stream_chunk_emits_parameter_value_before_parameter_close(self):
+        response_parser = _build_response_parser()
+        chunks = [
+            '</think>',
+            '<tool_call>',
+            '<function=get_current_temperature>',
+            '<parameter=location>',
+            'San',
+            ' Francisco',
+            ', CA',
+        ]
 
-            # Tool-call expectations in this fixture are placeholders for now.
-            # Only enforce the exact tool_emitted flag when an explicit tool
-            # delta shape is provided.
-            if (
-                exp_function_name is None
-                and exp_function_arguments is None
-                and exp_type is None
-                and exp_reasoning is None
-                and exp_content is None
-            ):
-                continue
+        argument_fragments = []
+        emitted_before_close = False
+        for chunk in chunks:
+            for event in _flatten_stream_deltas(response_parser.stream_chunk(delta_text=chunk, delta_token_ids=[])):
+                fragment = event.get('arguments')
+                if fragment:
+                    argument_fragments.append(fragment)
+                    emitted_before_close = True
 
-            assert tool_emitted == exp_tool_emitted
-
-            if tool_emitted:
-                assert delta_msg.tool_calls is not None
-                assert len(delta_msg.tool_calls) == 1
-                call = delta_msg.tool_calls[0]
-                assert isinstance(call, DeltaToolCall)
-                assert call.type == exp_type
-                assert call.function is not None
-                assert call.function.name == exp_function_name
-                assert call.function.arguments == exp_function_arguments
+        assert emitted_before_close is True
+        assert ''.join(argument_fragments) == '{"location": "San Francisco, CA'
 
     def test_parse_complete_parallel_tool_calls_keep_distinct_arguments(self):
         """Regression: parallel tool calls must not reuse the first call's args."""

--- a/tests/test_lmdeploy/serve/parsers/test_qwen3_5_parser.py
+++ b/tests/test_lmdeploy/serve/parsers/test_qwen3_5_parser.py
@@ -342,3 +342,16 @@ null
 
         assert complete_tool_call is not None
         assert streamed_arguments == complete_tool_call.function.arguments
+
+    def test_streamed_arguments_match_complete_parse_when_close_chunk_has_value_tail(self):
+        parser = Qwen3CoderToolParser()
+        payload = '<function=f><parameter=a>San Francisco</parameter></function>'
+
+        streamed_arguments = _stream_tool_arguments(
+            parser,
+            ['<function=f>', '<parameter=a>San ', 'Francisco</parameter></function>'],
+        )
+        complete_tool_call = parser.parse_tool_call_complete(payload)
+
+        assert complete_tool_call is not None
+        assert streamed_arguments == complete_tool_call.function.arguments

--- a/tests/test_lmdeploy/serve/parsers/test_qwen3_5_parser.py
+++ b/tests/test_lmdeploy/serve/parsers/test_qwen3_5_parser.py
@@ -306,6 +306,39 @@ null
         assert complete_tool_call is not None
         assert streamed_arguments == complete_tool_call.function.arguments
 
+    def test_streamed_arguments_match_complete_parse_for_string_schema_value_with_whitespace(self):
+        parser = Qwen3CoderToolParser()
+        request = ChatCompletionRequest(
+            model=MODEL_ID,
+            messages=[],
+            tools=[{
+                'type': 'function',
+                'function': {
+                    'name': 'typed_tool',
+                    'parameters': {
+                        'type': 'object',
+                        'properties': {
+                            'name': {
+                                'type': 'string'
+                            },
+                        },
+                    },
+                },
+            }],
+            tool_choice='auto',
+        )
+        parser.adjust_request(request)
+        payload = '<function=typed_tool><parameter=name>  abc  </parameter></function>'
+
+        streamed_arguments = _stream_tool_arguments(
+            parser,
+            ['<function=typed_tool>', '<parameter=name>  a', 'bc  </parameter></function>'],
+        )
+        complete_tool_call = parser.parse_tool_call_complete(payload)
+
+        assert complete_tool_call is not None
+        assert streamed_arguments == complete_tool_call.function.arguments
+
     def test_streamed_arguments_match_complete_parse_for_newline_escaped_quoted_string_value(self):
         parser = Qwen3CoderToolParser()
         payload = r'<function=find_user><parameter=name>"A\nB"</parameter></function>'

--- a/tests/test_lmdeploy/serve/parsers/test_qwen3_5_parser.py
+++ b/tests/test_lmdeploy/serve/parsers/test_qwen3_5_parser.py
@@ -323,3 +323,22 @@ null
 
         assert complete_tool_call is not None
         assert streamed_arguments == complete_tool_call.function.arguments
+
+    def test_streamed_arguments_match_complete_parse_when_next_param_starts_with_previous_close(self):
+        parser = Qwen3CoderToolParser()
+        payload = '<function=two_args><parameter=a>one</parameter><parameter=b>two</parameter></function>'
+
+        streamed_arguments = _stream_tool_arguments(
+            parser,
+            [
+                '<function=two_args>',
+                '<parameter=a>',
+                'one',
+                '</parameter><parameter=b>two',
+                '</parameter></function>',
+            ],
+        )
+        complete_tool_call = parser.parse_tool_call_complete(payload)
+
+        assert complete_tool_call is not None
+        assert streamed_arguments == complete_tool_call.function.arguments

--- a/tests/test_lmdeploy/serve/parsers/test_qwen3_parser.py
+++ b/tests/test_lmdeploy/serve/parsers/test_qwen3_parser.py
@@ -152,14 +152,17 @@ class TestQwenResponseParserStreaming:
               after streaming completes.
         """
 
-        expected = [
-            (exp_reasoning, exp_content, exp_tool_emitted, exp_function_name, exp_function_arguments, exp_type)
-            for (_, exp_delta_msg, exp_reasoning, exp_content, exp_tool_emitted, exp_function_name,
-                 exp_function_arguments, exp_type) in reference_chunks
-            if exp_delta_msg
-        ]
+        expected_reasoning = [row[2] for row in reference_chunks if row[1] and row[2] is not None]
+        expected_content = [row[3] for row in reference_chunks if row[1] and row[3] is not None]
+        expected_names = [row[5] for row in reference_chunks if row[1] and row[5] is not None]
+        expected_types = [row[7] for row in reference_chunks if row[1] and row[7] is not None]
+        expected_arguments = ''.join(row[6] or '' for row in reference_chunks if row[1])
 
-        actual = []
+        actual_reasoning = []
+        actual_content = []
+        actual_names = []
+        actual_types = []
+        actual_arguments = []
         for (delta_text, *_) in reference_chunks:
             if delta_text is None:
                 continue
@@ -169,23 +172,39 @@ class TestQwenResponseParserStreaming:
             ):
                 if delta_msg is None:
                     continue
-                actual.append((delta_msg, tool_emitted))
+                if delta_msg.reasoning_content is not None:
+                    actual_reasoning.append(delta_msg.reasoning_content)
+                    assert tool_emitted is False
+                if delta_msg.content is not None:
+                    actual_content.append(delta_msg.content)
+                    assert tool_emitted is False
+                if delta_msg.tool_calls:
+                    assert tool_emitted is True
+                    assert len(delta_msg.tool_calls) == 1
+                    call = delta_msg.tool_calls[0]
+                    assert isinstance(call, DeltaToolCall)
+                    assert call.function is not None
+                    if call.type is not None:
+                        actual_types.append(call.type)
+                    if call.function.name is not None:
+                        actual_names.append(call.function.name)
+                    if call.function.arguments is not None:
+                        actual_arguments.append(call.function.arguments)
+                else:
+                    assert tool_emitted is False
 
-        assert len(actual) == len(expected)
-        for (delta_msg, tool_emitted), (exp_reasoning, exp_content, exp_tool_emitted, exp_function_name,
-                                        exp_function_arguments, exp_type) in zip(actual, expected):
-            assert delta_msg.reasoning_content == exp_reasoning
-            assert delta_msg.content == exp_content
-            assert tool_emitted == exp_tool_emitted
-            if tool_emitted:
-                assert delta_msg.tool_calls is not None
-                assert len(delta_msg.tool_calls) == 1
-                call = delta_msg.tool_calls[0]
-                assert isinstance(call, DeltaToolCall)
-                assert call.type == exp_type
-                assert call.function is not None
-                assert call.function.name == exp_function_name
-                assert call.function.arguments == exp_function_arguments
+        assert actual_reasoning == expected_reasoning
+        assert actual_content == expected_content
+        assert actual_names == expected_names
+        assert actual_types == expected_types
+        assert ''.join(actual_arguments) == expected_arguments
+        if actual_arguments:
+            assert actual_arguments[0] != expected_arguments
+            assert len(actual_arguments) > 1
+            assert all(fragment for fragment in actual_arguments)
+            complete_text = ''.join(row[0] or '' for row in reference_chunks)
+            _, complete_tool_calls, _ = response_parser.parse_complete(complete_text)
+            assert complete_tool_calls[0].function.arguments == expected_arguments
 
     def test_stream_chunk_handles_mixed_reasoning_content_tool(self, response_parser):
         """A single delta may contain reasoning/content/tool segments together.


### PR DESCRIPTION
## Summary
- Stream tool-call argument fragments from XML and JSON response parsers before complete parameter payloads are available.
- Suppress empty chat SSE content chunks while tool payload syntax is being buffered.
- Update parser reference coverage for incremental argument deltas, with qwen3coder/glm47 and shared JSON parser coverage.

## Test Plan
- python -m pytest tests/test_lmdeploy/serve/parsers/test_qwen3_5_parser.py tests/test_lmdeploy/serve/parsers/test_glm47_parser.py tests/test_lmdeploy/serve/parsers/test_llama3_parser.py tests/test_lmdeploy/serve/parsers/test_qwen3_parser.py -q
- python -m pytest tests/test_lmdeploy/serve/openai/chat_completions tests/test_lmdeploy/serve/openai/responses/test_streaming.py -q