### PR TITLE
fix(serve): tool close tag split across streaming chunks leaked into tool payload

### DIFF
--- a/lmdeploy/serve/parsers/response_parser.py
+++ b/lmdeploy/serve/parsers/response_parser.py
@@ -563,6 +563,16 @@ class BaseResponseParser(ResponseParser):
         if idx < 0:
             if not self._pending:
                 return [], False
+            # No close tag found. Keep a possible close-tag prefix suffix in
+            # buffer so a close tag split across chunks can still be
+            # recognized, mirroring _consume_reasoning's handling.
+            keep = self._longest_open_tag_prefix_suffix(self._pending, [close_tag])
+            if keep > 0:
+                if keep >= len(self._pending):
+                    return [], False
+                emit = self._pending[:-keep]
+                self._pending = self._pending[-keep:]
+                return self.tool_parser.decode_tool_incremental(added_text=emit, final=False), True
             emit = self._pending
             self._pending = ''
             return self.tool_parser.decode_tool_incremental(added_text=emit, final=False), True

--- a/lmdeploy/serve/parsers/response_parser.py
+++ b/lmdeploy/serve/parsers/response_parser.py
@@ -565,7 +565,7 @@ class BaseResponseParser(ResponseParser):
                 return [], False
             # No close tag found. Keep a possible close-tag prefix suffix in
             # buffer so a close tag split across chunks can still be
-            # recognized, mirroring _consume_reasoning's handling.
+            # recognized.
             keep = self._longest_open_tag_prefix_suffix(self._pending, [close_tag])
             if keep > 0:
                 if keep >= len(self._pending):

--- a/tests/test_lmdeploy/serve/parsers/test_response_parser_tool_close_tag_split.py
+++ b/tests/test_lmdeploy/serve/parsers/test_response_parser_tool_close_tag_split.py
@@ -23,8 +23,7 @@ class TestResponseParserToolCloseTagAcrossChunks:
     so real token-by-token streaming can split it across multiple
     ``stream_chunk`` calls.
 
-    _consume_tool must buffer a possible partial-tag suffix instead of leaking it into the tool payload, mirroring how
-    _consume_reasoning already handles a split reasoning close tag.
+    _consume_tool must buffer a possible partial-tag suffix instead of leaking it into the tool payload.
     """
 
     def test_close_tag_split_across_two_chunks_is_not_leaked(self):

--- a/tests/test_lmdeploy/serve/parsers/test_response_parser_tool_close_tag_split.py
+++ b/tests/test_lmdeploy/serve/parsers/test_response_parser_tool_close_tag_split.py
@@ -1,0 +1,77 @@
+from lmdeploy.serve.openai.protocol import ChatCompletionRequest
+from lmdeploy.serve.parsers import ResponseParserManager
+from lmdeploy.serve.parsers.tool_parser import ToolParserManager
+
+from .helpers import first_stream_delta
+
+
+def _build_parser():
+    cls = ResponseParserManager.get('default')
+    cls.reasoning_parser_cls = None
+    cls.tool_parser_cls = ToolParserManager.get('intern-s1')
+    request = ChatCompletionRequest(
+        model='intern-s1',
+        messages=[],
+        stream=True,
+        tool_choice='auto',
+    )
+    return cls(request=request)
+
+
+class TestResponseParserToolCloseTagAcrossChunks:
+    """A tool close tag (e.g. ``<|action_end|>``) is not a single vocab
+    token, so real token-by-token streaming can split it across multiple
+    ``stream_chunk`` calls. _consume_tool must buffer a possible
+    partial-tag suffix instead of leaking it into the tool payload,
+    mirroring how _consume_reasoning already handles a split reasoning
+    close tag.
+    """
+
+    def test_close_tag_split_across_two_chunks_is_not_leaked(self):
+        parser = _build_parser()
+        chunks = [
+            '<|action_start|><|plugin|>',
+            '\n{\n    "name": "get_weather",\n    "parameters": {"city": "Berlin"}\n}',
+            '<|action_e',
+            'nd|>',
+        ]
+
+        seen_name = False
+        seen_args = False
+        leaked_tag_text = []
+
+        for chunk in chunks:
+            delta, _tool_emitted = first_stream_delta(parser.stream_chunk(delta_text=chunk, delta_token_ids=[]))
+            if delta is None:
+                continue
+            if delta.content:
+                leaked_tag_text.append(delta.content)
+            if delta.tool_calls:
+                for call in delta.tool_calls:
+                    if call.function and call.function.name == 'get_weather':
+                        seen_name = True
+                    if call.function and call.function.arguments == '{"city": "Berlin"}':
+                        seen_args = True
+
+        assert seen_name
+        assert seen_args
+        assert '<|action_end|>' not in ''.join(leaked_tag_text)
+
+    def test_intact_close_tag_in_single_chunk_still_works(self):
+        """Regression guard: the common case (tag arrives whole) must be
+        unaffected."""
+        parser = _build_parser()
+        chunks = [
+            '<|action_start|><|plugin|>',
+            '\n{\n    "name": "get_weather",\n    "parameters": {"city": "Berlin"}\n}<|action_end|>',
+        ]
+
+        seen_name = False
+        for chunk in chunks:
+            delta, _tool_emitted = first_stream_delta(parser.stream_chunk(delta_text=chunk, delta_token_ids=[]))
+            if delta and delta.tool_calls:
+                for call in delta.tool_calls:
+                    if call.function and call.function.name == 'get_weather':
+                        seen_name = True
+
+        assert seen_name

--- a/tests/test_lmdeploy/serve/parsers/test_response_parser_tool_close_tag_split.py
+++ b/tests/test_lmdeploy/serve/parsers/test_response_parser_tool_close_tag_split.py
@@ -19,12 +19,12 @@ def _build_parser():
 
 
 class TestResponseParserToolCloseTagAcrossChunks:
-    """A tool close tag (e.g. ``<|action_end|>``) is not a single vocab
-    token, so real token-by-token streaming can split it across multiple
-    ``stream_chunk`` calls. _consume_tool must buffer a possible
-    partial-tag suffix instead of leaking it into the tool payload,
-    mirroring how _consume_reasoning already handles a split reasoning
-    close tag.
+    """A tool close tag (e.g. ``<|action_end|>``) is not a single vocab token,
+    so real token-by-token streaming can split it across multiple
+    ``stream_chunk`` calls.
+
+    _consume_tool must buffer a possible partial-tag suffix instead of leaking it into the tool payload, mirroring how
+    _consume_reasoning already handles a split reasoning close tag.
     """
 
     def test_close_tag_split_across_two_chunks_is_not_leaked(self):


### PR DESCRIPTION
## Motivation

`BaseResponseParser._consume_tool`'s "no close tag found" branch flushes the *entire* `self._pending` buffer as tool-call payload text and clears it, with no handling for the tool close tag (e.g. `<|action_end|>`) being split across two `stream_chunk` calls:

```python
idx = self._pending.find(close_tag)
if idx < 0:
    if not self._pending:
        return [], False
    emit = self._pending
    self._pending = ''
    return self.tool_parser.decode_tool_incremental(added_text=emit, final=False), True
```

The close tag is not a single vocab token, so under real token-by-token streaming it can arrive split across multiple chunks. This is the exact same bug class already found and fixed in the sibling method `_consume_reasoning` (reasoning close tag) — see #4754. `_consume_tool` never got the analogous fix.

**Symptom**: streaming a tool close tag as two separate chunks (e.g. `'<|action_e'`, `'nd|>'`) leaks the partial tag text into the tool payload passed to `tool_parser.decode_tool_incremental`, corrupting the JSON being incrementally parsed (in my repro, `arguments` never resolves to the clean expected value) and the parser never transitions back to `MODE_PLAIN` via the close-tag branch.

## Modification

`_consume_tool`'s close-tag-not-found branch now reuses the same `_longest_open_tag_prefix_suffix` helper already used by `_consume_plain` (open tags) and `_consume_reasoning` (reasoning close tag) to detect and buffer a possible partial-close-tag suffix instead of flushing it as payload text.

```python
idx = self._pending.find(close_tag)
if idx < 0:
    if not self._pending:
        return [], False
    keep = self._longest_open_tag_prefix_suffix(self._pending, [close_tag])
    if keep > 0:
        if keep >= len(self._pending):
            return [], False
        emit = self._pending[:-keep]
        self._pending = self._pending[-keep:]
        return self.tool_parser.decode_tool_incremental(added_text=emit, final=False), True
    emit = self._pending
    self._pending = ''
    return self.tool_parser.decode_tool_incremental(added_text=emit, final=False), True
```

The other branch of `_consume_tool` (the `not close_tag` / JSON-completeness-detection path used by close-tag-less tool formats) is unaffected — this fix only touches the close-tag-present path.

## Checklist

1. Pre-commit / lint: `ruff check` clean on both changed files.
2. Unit tests: added `tests/test_lmdeploy/serve/parsers/test_response_parser_tool_close_tag_split.py` covering the split-close-tag case (using the `intern-s1` tool parser, whose close tag `<|action_end|>` is a realistic multi-token string) and an intact-single-chunk regression guard. Verified red-before/green-after by stashing the source fix and confirming failure, then restoring it. Full `tests/test_lmdeploy/serve/parsers/`: 32 passed, 1 skipped (unrelated pre-existing skip).
3. No downstream-version dependency.
4. No public API / docstring changes needed — internal streaming state-machine fix only.

**AI disclosure**: found via an AI-assisted (Claude) review pass over `lmdeploy/serve/parsers/` (specifically, by comparing `_consume_tool` against the already-fixed `_consume_reasoning` for the same bug class), independently reproduced, fixed, and verified before submitting.