### PR TITLE
fix(serve): don't leak a reasoning close tag split across streaming chunks

### DIFF
--- a/lmdeploy/serve/parsers/response_parser.py
+++ b/lmdeploy/serve/parsers/response_parser.py
@@ -508,10 +508,19 @@ class BaseResponseParser(ResponseParser):
             raise RuntimeError('Invariant violated: MODE_REASONING requires a reasoning_close_tag.')
 
         idx = self._pending.find(close_tag)
-        # No close tag found, treat the whole pending text as reasoning content.
+        # No close tag found. Keep a possible close-tag prefix suffix in
+        # buffer so a close tag split across chunks can still be recognized,
+        # mirroring _consume_plain's handling of split open tags.
         if idx < 0:
             if not self._pending:
                 return None, False
+            keep = self._longest_open_tag_prefix_suffix(self._pending, [close_tag])
+            if keep > 0:
+                if keep >= len(self._pending):
+                    return None, False
+                out = self._pending[:-keep]
+                self._pending = self._pending[-keep:]
+                return (out if out else None), bool(out)
             out = self._pending
             self._pending = ''
             return out, True

--- a/tests/test_lmdeploy/serve/parsers/test_response_parser_streaming.py
+++ b/tests/test_lmdeploy/serve/parsers/test_response_parser_streaming.py
@@ -1,0 +1,67 @@
+from lmdeploy.serve.openai.protocol import ChatCompletionRequest
+from lmdeploy.serve.parsers import ResponseParserManager
+from lmdeploy.serve.parsers.reasoning_parser import ReasoningParserManager
+
+from .helpers import first_stream_delta
+
+MODEL_ID = 'test/default-reasoning-model'
+
+
+def _make_parser():
+    cls = ResponseParserManager.get('default')
+    cls.reasoning_parser_cls = ReasoningParserManager.get('default')
+    cls.tool_parser_cls = None
+    request = ChatCompletionRequest(
+        model=MODEL_ID,
+        messages=[],
+        stream=True,
+        chat_template_kwargs={'enable_thinking': True},
+    )
+    return cls(request=request)
+
+
+class TestResponseParserReasoningCloseTagAcrossChunks:
+    """A reasoning close tag (e.g. ``</think>``) is not a single vocab
+    token, so real token-by-token streaming can split it across multiple
+    ``stream_chunk`` calls. _consume_reasoning must buffer a possible
+    partial-tag suffix instead of flushing it as reasoning content,
+    mirroring how _consume_plain already handles split open tags.
+    """
+
+    def test_close_tag_split_across_two_chunks_is_not_leaked(self):
+        parser = _make_parser()
+
+        reasoning_text = ''
+        content_text = ''
+        for chunk in ['Let me think about this', '</th', 'ink>', ' The answer is 42.']:
+            for delta_msg, _ in parser.stream_chunk(delta_text=chunk, delta_token_ids=[]):
+                if delta_msg.reasoning_content:
+                    reasoning_text += delta_msg.reasoning_content
+                if delta_msg.content:
+                    content_text += delta_msg.content
+
+        assert reasoning_text == 'Let me think about this'
+        assert content_text == ' The answer is 42.'
+
+    def test_close_tag_split_byte_by_byte_is_not_leaked(self):
+        parser = _make_parser()
+        close_tag = '</think>'
+
+        reasoning_text = ''
+        for chunk in list('reasoning ') + list(close_tag):
+            for delta_msg, _ in parser.stream_chunk(delta_text=chunk, delta_token_ids=[]):
+                if delta_msg.reasoning_content:
+                    reasoning_text += delta_msg.reasoning_content
+
+        assert reasoning_text == 'reasoning '
+        assert close_tag not in reasoning_text
+
+    def test_intact_close_tag_in_single_chunk_still_works(self):
+        """Regression guard: the common case (tag arrives whole) must be
+        unaffected."""
+        parser = _make_parser()
+
+        delta_msg, _ = first_stream_delta(
+            parser.stream_chunk(delta_text='reasoning</think> content', delta_token_ids=[]))
+        assert delta_msg.reasoning_content == 'reasoning'
+        assert delta_msg.content is None

--- a/tests/test_lmdeploy/serve/parsers/test_response_parser_streaming.py
+++ b/tests/test_lmdeploy/serve/parsers/test_response_parser_streaming.py
@@ -21,11 +21,12 @@ def _make_parser():
 
 
 class TestResponseParserReasoningCloseTagAcrossChunks:
-    """A reasoning close tag (e.g. ``</think>``) is not a single vocab
-    token, so real token-by-token streaming can split it across multiple
-    ``stream_chunk`` calls. _consume_reasoning must buffer a possible
-    partial-tag suffix instead of flushing it as reasoning content,
-    mirroring how _consume_plain already handles split open tags.
+    """A reasoning close tag (e.g. ``</think>``) is not a single vocab token,
+    so real token-by-token streaming can split it across multiple
+    ``stream_chunk`` calls.
+
+    _consume_reasoning must buffer a possible partial-tag suffix instead of flushing it as reasoning content, mirroring
+    how _consume_plain already handles split open tags.
     """
 
     def test_close_tag_split_across_two_chunks_is_not_leaked(self):


### PR DESCRIPTION
## Motivation

`BaseResponseParser._consume_reasoning` flushes the *entire* `self._pending` buffer as `reasoning_content` whenever the reasoning close tag (e.g. `</think>`) isn't found yet:

```python
idx = self._pending.find(close_tag)
if idx < 0:
    if not self._pending:
        return None, False
    out = self._pending
    self._pending = ''
    return out, True
```

The close tag is not a single vocab token, so under real token-by-token streaming it routinely arrives split across multiple `stream_chunk` calls. The sibling `_consume_plain` already guards exactly this scenario for *open* tags via `_longest_open_tag_prefix_suffix` (keeping a possible partial-tag suffix buffered instead of flushing it), but `_consume_reasoning` had no equivalent protection for the close tag.

**Symptom**: streaming `</think>` as two separate chunks (e.g. `'</th'`, `'ink>'`) leaks the literal tag text into `reasoning_content`, the mode never switches to `MODE_PLAIN`, and any genuine visible answer text that follows (in the same or a later chunk) is misclassified as reasoning content instead of content. For any client that displays "thinking" separately from the final answer, the final answer becomes invisible.

## Modification

Reuse `_longest_open_tag_prefix_suffix` (already generic over any tag list, despite its name) for the close tag too, mirroring `_consume_plain`'s existing pattern: keep a possible partial-tag suffix buffered instead of flushing it.

## Use cases

Repro before the fix:
```python
BaseResponseParser.set_parsers(reasoning_parser_name='default', tool_parser_name=None)
parser = BaseResponseParser(ChatCompletionRequest(model='m', messages=[]))
for chunk in ['Let me think about this', '</th', 'ink>', ' The answer is 42.']:
    for delta, _ in parser.stream_chunk(chunk, []):
        ...
# reasoning_content == 'Let me think about this</think> The answer is 42.'  (WRONG)
# content == ''                                                              (WRONG)
```
After the fix: `reasoning_content == 'Let me think about this'`, `content == ' The answer is 42.'`.

## Checklist

1. Pre-commit / lint: `ruff check` clean on both changed files.
2. Unit tests: added `tests/test_lmdeploy/serve/parsers/test_response_parser_streaming.py` (no unit tests existed for this shared streaming state machine before) covering: close tag split across two chunks, split byte-by-byte, and an intact single-chunk close tag as a regression guard for the common case. Verified red-before/green-after by stashing the source fix and confirming failure, then restoring it. Full `tests/test_lmdeploy/serve/parsers/`: 33 passed, 1 skipped (unrelated pre-existing skip, unaffected by this diff).
3. No downstream-version dependency.
4. No public API / docstring changes needed — internal streaming state-machine fix only.

**AI disclosure**: found via an AI-assisted (Claude) review pass over `lmdeploy/serve/parsers/`, independently reproduced, fixed, and verified before submitting.