### PR TITLE
Guard DP dummy inputs around pending work

### DIFF
--- a/lmdeploy/pytorch/engine/model_agent/agent.py
+++ b/lmdeploy/pytorch/engine/model_agent/agent.py
@@ -953,7 +953,13 @@ class BaseModelAgent:
             self._pending_h2d_transfers.popleft()
 
     async def _async_loop_inputs_preprocess(self, forward_event: asyncio.Event = None):
-        """Async loop inputs preprocess."""
+        """Move queued CPU-side forward inputs to the CUDA-ready queue.
+
+        ``set_forward_inputs`` writes to ``_pre_in_que``. Until this coroutine
+        finishes H2D/preprocessing and pushes the item to ``_in_que``, the DP
+        input maker treats ``_pre_in_que`` as pending real work and avoids
+        falling back to dummy inputs.
+        """
         non_blocking = True
         keys = ['inputs', 'delta', 'sampling_inputs', 'stopping_criteria', 'extra_inputs']
         while True:

--- a/lmdeploy/pytorch/engine/model_agent/inputs_maker.py
+++ b/lmdeploy/pytorch/engine/model_agent/inputs_maker.py
@@ -11,6 +11,16 @@ if TYPE_CHECKING:
     from .agent import BaseModelAgent
 
 
+# Polling is only used inside the worker actor while a real input is in the
+# CPU-side preprocess queue but has not reached the CUDA-ready queue yet.
+_PREPROCESS_POLL_INTERVAL = 0.001
+
+# Ray actor delivery of forward_async may lag behind the background forward
+# loop by a few event-loop turns. Yield briefly before falling back to dummy
+# inputs so just-scheduled real inputs can reach _pre_in_que.
+_FORWARD_RPC_YIELD_TURNS = 2
+
+
 class DefaultForwardInputsMaker:
     """Default forward inputs maker."""
 
@@ -28,7 +38,16 @@ class DefaultForwardInputsMaker:
 
 
 class DPForwardInputsMaker:
-    """Dp forward inputs maker."""
+    """DP forward inputs maker.
+
+    DP workers must enter a forward step even when a rank has no local request,
+    so this maker creates dummy inputs as a fallback. Real inputs arrive in two
+    stages: ``set_forward_inputs`` enqueues CPU-side data into ``_pre_in_que``,
+    then the preprocess task moves CUDA-ready data to ``_in_que``. A non-empty
+    ``_pre_in_que`` is therefore pending real work and should delay dummy
+    fallback, except while the model agent is sleeping because those queued
+    items may be stale across sleep/wakeup.
+    """
 
     def __init__(self, model_agent: 'BaseModelAgent'):
         self.model_agent = model_agent
@@ -37,6 +56,7 @@ class DPForwardInputsMaker:
         self.cache_config = model_agent.cache_config
         self.inputs_strategy = model_agent.inputs_strategy
         self.device = model_agent.device
+        self._pre_in_que = model_agent._pre_in_que
         self._in_que = model_agent._in_que
 
         # maker metas
@@ -62,6 +82,46 @@ class DPForwardInputsMaker:
         forward_inputs = dict(inputs=model_inputs, extra_inputs=extra_inputs, return_logits=return_logits)
         return forward_inputs
 
+    def _is_sleeping(self):
+        """Whether the model agent is entering sleep."""
+        state = getattr(self.model_agent, 'state', None)
+        return bool(getattr(state, 'is_sleeping', False))
+
+    def _has_pending_real_inputs(self):
+        """Whether real inputs are waiting for preprocessing or ready.
+
+        ``_pre_in_que`` matters even when ``_in_que`` is empty: H2D transfer and
+        lightweight preprocessing happen between those queues, and replacing
+        that pending real input with a dummy would waste a DP forward step.
+        """
+        if self._is_sleeping():
+            return False
+        return self._in_que.qsize() > 0 or self._pre_in_que.qsize() > 0
+
+    async def _wait_preprocessed_real_inputs(self):
+        """Wait until queued real inputs are ready for forward.
+
+        Keep checking the sleep state while waiting so sleep/wakeup can ignore stale queued inputs and let the normal
+        dummy/sleep metadata path run.
+        """
+        while not self._is_sleeping() and self._in_que.qsize() == 0 and self._pre_in_que.qsize() > 0:
+            await asyncio.sleep(_PREPROCESS_POLL_INTERVAL)
+
+    async def _yield_to_forward_rpc(self):
+        """Let scheduled worker RPCs enqueue inputs before dummy fallback.
+
+        The scheduler may have already issued ``worker.forward_async.remote``,
+        while the worker actor has not yet executed ``set_forward_inputs``.
+        A few zero-time yields reduce dummy forwards caused by this async
+        delivery gap without making the loop block when no real work exists.
+        """
+        if self._is_sleeping():
+            return
+        for _ in range(_FORWARD_RPC_YIELD_TURNS):
+            if self._has_pending_real_inputs():
+                return
+            await asyncio.sleep(0)
+
     async def _gather_has_inputs(self, has_inputs: bool = False):
         """Broadcast has inputs."""
         attn_tp_group = self.dist_ctx.attn_tp_group
@@ -79,6 +139,11 @@ class DPForwardInputsMaker:
         return (has_inputs > 0).item()
 
     async def _get_inputs(self):
+        if self._is_sleeping():
+            return None
+
+        await self._wait_preprocessed_real_inputs()
+
         # get local forward inputs
         try:
             forward_inputs = self._in_que.get_nowait()
@@ -95,8 +160,10 @@ class DPForwardInputsMaker:
     async def get(self):
         """get."""
         # # wait until has inputs or prev forward finish
-        while self._in_que.qsize() == 0 and not self._ready_event.query():
-            await asyncio.sleep(0.001)
+        while not self._has_pending_real_inputs() and not self._ready_event.query():
+            await asyncio.sleep(_PREPROCESS_POLL_INTERVAL)
+
+        await self._yield_to_forward_rpc()
 
         # try get inputs
         forward_inputs = await self._get_inputs()

--- a/tests/pytorch/engine/test_model_agent.py
+++ b/tests/pytorch/engine/test_model_agent.py
@@ -181,6 +181,102 @@ class TestDrainQueues:
         assert agent._out_que.get_nowait() == 'new'
 
 
+class TestDPForwardInputsMaker:
+
+    @staticmethod
+    def _make_ready_event():
+
+        class _ReadyEvent:
+
+            def query(self):
+                return True
+
+        return _ReadyEvent()
+
+    @staticmethod
+    def _make_maker(is_sleeping=False, dummy_forward_inputs=None):
+        from lmdeploy.pytorch.engine.model_agent.inputs_maker import DPForwardInputsMaker
+
+        maker = DPForwardInputsMaker.__new__(DPForwardInputsMaker)
+        maker.model_agent = SimpleNamespace(state=SimpleNamespace(is_sleeping=is_sleeping))
+        maker._pre_in_que = asyncio.Queue()
+        maker._in_que = asyncio.Queue()
+        maker._ready_event = TestDPForwardInputsMaker._make_ready_event()
+
+        async def _gather_has_inputs(has_inputs=False):
+            return has_inputs
+
+        def _make_dummy_forward_inputs():
+            if dummy_forward_inputs is not None:
+                return dummy_forward_inputs
+            raise AssertionError('pending real input must not be replaced with a dummy')
+
+        maker._gather_has_inputs = _gather_has_inputs
+        maker._make_dummy_forward_inputs = _make_dummy_forward_inputs
+        return maker
+
+    def test_get_waits_for_queued_preprocess_input(self):
+        async def _run():
+            maker = self._make_maker()
+            maker._pre_in_que.put_nowait({'inputs': 'queued'})
+
+            task = asyncio.create_task(maker.get())
+            await asyncio.sleep(0.01)
+            assert not task.done()
+
+            real_inputs = {'inputs': 'real'}
+            maker._pre_in_que.get_nowait()
+            maker._in_que.put_nowait(real_inputs)
+
+            assert await asyncio.wait_for(task, timeout=1.0) is real_inputs
+
+        asyncio.run(_run())
+
+    def test_get_yields_for_worker_forward_rpc_before_dummy(self):
+
+        async def _run():
+            maker = self._make_maker()
+            real_inputs = {'inputs': 'real'}
+
+            async def _enqueue_after_model_agent_yields():
+                await asyncio.sleep(0)
+                maker._pre_in_que.put_nowait({'inputs': 'queued'})
+                await asyncio.sleep(0)
+                maker._pre_in_que.get_nowait()
+                maker._in_que.put_nowait(real_inputs)
+
+            enqueue_task = asyncio.create_task(_enqueue_after_model_agent_yields())
+
+            assert await asyncio.wait_for(maker.get(), timeout=1.0) is real_inputs
+            await asyncio.wait_for(enqueue_task, timeout=1.0)
+
+        asyncio.run(_run())
+
+    def test_get_uses_dummy_for_sleeping_preprocess_queue(self):
+        async def _run():
+            dummy_inputs = {'inputs': 'sleep_dummy'}
+            maker = self._make_maker(is_sleeping=True, dummy_forward_inputs=dummy_inputs)
+            maker._pre_in_que.put_nowait({'inputs': 'stale'})
+
+            assert await asyncio.wait_for(maker.get(), timeout=1.0) is dummy_inputs
+            assert maker._pre_in_que.qsize() == 1
+            assert maker._in_que.qsize() == 0
+
+        asyncio.run(_run())
+
+    def test_get_uses_dummy_for_sleeping_ready_queue(self):
+        async def _run():
+            dummy_inputs = {'inputs': 'sleep_dummy'}
+            maker = self._make_maker(is_sleeping=True, dummy_forward_inputs=dummy_inputs)
+            maker._in_que.put_nowait({'inputs': 'stale_ready'})
+
+            assert await asyncio.wait_for(maker.get(), timeout=1.0) is dummy_inputs
+            assert maker._pre_in_que.qsize() == 0
+            assert maker._in_que.qsize() == 1
+
+        asyncio.run(_run())
+
+
 class TestDPForwardMeta:
 
     def test_field_names_follow_enabled_features(self):

--- a/tests/pytorch/spec_decode/test_guided_spec_integration.py
+++ b/tests/pytorch/spec_decode/test_guided_spec_integration.py
@@ -341,7 +341,7 @@ class TestSimulatedRejectionSamplingGrammarState:
         assert allowed != allowed_initial, 'Grammar should have advanced from initial state'
 
     def test_grammar_state_partial_rejection_greedy(self, compiler, tokenizer_info, guided_manager):
-        """Partial rejection (greedy) → grammar state reflects only accepted
+        """Partial rejection (greedy) -> grammar state reflects only accepted
         tokens + replacement + bonus."""
         schema = {'type': 'object', 'properties': {'x': {'type': 'integer'}}, 'required': ['x']}
         original = _json_matcher(compiler, schema)
@@ -1133,7 +1133,7 @@ class TestEagle3GetOutputs:
     def test_get_outputs_multi_step_with_fork(self, compiler, tokenizer_info,
                                                 guided_manager):
         """Multi-step draft loop calling get_outputs repeatedly with the same
-        fork — same pattern as _async_model_forward."""
+        fork - same pattern as _async_model_forward."""
         schema = {'type': 'object', 'properties': {'x': {'type': 'integer'}}, 'required': ['x']}
         original = _json_matcher(compiler, schema)
         vocab_size = tokenizer_info.vocab_size


### PR DESCRIPTION
This pr could reduce numbers of dummy inputs when dp>1 is enabled.