### PR TITLE
Fix GLM MTP 

### DIFF
--- a/lmdeploy/pytorch/engine/model_agent/agent.py
+++ b/lmdeploy/pytorch/engine/model_agent/agent.py
@@ -341,12 +341,8 @@ class BaseModelAgent:
                                            self.inputs_strategy,
                                            self.agent_strategy,
                                            misc_config=misc_config,
-                                           device=device)
-        if self.spec_agent.is_enabled():
-            from lmdeploy.pytorch.spec_decode.guided_spec_helper import GuidedSpecHelper
-            helper = GuidedSpecHelper(self.guided_decoding_manager)
-            self.spec_agent.guided_helper = helper
-            self.spec_agent.proposer.guided_helper = helper
+                                           device=device,
+                                           guided_decoding_manager=self.guided_decoding_manager)
         # sleep wakeup state
         self.state: SleepWakeupState = SleepWakeupState()
 

--- a/lmdeploy/pytorch/spec_decode/__init__.py
+++ b/lmdeploy/pytorch/spec_decode/__init__.py
@@ -10,8 +10,31 @@ def build_spec_agent(specdecode_config: SpecDecodeConfig,
                      inputs_strategy,
                      agent_strategy,
                      misc_config: MiscConfig,
-                     device: str = 'cuda'):
-    """Build spec agent."""
+                     device: str = 'cuda',
+                     guided_decoding_manager=None):
+    """Build a rank-local speculative decoding agent.
+
+    Args:
+        specdecode_config (SpecDecodeConfig): Speculative decoding config. If
+            ``None``, speculative decoding is disabled.
+        backend_config (BackendConfig): Backend config used by the draft model.
+        dist_ctx (DistContext): Rank-local distributed context of the target
+            model.
+        inputs_strategy: Strategy for preparing model inputs.
+        agent_strategy: Strategy for model-agent operations such as
+            post-broadcast.
+        misc_config (MiscConfig): Misc runtime config.
+        device (str): Device used by the draft model.
+        guided_decoding_manager: Optional guided-decoding manager. It is passed
+            only to proposer-owning ``SpecModelAgent`` ranks so the draft
+            proposer and target rejection sampling share one guided helper.
+
+    Returns:
+        A ``SpecModelAgent`` on ranks that own a draft proposer. Returns a
+        ``BaseSpecModelAgent`` when speculative decoding is disabled, or on
+        follower ranks that participate in target-side broadcasts but do not
+        own a draft proposer.
+    """
     enable = False
     if specdecode_config is not None:
         draft_tp = specdecode_config.dist_config.tp
@@ -27,10 +50,11 @@ def build_spec_agent(specdecode_config: SpecDecodeConfig,
                               agent_strategy,
                               misc_config,
                               dist_ctx,
-                              device=device)
-    else:
-        from .base import BaseSpecModelAgent
-        return BaseSpecModelAgent(specdecode_config,
+                              device=device,
+                              guided_decoding_manager=guided_decoding_manager)
+
+    from .base import BaseSpecModelAgent
+    return BaseSpecModelAgent(specdecode_config,
                               backend_config,
                               inputs_strategy,
                               agent_strategy,

--- a/lmdeploy/pytorch/spec_decode/guided_spec_helper.py
+++ b/lmdeploy/pytorch/spec_decode/guided_spec_helper.py
@@ -157,11 +157,10 @@ class GuidedSpecHelper:
 
         for pos in range(num_expand):
             await asyncio.to_thread(self._fill_bitmask, forked, bitmask)
-            pos_logits = scores_3d[:, pos, :].contiguous()
-            self._mgr.apply_batched_bitmap(pos_logits, bitmask)
-            # Copying back mutates inference-mode logits from model forward.
+            pos_logits = scores_3d[:, pos, :]
+            # Masking updates inference-mode logits from model forward.
             with torch.inference_mode():
-                scores_3d[:, pos, :] = pos_logits
+                self._mgr.apply_batched_bitmap(pos_logits, bitmask)
 
             # Advance fork using draft tokens for draft positions.
             if pos < num_spec_tokens:

--- a/lmdeploy/pytorch/spec_decode/guided_spec_helper.py
+++ b/lmdeploy/pytorch/spec_decode/guided_spec_helper.py
@@ -157,9 +157,11 @@ class GuidedSpecHelper:
 
         for pos in range(num_expand):
             await asyncio.to_thread(self._fill_bitmask, forked, bitmask)
-            pos_logits = scores_3d[:, pos, :]
+            pos_logits = scores_3d[:, pos, :].contiguous()
             self._mgr.apply_batched_bitmap(pos_logits, bitmask)
-            scores_3d[:, pos, :] = pos_logits
+            # Copying back mutates inference-mode logits from model forward.
+            with torch.inference_mode():
+                scores_3d[:, pos, :] = pos_logits
 
             # Advance fork using draft tokens for draft positions.
             if pos < num_spec_tokens:

--- a/lmdeploy/pytorch/spec_decode/spec_agent.py
+++ b/lmdeploy/pytorch/spec_decode/spec_agent.py
@@ -158,6 +158,7 @@ class SpecModelAgent(BaseSpecModelAgent):
         misc_config: MiscConfig,
         dist_ctx: DistContext,
         device: str = 'cuda',
+        guided_decoding_manager=None,
     ):
         super().__init__(specdecode_config,
                          backend_config,
@@ -168,10 +169,9 @@ class SpecModelAgent(BaseSpecModelAgent):
                          device,
                          )
 
+        self.guided_helper = GuidedSpecHelper(guided_decoding_manager)
         self.proposer = build_specdecode_proposer(specdecode_config, device=device)
-
-        # Guided decoding — set by ModelAgent after construction
-        self.guided_helper = GuidedSpecHelper()
+        self.proposer.guided_helper = self.guided_helper
 
         # make dummy meta
         self.make_dummy_meta = self.inputs_strategy.create_make_dummy_meta(self.model_config)

--- a/tests/pytorch/engine/test_model_agent.py
+++ b/tests/pytorch/engine/test_model_agent.py
@@ -115,6 +115,66 @@ def test_model_agent_reset_runtime_state_discards_decode_and_chunk_carry():
     assert events == ['build_step_inputs', 'reset_spec']
 
 
+def test_build_spec_agent_allows_guided_spec_followers_without_proposer():
+    from lmdeploy.pytorch.config import DistConfig, SpecDecodeConfig
+    from lmdeploy.pytorch.distributed import DistContext
+    from lmdeploy.pytorch.spec_decode import build_spec_agent
+
+    guided_manager = object()
+    specdecode_config = SpecDecodeConfig(
+        model='draft-model',
+        method='deepseek_mtp',
+        dist_config=DistConfig(),
+        num_speculative_tokens=3,
+    )
+    spec_agent = build_spec_agent(
+        specdecode_config,
+        backend_config=None,
+        dist_ctx=DistContext(rank=1, dist_config=DistConfig(tp=2)),
+        inputs_strategy=None,
+        agent_strategy=None,
+        misc_config=None,
+        device='cpu',
+        guided_decoding_manager=guided_manager,
+    )
+    assert spec_agent.is_enabled()
+    assert spec_agent.proposer is None
+    assert not hasattr(spec_agent, 'guided_helper')
+
+
+def test_build_spec_agent_shares_guided_helper_with_proposer(monkeypatch):
+    import lmdeploy.pytorch.spec_decode.spec_agent as spec_agent_mod
+    from lmdeploy.pytorch.config import DistConfig, SpecDecodeConfig
+    from lmdeploy.pytorch.distributed import DistContext
+    from lmdeploy.pytorch.spec_decode import build_spec_agent
+
+    guided_manager = object()
+    proposer = SimpleNamespace(guided_helper=None)
+    monkeypatch.setattr(spec_agent_mod, 'build_specdecode_proposer', lambda *args, **kwargs: proposer)
+    inputs_strategy = SimpleNamespace(create_make_dummy_meta=lambda model_config: None)
+    specdecode_config = SpecDecodeConfig(
+        model='draft-model',
+        method='deepseek_mtp',
+        dist_config=DistConfig(),
+        num_speculative_tokens=3,
+    )
+
+    spec_agent = build_spec_agent(
+        specdecode_config,
+        backend_config=None,
+        dist_ctx=DistContext(rank=0, dist_config=DistConfig(tp=2)),
+        inputs_strategy=inputs_strategy,
+        agent_strategy=None,
+        misc_config=None,
+        device='cpu',
+        guided_decoding_manager=guided_manager,
+    )
+
+    assert spec_agent.proposer is proposer
+    assert spec_agent.guided_helper.manager is guided_manager
+    assert proposer.guided_helper is spec_agent.guided_helper
+
+
 def test_spec_agent_reset_runtime_state_discards_chunk_carry():
     from lmdeploy.pytorch.spec_decode.spec_agent import SpecModelAgent
 

--- a/tests/pytorch/spec_decode/test_spec_agent.py
+++ b/tests/pytorch/spec_decode/test_spec_agent.py
@@ -89,6 +89,56 @@ class _DummyProposer:
         )
 
 
+def test_guided_serial_bitmask_updates_inference_tensor():
+    """Serial guided masking can update logits produced under inference
+    mode."""
+
+    class _Processor:
+
+        def fork(self):
+            return _Processor()
+
+    class _GuidedManager:
+
+        def __init__(self):
+            self.accepted = []
+
+        def allocate_batched_bitmap(self, batch_size):
+            return torch.zeros(batch_size, 1, dtype=torch.int32)
+
+        def fill_bitmap(self, processor, guided_bitmask, index):
+            return None
+
+        def apply_batched_bitmap(self, logits, guided_bitmask):
+            logits[:, 0] = -123.0
+
+        def is_terminated(self, processor):
+            return False
+
+        def accept_token(self, processor, token):
+            self.accepted.append(token)
+
+    manager = _GuidedManager()
+    helper = GuidedSpecHelper(manager)
+    batch_size = 2
+    num_spec_tokens = 2
+    num_expand = num_spec_tokens + 1
+    vocab_size = 4
+    with torch.inference_mode():
+        scores_3d = torch.zeros(batch_size, num_expand, vocab_size)
+
+    asyncio.run(
+        helper.apply_serial_bitmask(
+            scores_3d,
+            processors={0: _Processor(), 1: _Processor()},
+            draft_token_ids=torch.tensor([[10, 11], [20, 21]], dtype=torch.long),
+            num_spec_tokens=num_spec_tokens,
+        ))
+
+    torch.testing.assert_close(scores_3d[:, :, 0], torch.full((batch_size, num_expand), -123.0))
+    assert manager.accepted == [10, 20, 11, 21]
+
+
 def test_prepare_inputs_from_main_dp_non_last_first_chunk_shifts_last_token_indices():
     """DP non-last first chunks run draft forwards, so indices must match
     shifted draft inputs."""

--- a/tests/pytorch/spec_decode/test_spec_agent.py
+++ b/tests/pytorch/spec_decode/test_spec_agent.py
@@ -102,6 +102,9 @@ def test_guided_serial_bitmask_updates_inference_tensor():
 
         def __init__(self):
             self.accepted = []
+            self.seen_is_contiguous = []
+            self.seen_is_inference = []
+            self.seen_inference_mode = []
 
         def allocate_batched_bitmap(self, batch_size):
             return torch.zeros(batch_size, 1, dtype=torch.int32)
@@ -110,6 +113,9 @@ def test_guided_serial_bitmask_updates_inference_tensor():
             return None
 
         def apply_batched_bitmap(self, logits, guided_bitmask):
+            self.seen_is_contiguous.append(logits.is_contiguous())
+            self.seen_is_inference.append(logits.is_inference())
+            self.seen_inference_mode.append(torch.is_inference_mode_enabled())
             logits[:, 0] = -123.0
 
         def is_terminated(self, processor):
@@ -136,6 +142,9 @@ def test_guided_serial_bitmask_updates_inference_tensor():
         ))
 
     torch.testing.assert_close(scores_3d[:, :, 0], torch.full((batch_size, num_expand), -123.0))
+    assert manager.seen_is_contiguous == [False, False, False]
+    assert manager.seen_is_inference == [True, True, True]
+    assert manager.seen_inference_mode == [True, True, True]
     assert manager.accepted == [10, 20, 11, 21]
 
 

--- a/tests/test_lmdeploy/test_grammar.py
+++ b/tests/test_lmdeploy/test_grammar.py
@@ -55,6 +55,20 @@ SCHEMA_MAP = {
     'json_object': None,
 }
 
+MIXED_SCHEMA = {
+    'type': 'object',
+    'properties': {
+        'name': {
+            'type': 'string'
+        },
+        'age': {
+            'type': 'integer'
+        },
+    },
+    'required': ['name', 'age'],
+    'additionalProperties': False,
+}
+
 
 @pytest.mark.parametrize('model_id', MODEL_IDS)
 @pytest.mark.parametrize('backend_name,backend_factory', BACKEND_FACTORIES)
@@ -110,14 +124,15 @@ def test_mix_guided_matrix(model_id, backend_name, backend_factory):
 
     schema_type = 'json_schema'
     response_format = {'type': schema_type}
-    schema = SCHEMA_MAP[schema_type]
+    schema = MIXED_SCHEMA
     response_format[schema_type] = dict(name='test', schema=schema)
 
     prompts = ['Make a self introduction please.'] * 4
     try:
-        config = GenerationConfig(response_format=response_format)
-
-        gen_config = [None if idx % 3 else config for idx in range(4)]
+        gen_config = [
+            GenerationConfig(max_new_tokens=128, response_format=response_format)
+            if idx % 3 == 0 else None for idx in range(4)
+        ]
 
         responses = pipe.batch_infer(prompts, gen_config=gen_config)
 


### PR DESCRIPTION

## Motivation

Fix GLM MTP 
## Modification

- Fix GLM/DeepSeek MTP guided decoding by initializing GuidedSpecHelper inside SpecModelAgent and sharing it with the proposer only on proposer-owning ranks.
- Fix guided spec logits copy-back for inference-mode tensors.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
