### PR TITLE
fix(security): reject pickled update_weights payloads by default

### DIFF
--- a/lmdeploy/pytorch/engine/model_agent/agent.py
+++ b/lmdeploy/pytorch/engine/model_agent/agent.py
@@ -10,6 +10,7 @@ from typing import Any
 
 import numpy as np
 import pybase64
+import os
 import torch
 import torch.distributed as dist
 from torch.profiler import record_function
@@ -1222,6 +1223,11 @@ class BaseModelAgent:
             return ipc_tensor.clone() if require_clone else ipc_tensor
 
         def _deserialize_weights(serialized_data):
+            if os.environ.get('LMDEPLOY_ALLOW_PICKLE_UPDATE_PARAMS', '0') != '1':
+                raise ValueError(
+                    'Pickled serialized_named_tensors is disabled by default. '
+                    'Pass structured tensors, or set LMDEPLOY_ALLOW_PICKLE_UPDATE_PARAMS=1 '
+                    'only for trusted local IPC.')
             weights = ForkingPickler.loads(pybase64.b64decode(serialized_data))
             if request.load_format == 'flattened_bucket':
                 metadata: list[FlattenedTensorMetadata] = weights['metadata']

--- a/lmdeploy/serve/openai/api_server.py
+++ b/lmdeploy/serve/openai/api_server.py
@@ -1216,6 +1216,16 @@ async def get_ppl(request: PPLRequest, raw_request: Request = None):
 @router.post('/update_weights', dependencies=[Depends(validate_json_request)])
 def update_params(request: UpdateParamsRequest, raw_request: Request = None):
     """Update weights for the model."""
+    # Reject request-controlled pickle payloads over HTTP. Unauthenticated
+    # pickle.loads (ForkingPickler.loads) is RCE. Only structured dict/list
+    # tensors are accepted on this public endpoint.
+    payload = request.serialized_named_tensors
+    if isinstance(payload, str) or (
+            isinstance(payload, list) and payload and isinstance(payload[0], str)):
+        return create_error_response(
+            HTTPStatus.BAD_REQUEST,
+            'serialized_named_tensors must be a structured dict/list of tensors; '
+            'pickled string payloads are not accepted over HTTP for security reasons.')
     VariableInterface.async_engine.engine.update_params(request)
     return JSONResponse(content=None)
 

--- a/lmdeploy/turbomind/turbomind.py
+++ b/lmdeploy/turbomind/turbomind.py
@@ -332,6 +332,13 @@ class TurboMind:
 
         with torch.cuda.device(self.devices[0]):
             if isinstance(request.serialized_named_tensors, str):
+                # Pickle payloads are only for trusted in-process IPC. HTTP must
+                # not reach here with a string (api_server rejects them).
+                if os.environ.get('LMDEPLOY_ALLOW_PICKLE_UPDATE_PARAMS', '0') != '1':
+                    raise ValueError(
+                        'Pickled serialized_named_tensors is disabled by default. '
+                        'Pass structured tensors, or set LMDEPLOY_ALLOW_PICKLE_UPDATE_PARAMS=1 '
+                        'only for trusted local IPC.')
                 weights = ForkingPickler.loads(pybase64.b64decode(request.serialized_named_tensors))
                 weights = {k: _construct(v) for k, v in weights}
             else:


### PR DESCRIPTION
## Summary
`POST /update_weights` accepted `serialized_named_tensors` as a base64 pickle string and deserialized it with `ForkingPickler.loads` (native pickle) before any tensor validation. With the default unauthenticated `api_server` bound to `0.0.0.0`, this is unauthenticated RCE.

### Changes
1. **HTTP gate** (`api_server.py`): reject `str` / `list[str]` pickle payloads with HTTP 400; only structured dict/list tensors are accepted over the public endpoint.
2. **Engine gates** (TurboMind + PyTorch agent): pickle loads require `LMDEPLOY_ALLOW_PICKLE_UPDATE_PARAMS=1` so trusted local IPC can still opt in; default is deny.

## Testing
- Static review of call sites
- Full suite not run here (GPU/engine env); CI should cover

Fixes #4698
