### PR TITLE
fix(turbomind): avoid async TP shutdown deadlock

### DIFF
--- a/src/turbomind/engine/engine.cc
+++ b/src/turbomind/engine/engine.cc
@@ -114,6 +114,13 @@ struct Engine::Impl {
         executor_.Start();
     }
 
+    void Join()
+    {
+        if (internal_thread_.joinable()) {
+            internal_thread_.join();
+        }
+    }
+
     void UpdateScheduleMetrics();
 
     void MaybeLogCacheStats();
@@ -188,9 +195,10 @@ Engine::Impl::~Impl()
     }
     inbound_.close();
     outbound_.close();
-    if (internal_thread_.joinable()) {
-        internal_thread_.join();
-    }
+    // Normally TurboMind joins every engine loop before destroying any engine,
+    // so this is a no-op. Keep the fallback for partial construction or
+    // exception unwinding: destroying a joinable std::thread calls terminate.
+    Join();
     executor_ = {};
 
     for (auto& state : states_) {
@@ -882,6 +890,13 @@ Engine::Engine(EngineParam                  param,
 void Engine::Start()
 {
     return impl_->Start();
+}
+
+void Engine::Join()
+{
+    if (impl_) {
+        impl_->Join();
+    }
 }
 
 void Engine::Impl::MaybeLogCacheStats()

--- a/src/turbomind/engine/engine.h
+++ b/src/turbomind/engine/engine.h
@@ -41,6 +41,10 @@ public:
 
     void Start();
 
+    // Wait for the engine loop to observe gateway shutdown. This intentionally
+    // leaves the executor queues open until every TP peer has exited its loop.
+    void Join();
+
     std::shared_ptr<ScheduleMetrics> GetScheduleMetrics();
 
 private:

--- a/src/turbomind/turbomind.cc
+++ b/src/turbomind/turbomind.cc
@@ -136,6 +136,14 @@ TurboMind::Impl::~Impl()
     if (gateway_) {
         gateway_->shutdown();
     }
+    // Keep every engine and executor queue alive until the gateway abort has
+    // propagated through each TP group. Closing one rank's queues before this
+    // handshake completes can strand its peers in the host communicator.
+    for (auto& engine : engines_) {
+        if (engine) {
+            engine.Join();
+        }
+    }
     for (int i = 0; i < (int)engines_.size(); ++i) {
         /// TODO: make device part of core::Context
         CudaDeviceGuard device(engine_param_.devices[i]);


### PR DESCRIPTION
## Motivation

Async tensor-parallel shutdown can deadlock when engines are destroyed sequentially. Closing one rank's executor queues before all engine loops observe the gateway shutdown may leave peer ranks blocked in host communication.

## Modification

- Add an explicit `Engine::Join()` method.
- Shut down the gateway and join all engine threads before destroying any engine.
- Keep the destructor join as a fallback for partial construction and exception unwinding.
- Preserve executor queues until the shutdown handshake completes across all TP ranks.

## BC-breaking

No.
