### PR TITLE
feat(turbomind): Derive composable TurboMind parallel configurations

### DIFF
--- a/lmdeploy/turbomind/parallel_config.py
+++ b/lmdeploy/turbomind/parallel_config.py
@@ -1,0 +1,124 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+"""Derivation of TurboMind's per-module parallel configuration.
+
+Pure stdlib module (no torch / no compiled extension).  Constraint system:
+
+    dev == outer_dp * attn_dp * attn_tp * cp == outer_dp * ep * mlp_tp
+    dp  == outer_dp * attn_dp
+    attn_tp == tp || mlp_tp == tp
+    tp % attn_tp == 0 && tp % mlp_tp == 0
+
+When ``device_num`` is unset, ``dev`` is scanned over the divisors of the
+``derive_device_num`` upper bound in descending order (capped by the
+available GPU count) and the largest device count admitting a valid layout
+wins.  Within a given ``dev``, ``outer_dp``
+is scanned over the divisors of ``dp`` in ascending order and the first
+valid config wins (smallest ``outer_dp``, i.e. largest valid ``mlp_tp``).
+``tp % mlp_tp == 0`` forces ``mlp_tp = 1`` when ``tp == 1``, which
+reproduces the legacy replicated-island configs for pure-DP setups without
+special-casing.  Configs that cannot satisfy the system are rejected;
+notably the legacy spelling ``tp=1, ep=8`` (dp=1) must now be written
+``tp=8, ep=8``.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from math import gcd
+
+
+@dataclass
+class ParallelConfig:
+    device_num: int
+    outer_dp_size: int
+    attn_dp_size: int
+    attn_tp_size: int
+    attn_cp_size: int
+    mlp_dp_size: int
+    mlp_tp_size: int
+    mlp_ep_size: int
+
+
+def derive_device_num(dp: int, tp: int, ep: int, cp: int) -> int:
+    """Upper bound on the device count for the requested parallelism.
+
+    Any valid layout satisfies ``dev == dp * attn_tp * cp`` with
+    ``attn_tp | tp`` and ``dev == outer_dp * ep * mlp_tp`` with
+    ``outer_dp | dp`` and ``mlp_tp | tp``, so ``dev`` divides both
+    ``dp*tp*cp`` and ``dp*tp*ep`` — hence their gcd.
+    ``derive_parallel_config`` scans its divisors for the largest
+    attainable device count.
+    """
+    return dp * tp * gcd(cp, ep)
+
+
+def _try_layout(dp: int, tp: int, ep: int, cp: int, dev: int) -> ParallelConfig | None:
+    """Solve the constraint system for a fixed device count; None if
+    unsatisfiable."""
+    if dev % (dp * cp) != 0:
+        return None
+    attn_tp = dev // (dp * cp)
+    if tp % attn_tp != 0:
+        return None
+    for outer_dp in (x for x in range(1, dp + 1) if dp % x == 0):
+        if dev % (outer_dp * ep) != 0:
+            continue
+        mlp_tp = dev // (outer_dp * ep)
+        if tp % mlp_tp != 0:
+            continue
+        if attn_tp != tp and mlp_tp != tp:
+            continue
+        return ParallelConfig(device_num=dev,
+                              outer_dp_size=outer_dp,
+                              attn_dp_size=dp // outer_dp,
+                              attn_tp_size=attn_tp,
+                              attn_cp_size=cp,
+                              mlp_dp_size=1,
+                              mlp_tp_size=mlp_tp,
+                              mlp_ep_size=ep)
+    return None
+
+
+def _device_num_candidates(total: int, device_num: int | None, available_devices: int | None) -> list[int]:
+    """Device counts to try, in order of preference.
+
+    An explicit ``device_num`` is the only candidate (it must divide the
+    ``total`` upper bound); otherwise every divisor of ``total`` within
+    ``available_devices``, largest first.
+    """
+    if device_num is not None:
+        assert isinstance(device_num, int) and device_num >= 1, \
+            f'device_num must be a positive integer, got {device_num!r}'
+        assert total % device_num == 0, (f'config requires {total} devices; '
+                                         f'device_num={device_num} is not a divisor')
+        return [device_num]
+    cap = min(total, available_devices) if available_devices is not None else total
+    return [dev for dev in range(cap, 0, -1) if total % dev == 0]
+
+
+def derive_parallel_config(dp: int,
+                           tp: int,
+                           ep: int,
+                           cp: int,
+                           device_num: int | None,
+                           available_devices: int | None = None) -> ParallelConfig:
+    """Derive per-module parallel sizes from user-facing dp/tp/ep/cp.
+
+    ``device_num`` is the explicit device count; pass None to derive it as
+    the largest divisor of ``derive_device_num(...)`` within
+    ``available_devices`` that admits a valid layout.  Asserts on invalid
+    configs.
+    """
+    for name, value in (('dp', dp), ('tp', tp), ('ep', ep), ('cp', cp)):
+        assert isinstance(value, int) and value >= 1, f'{name} must be a positive integer, got {value!r}'
+    assert available_devices is None or (isinstance(available_devices, int) and available_devices >= 1), \
+        f'available_devices must be a positive integer or None, got {available_devices!r}'
+
+    total = derive_device_num(dp, tp, ep, cp)
+    for dev in _device_num_candidates(total, device_num, available_devices):
+        config = _try_layout(dp, tp, ep, cp, dev)
+        if config is not None:
+            return config
+
+    raise AssertionError(f'no valid parallel config: dp={dp}, tp={tp}, ep={ep}, cp={cp}, '
+                         f'device_num={device_num}, available_devices={available_devices}; '
+                         f'note the legacy "tp=1, ep=N" spelling must be "tp=N, ep=N"')

--- a/lmdeploy/turbomind/turbomind.py
+++ b/lmdeploy/turbomind/turbomind.py
@@ -22,6 +22,7 @@ from lmdeploy.serve.openai.protocol import UpdateParamsRequest
 from lmdeploy.tokenizer import Tokenizer
 from lmdeploy.utils import get_logger, get_max_batch_size, get_model
 
+from .parallel_config import derive_parallel_config
 from .supported_models import is_supported
 
 # TODO: find another way import _turbomind
@@ -66,9 +67,11 @@ def _tm_dict_to_torch_dict(tm_dict: _tm.TensorMap):
 
 
 def complete_parallel_config(cfg: TurbomindEngineConfig):
-    if any((cfg.attn_dp_size, cfg.attn_tp_size, cfg.mlp_dp_size, cfg.mlp_tp_size, cfg.outer_dp_size)):
+    if any((cfg.attn_dp_size, cfg.attn_tp_size, cfg.attn_cp_size, cfg.mlp_dp_size, cfg.mlp_tp_size,
+            cfg.outer_dp_size)):
         cfg.attn_dp_size = cfg.attn_dp_size or 1
         cfg.attn_tp_size = cfg.attn_tp_size or 1
+        cfg.attn_cp_size = cfg.attn_cp_size or 1
         cfg.mlp_dp_size = cfg.mlp_dp_size or 1
         cfg.mlp_tp_size = cfg.mlp_tp_size or 1
         cfg.outer_dp_size = cfg.outer_dp_size or 1
@@ -82,28 +85,18 @@ def complete_parallel_config(cfg: TurbomindEngineConfig):
 
 def update_parallel_config(cfg: TurbomindEngineConfig):
     cfg.device_num = len(cfg.devices) * cfg.nnodes if cfg.devices else cfg.device_num
-    assert cfg.ep == 1 or cfg.tp == 1
     if not complete_parallel_config(cfg):
-        total = cfg.dp * cfg.ep * cfg.tp
-        if not cfg.device_num:
-            count = torch.cuda.device_count() * cfg.nnodes
-            if total < count:
-                count = total
-            cfg.device_num = count
-        assert total % cfg.device_num == 0
-        size = max(cfg.ep, cfg.tp)
-        overlap = total // cfg.device_num
-        inner_tp_size = size // overlap
-        cfg.outer_dp_size = cfg.dp // overlap
-        cfg.attn_dp_size = overlap
-        cfg.attn_tp_size = inner_tp_size // cfg.cp
-        cfg.attn_cp_size = cfg.cp
-        comm_size = cfg.attn_dp_size * cfg.attn_tp_size * cfg.attn_cp_size
-        cfg.mlp_dp_size = 1
-        cfg.mlp_tp_size = comm_size // cfg.ep if cfg.ep > 1 else overlap * inner_tp_size
+        available = torch.cuda.device_count() * cfg.nnodes
+        parallel = derive_parallel_config(cfg.dp, cfg.tp, cfg.ep, cfg.cp, cfg.device_num, available)
+        cfg.device_num = parallel.device_num
+        cfg.outer_dp_size = parallel.outer_dp_size
+        cfg.attn_dp_size = parallel.attn_dp_size
+        cfg.attn_tp_size = parallel.attn_tp_size
+        cfg.attn_cp_size = parallel.attn_cp_size
+        cfg.mlp_dp_size = parallel.mlp_dp_size
+        cfg.mlp_tp_size = parallel.mlp_tp_size
     if cfg.ep > 1:
         assert cfg.nnodes == 1, 'ep > 1 is only supported in single-node mode'
-        assert cfg.mlp_tp_size == 1, 'Only support mlp_tp_size == 1 when ep > 1'
     assert cfg.attn_dp_size * cfg.attn_tp_size * cfg.attn_cp_size * cfg.outer_dp_size == cfg.device_num
     # update devices
     cfg.devices = cfg.devices or list(range(cfg.device_num // cfg.nnodes))

--- a/scripts/test_turbomind_model.py
+++ b/scripts/test_turbomind_model.py
@@ -10,6 +10,8 @@ Stdout is plain text in short sections, for example:
   model: <path>
   tp: <tp>
   cp: <cp>
+  ep: <ep>
+  dp: <dp>
   gpus: <gpus>
   max_new_tokens: 256
   async: 1
@@ -47,9 +49,11 @@ Usage (from repo root):
   python scripts/test_turbomind_model.py \\
       --model-id ID \\
       --cache-dir PATH \\
-      --tp N \\
-      --cp N \\
       --gpus DEVICES \\
+      [--tp N] \\
+      [--cp N] \\
+      [--ep N] \\
+      [--dp N] \\
       [--prompt TEXT ...] \\
       [--prompt-file PATH] \\
       [--prompt-ids N [N ...]] \\
@@ -92,9 +96,10 @@ Example with prefix caching and repeated prompts:
       --prompt "A" --prompt "B" \\
       --prompt-ids 0 0 1
 
-Optional engine params (defaults shown): --max-new-tokens 256, --async 1,
---session-len 16384, --max-batch-size 8. Prefix caching: pass
---enable-prefix-caching (default off).
+Optional parallelism params default to 1: --tp, --cp, --ep, --dp. Other optional
+engine params (defaults shown): --max-new-tokens 256, --async 1, --session-len
+16384, --max-batch-size 8. Prefix caching: pass --enable-prefix-caching
+(default off).
 
 Optional --debug sets CUDA_LAUNCH_BLOCKING=1 before loading TurboMind so CUDA
 kernels run synchronously and errors surface at the launch site.
@@ -189,6 +194,10 @@ def _positive_int(value: str) -> int:
 
 def _validate_engine_params(
     *,
+    tp: int,
+    cp: int,
+    ep: int,
+    dp: int,
     max_new_tokens: int,
     async_: int,
     session_len: int,
@@ -196,6 +205,9 @@ def _validate_engine_params(
     max_prefill_token_num: int,
     cache_checkpoint_interval: int,
 ) -> None:
+    for name, value in (('tp', tp), ('cp', cp), ('ep', ep), ('dp', dp)):
+        if value < 1:
+            raise ValueError(f'{name} must be >= 1, got {value}')
     if max_new_tokens < 1:
         raise ValueError(f'max_new_tokens must be >= 1, got {max_new_tokens}')
     if async_ not in (0, 1):
@@ -286,6 +298,10 @@ def build_arg_parser() -> argparse.ArgumentParser:
 stdout sections: --- setup ---, --- timing ---, --- tokens ---, --- response N begin/end ---
 Optional prompts: --prompt, --prompt-file, --prompt-ids
 Optional engine params:
+    --tp
+    --cp
+    --ep
+    --dp
     --max-new-tokens
     --async
     --session-len
@@ -300,8 +316,20 @@ Exit 0: load + inference complete. Exit 1: exception (traceback on stderr). Exit
     )
     parser.add_argument('--model-id', required=True, help='HuggingFace model id or local path')
     parser.add_argument('--cache-dir', required=True, help='HF hub cache directory (HF_HUB_CACHE)')
-    parser.add_argument('--tp', required=True, type=int, help='Tensor parallel size')
-    parser.add_argument('--cp', required=True, type=int, help='Context parallel size')
+    parser.add_argument(
+        '--tp', type=_positive_int, default=1, help='Tensor parallel size (default: 1)')
+    parser.add_argument(
+        '--cp', type=_positive_int, default=1, help='Context parallel size (default: 1)')
+    parser.add_argument(
+        '--ep', type=_positive_int, default=1, help='Expert parallel size (default: 1)')
+    parser.add_argument(
+        '--dp', type=_positive_int, default=1, help='Data parallel size (default: 1)')
+    parser.add_argument(
+        '--communicator',
+        default='nccl',
+        choices=['nccl', 'cuda-ipc'],
+        help='Device communicator backend (default: nccl)',
+    )
     parser.add_argument('--gpus', required=True, help='CUDA_VISIBLE_DEVICES value, e.g. "0" or "0,1"')
     parser.add_argument(
         '--max-new-tokens',
@@ -405,11 +433,14 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
 def run_smoke_infer(
     model_id: str,
     cache_dir: str,
-    tp: int,
     gpus: str,
     resolved: ResolvedPrompts,
     *,
-    cp: int,
+    tp: int = 1,
+    cp: int = 1,
+    ep: int = 1,
+    dp: int = 1,
+    communicator: str = 'nccl',
     max_new_tokens: int = DEFAULT_MAX_NEW_TOKENS,
     async_: int = DEFAULT_ASYNC,
     session_len: int = DEFAULT_SESSION_LEN,
@@ -423,6 +454,10 @@ def run_smoke_infer(
     debug: bool = False,
 ) -> SmokeResult:
     _validate_engine_params(
+        tp=tp,
+        cp=cp,
+        ep=ep,
+        dp=dp,
         max_new_tokens=max_new_tokens,
         async_=async_,
         session_len=session_len,
@@ -445,9 +480,10 @@ def run_smoke_infer(
         max_prefill_token_num=max_prefill_token_num,
         tp=tp,
         cp=cp,
-        dp=1,
+        dp=dp,
+        ep=ep,
         enable_metrics=False,
-        communicator='nccl',
+        communicator=communicator,
         enable_prefix_caching=enable_prefix_caching,
         cache_checkpoint_interval=cache_checkpoint_interval,
         cache_prompt=cache_prompt,
@@ -487,12 +523,15 @@ def run_smoke_infer(
 
 def print_report(
     model_id: str,
-    tp: int,
     gpus: str,
     resolved: ResolvedPrompts,
     result: SmokeResult,
     *,
-    cp: int,
+    tp: int = 1,
+    cp: int = 1,
+    ep: int = 1,
+    dp: int = 1,
+    communicator: str = 'nccl',
     max_new_tokens: int = DEFAULT_MAX_NEW_TOKENS,
     async_: int = DEFAULT_ASYNC,
     session_len: int = DEFAULT_SESSION_LEN,
@@ -509,7 +548,10 @@ def print_report(
     print(f'model: {model_id}')
     print(f'tp: {tp}')
     print(f'cp: {cp}')
+    print(f'ep: {ep}')
+    print(f'dp: {dp}')
     print(f'gpus: {gpus}')
+    print(f'communicator: {communicator}')
     print(f'max_new_tokens: {max_new_tokens}')
     print(f'async: {async_}')
     print(f'session_len: {session_len}')
@@ -550,9 +592,12 @@ def run_smoke_test(
     *,
     model_id: str,
     cache_dir: str,
-    tp: int,
-    cp: int,
     gpus: str,
+    tp: int = 1,
+    cp: int = 1,
+    ep: int = 1,
+    dp: int = 1,
+    communicator: str = 'nccl',
     prompts: list[str] | None = None,
     prompt_file: str | None = None,
     prompt_ids: list[int] | None = None,
@@ -577,10 +622,13 @@ def run_smoke_test(
     result = run_smoke_infer(
         model_id,
         cache_dir,
-        tp,
         gpus,
         resolved,
+        tp=tp,
         cp=cp,
+        ep=ep,
+        dp=dp,
+        communicator=communicator,
         max_new_tokens=max_new_tokens,
         async_=async_,
         session_len=session_len,
@@ -596,11 +644,14 @@ def run_smoke_test(
     if emit_report:
         print_report(
             model_id,
-            tp,
             gpus,
             resolved,
             result,
+            tp=tp,
             cp=cp,
+            ep=ep,
+            dp=dp,
+            communicator=communicator,
             max_new_tokens=max_new_tokens,
             async_=async_,
             session_len=session_len,
@@ -627,6 +678,9 @@ def main() -> None:
         prompts=args.prompt,
         prompt_file=args.prompt_file,
         prompt_ids=args.prompt_ids,
+        ep=args.ep,
+        dp=args.dp,
+        communicator=args.communicator,
         max_new_tokens=args.max_new_tokens,
         async_=args.async_,
         session_len=args.session_len,


### PR DESCRIPTION
## Summary

This PR replaces TurboMind's ad hoc parallelism calculations with a constraint-based derivation system for TP, CP, EP, and DP.

The new system supports configurations where expert parallelism and MLP tensor parallelism are both greater than 1. For example:

```text
tp=4, ep=2 -> attn_tp=4, mlp_tp=2, ep=2
```

## Parallel layout derivation

The new `parallel_config.py` derives per-module parallel sizes using these invariants:

```text
device_num = outer_dp * attn_dp * attn_tp * cp
device_num = outer_dp * ep * mlp_tp
dp = outer_dp * attn_dp

attn_tp == tp or mlp_tp == tp
tp % attn_tp == 0
tp % mlp_tp == 0
```

The solver:

- Computes `dp * tp * gcd(cp, ep)` as the device-count upper bound.
- Validates an explicit `device_num`, or scans valid divisors within the available GPU count.
- Chooses the largest valid device count.
- Scans divisors of `dp` to derive `outer_dp`, attention DP/TP, and MLP TP.
- Rejects configurations that cannot satisfy the layout constraints.

This keeps the derivation independent of CUDA and compiled extensions, making it easier to test and reason about.

## Integration changes

- Route TurboMind configuration through the new derivation system.
- Preserve explicit per-module parallel configurations.
- Include `attn_cp_size` when completing partial explicit configurations.
- Keep EP restricted to single-node execution.
- Allow `mlp_tp_size > 1` together with `ep > 1`.
- Update the TurboMind smoke-test script to pass and report TP, CP, EP, and DP consistently.

## Compatibility

Legacy configurations such as `tp=1, ep=N` no longer describe a valid layout. They must specify the global tensor-parallel width explicitly, for example:

```text
tp=N, ep=N
```

This ensures the requested global parallelism is consistent with every derived attention and MLP parallel group.