### PR TITLE
Support fp8 moe only for qwen3.5

### DIFF
--- a/lmdeploy/pytorch/config.py
+++ b/lmdeploy/pytorch/config.py
@@ -672,6 +672,13 @@ class QuantizationConfig:
     fp8_quant_scope: str | None = None
     hf_quant_config: dict[str, Any] = field(default_factory=dict)
 
+    def __post_init__(self):
+        """Validate quantization scope."""
+        if self.fp8_quant_scope not in {None, 'moe_only'}:
+            raise ValueError(f'Unsupported fp8 quant scope: {self.fp8_quant_scope}')
+        if self.fp8_quant_scope is not None and self.quant_method != 'fp8':
+            raise ValueError('fp8_quant_scope is only supported for fp8 quantization.')
+
     @classmethod
     def from_config(cls, hf_config: Any):
         quant_config = getattr(hf_config, 'quantization_config', None)
@@ -743,11 +750,9 @@ class QuantizationConfig:
         """Get quant method for module."""
         if module_kind not in {'linear', 'moe', 'norm'}:
             raise ValueError(f'Unsupported quant module kind: {module_kind}')
-        if self.fp8_quant_scope == 'moe_only' and module_kind != 'moe':
+        if self.quant_method == 'fp8' and self.fp8_quant_scope == 'moe_only' and module_kind != 'moe':
             quant_method = None
             return quant_method
-        if self.fp8_quant_scope not in {None, 'moe_only'}:
-            raise ValueError(f'Unsupported fp8 quant scope: {self.fp8_quant_scope}')
         if not prefix or not self.ignored_layers:
             quant_method = self.quant_method
             return quant_method

--- a/lmdeploy/pytorch/config.py
+++ b/lmdeploy/pytorch/config.py
@@ -320,7 +320,11 @@ def _patch_quantization_config(hf_config: Any, model_format: str = None):
     if model_format == 'fp8':
         logger.debug('Patch quantization config for fp8.')
         from lmdeploy.pytorch.envs import scale_fmt
-        quantization_config = dict(quant_method='fp8', fmt='e4m3', weight_block_size=[128, 128], scale_fmt=scale_fmt)
+        quantization_config = dict(quant_method='fp8',
+                                   fmt='e4m3',
+                                   weight_block_size=[128, 128],
+                                   scale_fmt=scale_fmt,
+                                   lmdeploy_patched=True)
     else:
         raise RuntimeError(f'Unsupported weight quantization method: {model_format}')
 
@@ -665,6 +669,7 @@ class QuantizationConfig:
     weight_block_size: tuple[int] = None
     activation_scheme: str = None
     ignored_layers: list[str] = field(default_factory=list)
+    fp8_quant_scope: str | None = None
     hf_quant_config: dict[str, Any] = field(default_factory=dict)
 
     @classmethod
@@ -686,6 +691,7 @@ class QuantizationConfig:
         scale_fmt = quant_config.get('scale_fmt', None)
         weight_block_size = quant_config.get('weight_block_size', None)
         activation_scheme = quant_config.get('activation_scheme', None)
+        fp8_quant_scope = quant_config.get('fp8_quant_scope', None)
 
         bits = None
         group_size = None
@@ -729,13 +735,22 @@ class QuantizationConfig:
             weight_block_size=weight_block_size,
             activation_scheme=activation_scheme,
             ignored_layers=ignored_layers,
+            fp8_quant_scope=fp8_quant_scope,
             hf_quant_config=quant_config,
         )
 
-    def get_quant_method(self, prefix: str = ''):
+    def get_quant_method(self, prefix: str = '', module_kind: str = 'linear'):
         """Get quant method for module."""
+        if module_kind not in {'linear', 'moe', 'norm'}:
+            raise ValueError(f'Unsupported quant module kind: {module_kind}')
+        if self.fp8_quant_scope == 'moe_only' and module_kind != 'moe':
+            quant_method = None
+            return quant_method
+        if self.fp8_quant_scope not in {None, 'moe_only'}:
+            raise ValueError(f'Unsupported fp8 quant scope: {self.fp8_quant_scope}')
         if not prefix or not self.ignored_layers:
-            return self.quant_method
+            quant_method = self.quant_method
+            return quant_method
 
         is_ignore = any([prefix in layer_name for layer_name in self.ignored_layers])
         quant_method = None if is_ignore else self.quant_method

--- a/lmdeploy/pytorch/configurations/qwen3_5.py
+++ b/lmdeploy/pytorch/configurations/qwen3_5.py
@@ -2,11 +2,13 @@
 import torch
 
 from lmdeploy.pytorch import envs as _envs
-from lmdeploy.utils import is_bf16_supported
+from lmdeploy.utils import get_logger, is_bf16_supported
 
 from .builder import AutoModelConfigBuilder
 from .default import DefaultModelConfigBuilder
 from .qwen3_next import _check_env_qwen3_next
+
+logger = get_logger('lmdeploy')
 
 
 class Qwen3_5ModelConfigBuilder(AutoModelConfigBuilder):
@@ -35,6 +37,16 @@ class Qwen3_5ModelConfigBuilder(AutoModelConfigBuilder):
 
         if getattr(hf_config.text_config, 'attn_output_gate', False):
             cfg.num_attention_heads *= 2
+
+        is_lmdeploy_patched_fp8 = (quantization_config is not None and quantization_config.get('quant_method') == 'fp8'
+                                   and quantization_config.get('lmdeploy_patched', False))
+        is_moe_model = hf_config.model_type in ['qwen3_5_moe', 'intern_s2_preview']
+        if is_lmdeploy_patched_fp8 and _envs.fp8_moe_only and is_moe_model:
+            quantization_config['fp8_quant_scope'] = 'moe_only'
+            logger.info(f'Enable fp8_quant_scope=moe_only for {hf_config.model_type} '
+                        f'(is_draft_model={is_draft_model}, spec_method={spec_method}) because '
+                        'LMDEPLOY_FP8_MOE_ONLY=1 and the FP8 quantization config is LMDeploy-synthesized.')
+
         # update num layers
         num_layers = cfg.num_layers
         layer_types = text_config.layer_types

--- a/lmdeploy/pytorch/envs.py
+++ b/lmdeploy/pytorch/envs.py
@@ -183,6 +183,7 @@ with set_envs():
 
     # model format
     scale_fmt = os.getenv('LMDEPLOY_SCALE_FMT', None)
+    fp8_moe_only = env_to_bool('LMDEPLOY_FP8_MOE_ONLY', False)
 
     # repetition check
     repetition_window_size = env_to_int('LMDEPLOY_REPETITION_WINDOW_SIZE', 1024)

--- a/lmdeploy/pytorch/nn/linear/__init__.py
+++ b/lmdeploy/pytorch/nn/linear/__init__.py
@@ -37,7 +37,7 @@ def build_linear(
     quant_method = None
     if quant_config is not None:
         quant_config = get_build_model_context().quant_config
-        quant_method = quant_config.get_quant_method(prefix)
+        quant_method = quant_config.get_quant_method(prefix, module_kind='linear')
 
     if dp_gather and quant_method is not None:
         assert quant_method in ['fp8'], (f'Do not support dp_gather with quant_method={quant_method}')
@@ -201,7 +201,7 @@ def build_merged_colwise_linear(
     quant_method = None
     if quant_config is not None:
         quant_config = get_build_model_context().quant_config
-        quant_method = quant_config.get_quant_method(prefix)
+        quant_method = quant_config.get_quant_method(prefix, module_kind='linear')
     if dp_gather and quant_method is not None:
         assert quant_method in ['fp8'], (f'Do not support dp_gather with quant_method={quant_method}')
 
@@ -273,7 +273,7 @@ def build_qkv_proj(in_features: int,
     quant_method = None
     if quant_config is not None:
         quant_config = get_build_model_context().quant_config
-        quant_method = quant_config.get_quant_method(prefix)
+        quant_method = quant_config.get_quant_method(prefix, module_kind='linear')
     if head_size_v is None:
         head_size_v = head_size
 

--- a/lmdeploy/pytorch/nn/moe/__init__.py
+++ b/lmdeploy/pytorch/nn/moe/__init__.py
@@ -28,7 +28,7 @@ def build_fused_moe(
     quant_method = None
     if quant_config is not None:
         quant_config = get_build_model_context().quant_config
-        quant_method = quant_config.get_quant_method(prefix)
+        quant_method = quant_config.get_quant_method(prefix, module_kind='moe')
 
     if quant_method is None:
         from .default import FusedMoE

--- a/lmdeploy/pytorch/nn/norm.py
+++ b/lmdeploy/pytorch/nn/norm.py
@@ -30,7 +30,7 @@ class RMSNorm(nn.Module):
         quant_method = None
         if quant_config is not None:
             quant_config = get_build_model_context().quant_config
-            quant_method = quant_config.get_quant_method(prefix)
+            quant_method = quant_config.get_quant_method(prefix, module_kind='norm')
 
         w8a8_flag = quant_method == 'smooth_quant'
 

--- a/tests/pytorch/config/test_fp8_quant_scope.py
+++ b/tests/pytorch/config/test_fp8_quant_scope.py
@@ -1,0 +1,201 @@
+import pytest
+import torch
+
+from lmdeploy.pytorch.config import CacheConfig, DistConfig, ModelConfig, QuantizationConfig, SpecDecodeConfig
+
+
+def _qwen35_moe_config_factory(quantization_config=None):
+    from transformers import PretrainedConfig
+
+    def _factory():
+        text_config = PretrainedConfig(torch_dtype='float16', tie_word_embeddings=False)
+        text_config.model_type = 'qwen3_5_moe_text'
+        text_config.layer_types = ['full_attention']
+        text_config.linear_key_head_dim = 8
+        text_config.linear_value_head_dim = 8
+        text_config.linear_num_key_heads = 2
+        text_config.linear_num_value_heads = 2
+        text_config.linear_conv_kernel_dim = 4
+        text_config.mtp_num_hidden_layers = 1
+
+        hf_config = PretrainedConfig(torch_dtype='float16', tie_word_embeddings=False)
+        hf_config.model_type = 'qwen3_5_moe'
+        hf_config.architectures = ['Qwen3_5MoeForConditionalGeneration']
+        hf_config.text_config = text_config
+        if quantization_config is not None:
+            hf_config.quantization_config = dict(quantization_config)
+        return hf_config
+
+    return _factory
+
+
+def _qwen35_dense_config_factory():
+    from transformers import PretrainedConfig
+
+    def _factory():
+        text_config = PretrainedConfig(torch_dtype='float16', tie_word_embeddings=False)
+        text_config.model_type = 'qwen3_5_text'
+        text_config.layer_types = ['full_attention']
+        text_config.linear_key_head_dim = 8
+        text_config.linear_value_head_dim = 8
+        text_config.linear_num_key_heads = 2
+        text_config.linear_num_value_heads = 2
+        text_config.linear_conv_kernel_dim = 4
+        text_config.mtp_num_hidden_layers = 1
+
+        hf_config = PretrainedConfig(torch_dtype='float16', tie_word_embeddings=False)
+        hf_config.model_type = 'qwen3_5'
+        hf_config.architectures = ['Qwen3_5ForConditionalGeneration']
+        hf_config.text_config = text_config
+        return hf_config
+
+    return _factory
+
+
+def _plain_config_factory():
+    from transformers import PretrainedConfig
+
+    def _factory():
+        hf_config = PretrainedConfig(torch_dtype='float16', tie_word_embeddings=False)
+        hf_config.model_type = 'fake'
+        hf_config.architectures = ['FakeForCausalLM']
+        return hf_config
+
+    return _factory
+
+
+def _patch_config_builder(monkeypatch, config_factory):
+    from lmdeploy.pytorch import transformers as pytorch_transformers
+    from lmdeploy.pytorch.configurations.default import DefaultModelConfigBuilder
+
+    def fake_config_from_pretrained(pretrained_model_name_or_path, **kwargs):
+        return config_factory()
+
+    def fake_build(cls, hf_config, model_path=None, **kwargs):
+        return ModelConfig(hidden_size=16,
+                           num_layers=1,
+                           num_attention_heads=2,
+                           num_key_value_heads=2,
+                           bos_token_id=1,
+                           eos_token_id=[2],
+                           head_dim=8,
+                           dtype=torch.float16,
+                           vocab_size=32,
+                           llm_config=hf_config)
+
+    monkeypatch.setattr(pytorch_transformers, 'config_from_pretrained', fake_config_from_pretrained)
+    monkeypatch.setattr(DefaultModelConfigBuilder, 'build', classmethod(fake_build))
+
+
+def test_fp8_moe_only_scope_enabled_for_synthesized_qwen35_moe(monkeypatch):
+    from lmdeploy.pytorch import envs
+
+    monkeypatch.setattr(envs, 'fp8_moe_only', True)
+    _patch_config_builder(monkeypatch, _qwen35_moe_config_factory())
+
+    model_config = ModelConfig.from_pretrained('fake-model', model_format='fp8')
+
+    assert model_config.quant_config.quant_method == 'fp8'
+    assert model_config.quant_config.fp8_quant_scope == 'moe_only'
+    assert model_config.quant_config.hf_quant_config['lmdeploy_patched']
+    assert model_config.quant_config.hf_quant_config['fp8_quant_scope'] == 'moe_only'
+
+
+def test_fp8_moe_only_scope_requires_env(monkeypatch):
+    from lmdeploy.pytorch import envs
+
+    monkeypatch.setattr(envs, 'fp8_moe_only', False)
+    _patch_config_builder(monkeypatch, _qwen35_moe_config_factory())
+
+    model_config = ModelConfig.from_pretrained('fake-model', model_format='fp8')
+
+    assert model_config.quant_config.quant_method == 'fp8'
+    assert model_config.quant_config.fp8_quant_scope is None
+    assert 'fp8_quant_scope' not in model_config.quant_config.hf_quant_config
+
+
+def test_fp8_moe_only_scope_only_for_qwen35_moe(monkeypatch):
+    from lmdeploy.pytorch import envs
+
+    monkeypatch.setattr(envs, 'fp8_moe_only', True)
+    _patch_config_builder(monkeypatch, _plain_config_factory())
+
+    model_config = ModelConfig.from_pretrained('fake-model', model_format='fp8')
+
+    assert model_config.quant_config.quant_method == 'fp8'
+    assert model_config.quant_config.fp8_quant_scope is None
+
+
+def test_fp8_moe_only_scope_does_not_apply_to_dense_qwen35(monkeypatch):
+    from lmdeploy.pytorch import envs
+
+    monkeypatch.setattr(envs, 'fp8_moe_only', True)
+    _patch_config_builder(monkeypatch, _qwen35_dense_config_factory())
+
+    model_config = ModelConfig.from_pretrained('fake-model', model_format='fp8')
+
+    assert model_config.quant_config.quant_method == 'fp8'
+    assert model_config.quant_config.fp8_quant_scope is None
+    assert model_config.quant_config.hf_quant_config['lmdeploy_patched']
+    assert 'fp8_quant_scope' not in model_config.quant_config.hf_quant_config
+
+
+def test_fp8_moe_only_scope_does_not_override_prequantized_config(monkeypatch):
+    from lmdeploy.pytorch import envs
+
+    monkeypatch.setattr(envs, 'fp8_moe_only', True)
+    quantization_config = dict(quant_method='fp8', fmt='e4m3', weight_block_size=[128, 128])
+    _patch_config_builder(monkeypatch, _qwen35_moe_config_factory(quantization_config))
+
+    model_config = ModelConfig.from_pretrained('fake-model', model_format='fp8')
+
+    assert model_config.quant_config.quant_method == 'fp8'
+    assert model_config.quant_config.fp8_quant_scope is None
+    assert 'lmdeploy_patched' not in model_config.quant_config.hf_quant_config
+    assert 'fp8_quant_scope' not in model_config.quant_config.hf_quant_config
+
+
+def test_quantization_config_fp8_moe_only_module_kinds():
+    quant_config = QuantizationConfig(quant_method='fp8', fp8_quant_scope='moe_only')
+
+    assert quant_config.get_quant_method('model.layers.0.mlp.experts', module_kind='moe') == 'fp8'
+    assert quant_config.get_quant_method('model.layers.0.self_attn.qkv_proj', module_kind='linear') is None
+    assert quant_config.get_quant_method('model.layers.0.input_layernorm', module_kind='norm') is None
+    assert quant_config.get_quant_method('', module_kind='linear') is None
+
+    all_scope_quant_config = QuantizationConfig(quant_method='fp8')
+    assert all_scope_quant_config.get_quant_method('model.layers.0.self_attn.qkv_proj',
+                                                   module_kind='linear') == 'fp8'
+    assert all_scope_quant_config.get_quant_method('model.layers.0.input_layernorm', module_kind='norm') == 'fp8'
+    with pytest.raises(ValueError, match='Unsupported quant module kind'):
+        quant_config.get_quant_method(module_kind='gate')
+    with pytest.raises(ValueError, match='Unsupported fp8 quant scope'):
+        QuantizationConfig(quant_method='fp8', fp8_quant_scope='all').get_quant_method()
+
+
+def test_fp8_moe_only_scope_survives_mtp_draft_config(monkeypatch):
+    from lmdeploy.pytorch import envs
+
+    monkeypatch.setattr(envs, 'fp8_moe_only', True)
+    _patch_config_builder(monkeypatch, _qwen35_moe_config_factory())
+    target_cache_cfg = CacheConfig(max_batches=1,
+                                   block_size=64,
+                                   num_cpu_blocks=0,
+                                   num_gpu_blocks=0)
+
+    specdecode_config = SpecDecodeConfig.from_config(method='qwen3_5_mtp',
+                                                     num_speculative_tokens=1,
+                                                     model=None,
+                                                     target_model='fake-model',
+                                                     target_cache_cfg=target_cache_cfg,
+                                                     dist_config=DistConfig(),
+                                                     model_format='fp8')
+    main_model_config = ModelConfig.from_pretrained('fake-model',
+                                                   model_format='fp8',
+                                                   spec_method=specdecode_config.method,
+                                                   num_spec_tokens=specdecode_config.num_speculative_tokens)
+
+    assert specdecode_config.model_config.quant_config.quant_method == 'fp8'
+    assert main_model_config.quant_config.quant_method == 'fp8'
+    assert specdecode_config.model_config.quant_config.fp8_quant_scope == 'moe_only'
+    assert main_model_config.quant_config.fp8_quant_scope == 'moe_only'

--- a/tests/pytorch/config/test_fp8_quant_scope.py
+++ b/tests/pytorch/config/test_fp8_quant_scope.py
@@ -52,6 +52,29 @@ def _qwen35_dense_config_factory():
     return _factory
 
 
+def _intern_s2_preview_config_factory():
+    from transformers import PretrainedConfig
+
+    def _factory():
+        text_config = PretrainedConfig(torch_dtype='float16', tie_word_embeddings=False)
+        text_config.model_type = 'qwen3_5_moe_text'
+        text_config.layer_types = ['full_attention']
+        text_config.linear_key_head_dim = 8
+        text_config.linear_value_head_dim = 8
+        text_config.linear_num_key_heads = 2
+        text_config.linear_num_value_heads = 2
+        text_config.linear_conv_kernel_dim = 4
+        text_config.mtp_num_hidden_layers = 1
+
+        hf_config = PretrainedConfig(torch_dtype='float16', tie_word_embeddings=False)
+        hf_config.model_type = 'intern_s2_preview'
+        hf_config.architectures = ['InternS2PreviewForConditionalGeneration']
+        hf_config.text_config = text_config
+        return hf_config
+
+    return _factory
+
+
 def _plain_config_factory():
     from transformers import PretrainedConfig
 
@@ -65,6 +88,8 @@ def _plain_config_factory():
 
 
 def _patch_config_builder(monkeypatch, config_factory):
+    import lmdeploy.pytorch.config as pytorch_config
+    import lmdeploy.pytorch.configurations.qwen3_5 as qwen3_5_config
     from lmdeploy.pytorch import transformers as pytorch_transformers
     from lmdeploy.pytorch.configurations.default import DefaultModelConfigBuilder
 
@@ -85,6 +110,8 @@ def _patch_config_builder(monkeypatch, config_factory):
 
     monkeypatch.setattr(pytorch_transformers, 'config_from_pretrained', fake_config_from_pretrained)
     monkeypatch.setattr(DefaultModelConfigBuilder, 'build', classmethod(fake_build))
+    monkeypatch.setattr(pytorch_config, 'is_bf16_supported', lambda device_type='auto': True)
+    monkeypatch.setattr(qwen3_5_config, 'is_bf16_supported', lambda device_type='auto': True)
 
 
 def test_fp8_moe_only_scope_enabled_for_synthesized_qwen35_moe(monkeypatch):
@@ -140,6 +167,20 @@ def test_fp8_moe_only_scope_does_not_apply_to_dense_qwen35(monkeypatch):
     assert 'fp8_quant_scope' not in model_config.quant_config.hf_quant_config
 
 
+def test_fp8_moe_only_scope_applies_to_intern_s2_preview(monkeypatch):
+    from lmdeploy.pytorch import envs
+
+    monkeypatch.setattr(envs, 'fp8_moe_only', True)
+    _patch_config_builder(monkeypatch, _intern_s2_preview_config_factory())
+
+    model_config = ModelConfig.from_pretrained('fake-model', model_format='fp8')
+
+    assert model_config.quant_config.quant_method == 'fp8'
+    assert model_config.quant_config.fp8_quant_scope == 'moe_only'
+    assert model_config.quant_config.hf_quant_config['lmdeploy_patched']
+    assert model_config.quant_config.hf_quant_config['fp8_quant_scope'] == 'moe_only'
+
+
 def test_fp8_moe_only_scope_does_not_override_prequantized_config(monkeypatch):
     from lmdeploy.pytorch import envs
 
@@ -170,7 +211,9 @@ def test_quantization_config_fp8_moe_only_module_kinds():
     with pytest.raises(ValueError, match='Unsupported quant module kind'):
         quant_config.get_quant_method(module_kind='gate')
     with pytest.raises(ValueError, match='Unsupported fp8 quant scope'):
-        QuantizationConfig(quant_method='fp8', fp8_quant_scope='all').get_quant_method()
+        QuantizationConfig(quant_method='fp8', fp8_quant_scope='all')
+    with pytest.raises(ValueError, match='fp8_quant_scope is only supported for fp8 quantization'):
+        QuantizationConfig(quant_method='awq', fp8_quant_scope='moe_only')
 
 
 def test_fp8_moe_only_scope_survives_mtp_draft_config(monkeypatch):


### PR DESCRIPTION

## Motivation

support only moe do fp8 quant when --model-format fp8 and input model is bf16
## Modification

export LMDEPLOY_FP8_MOE_ONLY=1 to enable 

## BC-breaking (Optional)

None
## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
