### PR TITLE
fix: install xgrammar for jetson docker

### DIFF
--- a/docker/Dockerfile.jetson
+++ b/docker/Dockerfile.jetson
@@ -27,8 +27,8 @@ RUN --mount=type=cache,target=/root/.cache \
 COPY . /opt/lmdeploy
 WORKDIR /opt/lmdeploy
 
-# The Jetson AI Lab index may lag xgrammar releases, while CUDA/Torch wheels
-# should still come from the Jetson index. Preinstall only xgrammar from PyPI.
+# The Jetson AI Lab index may lag xgrammar releases. Force xgrammar from PyPI,
+# while keeping the LMDeploy wheel and its CUDA/Torch dependencies on the Jetson index.
 RUN --mount=type=cache,target=/root/.cache \
     --mount=type=cache,target=/opt/pytorch \
     pip install build change-wheel-version && \

--- a/docker/Dockerfile.jetson
+++ b/docker/Dockerfile.jetson
@@ -27,9 +27,12 @@ RUN --mount=type=cache,target=/root/.cache \
 COPY . /opt/lmdeploy
 WORKDIR /opt/lmdeploy
 
+# The Jetson AI Lab index may lag xgrammar releases, while CUDA/Torch wheels
+# should still come from the Jetson index. Preinstall only xgrammar from PyPI.
 RUN --mount=type=cache,target=/root/.cache \
     --mount=type=cache,target=/opt/pytorch \
     pip install build change-wheel-version && \
     python -m build -w -o /wheels -v . && \
     change_wheel_version --local-version cu126 --delete-old-wheel /wheels/lmdeploy*.whl && \
+    pip install -v --no-deps xgrammar==0.1.33 --index-url https://pypi.org/simple/ && \
     pip install -v /wheels/lmdeploy*.whl --index-url https://pypi.jetson-ai-lab.io/jp6/cu126/+simple/

--- a/docker/Dockerfile.jetson
+++ b/docker/Dockerfile.jetson
@@ -34,5 +34,5 @@ RUN --mount=type=cache,target=/root/.cache \
     pip install build change-wheel-version && \
     python -m build -w -o /wheels -v . && \
     change_wheel_version --local-version cu126 --delete-old-wheel /wheels/lmdeploy*.whl && \
-    pip install -v --no-deps xgrammar==0.1.33 --index-url https://pypi.org/simple/ && \
+    pip install -v --no-deps --only-binary=:all: xgrammar==0.1.33 --index-url https://pypi.org/simple/ && \
     pip install -v /wheels/lmdeploy*.whl --index-url https://pypi.jetson-ai-lab.io/jp6/cu126/+simple/


### PR DESCRIPTION
## Motivation

The Jetson AI Lab package index may lag xgrammar releases, which can prevent the Jetson Docker image from resolving LMDeploy's xgrammar dependency.

## Modification

Preinstall `xgrammar==0.1.33` without dependencies from PyPI, while continuing to install the LMDeploy wheel and its CUDA/Torch dependencies from the Jetson AI Lab index.

## BC-breaking (Optional)

No.

## Testing

Not run (per request; Dockerfile-only dependency installation change).

## Assistance

Assisted with Codex + GPT-5.6-Sol xHigh, reviewed manually
