### PR TITLE
Fix Docker Hub rate limit on self-hosted CI container jobs

### DIFF
--- a/.github/workflows/pr_ete_test.yml
+++ b/.github/workflows/pr_ete_test.yml
@@ -36,6 +36,9 @@ jobs:
       SERVER_LOG: /nvme/qa_test_models/server_log/${{ github.head_ref }}_${{ github.run_id }}
     container:
       image: openmmlab/lmdeploy:dev-cu12.8
+      credentials:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
       options: --gpus all --ipc=host --user root -e PIP_CACHE_DIR=/root/.cache/pip --pull never
       volumes:
         - /nvme/share_data/github-actions/pip-cache:/root/.cache/pip

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -40,6 +40,9 @@ jobs:
     timeout-minutes: 4320 # 72hours
     container:
       image: openmmlab/lmdeploy:dev-cu12.8
+      credentials:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
       options: "--gpus=all --ipc=host --user root -e PIP_CACHE_DIR=/root/.cache/pip -e CUDA_VISIBLE_DEVICES=2,3 -e HF_HOME=/root/.cache/huggingface --pull never"
       volumes:
         - /nvme/share_data/github-actions/pip-cache:/root/.cache/pip


### PR DESCRIPTION
Fix the following issue:
```
Starting job container
  /usr/bin/docker pull openmmlab/lmdeploy:dev-cu12.8
  Error response from daemon: toomanyrequests: You have reached your unauthenticated pull rate limit. https://www.docker.com/increase-rate-limit
  Warning: Docker pull failed with exit code 1, back off 6.854 seconds before retry.
```