### PR TITLE
Fix MTP recurrent state round-trip for Qwen3.5

### DIFF
--- a/lmdeploy/pytorch/kernels/cuda/gated_delta_rule.py
+++ b/lmdeploy/pytorch/kernels/cuda/gated_delta_rule.py
@@ -71,6 +71,20 @@ def store_default_state_tile_direct(State: T.Buffer, h_local: T.Buffer, state_id
 
 
 @T.macro
+def round_state_tile_to_cache_dtype(h_local: T.Buffer, k_off, v_off, K: int, V: int, k_per_thr: int,
+                                    v_per_warp: int, state_dtype) -> None:
+    """Apply the same cache-dtype round-trip as storing and reloading state."""
+    for j in T.Unroll(k_per_thr):
+        if (k_off + j) < K:
+            for i in T.Unroll(v_per_warp):
+                v_idx = v_off + i
+                if v_idx < V:
+                    h_local[j, i] = T.cast(T.cast(h_local[j, i], state_dtype), T.float32)
+                else:
+                    h_local[j, i] = 0.0
+
+
+@T.macro
 def store_transposed_state_tile(State: T.Buffer, h_local: T.Buffer, state_id, state_update_id, hv_id, k_off, v_off,
                                 K: int, V: int, k_per_thr: int, v_per_warp: int) -> None:
     """Per-warp store for transposed State layout [V, K]."""
@@ -301,6 +315,7 @@ def fused_recurrent_gated_delta_rule_fwd(SEQLEN,
     write_direct_circular_state = write_circular_state and not use_coalesced_circular_write
     write_coalesced_circular_state = write_circular_state and use_coalesced_circular_write
     write_final_state = output_final_state and not is_circular_buffer
+    roundtrip_state_between_tokens = state_dtype != torch.float32
 
     B = T.dynamic('B')
     N = B if not use_state_indices else T.dynamic('N')
@@ -397,13 +412,18 @@ def fused_recurrent_gated_delta_rule_fwd(SEQLEN,
                         if write_direct_circular_state:
                             store_default_state_tile_direct(State, h_local, state_id, state_update_id, hv_id, k_off,
                                                             v_off, K, V, k_per_thr, v_per_warp, state_vw)
-                            state_update_id = (state_update_id + 1) % NUM_STATE
 
                         o_local = T.alloc_local([v_per_warp], dtype)
                         compute_output_tile(q_local, h_local, o_local, k_per_thr, v_per_warp)
 
                         if lane_id == 0:
                             vec_store_output(Out, o_local, b_id, seq_id, hv_id, v_off, V, v_per_warp, data_vw)
+
+                        if roundtrip_state_between_tokens and write_direct_circular_state and seq_id < SEQLEN - 1:
+                            round_state_tile_to_cache_dtype(h_local, k_off, v_off, K, V, k_per_thr, v_per_warp,
+                                                            state_dtype)
+                        if write_direct_circular_state:
+                            state_update_id = (state_update_id + 1) % NUM_STATE
 
                         if write_coalesced_circular_state:
                             stage_state_tile_to_smem(h_smem, h_local, k_off, v_warp_off, K, k_per_thr, v_per_warp,
@@ -412,6 +432,9 @@ def fused_recurrent_gated_delta_rule_fwd(SEQLEN,
                                 v_idx = v_start * v_per_cta + j
                                 if v_idx < V:
                                     State[state_id, state_update_id, hv_id, i, v_idx] = h_smem[i, j]
+                            if roundtrip_state_between_tokens and seq_id < SEQLEN - 1:
+                                load_state_tile_from_smem(h_smem, h_local, k_off, v_warp_off, K, k_per_thr,
+                                                          v_per_warp, state_vw)
                             state_update_id = (state_update_id + 1) % NUM_STATE
 
                         if write_final_state:
@@ -524,13 +547,18 @@ def fused_recurrent_gated_delta_rule_fwd(SEQLEN,
                         if write_circular_state:
                             store_transposed_state_tile(State, h_local, state_id, state_update_id, hv_id, k_off, v_off,
                                                         K, V, k_per_thr, v_per_warp)
-                            state_update_id = (state_update_id + 1) % NUM_STATE
 
                         o_local = T.alloc_local([v_per_warp], dtype)
                         compute_output_tile(q_local, h_local, o_local, k_per_thr, v_per_warp)
 
                         if lane_id == 0:
                             vec_store_output(Out, o_local, b_id, seq_id, hv_id, v_off, V, v_per_warp, data_vw)
+
+                        if roundtrip_state_between_tokens and write_circular_state and seq_id < SEQLEN - 1:
+                            round_state_tile_to_cache_dtype(h_local, k_off, v_off, K, V, k_per_thr, v_per_warp,
+                                                            state_dtype)
+                        if write_circular_state:
+                            state_update_id = (state_update_id + 1) % NUM_STATE
 
                     if write_final_state:
                         store_transposed_state_tile(State, h_local, state_id, state_update_id, hv_id, k_off, v_off, K,

--- a/tests/pytorch/kernel/test_gated_delta_rule.py
+++ b/tests/pytorch/kernel/test_gated_delta_rule.py
@@ -314,7 +314,10 @@ class TestRecurrentGatedDeltaRule:
             ref_out[:, t] = torch.einsum('bhd,bhdm->bhm', b_q, h)
 
             # scatter write state into circular buffer
-            expected_state[torch.arange(batch, device='cuda'), write_slots] = h
+            state_snapshot = h.to(circular_state.dtype).float()
+            expected_state[torch.arange(batch, device='cuda'), write_slots] = state_snapshot
+            if t < seqlen - 1:
+                h = state_snapshot
 
         ref_out = ref_out.to(q.dtype)
 
@@ -364,7 +367,10 @@ class TestRecurrentGatedDeltaRule:
             delta_v = (b_v - hk) * b_beta.unsqueeze(-1)
             h = h + b_k.unsqueeze(-1) * delta_v.unsqueeze(-2)
             ref_out[:, t] = torch.einsum('bhd,bhdm->bhm', b_q, h)
-            expected_state[state_indices, write_slots] = h
+            state_snapshot = h.to(transposed_state.dtype).float()
+            expected_state[state_indices, write_slots] = state_snapshot
+            if t < seqlen - 1:
+                h = state_snapshot
 
         ref_out = ref_out.to(q.dtype)
         state_copy = transposed_state.clone()
@@ -388,3 +394,69 @@ class TestRecurrentGatedDeltaRule:
                                        expected_state[state_indices, write_slots].to(out_state.dtype).float(),
                                        atol=1e-2,
                                        rtol=1e-3)
+
+    def test_circular_buffer_roundtrips_cache_dtype_between_tokens(self):
+        """MTP packet decode must match sequential cache-dtype state reuse."""
+        from lmdeploy.pytorch.kernels.cuda.gated_delta_rule import fused_recurrent_gated_delta_rule
+
+        torch.manual_seed(10)
+        batch, seqlen, num_heads, head_dim, value_dim = 2, 4, 1, 32, 16
+        num_cache_states = 5
+        num_slots = seqlen + 2
+
+        q = torch.randn(batch, seqlen, num_heads, head_dim) * 4
+        k = torch.randn(batch, seqlen, num_heads, head_dim)
+        v = torch.randn(batch, seqlen, num_heads, value_dim) * 5
+        g = -0.01 * torch.rand(batch, seqlen, num_heads)
+        beta = torch.rand(batch, seqlen, num_heads) * 0.9 + 0.1
+        transposed_state = torch.randn(num_cache_states, num_slots, num_heads, value_dim, head_dim) * 20
+        state_indices = torch.tensor([1, 3], dtype=torch.int64)
+        cache_seqlens = torch.tensor([0, 2], dtype=torch.int32)
+
+        scale = 1 / (head_dim**0.5)
+        rq = q.float() * scale
+        rk = k.float()
+        rv = v.float()
+        rg = g.float()
+        rb = beta.float()
+        read_slots = (cache_seqlens % num_slots).long()
+        write_base = read_slots + 1
+        state_for_ref = transposed_state.transpose(-1, -2).contiguous().float()
+        expected_state = state_for_ref.clone()
+        h = state_for_ref[state_indices, read_slots]
+        ref_out = torch.zeros(batch, seqlen, num_heads, value_dim, device='cuda', dtype=torch.float32)
+
+        for t in range(seqlen):
+            h = h * rg[:, t].exp().unsqueeze(-1).unsqueeze(-1)
+            hk = (h * rk[:, t].unsqueeze(-1)).sum(-2)
+            delta_v = (rv[:, t] - hk) * rb[:, t].unsqueeze(-1)
+            h = h + rk[:, t].unsqueeze(-1) * delta_v.unsqueeze(-2)
+            ref_out[:, t] = (rq[:, t].unsqueeze(-1) * h).sum(-2)
+
+            write_slots = (write_base + t) % num_slots
+            state_snapshot = h.to(transposed_state.dtype).float()
+            expected_state[state_indices, write_slots] = state_snapshot
+            if t < seqlen - 1:
+                h = state_snapshot
+
+        state_copy = transposed_state.clone()
+        out, out_state = fused_recurrent_gated_delta_rule(
+            q=q,
+            k=k,
+            v=v,
+            g=g,
+            beta=beta,
+            initial_state=state_copy,
+            output_final_state=True,
+            state_indices=state_indices,
+            cache_seqlens=cache_seqlens,
+            transpose_state_layout=True,
+        )
+
+        torch.testing.assert_close(out.float(), ref_out.to(out.dtype).float(), atol=1.0, rtol=5e-3)
+        for t in range(seqlen):
+            write_slots = (write_base + t) % num_slots
+            torch.testing.assert_close(out_state[state_indices, write_slots].transpose(-1, -2).float(),
+                                       expected_state[state_indices, write_slots].to(out_state.dtype).float(),
+                                       atol=1.0,
+                                       rtol=5e-3)


### PR DESCRIPTION

## Motivation



## Modification

Fixes MTP target-token drift for Qwen3.5
- Root cause: packet decode reused fp32 recurrent state between target positions.
- Sequential decode reloads recurrent state through cache dtype between tokens.
- New behavior: circular MTP state rounds through state_dtype between packet positions.
- No change for fp32 state cache or non-circular/no-MTP decode.


### AIME2026 bench results 

avg generated token length stays stable after fix

version |  draft 1 | draft 3 | draft 5  | draft 7 |max-min spread|spread/mean
-- | -- | -- | -- | -- | --|--
baseline  | 33136.2 | 31203.8 |  24251.5 | 30268.4|8884.7|29.90%
fp32state | 25061.7 | 25046.9 | 24308.6 |  25513.4 |1204.8|4.82%
fp16state+fix |  29142.9 | 29601.1 | 28969.1 |  29075.6 |632.0|2.16%
## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
