### PR TITLE
fix(vl): re-validate every redirect hop when fetching image_url (SSRF #4761)

### DIFF
--- a/lmdeploy/vl/media/connection.py
+++ b/lmdeploy/vl/media/connection.py
@@ -4,7 +4,7 @@ import os
 import socket
 from pathlib import Path
 from typing import TypeVar
-from urllib.parse import ParseResult, urlparse
+from urllib.parse import ParseResult, urljoin, urlparse
 from urllib.request import url2pathname
 
 import requests
@@ -63,12 +63,26 @@ def _load_http_url(url_spec: ParseResult, media_io: MediaIO[_M]) -> _M:
     elif isinstance(media_io, VideoMediaIO):
         fetch_timeout = int(os.environ.get('LMDEPLOY_VIDEO_FETCH_TIMEOUT', 30))
 
+    max_redirects = 3
     client = requests.Session()
-    client.max_redirects = 3
-    response = client.get(url_spec.geturl(), headers=headers, timeout=fetch_timeout, allow_redirects=True)
-    response.raise_for_status()
+    current_url = url
+    # Follow redirects manually so _is_safe_url runs on every hop. requests'
+    # built-in redirect handling only validates the original URL, so a public
+    # host that passes the guard could 302 to an internal or cloud-metadata
+    # address and have its response returned (SSRF).
+    for _ in range(max_redirects + 1):
+        response = client.get(current_url, headers=headers, timeout=fetch_timeout, allow_redirects=False)
+        if response.is_redirect:
+            next_url = urljoin(current_url, response.headers['location'])
+            is_safe, reason = _is_safe_url(next_url)
+            if not is_safe:
+                raise ValueError(f'URL is blocked for security reasons: {reason}')
+            current_url = next_url
+            continue
+        response.raise_for_status()
+        return media_io.load_bytes(response.content)
 
-    return media_io.load_bytes(response.content)
+    raise ValueError(f'Exceeded maximum number of redirects ({max_redirects})')
 
 
 def _load_data_url(url_spec: ParseResult, media_io: MediaIO[_M]) -> _M:

--- a/tests/test_lmdeploy/test_vl/test_safe_url.py
+++ b/tests/test_lmdeploy/test_vl/test_safe_url.py
@@ -40,8 +40,26 @@ def test_load_http_url_logic(mock_safe, mock_get):
     media_io = MagicMock()
     url_spec = urlparse('https://example.com/img.jpg')
 
-    # test success with allow_redirects=True
-    mock_get.return_value = MagicMock(content=b'data', status_code=200)
+    # A non-redirect response is returned directly. Redirects are now followed
+    # manually (allow_redirects=False) so every hop can be re-validated.
+    mock_get.return_value = MagicMock(is_redirect=False, content=b'data', status_code=200)
     media_io.load_bytes.return_value = 'loaded'
     assert _load_http_url(url_spec, media_io) == 'loaded'
-    assert mock_get.call_args.kwargs['allow_redirects'] is True
+    assert mock_get.call_args.kwargs['allow_redirects'] is False
+
+
+@patch('requests.Session.get')
+def test_load_http_url_revalidates_redirect_target(mock_get):
+    media_io = MagicMock()
+    url_spec = urlparse('https://example.com/img.jpg')
+
+    # The server 302s to a cloud-metadata address. The original host passes the
+    # guard but the redirect target must be re-validated and rejected (SSRF).
+    redirect = MagicMock(is_redirect=True)
+    redirect.headers = {'location': 'http://169.254.169.254/latest/meta-data'}
+    mock_get.return_value = redirect
+
+    with patch('lmdeploy.vl.media.connection._is_safe_url',
+               side_effect=[(True, ''), (False, 'blocked')]):
+        with pytest.raises(ValueError, match='blocked for security reasons'):
+            _load_http_url(url_spec, media_io)


### PR DESCRIPTION
### Summary

Fixes #4761 — an unauthenticated SSRF in the multimodal `image_url` fetch path. The private-IP guard `_is_safe_url` was applied only to the **original** URL, after which the response was fetched with `allow_redirects=True`. `requests` follows a `302` `Location` without re-running the guard, so an attacker-controlled public host (which passes the guard) can redirect to `http://127.0.0.1:.../` or `http://169.254.169.254/...` and have the internal/metadata bytes returned through the image pipeline. On the default `0.0.0.0` + no-auth server, any client of a vision deployment can reach this.

### Fix

`_load_http_url` now follows redirects **manually** with `allow_redirects=False`, and re-runs `_is_safe_url` on each resolved `Location` before following it. The redirect budget (`max_redirects = 3`) is preserved. Non-http(s) schemes are already rejected by `_is_safe_url`, so a redirect can no longer switch to a disallowed scheme either.

### Verification

Local unit-level reproduction against the changed function (no GPU / model download):

- Direct internal URL → blocked (unchanged).
- Public host that `302`-redirects to an internal target → now **blocked** at the redirect hop with `URL is blocked for security reasons: ...` (previously the internal bytes were returned).
- Normal same-origin / public redirects still succeed within the 3-hop budget.

This keeps the change tight to the reported redirect-bypass. Connection-level IP pinning (DNS-rebinding hardening) and default-auth are separate concerns noted in the issue and are intentionally left out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
