### PR TITLE
ci: pin jlumbroso/free-disk-space to a full commit SHA

### DIFF
--- a/.github/workflows/api_eval.yml
+++ b/.github/workflows/api_eval.yml
@@ -67,7 +67,7 @@ jobs:
       OUTPUT_FOLDER: cuda12.8_dist_${{ github.run_id }}
     steps:
       - name: Free disk space
-        uses: jlumbroso/free-disk-space@main
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # main
         with:
           # This might remove tools that are actually needed, if set to "true" but frees about 6 GB
           tool-cache: false

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -63,7 +63,7 @@ jobs:
       DOCKER_TAG: cuda12.8
     steps:
       - name: Free disk space
-        uses: jlumbroso/free-disk-space@main
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # main
         with:
           # This might remove tools that are actually needed, if set to "true" but frees about 6 GB
           tool-cache: false

--- a/.github/workflows/daily_ete_test.yml
+++ b/.github/workflows/daily_ete_test.yml
@@ -73,7 +73,7 @@ jobs:
       DOCKER_TAG: cuda12.8
     steps:
       - name: Free disk space
-        uses: jlumbroso/free-disk-space@main
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # main
         with:
           # This might remove tools that are actually needed, if set to "true" but frees about 6 GB
           tool-cache: false

--- a/.github/workflows/daily_ete_test_3090.yml
+++ b/.github/workflows/daily_ete_test_3090.yml
@@ -72,7 +72,7 @@ jobs:
       DOCKER_TAG: cuda12.4
     steps:
       - name: Free disk space
-        uses: jlumbroso/free-disk-space@main
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # main
         with:
           # This might remove tools that are actually needed, if set to "true" but frees about 6 GB
           tool-cache: false

--- a/.github/workflows/daily_ete_test_5080.yml
+++ b/.github/workflows/daily_ete_test_5080.yml
@@ -72,7 +72,7 @@ jobs:
       DOCKER_TAG: cuda12.8
     steps:
       - name: Free disk space
-        uses: jlumbroso/free-disk-space@main
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # main
         with:
           # This might remove tools that are actually needed, if set to "true" but frees about 6 GB
           tool-cache: false

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -49,7 +49,7 @@ jobs:
         with:
           ref: ${{github.event.inputs.repo_ref}}
       - name: Free disk space
-        uses: jlumbroso/free-disk-space@main
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # main
         with:
           # This might remove tools that are actually needed, if set to "true" but frees about 6 GB
           tool-cache: false
@@ -108,7 +108,7 @@ jobs:
         with:
           ref: ${{github.event.inputs.repo_ref}}
       - name: Free disk space
-        uses: jlumbroso/free-disk-space@main
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # main
         with:
           # This might remove tools that are actually needed, if set to "true" but frees about 6 GB
           tool-cache: false

--- a/.github/workflows/docker_nightly.yml
+++ b/.github/workflows/docker_nightly.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           ref: ${{ github.event.inputs.repo_ref || 'main' }}
       - name: Free disk space
-        uses: jlumbroso/free-disk-space@main
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # main
         with:
           # This might remove tools that are actually needed, if set to "true" but frees about 6 GB
           tool-cache: false

--- a/.github/workflows/evaluate.yml
+++ b/.github/workflows/evaluate.yml
@@ -62,7 +62,7 @@ jobs:
       OUTPUT_FOLDER: cuda12.8_dist_${{ github.run_id }}
     steps:
       - name: Free disk space
-        uses: jlumbroso/free-disk-space@main
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # main
         with:
           # This might remove tools that are actually needed, if set to "true" but frees about 6 GB
           tool-cache: false

--- a/.github/workflows/linux_x64_gpu.yml
+++ b/.github/workflows/linux_x64_gpu.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Free disk space
-        uses: jlumbroso/free-disk-space@main
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # main
         with:
           # This might remove tools that are actually needed, if set to "true" but frees about 6 GB
           tool-cache: false

--- a/.github/workflows/mllm_api_eval.yml
+++ b/.github/workflows/mllm_api_eval.yml
@@ -71,7 +71,7 @@ jobs:
       OUTPUT_FOLDER: cuda12.8_dist_${{ github.run_id }}
     steps:
       - name: Free disk space
-        uses: jlumbroso/free-disk-space@main
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # main
         with:
           # This might remove tools that are actually needed, if set to "true" but frees about 6 GB
           tool-cache: false

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -22,7 +22,7 @@ jobs:
       OUTPUT_FOLDER: cuda12.8_dist
     steps:
       - name: Free disk space
-        uses: jlumbroso/free-disk-space@main
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # main
         with:
           # This might remove tools that are actually needed, if set to "true" but frees about 6 GB
           tool-cache: false

--- a/.github/workflows/test_docker.yml
+++ b/.github/workflows/test_docker.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           ref: ${{github.event.inputs.repo_ref}}
       - name: Free disk space
-        uses: jlumbroso/free-disk-space@main
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # main
         with:
           # This might remove tools that are actually needed, if set to "true" but frees about 6 GB
           tool-cache: false
@@ -72,7 +72,7 @@ jobs:
         with:
           ref: ${{github.event.inputs.repo_ref}}
       - name: Free disk space
-        uses: jlumbroso/free-disk-space@main
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # main
         with:
           # This might remove tools that are actually needed, if set to "true" but frees about 6 GB
           tool-cache: false
@@ -113,7 +113,7 @@ jobs:
         with:
           ref: ${{github.event.inputs.repo_ref}}
       - name: Free disk space
-        uses: jlumbroso/free-disk-space@main
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # main
         with:
           # This might remove tools that are actually needed, if set to "true" but frees about 6 GB
           tool-cache: false


### PR DESCRIPTION
### What

Pin `jlumbroso/free-disk-space@main` → `54081f1…` everywhere it's used (15 occurrences across 12
workflows), keeping the tag in a trailing comment.

### Why

`@main` is a moving reference — whatever it points to at run time runs in the job. Several of these jobs
hold publishing credentials:

- [`docker.yml`](https://github.com/InternLM/lmdeploy/blob/b56ddfb634f069b600f0fe3f4730fe289ac7fafe/.github/workflows/docker.yml) / `docker_nightly.yml` — DockerHub login + push
- [`pypi.yml`](https://github.com/InternLM/lmdeploy/blob/b56ddfb634f069b600f0fe3f4730fe289ac7fafe/.github/workflows/pypi.yml) — `twine upload` with `pypi_password`

If the action's `main` were moved (compromise or an accidental change), the new code would run in a job
holding registry / PyPI credentials — the class of issue behind the 2025 `tj-actions/changed-files`
incident, here with the ability to tamper with published images and wheels.

### Scope / safety

- Behaviour unchanged — the SHA is the current tip of the action's `main`.
- Renovate/Dependabot can still bump a SHA pin (the tag comment keeps it readable). DCO signed-off.

Per GitHub's guidance to [pin actions to a full-length commit SHA](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions).

<sub>AI-assisted; I verified the workflows, the credential exposure, and the pinned SHA myself.</sub>
