### PR TITLE
fix: gzip torch profiler traces by default

### DIFF
--- a/docs/en/advance/pytorch_profiling.md
+++ b/docs/en/advance/pytorch_profiling.md
@@ -17,9 +17,11 @@ export LMDEPLOY_PROFILE_DELAY=3
 export LMDEPLOY_PROFILE_DURATION=10
 # prefix path to save profile files
 export LMDEPLOY_PROFILE_OUT_PREFIX="/path/to/save/profile_"
+# save gzip-compressed traces by default; set to 0 for uncompressed JSON
+export LMDEPLOY_PROFILE_USE_GZIP=1
 ```
 
-After the program exits, the profiling data will be saved to the path specified by `LMDEPLOY_PROFILE_OUT_PREFIX` for performance analysis.
+After the program exits, the profiling data will be saved to the path specified by `LMDEPLOY_PROFILE_OUT_PREFIX` for performance analysis. Profile traces are gzip-compressed by default.
 
 ## Nsight System
 

--- a/docs/zh_cn/advance/pytorch_profiling.md
+++ b/docs/zh_cn/advance/pytorch_profiling.md
@@ -17,9 +17,11 @@ export LMDEPLOY_PROFILE_DELAY=3
 export LMDEPLOY_PROFILE_DURATION=10
 # prefix path to save profile files
 export LMDEPLOY_PROFILE_OUT_PREFIX="/path/to/save/profile_"
+# 默认使用 gzip 压缩 trace；设置为 0 可保存未压缩的 JSON
+export LMDEPLOY_PROFILE_USE_GZIP=1
 ```
 
-这样在退出程序后，统计信息会被存储在 `LMDEPLOY_PROFILE_OUT_PREFIX` 指定的地址，方便进行性能分析。
+这样在退出程序后，统计信息会被存储在 `LMDEPLOY_PROFILE_OUT_PREFIX` 指定的地址，方便进行性能分析。Profile trace 默认使用 gzip 压缩。
 
 ## Nsight System
 

--- a/docs/zh_cn/advance/pytorch_profiling.md
+++ b/docs/zh_cn/advance/pytorch_profiling.md
@@ -17,7 +17,7 @@ export LMDEPLOY_PROFILE_DELAY=3
 export LMDEPLOY_PROFILE_DURATION=10
 # prefix path to save profile files
 export LMDEPLOY_PROFILE_OUT_PREFIX="/path/to/save/profile_"
-# 默认使用 gzip 压缩 trace；设置为 0 可保存未压缩的 JSON
+# save gzip-compressed traces by default; set to 0 for uncompressed JSON
 export LMDEPLOY_PROFILE_USE_GZIP=1
 ```
 

--- a/lmdeploy/pytorch/engine/model_agent/profiler.py
+++ b/lmdeploy/pytorch/engine/model_agent/profiler.py
@@ -26,6 +26,7 @@ class AgentProfiler:
 
         self.profiler = self._build_profiler()
         self.prefix = envs.torch_profile_output_prefix
+        self.use_gzip = envs.torch_profile_use_gzip
         self._task = None
         self._started = False
         if self.dp > 1 and self.duration < 0 and self.profiler is not None:
@@ -59,7 +60,8 @@ class AgentProfiler:
         try:
             self.profiler.stop()
             rank = self.rank
-            dump_path = f'{self.prefix}{rank}.json'
+            suffix = '.json.gz' if self.use_gzip else '.json'
+            dump_path = f'{self.prefix}{rank}{suffix}'
             self.profiler.export_chrome_trace(dump_path)
             logger.warning(f'Profiler {self.name} dump to {dump_path}.')
         except Exception as e:

--- a/lmdeploy/pytorch/envs.py
+++ b/lmdeploy/pytorch/envs.py
@@ -131,6 +131,7 @@ with set_envs():
     torch_profile_delay = env_to_int('LMDEPLOY_PROFILE_DELAY', 0)
     torch_profile_duration = env_to_int('LMDEPLOY_PROFILE_DURATION', -1)
     torch_profile_output_prefix = os.getenv('LMDEPLOY_PROFILE_OUT_PREFIX', 'lmdeploy_profile_')
+    torch_profile_use_gzip = env_to_bool('LMDEPLOY_PROFILE_USE_GZIP', True)
 
     # ray timeline
     ray_timeline_enable = env_to_bool('LMDEPLOY_RAY_TIMELINE_ENABLE', False)


### PR DESCRIPTION
## Motivation

PyTorch profiler traces can grow large, while LMDeploy currently exports them as plain JSON. vLLM enables gzip by default for the same `export_chrome_trace` flow to reduce storage use.

## Changes

- Export LMDeploy PyTorch profiler traces as `.json.gz` by default.
- Allow uncompressed JSON with `LMDEPLOY_PROFILE_USE_GZIP=0`.
- Document the setting in the English and Chinese profiling guides.

## Validation

- Verified that the default output is valid gzip-compressed JSON.
- A profiler smoke capture decreased from **49,729 bytes to 4,508 bytes (90.9% smaller)**.
- Verified that the opt-out writes valid uncompressed JSON.
- File-level pre-commit hooks passed.

## Assistance

Assisted with Codex + GPT-5.5 xHigh Fast, reviewed manually