### PR TITLE
[Fix] completions_v1: abort session and return 400 on client disconnect

### DIFF
--- a/lmdeploy/serve/openai/api_server.py
+++ b/lmdeploy/serve/openai/api_server.py
@@ -932,7 +932,7 @@ async def completions_v1(request: CompletionRequest, raw_request: Request = None
             async for res in cleanup_generator:
                 if await raw_request.is_disconnected():
                     # Abort the request if the client disconnects.
-                    await VariableInterface.async_engine.stop_session(request.session_id)
+                    await session.async_abort()
                     return create_error_response(HTTPStatus.BAD_REQUEST, 'Client disconnected')
                 final_res = res
                 text += res.response
@@ -960,7 +960,10 @@ async def completions_v1(request: CompletionRequest, raw_request: Request = None
         usage.completion_tokens += final_res.generate_token_len
         usage.total_tokens += total_tokens
 
-    await asyncio.gather(*[_inner_call(i, generators[i], sessions[i]) for i in range(len(generators))])
+    inner_results = await asyncio.gather(*[_inner_call(i, generators[i], sessions[i]) for i in range(len(generators))])
+    for inner_result in inner_results:
+        if inner_result is not None:
+            return inner_result
 
     response = CompletionResponse(
         id=request_id,

--- a/tests/test_lmdeploy/serve/test_session_cleanup.py
+++ b/tests/test_lmdeploy/serve/test_session_cleanup.py
@@ -257,3 +257,103 @@ async def _run_max_new_tokens_zero_cleans_up_session():
 
 def test_max_new_tokens_zero_cleans_up_session():
     asyncio.run(_run_max_new_tokens_zero_cleans_up_session())
+
+
+async def _run_completions_v1_disconnect_aborts_active_handle():
+    from types import SimpleNamespace
+
+    from lmdeploy.serve.core.async_engine import GenOut
+    from lmdeploy.serve.openai.api_server import VariableInterface, completions_v1
+    from lmdeploy.serve.openai.protocol import CompletionRequest
+
+    class _SpyHandle(_FakeHandle):
+
+        def __init__(self):
+            self.cancelled_session_ids = []
+
+        async def async_cancel(self, session_id: int):
+            self.cancelled_session_ids.append(session_id)
+
+    class _FakeAsyncEngine:
+        model_name = 'test-model'
+        epoch = 0
+
+        def __init__(self):
+            self.backend_config = SimpleNamespace()
+            self.session_mgr = SessionManager()
+            self.handle = _SpyHandle()
+
+        async def generate(self, prompt, session, **kwargs):
+            # Mirror the real AsyncEngine: a handle is held for the duration of generation.
+            session._handle = self.handle
+            yield GenOut(response='hi', input_token_len=1, generate_token_len=1, finish_reason=None)
+            await asyncio.Event().wait()
+
+    class _FakeRawRequest:
+
+        async def json(self):
+            return {}
+
+        async def is_disconnected(self):
+            return True
+
+    engine = _FakeAsyncEngine()
+    origin_async_engine = VariableInterface.async_engine
+    VariableInterface.async_engine = engine
+    try:
+        request = CompletionRequest(model='test-model', prompt='hello', stream=False)
+        await completions_v1(request, _FakeRawRequest())
+    finally:
+        VariableInterface.async_engine = origin_async_engine
+
+    assert engine.handle.cancelled_session_ids == [0]
+
+
+def test_completions_v1_disconnect_aborts_active_handle():
+    asyncio.run(_run_completions_v1_disconnect_aborts_active_handle())
+
+
+async def _run_completions_v1_disconnect_returns_client_disconnected_response():
+    from types import SimpleNamespace
+
+    from fastapi.responses import JSONResponse
+
+    from lmdeploy.serve.core.async_engine import GenOut
+    from lmdeploy.serve.openai.api_server import VariableInterface, completions_v1
+    from lmdeploy.serve.openai.protocol import CompletionRequest
+
+    class _FakeAsyncEngine:
+        model_name = 'test-model'
+        epoch = 0
+
+        def __init__(self):
+            self.backend_config = SimpleNamespace()
+            self.session_mgr = SessionManager()
+
+        async def generate(self, prompt, session, **kwargs):
+            yield GenOut(response='hi', input_token_len=1, generate_token_len=1, finish_reason=None)
+            await asyncio.Event().wait()
+
+    class _FakeRawRequest:
+
+        async def json(self):
+            return {}
+
+        async def is_disconnected(self):
+            return True
+
+    origin_async_engine = VariableInterface.async_engine
+    VariableInterface.async_engine = _FakeAsyncEngine()
+    try:
+        request = CompletionRequest(model='test-model', prompt='hello', stream=False)
+        result = await completions_v1(request, _FakeRawRequest())
+    finally:
+        VariableInterface.async_engine = origin_async_engine
+
+    assert isinstance(result, JSONResponse)
+    assert result.status_code == 400
+    assert b'Client disconnected' in result.body
+
+
+def test_completions_v1_disconnect_returns_client_disconnected_response():
+    asyncio.run(_run_completions_v1_disconnect_returns_client_disconnected_response())


### PR DESCRIPTION
Fixes #4776

### Root cause

`completions_v1`'s non-streaming path (`_inner_call`, the disconnect branch) calls `VariableInterface.async_engine.stop_session(request.session_id)`. `AsyncEngine` has never had a `stop_session` method (checked by enumerating every method on the class), so this raises `AttributeError` on every client disconnect instead of aborting the session. The three sibling disconnect handlers in this file (`chat_completions_v1`, `/generate`'s non-streaming branch, `/end_session`) all correctly call `session.async_abort()`. `git log -G` shows this call site was added by #4655 (client-disconnect session-leak fix for the PyTorch MP engine), reusing a pre-refactor pattern from before #4253 introduced `Session`/`SessionManager`; not a revert of a prior attempt.

Fixing only that call is not sufficient: `_inner_call`'s `return create_error_response(...)` is the return value of a coroutine handed to `asyncio.gather(...)`, and `asyncio.gather`'s result is discarded. A disconnected generator's `choices[i]` slot is left `None`, and building `CompletionResponse` from a `choices` list containing `None` raises a pydantic `ValidationError`, so the client still never gets the intended `400`, just a different crash.

### Fix

- Route the disconnect abort through `session.async_abort()`, matching the sibling handlers.
- Collect `asyncio.gather`'s per-generator results and return the first non-`None` one (each `_inner_call` already returns the error response on disconnect and implicitly returns `None` otherwise), so the `400` actually reaches the caller.

### Verification

Docker (`python:3.11-slim`, CPU `torch`/`transformers`/`xgrammar`/etc., no GPU needed), current HEAD `2aae7d77`. Imported the real, unmodified `completions_v1`, `VariableInterface`, `CompletionRequest`, `SessionManager`, `GenOut` and drove the endpoint directly with a fake `AsyncEngine.generate()` yielding one item and `raw_request.is_disconnected()` returning `True`:
- On unpatched main: `AttributeError: 'FakeAsyncEngine' object has no attribute 'stop_session'`, raised from the exact line in the issue.
- On this branch: returns a clean `JSONResponse(400, {"message": "Client disconnected", ...})`, and the active request handle's `async_cancel` is actually invoked.
- The success (no-disconnect) path still returns the expected `choices`/`usage` payload, unaffected by the `gather`-result change.

Added two regression tests to `tests/test_lmdeploy/serve/test_session_cleanup.py`, mirroring that file's existing fake-engine style:
- `test_completions_v1_disconnect_aborts_active_handle`: asserts the session's active handle is cancelled on disconnect (pins the `stop_session` -> `async_abort` fix).
- `test_completions_v1_disconnect_returns_client_disconnected_response`: asserts the endpoint returns the `400` `JSONResponse`, not a crash (pins the `gather`-result-propagation fix).

Both fail on unpatched main (`AttributeError`) and pass on this branch. Ran the full `tests/test_lmdeploy/serve/test_session_cleanup.py` module: 11 passed, 0 failed, no regressions in the 9 pre-existing tests.

Not verified: no live end-to-end HTTP request through a running `uvicorn` server or a real inference backend; the fake `AsyncEngine`/`raw_request` drive the actual production `completions_v1` function directly, not through FastAPI's request-handling layer.

`ruff check` clean on both changed files; `pylint` shows no new messages in the changed line ranges. No CHANGELOG entry found in this repo's convention for a fix of this size.
