### PR TITLE
Add GDR CP controls and legacy kernel override

### DIFF
--- a/src/turbomind/kernels/linear_attn/delta_rule.cu
+++ b/src/turbomind/kernels/linear_attn/delta_rule.cu
@@ -2,12 +2,66 @@
 
 #include "src/turbomind/kernels/linear_attn/registry.h"
 
+#include <cstdlib>
+#include <cstring>
 #include <stdexcept>
 #include <string>
+#include <string_view>
 #include <utility>
 
 namespace turbomind::linear_attn::delta_rule {
 namespace {
+
+constexpr std::string_view kPreSm90Architecture{"pre_sm90"};
+constexpr std::string_view kSm90Architecture{"sm90"};
+constexpr std::string_view kSm120Architecture{"sm120"};
+
+bool ForceLegacyGdr()
+{
+    struct Result {
+        bool        value{};
+        std::string error;
+    };
+
+    static const Result result = [] {
+        const char* value = std::getenv("TM_GDR_FORCE_LEGACY");
+        if (value == nullptr || std::strcmp(value, "0") == 0) {
+            return Result{false, {}};
+        }
+        if (std::strcmp(value, "1") == 0) {
+            return Result{true, {}};
+        }
+        return Result{false, std::string{"TM_GDR_FORCE_LEGACY must be 0 or 1, got "} + value};
+    }();
+
+    if (!result.error.empty()) {
+        throw std::invalid_argument(result.error);
+    }
+    return result.value;
+}
+
+std::string_view SelectArchitecture(int arch, bool force_legacy)
+{
+    if (force_legacy || (arch > 0 && arch < 900)) {
+        return kPreSm90Architecture;
+    }
+    if (arch == 900) {
+        return kSm90Architecture;
+    }
+    if (arch == 1200) {
+        return kSm120Architecture;
+    }
+    return {};
+}
+
+Operation SelectOperation(const Operation& requested, bool force_legacy)
+{
+    Operation selected = requested;
+    if (force_legacy) {
+        selected.chunk_size = kAutoGdrChunkSize;
+    }
+    return selected;
+}
 
 const char* ModeName(GdrMode mode)
 {
@@ -20,15 +74,17 @@ const char* ModeName(GdrMode mode)
     return "invalid";
 }
 
-const GdrKernel& RequireGdrKernel(const Operation& operation, const PlanningContext& context)
+const GdrKernel&
+RequireGdrKernel(const Operation& operation, const PlanningContext& context, std::string_view architecture)
 {
-    const auto* kernel = GdrKernelRegistry::instance().Find(operation, context);
+    const auto* kernel = GdrKernelRegistry::instance().Find(operation, context, architecture);
     if (kernel == nullptr) {
-        throw std::invalid_argument(std::string{"GDR operation is not registered for requested configuration arch="}
-                                    + std::to_string(context.arch) + " mode=" + ModeName(operation.mode)
-                                    + " input_dtype=" + to_string(context.input_dtype) + " state_dtype="
-                                    + to_string(context.state_dtype) + " head_dim=" + std::to_string(context.head_dim)
-                                    + " chunk_size=" + std::to_string(operation.chunk_size));
+        const std::string kernel_architecture = architecture.empty() ? "unsupported" : std::string{architecture};
+        throw std::invalid_argument(
+            std::string{"GDR operation is not registered for requested configuration arch="}
+            + std::to_string(context.arch) + " kernel_arch=" + kernel_architecture + " mode=" + ModeName(operation.mode)
+            + " input_dtype=" + to_string(context.input_dtype) + " state_dtype=" + to_string(context.state_dtype)
+            + " head_dim=" + std::to_string(context.head_dim) + " chunk_size=" + std::to_string(operation.chunk_size));
     }
     return *kernel;
 }
@@ -43,9 +99,12 @@ const GdrKernel& RequireGdrKernel(const Plan& plan)
 
 }  // namespace
 
-bool GatedDeltaRule::Plan(const Operation& operation, const PlanningContext& context, delta_rule::Plan* plan) const
+bool GatedDeltaRule::Plan(const Operation& requested, const PlanningContext& context, delta_rule::Plan* plan) const
 {
-    const auto&      kernel = RequireGdrKernel(operation, context);
+    const bool       force_legacy = ForceLegacyGdr();
+    const Operation  operation    = SelectOperation(requested, force_legacy);
+    const auto       architecture = SelectArchitecture(context.arch, force_legacy);
+    const auto&      kernel       = RequireGdrKernel(operation, context, architecture);
     delta_rule::Plan candidate{};
     candidate.kernel = &kernel;
     if (!kernel.Plan(operation, context, &candidate)) {

--- a/src/turbomind/kernels/linear_attn/delta_rule.h
+++ b/src/turbomind/kernels/linear_attn/delta_rule.h
@@ -22,10 +22,11 @@ enum class GdrMode
 constexpr int kAutoGdrChunkSize      = 0;
 constexpr int kRecurrentGdrChunkSize = 1;
 
-enum class ContextParallelMode : int
+enum class ContextParallelLevel : int
 {
-    kAuto = 0,
-    kOff  = 1,
+    kOff   = 0,
+    kExact = 1,
+    kAll   = 2,
 };
 
 struct GdrKernelSpec {
@@ -38,9 +39,9 @@ struct GdrKernelSpec {
 };
 
 struct Operation {
-    GdrMode             mode{GdrMode::kChunked};
-    int                 chunk_size{kAutoGdrChunkSize};
-    ContextParallelMode cp_mode{ContextParallelMode::kAuto};
+    GdrMode              mode{GdrMode::kChunked};
+    int                  chunk_size{kAutoGdrChunkSize};
+    ContextParallelLevel cp_level{ContextParallelLevel::kAll};
 };
 
 struct PlanningContext {
@@ -109,12 +110,13 @@ struct TensorPlan {
 };
 
 struct ContextParallelPlan {
-    bool   enabled{};
-    int    segment_tokens{};
-    int    segment_chunks{};
-    int    total_segments{};
-    int    total_chunks{};
-    size_t workspace_bytes{};
+    ContextParallelLevel cp_level{ContextParallelLevel::kOff};
+    bool                 enabled{};
+    int                  segment_tokens{};
+    int                  segment_chunks{};
+    int                  total_segments{};
+    int                  total_chunks{};
+    size_t               workspace_bytes{};
 
     TensorPlan cp_q_offsets;
     TensorPlan cp_source_indices;

--- a/src/turbomind/kernels/linear_attn/kernel/CMakeLists.txt
+++ b/src/turbomind/kernels/linear_attn/kernel/CMakeLists.txt
@@ -19,15 +19,13 @@ set(LINEAR_ATTN_GDR_SM120_KERNEL_SOURCES
         sm_120/kkt_solve.cu
         sm_120/recurrent.cu)
 
-set(LINEAR_ATTN_GDR_PRE_SM90_ARCHS "")
+set(LINEAR_ATTN_GDR_PRE_SM90_ARCHS "${CMAKE_CUDA_ARCHITECTURES}")
 set(LINEAR_ATTN_GDR_SM90_ARCHS "")
 set(LINEAR_ATTN_GDR_SM100_PLUS_ARCHS "")
 foreach(arch IN LISTS CMAKE_CUDA_ARCHITECTURES)
     if(arch MATCHES "^([0-9]+)(a)?(-real)?$")
         set(arch_number "${CMAKE_MATCH_1}")
-        if(arch_number LESS 90)
-            list(APPEND LINEAR_ATTN_GDR_PRE_SM90_ARCHS "${arch}")
-        elseif(arch_number EQUAL 90)
+        if(arch_number EQUAL 90)
             list(APPEND LINEAR_ATTN_GDR_SM90_ARCHS "${arch}")
         elseif(arch_number GREATER_EQUAL 100 AND arch_number LESS 1000)
             list(APPEND LINEAR_ATTN_GDR_SM100_PLUS_ARCHS "${arch}")

--- a/src/turbomind/kernels/linear_attn/kernel/plan.cc
+++ b/src/turbomind/kernels/linear_attn/kernel/plan.cc
@@ -77,10 +77,11 @@ Problem BuildProblem(const PlanningContext& context, const GdrKernelSpec& spec)
     return problem;
 }
 
-ContextParallelPlan BuildDisabledContextParallelPlan(const Problem& problem)
+ContextParallelPlan BuildDisabledContextParallelPlan(const Problem& problem, ContextParallelLevel cp_level)
 {
     TensorPlan          zero{core::Layout{{0}}, kInt32};
     ContextParallelPlan cp{};
+    cp.cp_level           = cp_level;
     cp.total_segments     = problem.sequence_num;
     cp.segment_tokens     = problem.token_num;
     cp.segment_chunks     = IsRecurrentGdr(problem) ? CeilDiv(problem.token_num, problem.chunk_size) : 0;

--- a/src/turbomind/kernels/linear_attn/kernel/plan.h
+++ b/src/turbomind/kernels/linear_attn/kernel/plan.h
@@ -9,7 +9,7 @@ void   AddWorkspaceBytes(size_t* total, size_t bytes, size_t alignment = 16);
 
 bool                MatchesGdrSpec(const GdrKernelSpec&, const Operation&, const PlanningContext&);
 Problem             BuildProblem(const PlanningContext&, const GdrKernelSpec&);
-ContextParallelPlan BuildDisabledContextParallelPlan(const Problem&);
+ContextParallelPlan BuildDisabledContextParallelPlan(const Problem&, ContextParallelLevel);
 void                BuildOptimizedTensorPlans(Plan*, size_t direct_descriptor_bytes);
 
 }  // namespace turbomind::linear_attn::delta_rule::detail

--- a/src/turbomind/kernels/linear_attn/kernel/pre_sm90/chunked.cu
+++ b/src/turbomind/kernels/linear_attn/kernel/pre_sm90/chunked.cu
@@ -43,246 +43,240 @@ __global__ void ChunkedGdrKernel(T*             out,
                                  int            num_head_groups,
                                  int            heads_per_block)
 {
-#if __CUDA_ARCH__
-    if constexpr (__CUDA_ARCH__ < 900) {
-        constexpr int C = ChunkSize;
-        constexpr int D = HeadDim;
+    constexpr int C = ChunkSize;
+    constexpr int D = HeadDim;
 
-        const int sequence        = int(blockIdx.x) / hv;
-        const int value_head      = int(blockIdx.x) % hv;
-        const int key_head        = value_head / (hv / hq);
-        const int token_begin     = q_offsets[sequence];
-        const int sequence_length = q_offsets[sequence + 1] - token_begin;
+    const int sequence        = int(blockIdx.x) / hv;
+    const int value_head      = int(blockIdx.x) % hv;
+    const int key_head        = value_head / (hv / hq);
+    const int token_begin     = q_offsets[sequence];
+    const int sequence_length = q_offsets[sequence + 1] - token_begin;
 
-        const int head_group = value_head / heads_per_block;
-        const int local_head = value_head % heads_per_block;
-        auto*     state =
-            reinterpret_cast<StateT*>(static_cast<uintptr_t>(state_ptrs[sequence * num_head_groups + head_group]))
-            + state_layer_offset + int64_t(local_head) * D * D;
+    const int head_group = value_head / heads_per_block;
+    const int local_head = value_head % heads_per_block;
+    auto* state = reinterpret_cast<StateT*>(static_cast<uintptr_t>(state_ptrs[sequence * num_head_groups + head_group]))
+                  + state_layer_offset + int64_t(local_head) * D * D;
 
-        constexpr int tile_k    = 8;
-        constexpr int tile_v    = 8;
-        constexpr int k_threads = D / tile_k;
-        constexpr int v_threads = BlockDim / k_threads;
-        constexpr int v_iters   = (D / tile_v + v_threads - 1) / v_threads;
+    constexpr int tile_k    = 8;
+    constexpr int tile_v    = 8;
+    constexpr int k_threads = D / tile_k;
+    constexpr int v_threads = BlockDim / k_threads;
+    constexpr int v_iters   = (D / tile_v + v_threads - 1) / v_threads;
 
-        const int offset_k = threadIdx.x % k_threads;
-        const int offset_v = threadIdx.x / k_threads;
+    const int offset_k = threadIdx.x % k_threads;
+    const int offset_v = threadIdx.x / k_threads;
 
-        Array<float, tile_v> vec_S[v_iters][tile_k];
+    Array<float, tile_v> vec_S[v_iters][tile_k];
 
-        extern __shared__ __align__(16) char smem_buf[];
+    extern __shared__ __align__(16) char smem_buf[];
 
-        {
-            using Map_S          = ThreadMap_V2<D, D, sizeof(uint4) / sizeof(StateT), Raked, BlockDim / WARP_SIZE>;
-            constexpr int kBase  = sizeof(StateT) == 4 ? 2 : 3;
-            constexpr int kShift = 10 - kBase;
-            using Layout         = SmemLayoutV2<D, D, -1, -1, Swizzle<4, kBase, kShift>>;
-            SmemAccessor<StateT, Layout> smem_S{reinterpret_cast<StateT*>(smem_buf)};
+    {
+        using Map_S          = ThreadMap_V2<D, D, sizeof(uint4) / sizeof(StateT), Raked, BlockDim / WARP_SIZE>;
+        constexpr int kBase  = sizeof(StateT) == 4 ? 2 : 3;
+        constexpr int kShift = 10 - kBase;
+        using Layout         = SmemLayoutV2<D, D, -1, -1, Swizzle<4, kBase, kShift>>;
+        SmemAccessor<StateT, Layout> smem_S{reinterpret_cast<StateT*>(smem_buf)};
 
-            const int     warp_id  = threadIdx.x / WARP_SIZE;
-            const int     lane_id  = threadIdx.x % WARP_SIZE;
-            constexpr int kAccessC = Map_S::kAccessC;
+        const int     warp_id  = threadIdx.x / WARP_SIZE;
+        const int     lane_id  = threadIdx.x % WARP_SIZE;
+        constexpr int kAccessC = Map_S::kAccessC;
 
+        PRAGMA_UNROLL
+        for (int s = 0; s < Map_S::kIterS; ++s) {
+            Array<StateT, kAccessC> vec;
             PRAGMA_UNROLL
-            for (int s = 0; s < Map_S::kIterS; ++s) {
-                Array<StateT, kAccessC> vec;
+            for (int c = 0; c < Map_S::kIterC; ++c) {
+                const auto [vd, kd] = Map_S::get_offset(warp_id, lane_id);
+                const int final_vd  = vd + c * Map_S::kDeltaC;
+                const int final_kd  = kd + s * Map_S::kDeltaS;
+                Load(vec, state + final_kd * D + final_vd);
+                Store(&smem_S(final_kd, final_vd), vec);
+            }
+        }
+        __syncthreads();
+
+        PRAGMA_UNROLL
+        for (int v_iter = 0; v_iter < v_iters; ++v_iter) {
+            PRAGMA_UNROLL
+            for (int k_idx = 0; k_idx < tile_k; ++k_idx) {
+                static_assert(tile_v % Map_S::kAccessC == 0);
                 PRAGMA_UNROLL
-                for (int c = 0; c < Map_S::kIterC; ++c) {
-                    const auto [vd, kd] = Map_S::get_offset(warp_id, lane_id);
-                    const int final_vd  = vd + c * Map_S::kDeltaC;
-                    const int final_kd  = kd + s * Map_S::kDeltaS;
-                    Load(vec, state + final_kd * D + final_vd);
-                    Store(&smem_S(final_kd, final_vd), vec);
+                for (int c = 0; c < tile_v / Map_S::kAccessC; ++c) {
+                    Array<StateT, Map_S::kAccessC> tmp;
+                    Load(tmp,
+                         &smem_S(offset_k * tile_k + k_idx,
+                                 (offset_v + v_iter * v_threads) * tile_v + c * Map_S::kAccessC));
+                    reinterpret_cast<Array<float, Map_S::kAccessC>&>(vec_S[v_iter][k_idx][c * Map_S::kAccessC]) =
+                        cast<float>(tmp);
                 }
             }
-            __syncthreads();
+        }
+    }
+    __syncthreads();
+
+    constexpr int kSmemStride = D + 4;
+    float*        k_smem      = reinterpret_cast<float*>(smem_buf);
+    float*        q_smem      = k_smem + C * kSmemStride;
+    float*        v_smem      = q_smem + C * kSmemStride;
+    float*        beta_vals   = v_smem + C * kSmemStride;
+    float*        g_vals      = beta_vals + C;
+
+    constexpr int kThreadsPerToken   = BlockDim / C;
+    constexpr int kElementsPerThread = D / kThreadsPerToken;
+    const int     load_token         = threadIdx.x / kThreadsPerToken;
+    const int     load_lane          = threadIdx.x % kThreadsPerToken;
+
+    const int chunk_count = (sequence_length + C - 1) / C;
+    for (int chunk = 0; chunk < chunk_count; ++chunk) {
+        const int chunk_start  = token_begin + chunk * C;
+        const int valid_tokens = min(C, sequence_length - chunk * C);
+
+        if (load_token < valid_tokens) {
+            const int global_token   = chunk_start + load_token;
+            const int physical_batch = global_token / physical_token_slots;
+            const int token          = global_token % physical_token_slots;
+            const T*  q_ptr =
+                q + int64_t(physical_batch) * q_batch_stride + int64_t(token) * q_token_stride + int64_t(key_head) * D;
+            const T* k_ptr =
+                k + int64_t(physical_batch) * k_batch_stride + int64_t(token) * k_token_stride + int64_t(key_head) * D;
+            const T* v_ptr = v + int64_t(physical_batch) * v_batch_stride + int64_t(token) * v_token_stride
+                             + int64_t(value_head) * D;
+            PRAGMA_UNROLL
+            for (int element = 0; element < kElementsPerThread; ++element) {
+                const int d                          = load_lane * kElementsPerThread + element;
+                k_smem[load_token * kSmemStride + d] = float(k_ptr[d]);
+                q_smem[load_token * kSmemStride + d] = float(q_ptr[d]);
+                v_smem[load_token * kSmemStride + d] = float(v_ptr[d]);
+            }
+            if (load_lane == 0) {
+                beta_vals[load_token] =
+                    beta[int64_t(physical_batch) * gate_batch_stride + int64_t(token) * gate_token_stride + value_head];
+                g_vals[load_token] =
+                    g[int64_t(physical_batch) * gate_batch_stride + int64_t(token) * gate_token_stride + value_head];
+            }
+        }
+        else {
+            PRAGMA_UNROLL
+            for (int element = 0; element < kElementsPerThread; ++element) {
+                const int d                          = load_lane * kElementsPerThread + element;
+                k_smem[load_token * kSmemStride + d] = 0.f;
+                q_smem[load_token * kSmemStride + d] = 0.f;
+                v_smem[load_token * kSmemStride + d] = 0.f;
+            }
+        }
+        __syncthreads();
+
+        PRAGMA_UNROLL
+        for (int token_in_chunk = 0; token_in_chunk < C; ++token_in_chunk) {
+            if (token_in_chunk >= valid_tokens) {
+                break;
+            }
+
+            const float beta_value = beta_vals[token_in_chunk];
+            const float decay      = expf(g_vals[token_in_chunk]);
+            float       vec_k[tile_k];
+            float       vec_q[tile_k];
+            PRAGMA_UNROLL
+            for (int k_idx = 0; k_idx < tile_k; ++k_idx) {
+                vec_k[k_idx] = k_smem[token_in_chunk * kSmemStride + offset_k * tile_k + k_idx];
+                vec_q[k_idx] = q_smem[token_in_chunk * kSmemStride + offset_k * tile_k + k_idx];
+            }
+
+            const int global_token   = chunk_start + token_in_chunk;
+            const int physical_batch = global_token / physical_token_slots;
+            const int token          = global_token % physical_token_slots;
+            T*        out_ptr = out + int64_t(physical_batch) * out_batch_stride + int64_t(token) * out_token_stride
+                         + int64_t(value_head) * D;
 
             PRAGMA_UNROLL
             for (int v_iter = 0; v_iter < v_iters; ++v_iter) {
+                const int value_base = (offset_v + v_iter * v_threads) * tile_v;
+                float     vec_v[tile_v];
                 PRAGMA_UNROLL
-                for (int k_idx = 0; k_idx < tile_k; ++k_idx) {
-                    static_assert(tile_v % Map_S::kAccessC == 0);
+                for (int v_idx = 0; v_idx < tile_v; ++v_idx) {
+                    vec_v[v_idx] = v_smem[token_in_chunk * kSmemStride + value_base + v_idx];
+                }
+
+                Array<T, tile_v> vec_out;
+                PRAGMA_UNROLL
+                for (int v_idx = 0; v_idx < tile_v; ++v_idx) {
                     PRAGMA_UNROLL
-                    for (int c = 0; c < tile_v / Map_S::kAccessC; ++c) {
-                        Array<StateT, Map_S::kAccessC> tmp;
-                        Load(tmp,
-                             &smem_S(offset_k * tile_k + k_idx,
-                                     (offset_v + v_iter * v_threads) * tile_v + c * Map_S::kAccessC));
-                        reinterpret_cast<Array<float, Map_S::kAccessC>&>(vec_S[v_iter][k_idx][c * Map_S::kAccessC]) =
-                            cast<float>(tmp);
+                    for (int k_idx = 0; k_idx < tile_k; ++k_idx) {
+                        vec_S[v_iter][k_idx][v_idx] *= decay;
                     }
+
+                    float kv_memory = 0.f;
+                    PRAGMA_UNROLL
+                    for (int k_idx = 0; k_idx < tile_k; ++k_idx) {
+                        kv_memory += vec_S[v_iter][k_idx][v_idx] * vec_k[k_idx];
+                    }
+                    PRAGMA_UNROLL
+                    for (int mask = k_threads / 2; mask > 0; mask /= 2) {
+                        kv_memory += __shfl_xor_sync(0xffffffff, kv_memory, mask);
+                    }
+                    const float delta = (vec_v[v_idx] - kv_memory) * beta_value;
+                    PRAGMA_UNROLL
+                    for (int k_idx = 0; k_idx < tile_k; ++k_idx) {
+                        vec_S[v_iter][k_idx][v_idx] += vec_k[k_idx] * delta;
+                    }
+
+                    float value = 0.f;
+                    PRAGMA_UNROLL
+                    for (int k_idx = 0; k_idx < tile_k; ++k_idx) {
+                        value += vec_S[v_iter][k_idx][v_idx] * vec_q[k_idx];
+                    }
+                    PRAGMA_UNROLL
+                    for (int mask = k_threads / 2; mask > 0; mask /= 2) {
+                        value += __shfl_xor_sync(0xffffffff, value, mask);
+                    }
+                    vec_out[v_idx] = T(value * rsqrtf(float(D)));
+                }
+                if (offset_k == 0) {
+                    Store(&out_ptr[value_base], vec_out);
+                }
+            }
+        }
+        __syncthreads();
+    }
+
+    if (!finished[sequence]) {
+        using Map_S          = ThreadMap_V2<D, D, sizeof(uint4) / sizeof(StateT), Raked, BlockDim / WARP_SIZE>;
+        constexpr int kBase  = sizeof(StateT) == 4 ? 2 : 3;
+        constexpr int kShift = 10 - kBase;
+        using Layout         = SmemLayoutV2<D, D, -1, -1, Swizzle<4, kBase, kShift>>;
+        SmemAccessor<StateT, Layout> smem_S{reinterpret_cast<StateT*>(smem_buf)};
+        constexpr int                kAccessC = Map_S::kAccessC;
+
+        PRAGMA_UNROLL
+        for (int v_iter = 0; v_iter < v_iters; ++v_iter) {
+            PRAGMA_UNROLL
+            for (int k_idx = 0; k_idx < tile_k; ++k_idx) {
+                PRAGMA_UNROLL
+                for (int c = 0; c < tile_v / kAccessC; ++c) {
+                    auto tmp =
+                        cast<StateT>(reinterpret_cast<Array<float, kAccessC>&>(vec_S[v_iter][k_idx][c * kAccessC]));
+                    Store(&smem_S(offset_k * tile_k + k_idx, (offset_v + v_iter * v_threads) * tile_v + c * kAccessC),
+                          tmp);
                 }
             }
         }
         __syncthreads();
 
-        constexpr int kSmemStride = D + 4;
-        float*        k_smem      = reinterpret_cast<float*>(smem_buf);
-        float*        q_smem      = k_smem + C * kSmemStride;
-        float*        v_smem      = q_smem + C * kSmemStride;
-        float*        beta_vals   = v_smem + C * kSmemStride;
-        float*        g_vals      = beta_vals + C;
-
-        constexpr int kThreadsPerToken   = BlockDim / C;
-        constexpr int kElementsPerThread = D / kThreadsPerToken;
-        const int     load_token         = threadIdx.x / kThreadsPerToken;
-        const int     load_lane          = threadIdx.x % kThreadsPerToken;
-
-        const int chunk_count = (sequence_length + C - 1) / C;
-        for (int chunk = 0; chunk < chunk_count; ++chunk) {
-            const int chunk_start  = token_begin + chunk * C;
-            const int valid_tokens = min(C, sequence_length - chunk * C);
-
-            if (load_token < valid_tokens) {
-                const int global_token   = chunk_start + load_token;
-                const int physical_batch = global_token / physical_token_slots;
-                const int token          = global_token % physical_token_slots;
-                const T*  q_ptr = q + int64_t(physical_batch) * q_batch_stride + int64_t(token) * q_token_stride
-                                 + int64_t(key_head) * D;
-                const T* k_ptr = k + int64_t(physical_batch) * k_batch_stride + int64_t(token) * k_token_stride
-                                 + int64_t(key_head) * D;
-                const T* v_ptr = v + int64_t(physical_batch) * v_batch_stride + int64_t(token) * v_token_stride
-                                 + int64_t(value_head) * D;
-                PRAGMA_UNROLL
-                for (int element = 0; element < kElementsPerThread; ++element) {
-                    const int d                          = load_lane * kElementsPerThread + element;
-                    k_smem[load_token * kSmemStride + d] = float(k_ptr[d]);
-                    q_smem[load_token * kSmemStride + d] = float(q_ptr[d]);
-                    v_smem[load_token * kSmemStride + d] = float(v_ptr[d]);
-                }
-                if (load_lane == 0) {
-                    beta_vals[load_token] = beta[int64_t(physical_batch) * gate_batch_stride
-                                                 + int64_t(token) * gate_token_stride + value_head];
-                    g_vals[load_token]    = g[int64_t(physical_batch) * gate_batch_stride
-                                           + int64_t(token) * gate_token_stride + value_head];
-                }
-            }
-            else {
-                PRAGMA_UNROLL
-                for (int element = 0; element < kElementsPerThread; ++element) {
-                    const int d                          = load_lane * kElementsPerThread + element;
-                    k_smem[load_token * kSmemStride + d] = 0.f;
-                    q_smem[load_token * kSmemStride + d] = 0.f;
-                    v_smem[load_token * kSmemStride + d] = 0.f;
-                }
-            }
-            __syncthreads();
-
+        const int warp_id = threadIdx.x / WARP_SIZE;
+        const int lane_id = threadIdx.x % WARP_SIZE;
+        PRAGMA_UNROLL
+        for (int s = 0; s < Map_S::kIterS; ++s) {
+            Array<StateT, Map_S::kAccessC> vec;
             PRAGMA_UNROLL
-            for (int token_in_chunk = 0; token_in_chunk < C; ++token_in_chunk) {
-                if (token_in_chunk >= valid_tokens) {
-                    break;
-                }
-
-                const float beta_value = beta_vals[token_in_chunk];
-                const float decay      = expf(g_vals[token_in_chunk]);
-                float       vec_k[tile_k];
-                float       vec_q[tile_k];
-                PRAGMA_UNROLL
-                for (int k_idx = 0; k_idx < tile_k; ++k_idx) {
-                    vec_k[k_idx] = k_smem[token_in_chunk * kSmemStride + offset_k * tile_k + k_idx];
-                    vec_q[k_idx] = q_smem[token_in_chunk * kSmemStride + offset_k * tile_k + k_idx];
-                }
-
-                const int global_token   = chunk_start + token_in_chunk;
-                const int physical_batch = global_token / physical_token_slots;
-                const int token          = global_token % physical_token_slots;
-                T*        out_ptr = out + int64_t(physical_batch) * out_batch_stride + int64_t(token) * out_token_stride
-                             + int64_t(value_head) * D;
-
-                PRAGMA_UNROLL
-                for (int v_iter = 0; v_iter < v_iters; ++v_iter) {
-                    const int value_base = (offset_v + v_iter * v_threads) * tile_v;
-                    float     vec_v[tile_v];
-                    PRAGMA_UNROLL
-                    for (int v_idx = 0; v_idx < tile_v; ++v_idx) {
-                        vec_v[v_idx] = v_smem[token_in_chunk * kSmemStride + value_base + v_idx];
-                    }
-
-                    Array<T, tile_v> vec_out;
-                    PRAGMA_UNROLL
-                    for (int v_idx = 0; v_idx < tile_v; ++v_idx) {
-                        PRAGMA_UNROLL
-                        for (int k_idx = 0; k_idx < tile_k; ++k_idx) {
-                            vec_S[v_iter][k_idx][v_idx] *= decay;
-                        }
-
-                        float kv_memory = 0.f;
-                        PRAGMA_UNROLL
-                        for (int k_idx = 0; k_idx < tile_k; ++k_idx) {
-                            kv_memory += vec_S[v_iter][k_idx][v_idx] * vec_k[k_idx];
-                        }
-                        PRAGMA_UNROLL
-                        for (int mask = k_threads / 2; mask > 0; mask /= 2) {
-                            kv_memory += __shfl_xor_sync(0xffffffff, kv_memory, mask);
-                        }
-                        const float delta = (vec_v[v_idx] - kv_memory) * beta_value;
-                        PRAGMA_UNROLL
-                        for (int k_idx = 0; k_idx < tile_k; ++k_idx) {
-                            vec_S[v_iter][k_idx][v_idx] += vec_k[k_idx] * delta;
-                        }
-
-                        float value = 0.f;
-                        PRAGMA_UNROLL
-                        for (int k_idx = 0; k_idx < tile_k; ++k_idx) {
-                            value += vec_S[v_iter][k_idx][v_idx] * vec_q[k_idx];
-                        }
-                        PRAGMA_UNROLL
-                        for (int mask = k_threads / 2; mask > 0; mask /= 2) {
-                            value += __shfl_xor_sync(0xffffffff, value, mask);
-                        }
-                        vec_out[v_idx] = T(value * rsqrtf(float(D)));
-                    }
-                    if (offset_k == 0) {
-                        Store(&out_ptr[value_base], vec_out);
-                    }
-                }
-            }
-            __syncthreads();
-        }
-
-        if (!finished[sequence]) {
-            using Map_S          = ThreadMap_V2<D, D, sizeof(uint4) / sizeof(StateT), Raked, BlockDim / WARP_SIZE>;
-            constexpr int kBase  = sizeof(StateT) == 4 ? 2 : 3;
-            constexpr int kShift = 10 - kBase;
-            using Layout         = SmemLayoutV2<D, D, -1, -1, Swizzle<4, kBase, kShift>>;
-            SmemAccessor<StateT, Layout> smem_S{reinterpret_cast<StateT*>(smem_buf)};
-            constexpr int                kAccessC = Map_S::kAccessC;
-
-            PRAGMA_UNROLL
-            for (int v_iter = 0; v_iter < v_iters; ++v_iter) {
-                PRAGMA_UNROLL
-                for (int k_idx = 0; k_idx < tile_k; ++k_idx) {
-                    PRAGMA_UNROLL
-                    for (int c = 0; c < tile_v / kAccessC; ++c) {
-                        auto tmp =
-                            cast<StateT>(reinterpret_cast<Array<float, kAccessC>&>(vec_S[v_iter][k_idx][c * kAccessC]));
-                        Store(
-                            &smem_S(offset_k * tile_k + k_idx, (offset_v + v_iter * v_threads) * tile_v + c * kAccessC),
-                            tmp);
-                    }
-                }
-            }
-            __syncthreads();
-
-            const int warp_id = threadIdx.x / WARP_SIZE;
-            const int lane_id = threadIdx.x % WARP_SIZE;
-            PRAGMA_UNROLL
-            for (int s = 0; s < Map_S::kIterS; ++s) {
-                Array<StateT, Map_S::kAccessC> vec;
-                PRAGMA_UNROLL
-                for (int c = 0; c < Map_S::kIterC; ++c) {
-                    const auto [vd, kd] = Map_S::get_offset(warp_id, lane_id);
-                    const int final_vd  = vd + c * Map_S::kDeltaC;
-                    const int final_kd  = kd + s * Map_S::kDeltaS;
-                    Load(vec, &smem_S(final_kd, final_vd));
-                    Store(state + final_kd * D + final_vd, vec);
-                }
+            for (int c = 0; c < Map_S::kIterC; ++c) {
+                const auto [vd, kd] = Map_S::get_offset(warp_id, lane_id);
+                const int final_vd  = vd + c * Map_S::kDeltaC;
+                const int final_kd  = kd + s * Map_S::kDeltaS;
+                Load(vec, &smem_S(final_kd, final_vd));
+                Store(state + final_kd * D + final_vd, vec);
             }
         }
     }
-#endif
 }
 
 template<class T, class StateT>

--- a/src/turbomind/kernels/linear_attn/kernel/pre_sm90/entry.cu
+++ b/src/turbomind/kernels/linear_attn/kernel/pre_sm90/entry.cu
@@ -49,9 +49,9 @@ public:
         return context.arch > 0 && context.arch < 900 && detail::MatchesGdrSpec(spec(), operation, context);
     }
 
-    bool Plan(const Operation&, const PlanningContext& context, delta_rule::Plan* plan) const override
+    bool Plan(const Operation& operation, const PlanningContext& context, delta_rule::Plan* plan) const override
     {
-        return detail::PlanPreSm90Operation(spec(), context, plan);
+        return detail::PlanPreSm90Operation(spec(), operation, context, plan);
     }
 
     void Run(const Arguments& args, const delta_rule::Plan& plan, cudaStream_t stream) const override

--- a/src/turbomind/kernels/linear_attn/kernel/pre_sm90/entry.cu
+++ b/src/turbomind/kernels/linear_attn/kernel/pre_sm90/entry.cu
@@ -46,7 +46,7 @@ public:
 
     bool Match(const Operation& operation, const PlanningContext& context) const override
     {
-        return context.arch > 0 && context.arch < 900 && detail::MatchesGdrSpec(spec(), operation, context);
+        return detail::MatchesGdrSpec(spec(), operation, context);
     }
 
     bool Plan(const Operation& operation, const PlanningContext& context, delta_rule::Plan* plan) const override

--- a/src/turbomind/kernels/linear_attn/kernel/pre_sm90/internal.h
+++ b/src/turbomind/kernels/linear_attn/kernel/pre_sm90/internal.h
@@ -4,7 +4,7 @@
 
 namespace turbomind::linear_attn::delta_rule::detail {
 
-bool PlanPreSm90Operation(const GdrKernelSpec&, const PlanningContext&, Plan*);
+bool PlanPreSm90Operation(const GdrKernelSpec&, const Operation&, const PlanningContext&, Plan*);
 
 void RunPreSm90RecurrentF16F16(const Arguments&, const Plan&, cudaStream_t);
 void RunPreSm90RecurrentF16F32(const Arguments&, const Plan&, cudaStream_t);

--- a/src/turbomind/kernels/linear_attn/kernel/pre_sm90/plan.cc
+++ b/src/turbomind/kernels/linear_attn/kernel/pre_sm90/plan.cc
@@ -4,10 +4,13 @@
 
 namespace turbomind::linear_attn::delta_rule::detail {
 
-bool PlanPreSm90Operation(const GdrKernelSpec& spec, const PlanningContext& context, Plan* plan)
+bool PlanPreSm90Operation(const GdrKernelSpec&   spec,
+                          const Operation&       operation,
+                          const PlanningContext& context,
+                          Plan*                  plan)
 {
     plan->problem                        = BuildProblem(context, spec);
-    plan->cp                             = BuildDisabledContextParallelPlan(plan->problem);
+    plan->cp                             = BuildDisabledContextParallelPlan(plan->problem, operation.cp_level);
     const core::ssize_t value_row_size   = core::ssize_t(plan->problem.hv) * 128;
     const core::ssize_t value_batch_size = core::ssize_t(plan->problem.token_num) * value_row_size;
     const size_t        value_elements   = size_t(plan->problem.batch) * size_t(value_batch_size);

--- a/src/turbomind/kernels/linear_attn/kernel/pre_sm90/recurrent.cu
+++ b/src/turbomind/kernels/linear_attn/kernel/pre_sm90/recurrent.cu
@@ -32,114 +32,110 @@ __global__ __launch_bounds__(BlockDim, 2) void RecurrentGdrKernel(T*            
                                                                   int            num_head_groups,
                                                                   int            heads_per_block)
 {
-#if __CUDA_ARCH__
-    if constexpr (__CUDA_ARCH__ < 900) {
-        constexpr int tile_k    = 16;
-        constexpr int tile_v    = 4;
-        constexpr int k_threads = HeadDim / tile_k;
-        constexpr int v_threads = BlockDim / k_threads;
-        constexpr int v_iters   = (HeadDim / tile_v + v_threads - 1) / v_threads;
-        const int     offset_k  = threadIdx.x % k_threads;
-        const int     offset_v  = threadIdx.x / k_threads;
+    constexpr int tile_k    = 16;
+    constexpr int tile_v    = 4;
+    constexpr int k_threads = HeadDim / tile_k;
+    constexpr int v_threads = BlockDim / k_threads;
+    constexpr int v_iters   = (HeadDim / tile_v + v_threads - 1) / v_threads;
+    const int     offset_k  = threadIdx.x % k_threads;
+    const int     offset_v  = threadIdx.x / k_threads;
 
-        for (int work_idx = int(blockIdx.x); work_idx < total_work; work_idx += int(gridDim.x)) {
-            const int sequence   = work_idx / hv;
-            const int value_head = work_idx % hv;
-            const int key_head   = value_head / (hv / hq);
-            const T*  q_ptr      = q + int64_t(sequence) * q_batch_stride + int64_t(key_head) * HeadDim;
-            const T*  k_ptr      = k + int64_t(sequence) * k_batch_stride + int64_t(key_head) * HeadDim;
-            const T*  v_ptr      = v + int64_t(sequence) * v_batch_stride + int64_t(value_head) * HeadDim;
-            T*        out_ptr    = out + int64_t(sequence) * out_batch_stride + int64_t(value_head) * HeadDim;
-            const int head_group = value_head / heads_per_block;
-            const int local_head = value_head % heads_per_block;
-            auto*     state =
-                reinterpret_cast<StateT*>(static_cast<uintptr_t>(state_ptrs[sequence * num_head_groups + head_group]))
-                + state_layer_offset + int64_t(local_head) * HeadDim * HeadDim;
+    for (int work_idx = int(blockIdx.x); work_idx < total_work; work_idx += int(gridDim.x)) {
+        const int sequence   = work_idx / hv;
+        const int value_head = work_idx % hv;
+        const int key_head   = value_head / (hv / hq);
+        const T*  q_ptr      = q + int64_t(sequence) * q_batch_stride + int64_t(key_head) * HeadDim;
+        const T*  k_ptr      = k + int64_t(sequence) * k_batch_stride + int64_t(key_head) * HeadDim;
+        const T*  v_ptr      = v + int64_t(sequence) * v_batch_stride + int64_t(value_head) * HeadDim;
+        T*        out_ptr    = out + int64_t(sequence) * out_batch_stride + int64_t(value_head) * HeadDim;
+        const int head_group = value_head / heads_per_block;
+        const int local_head = value_head % heads_per_block;
+        auto*     state =
+            reinterpret_cast<StateT*>(static_cast<uintptr_t>(state_ptrs[sequence * num_head_groups + head_group]))
+            + state_layer_offset + int64_t(local_head) * HeadDim * HeadDim;
 
-            Array<float, tile_v> vec_S[v_iters][tile_k];
+        Array<float, tile_v> vec_S[v_iters][tile_k];
+        PRAGMA_UNROLL
+        for (int v_iter = 0; v_iter < v_iters; ++v_iter) {
+            PRAGMA_UNROLL
+            for (int k_idx = 0; k_idx < tile_k; ++k_idx) {
+                Array<StateT, tile_v> tmp;
+                Load(tmp, &state[(offset_k * tile_k + k_idx) * HeadDim + (offset_v + v_iter * v_threads) * tile_v]);
+                vec_S[v_iter][k_idx] = cast<float>(tmp);
+            }
+        }
+
+        const float beta_value = beta[int64_t(sequence) * gate_batch_stride + value_head];
+        const float decay      = expf(g[int64_t(sequence) * gate_batch_stride + value_head]);
+
+        Array<float, tile_k> vec_k;
+        Array<float, tile_k> vec_q;
+        Array<T, tile_k>     tmp_k;
+        Array<T, tile_k>     tmp_q;
+        Load(tmp_k, &k_ptr[offset_k * tile_k]);
+        Load(tmp_q, &q_ptr[offset_k * tile_k]);
+        vec_k = cast<float>(tmp_k);
+        vec_q = cast<float>(tmp_q);
+
+        float kq = 0.f;
+        PRAGMA_UNROLL
+        for (int k_idx = 0; k_idx < tile_k; ++k_idx) {
+            kq += vec_k[k_idx] * vec_q[k_idx];
+        }
+        PRAGMA_UNROLL
+        for (int mask = k_threads / 2; mask > 0; mask /= 2) {
+            kq += __shfl_xor_sync(0xffffffff, kq, mask);
+        }
+
+        Array<T, tile_v> vec_v[v_iters];
+        PRAGMA_UNROLL
+        for (int v_iter = 0; v_iter < v_iters; ++v_iter) {
+            Load(vec_v[v_iter], &v_ptr[(offset_v + v_iter * v_threads) * tile_v]);
+        }
+
+        PRAGMA_UNROLL
+        for (int v_iter = 0; v_iter < v_iters; ++v_iter) {
+            Array<T, tile_v> vec_out;
+            PRAGMA_UNROLL
+            for (int v_idx = 0; v_idx < tile_v; ++v_idx) {
+                float kv_memory = 0.f;
+                float sq        = 0.f;
+                PRAGMA_UNROLL
+                for (int k_idx = 0; k_idx < tile_k; ++k_idx) {
+                    const float s_decayed       = vec_S[v_iter][k_idx][v_idx] * decay;
+                    vec_S[v_iter][k_idx][v_idx] = s_decayed;
+                    kv_memory += s_decayed * vec_k[k_idx];
+                    sq += s_decayed * vec_q[k_idx];
+                }
+                PRAGMA_UNROLL
+                for (int mask = k_threads / 2; mask > 0; mask /= 2) {
+                    kv_memory += __shfl_xor_sync(0xffffffff, kv_memory, mask);
+                    sq += __shfl_xor_sync(0xffffffff, sq, mask);
+                }
+                const float delta = (float(vec_v[v_iter][v_idx]) - kv_memory) * beta_value;
+                PRAGMA_UNROLL
+                for (int k_idx = 0; k_idx < tile_k; ++k_idx) {
+                    vec_S[v_iter][k_idx][v_idx] += vec_k[k_idx] * delta;
+                }
+                vec_out[v_idx] = T((sq + delta * kq) * rsqrtf(float(HeadDim)));
+            }
+            if (offset_k == 0) {
+                Store(&out_ptr[(offset_v + v_iter * v_threads) * tile_v], vec_out);
+            }
+        }
+
+        if (!finished[sequence]) {
             PRAGMA_UNROLL
             for (int v_iter = 0; v_iter < v_iters; ++v_iter) {
                 PRAGMA_UNROLL
                 for (int k_idx = 0; k_idx < tile_k; ++k_idx) {
-                    Array<StateT, tile_v> tmp;
-                    Load(tmp, &state[(offset_k * tile_k + k_idx) * HeadDim + (offset_v + v_iter * v_threads) * tile_v]);
-                    vec_S[v_iter][k_idx] = cast<float>(tmp);
-                }
-            }
-
-            const float beta_value = beta[int64_t(sequence) * gate_batch_stride + value_head];
-            const float decay      = expf(g[int64_t(sequence) * gate_batch_stride + value_head]);
-
-            Array<float, tile_k> vec_k;
-            Array<float, tile_k> vec_q;
-            Array<T, tile_k>     tmp_k;
-            Array<T, tile_k>     tmp_q;
-            Load(tmp_k, &k_ptr[offset_k * tile_k]);
-            Load(tmp_q, &q_ptr[offset_k * tile_k]);
-            vec_k = cast<float>(tmp_k);
-            vec_q = cast<float>(tmp_q);
-
-            float kq = 0.f;
-            PRAGMA_UNROLL
-            for (int k_idx = 0; k_idx < tile_k; ++k_idx) {
-                kq += vec_k[k_idx] * vec_q[k_idx];
-            }
-            PRAGMA_UNROLL
-            for (int mask = k_threads / 2; mask > 0; mask /= 2) {
-                kq += __shfl_xor_sync(0xffffffff, kq, mask);
-            }
-
-            Array<T, tile_v> vec_v[v_iters];
-            PRAGMA_UNROLL
-            for (int v_iter = 0; v_iter < v_iters; ++v_iter) {
-                Load(vec_v[v_iter], &v_ptr[(offset_v + v_iter * v_threads) * tile_v]);
-            }
-
-            PRAGMA_UNROLL
-            for (int v_iter = 0; v_iter < v_iters; ++v_iter) {
-                Array<T, tile_v> vec_out;
-                PRAGMA_UNROLL
-                for (int v_idx = 0; v_idx < tile_v; ++v_idx) {
-                    float kv_memory = 0.f;
-                    float sq        = 0.f;
-                    PRAGMA_UNROLL
-                    for (int k_idx = 0; k_idx < tile_k; ++k_idx) {
-                        const float s_decayed       = vec_S[v_iter][k_idx][v_idx] * decay;
-                        vec_S[v_iter][k_idx][v_idx] = s_decayed;
-                        kv_memory += s_decayed * vec_k[k_idx];
-                        sq += s_decayed * vec_q[k_idx];
-                    }
-                    PRAGMA_UNROLL
-                    for (int mask = k_threads / 2; mask > 0; mask /= 2) {
-                        kv_memory += __shfl_xor_sync(0xffffffff, kv_memory, mask);
-                        sq += __shfl_xor_sync(0xffffffff, sq, mask);
-                    }
-                    const float delta = (float(vec_v[v_iter][v_idx]) - kv_memory) * beta_value;
-                    PRAGMA_UNROLL
-                    for (int k_idx = 0; k_idx < tile_k; ++k_idx) {
-                        vec_S[v_iter][k_idx][v_idx] += vec_k[k_idx] * delta;
-                    }
-                    vec_out[v_idx] = T((sq + delta * kq) * rsqrtf(float(HeadDim)));
-                }
-                if (offset_k == 0) {
-                    Store(&out_ptr[(offset_v + v_iter * v_threads) * tile_v], vec_out);
-                }
-            }
-
-            if (!finished[sequence]) {
-                PRAGMA_UNROLL
-                for (int v_iter = 0; v_iter < v_iters; ++v_iter) {
-                    PRAGMA_UNROLL
-                    for (int k_idx = 0; k_idx < tile_k; ++k_idx) {
-                        auto tmp = cast<StateT>(vec_S[v_iter][k_idx]);
-                        Store(&state[(offset_k * tile_k + k_idx) * HeadDim + (offset_v + v_iter * v_threads) * tile_v],
-                              tmp);
-                    }
+                    auto tmp = cast<StateT>(vec_S[v_iter][k_idx]);
+                    Store(&state[(offset_k * tile_k + k_idx) * HeadDim + (offset_v + v_iter * v_threads) * tile_v],
+                          tmp);
                 }
             }
         }
     }
-#endif
 }
 
 template<class T, class StateT>

--- a/src/turbomind/kernels/linear_attn/kernel/sm_120/entry.cu
+++ b/src/turbomind/kernels/linear_attn/kernel/sm_120/entry.cu
@@ -211,7 +211,7 @@ public:
 
     bool Match(const Operation& operation, const PlanningContext& context) const override
     {
-        return context.arch == 1200 && detail::MatchesGdrSpec(spec(), operation, context);
+        return detail::MatchesGdrSpec(spec(), operation, context);
     }
 
     bool Plan(const Operation& operation, const PlanningContext& context, delta_rule::Plan* plan) const override

--- a/src/turbomind/kernels/linear_attn/kernel/sm_120/plan.cc
+++ b/src/turbomind/kernels/linear_attn/kernel/sm_120/plan.cc
@@ -96,9 +96,10 @@ size_t BuildCpWorkspaceBytes(const Problem& problem, const ContextParallelPlan& 
     return bytes;
 }
 
-ContextParallelPlan BuildContextParallelPlan(const Problem& problem, const std::vector<int32_t>& q_offsets)
+ContextParallelPlan
+BuildContextParallelPlan(const Problem& problem, const std::vector<int32_t>& q_offsets, ContextParallelLevel cp_level)
 {
-    auto cp               = BuildDisabledContextParallelPlan(problem);
+    auto cp               = BuildDisabledContextParallelPlan(problem, cp_level);
     int  max_chunks       = 0;
     int  total_raw_chunks = 0;
     for (int sequence = 0; sequence < problem.sequence_num; ++sequence) {
@@ -169,10 +170,10 @@ bool PlanSm120Operation(const GdrKernelSpec&   spec,
                         const PlanningContext& context,
                         Plan*                  plan)
 {
-    plan->problem = BuildProblem(context, spec);
-    plan->cp      = operation.mode == GdrMode::kChunked && operation.cp_mode == ContextParallelMode::kAuto ?
-                        BuildContextParallelPlan(plan->problem, context.q_offsets) :
-                        BuildDisabledContextParallelPlan(plan->problem);
+    plan->problem         = BuildProblem(context, spec);
+    const bool cp_allowed = operation.mode == GdrMode::kChunked && operation.cp_level != ContextParallelLevel::kOff;
+    plan->cp = cp_allowed ? BuildContextParallelPlan(plan->problem, context.q_offsets, operation.cp_level) :
+                            BuildDisabledContextParallelPlan(plan->problem, operation.cp_level);
     const size_t descriptor_bytes =
         KktTmaDescriptorBytes(plan->problem) + FusedGdrTmaDescriptorBytes(plan->problem) + 127;
     BuildOptimizedTensorPlans(plan, descriptor_bytes);

--- a/src/turbomind/kernels/linear_attn/kernel/sm_120/prepare_h.h
+++ b/src/turbomind/kernels/linear_attn/kernel/sm_120/prepare_h.h
@@ -292,7 +292,8 @@ struct Sm120FusedGdrH {
                           int     token_num,
                           int     sequence_num,
                           int64_t gate_stride,
-                          int64_t gate_batch_stride)
+                          int64_t gate_batch_stride,
+                          bool    allow_warmup)
     {
         WarmupMetadata out{0, 0};
         const int      sequence_id = cp_source_indices[segment_id];
@@ -310,6 +311,9 @@ struct Sm120FusedGdrH {
         float           gate_sum         = 0.0f;
         out.chunks                       = segment_chunks;
         out.fallback                     = 1;
+        if (!allow_warmup) {
+            return out;
+        }
         for (int chunk = 0; chunk < segment_chunks; ++chunk) {
             const int     flat_token     = segment_end - chunk * kChunk32Size - 1;
             const int     physical_batch = flat_token / token_num;
@@ -344,6 +348,7 @@ struct Sm120FusedGdrH {
                                                int64_t        gate_batch_stride,
                                                int64_t        beta_stride,
                                                int64_t        beta_batch_stride,
+                                               bool           allow_warmup,
                                                unsigned char* smem_raw)
     {
         static_assert(BlockDv == kFusedGdrHBlockDv);
@@ -374,7 +379,8 @@ struct Sm120FusedGdrH {
                                            token_num,
                                            sequence_num,
                                            gate_stride,
-                                           gate_batch_stride);
+                                           gate_batch_stride,
+                                           allow_warmup);
             cp_fallback[static_cast<int64_t>(segment_id) * hv + value_head] = warmup.fallback != 0;
         }
         __syncthreads();
@@ -993,7 +999,8 @@ __global__ __launch_bounds__(
                                                                    int64_t gate_stride,
                                                                    int64_t gate_batch_stride,
                                                                    int64_t beta_stride,
-                                                                   int64_t beta_batch_stride)
+                                                                   int64_t beta_batch_stride,
+                                                                   bool    allow_warmup)
 {
 #if __CUDA_ARCH__
     if constexpr (__CUDA_ARCH__ >= 1000 && __CUDA_ARCH__ < 1300) {
@@ -1016,6 +1023,7 @@ __global__ __launch_bounds__(
                                         gate_batch_stride,
                                         beta_stride,
                                         beta_batch_stride,
+                                        allow_warmup,
                                         smem_raw);
     }
 #endif
@@ -1101,7 +1109,8 @@ void LaunchSm120FusedGdrHTyped(const core::Tensor&        k,
                                                         problem.gate_stride,
                                                         problem.gate_batch_stride,
                                                         problem.beta_stride,
-                                                        problem.beta_batch_stride);
+                                                        problem.beta_batch_stride,
+                                                        cp.cp_level == ContextParallelLevel::kAll);
     TM_CUDA_CHECK(cudaGetLastError());
 }
 

--- a/src/turbomind/kernels/linear_attn/kernel/sm_90/entry.cu
+++ b/src/turbomind/kernels/linear_attn/kernel/sm_90/entry.cu
@@ -429,7 +429,7 @@ public:
 
     bool Match(const Operation& operation, const PlanningContext& context) const override
     {
-        return context.arch == 900 && detail::MatchesGdrSpec(spec(), operation, context);
+        return detail::MatchesGdrSpec(spec(), operation, context);
     }
 
     bool Plan(const Operation& operation, const PlanningContext& context, delta_rule::Plan* plan) const override

--- a/src/turbomind/kernels/linear_attn/kernel/sm_90/plan.cc
+++ b/src/turbomind/kernels/linear_attn/kernel/sm_90/plan.cc
@@ -86,9 +86,10 @@ size_t BuildCpWorkspaceBytes(const Problem& problem, const ContextParallelPlan& 
     return bytes;
 }
 
-ContextParallelPlan BuildContextParallelPlan(const Problem& problem, const std::vector<int32_t>& q_offsets)
+ContextParallelPlan
+BuildContextParallelPlan(const Problem& problem, const std::vector<int32_t>& q_offsets, ContextParallelLevel cp_level)
 {
-    auto cp               = BuildDisabledContextParallelPlan(problem);
+    auto cp               = BuildDisabledContextParallelPlan(problem, cp_level);
     int  max_chunks       = 0;
     int  total_raw_chunks = 0;
     for (int sequence = 0; sequence < problem.sequence_num; ++sequence) {
@@ -154,10 +155,10 @@ bool PlanSm90Operation(const GdrKernelSpec&   spec,
                        const PlanningContext& context,
                        Plan*                  plan)
 {
-    plan->problem = BuildProblem(context, spec);
-    plan->cp      = operation.mode == GdrMode::kChunked && operation.cp_mode == ContextParallelMode::kAuto ?
-                        BuildContextParallelPlan(plan->problem, context.q_offsets) :
-                        BuildDisabledContextParallelPlan(plan->problem);
+    plan->problem         = BuildProblem(context, spec);
+    const bool cp_allowed = operation.mode == GdrMode::kChunked && operation.cp_level != ContextParallelLevel::kOff;
+    plan->cp = cp_allowed ? BuildContextParallelPlan(plan->problem, context.q_offsets, operation.cp_level) :
+                            BuildDisabledContextParallelPlan(plan->problem, operation.cp_level);
     const size_t descriptor_bytes =
         KktTmaDescriptorBytes(plan->problem) + FusedGdrTmaDescriptorBytes(plan->problem) + 127;
     BuildOptimizedTensorPlans(plan, descriptor_bytes);

--- a/src/turbomind/kernels/linear_attn/kernel/sm_90/prepare_h.h
+++ b/src/turbomind/kernels/linear_attn/kernel/sm_90/prepare_h.h
@@ -115,7 +115,8 @@ struct Sm90FusedGdrH {
                           int     token_num,
                           int     sequence_num,
                           int64_t gate_stride,
-                          int64_t gate_batch_stride)
+                          int64_t gate_batch_stride,
+                          bool    allow_warmup)
     {
         WarmupMetadata out{0, 0};
         const int      sequence_id = cp_source_indices[segment_id];
@@ -134,6 +135,9 @@ struct Sm90FusedGdrH {
         float           gate_sum         = 0.0f;
         out.chunks                       = segment_chunks;
         out.fallback                     = 1;
+        if (!allow_warmup) {
+            return out;
+        }
         for (int chunk = 0; chunk < segment_chunks; ++chunk) {
             const int     flat_token     = segment_end - chunk * kChunkSize - 1;
             const int     physical_batch = flat_token / token_num;
@@ -796,6 +800,7 @@ struct Sm90FusedGdrH {
                                                int64_t        gate_batch_stride,
                                                int64_t        beta_stride,
                                                int64_t        beta_batch_stride,
+                                               bool           allow_warmup,
                                                unsigned char* smem_raw)
     {
         auto& smem = *reinterpret_cast<SharedStorage*>(smem_raw);
@@ -813,7 +818,8 @@ struct Sm90FusedGdrH {
                                            token_num,
                                            sequence_num,
                                            gate_stride,
-                                           gate_batch_stride);
+                                           gate_batch_stride,
+                                           allow_warmup);
             cp_fallback[segment_id * hv + value_head] = warmup.fallback != 0;
         }
         __syncthreads();
@@ -886,7 +892,8 @@ __global__ __launch_bounds__(Sm90FusedGdrH<T>::kThreads, Sm90FusedGdrH<T>::kMinB
     int64_t gate_stride,
     int64_t gate_batch_stride,
     int64_t beta_stride,
-    int64_t beta_batch_stride)
+    int64_t beta_batch_stride,
+    bool    allow_warmup)
 {
 #if __CUDA_ARCH__
     if constexpr (__CUDA_ARCH__ >= 900 && __CUDA_ARCH__ < 1000) {
@@ -909,6 +916,7 @@ __global__ __launch_bounds__(Sm90FusedGdrH<T>::kThreads, Sm90FusedGdrH<T>::kMinB
                               gate_batch_stride,
                               beta_stride,
                               beta_batch_stride,
+                              allow_warmup,
                               smem_raw);
     }
 #endif
@@ -967,7 +975,8 @@ void LaunchSm90FusedGdrHTyped(const core::Tensor&        k,
                                               problem.gate_stride,
                                               problem.gate_batch_stride,
                                               problem.beta_stride,
-                                              problem.beta_batch_stride);
+                                              problem.beta_batch_stride,
+                                              cp.cp_level == ContextParallelLevel::kAll);
     TM_CUDA_CHECK(cudaGetLastError());
 }
 

--- a/src/turbomind/kernels/linear_attn/python_bind.cpp
+++ b/src/turbomind/kernels/linear_attn/python_bind.cpp
@@ -90,6 +90,17 @@ py::dict TensorPlanToDict(const TensorPlan& plan)
 py::dict ContextParallelPlanToDict(const ContextParallelPlan& plan)
 {
     py::dict out;
+    switch (plan.cp_level) {
+        case ContextParallelLevel::kOff:
+            out["cp_level"] = "off";
+            break;
+        case ContextParallelLevel::kExact:
+            out["cp_level"] = "exact";
+            break;
+        case ContextParallelLevel::kAll:
+            out["cp_level"] = "all";
+            break;
+    }
     out["enabled"]            = plan.enabled;
     out["segment_tokens"]     = plan.segment_tokens;
     out["segment_chunks"]     = plan.segment_chunks;
@@ -166,15 +177,18 @@ py::dict PlanToDict(const Plan& plan)
     return out;
 }
 
-ContextParallelMode ParseContextParallelMode(const std::string& mode)
+ContextParallelLevel ParseContextParallelLevel(const std::string& level)
 {
-    if (mode == "auto") {
-        return ContextParallelMode::kAuto;
+    if (level == "off") {
+        return ContextParallelLevel::kOff;
     }
-    if (mode == "off") {
-        return ContextParallelMode::kOff;
+    if (level == "exact") {
+        return ContextParallelLevel::kExact;
     }
-    throw py::value_error("cp_mode must be one of: auto, off");
+    if (level == "all") {
+        return ContextParallelLevel::kAll;
+    }
+    throw py::value_error("cp_level must be one of: off, exact, all");
 }
 
 GdrMode ParseMode(const std::string& mode)
@@ -202,9 +216,9 @@ DataType ParseStateDtype(const std::string& dtype)
     throw py::value_error("state_dtype must be one of: f16, float16, f32, float32, bf16, bfloat16");
 }
 
-Operation MakeOperation(GdrMode mode, std::optional<int> chunk_size, ContextParallelMode cp_mode)
+Operation MakeOperation(GdrMode mode, std::optional<int> chunk_size, ContextParallelLevel cp_level)
 {
-    return Operation{mode, chunk_size.value_or(kAutoGdrChunkSize), cp_mode};
+    return Operation{mode, chunk_size.value_or(kAutoGdrChunkSize), cp_level};
 }
 
 PlanningContext MakePlanningContext(const core::Tensor& q,
@@ -303,7 +317,7 @@ py::dict PlanBridge(const py::object&  q,
                     const std::string& state_dtype,
                     const std::string& mode,
                     std::optional<int> chunk_size,
-                    const std::string& cp_mode,
+                    const std::string& cp_level,
                     int                num_head_groups,
                     int                heads_per_block)
 {
@@ -318,7 +332,7 @@ py::dict PlanBridge(const py::object&  q,
 
     const auto parsed_mode        = ParseMode(mode);
     const auto parsed_state_dtype = ParseStateDtype(state_dtype);
-    const auto operation          = MakeOperation(parsed_mode, chunk_size, ParseContextParallelMode(cp_mode));
+    const auto operation          = MakeOperation(parsed_mode, chunk_size, ParseContextParallelLevel(cp_level));
     const auto context            = MakePlanningContext(q_tensor,
                                              v_tensor,
                                              g_tensor,
@@ -429,7 +443,7 @@ void bind_delta_rule(py::module_& module)
                "state_dtype"_a     = "f32",
                "mode"_a            = "chunked",
                "chunk_size"_a      = py::none(),
-               "cp_mode"_a         = "auto",
+               "cp_level"_a        = "all",
                "num_head_groups"_a = 1,
                "heads_per_block"_a = 0);
 

--- a/src/turbomind/kernels/linear_attn/registry.cu
+++ b/src/turbomind/kernels/linear_attn/registry.cu
@@ -23,10 +23,11 @@ bool GdrKernelRegistry::Add(std::unique_ptr<GdrKernel> kernel)
     return true;
 }
 
-const GdrKernel* GdrKernelRegistry::Find(const Operation& operation, const PlanningContext& context) const
+const GdrKernel*
+GdrKernelRegistry::Find(const Operation& operation, const PlanningContext& context, std::string_view architecture) const
 {
     for (const auto& kernel : kernels_) {
-        if (kernel->Match(operation, context)) {
+        if (std::string_view{kernel->spec().architecture} == architecture && kernel->Match(operation, context)) {
             return kernel.get();
         }
     }

--- a/src/turbomind/kernels/linear_attn/registry.h
+++ b/src/turbomind/kernels/linear_attn/registry.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <memory>
+#include <string_view>
 #include <vector>
 
 #include <cuda_runtime.h>
@@ -27,7 +28,7 @@ class GdrKernelRegistry {
 public:
     GdrKernelRegistry();
 
-    const GdrKernel*          Find(const Operation&, const PlanningContext&) const;
+    const GdrKernel*          Find(const Operation&, const PlanningContext&, std::string_view architecture) const;
     static GdrKernelRegistry& instance();
 
 private:

--- a/src/turbomind/models/llama/GatedDeltaNetLayer.cc
+++ b/src/turbomind/models/llama/GatedDeltaNetLayer.cc
@@ -3,6 +3,7 @@
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
+#include <cstring>
 #include <utility>
 #include <vector>
 
@@ -16,6 +17,27 @@
 #include "src/turbomind/utils/cuda_utils.h"
 
 namespace turbomind {
+namespace {
+
+using linear_attn::delta_rule::ContextParallelLevel;
+
+ContextParallelLevel GetCPLevel()
+{
+    const char* value = std::getenv("TM_GDR_CP_LEVEL");
+    if (value == nullptr || std::strcmp(value, "2") == 0) {
+        return ContextParallelLevel::kAll;
+    }
+    if (std::strcmp(value, "1") == 0) {
+        return ContextParallelLevel::kExact;
+    }
+    if (std::strcmp(value, "0") == 0) {
+        return ContextParallelLevel::kOff;
+    }
+    TM_CHECK(false) << "TM_GDR_CP_LEVEL must be 0 (off), 1 (exact), or 2 (all), got " << value;
+    return ContextParallelLevel::kAll;
+}
+
+}  // namespace
 
 auto get_lc_state_size(const DeltaNetWeight& weights, int tp)
 {
@@ -37,6 +59,7 @@ GatedDeltaNetLayer::GatedDeltaNetLayer(std::vector<DeltaNetWeight*> weights,
                                        int                          phases):
     tp_size_{engine.attn_tp_size * engine.attn_cp_size},
     recurrent_state_dtype_{engine.state_dtype},
+    gdr_cp_level_{GetCPLevel()},
     linear_{*context.linear}
 {
     TM_CHECK(!weights.empty());
@@ -115,7 +138,8 @@ GatedDeltaNetLayer::GatedDeltaNetLayer(std::vector<DeltaNetWeight*> weights,
             planning.q_offsets = {0, 16};
         }
         Operation operation{};
-        operation.mode = mode;
+        operation.mode     = mode;
+        operation.cp_level = gdr_cp_level_;
         Plan plan;
         TM_CHECK(delta_rule_.Plan(operation, planning, &plan));
     };
@@ -133,11 +157,12 @@ GatedDeltaNetLayer::GatedDeltaNetLayer(std::vector<DeltaNetWeight*> weights,
     registry.checkpoint().Register(conv_total_bytes_, 1);
 
     const size_t prefix_bytes = registry.prefix().accumulation_bytes();
-    TM_LOG_INFO("[GDN] input_dtype={} state_dtype={} block config L_b={} H_b={} -> "
+    TM_LOG_INFO("[GDN] input_dtype={} state_dtype={} gdr_cp_level={} block config L_b={} H_b={} -> "
                 "num_layer_groups={} num_head_groups={} num_blocks={} block_bytes={} "
                 "prefix_object_bytes={} ({})",
                 input_dtype_,
                 recurrent_state_dtype_,
+                static_cast<int>(gdr_cp_level_),
                 layers_per_block_,
                 heads_per_block_,
                 num_layer_groups_,
@@ -278,7 +303,8 @@ void GatedDeltaNetLayer::Setup(int phase, TensorMap& env)
         planning.beta_batch_stride = planning.gate_batch_stride;
         planning.q_offsets.assign(host_offsets.begin() + data.decode_count, host_offsets.end());
         linear_attn::delta_rule::Operation operation{};
-        operation.mode = linear_attn::delta_rule::GdrMode::kChunked;
+        operation.mode     = linear_attn::delta_rule::GdrMode::kChunked;
+        operation.cp_level = gdr_cp_level_;
         linear_attn::delta_rule::Plan plan;
         TM_CHECK(delta_rule_.Plan(operation, planning, &plan));
         data.chunked_plan.emplace(std::move(plan));

--- a/src/turbomind/models/llama/GatedDeltaNetLayer.h
+++ b/src/turbomind/models/llama/GatedDeltaNetLayer.h
@@ -45,6 +45,8 @@ private:
     const int      tp_size_;
     const DataType recurrent_state_dtype_;
 
+    const linear_attn::delta_rule::ContextParallelLevel gdr_cp_level_;
+
     LlamaLinear& linear_;
 
     // Per-phase batch data (mirrors UnifiedAttentionLayer pattern)

--- a/tests/turbomind/linear_attn/benchmark.py
+++ b/tests/turbomind/linear_attn/benchmark.py
@@ -27,7 +27,7 @@ from .cases import (
 )
 
 VALID_BACKENDS = ('reference', 'turbomind', 'fla', 'flashqla')
-VALID_CP_MODES = ('auto', 'off')
+VALID_CP_LEVELS = ('all', 'exact', 'off')
 VALID_CP_PATTERNS = ('auto', 'warmup', 'fallback', 'alternating')
 CP_FALLBACK_SEGMENT_LOG_DECAY = -5.0
 
@@ -41,7 +41,7 @@ class BenchmarkRequest:
     backend: str
     state_dtype: str
     chunk_size: int | None
-    cp_mode: str
+    cp_level: str
     cp_pattern: str
     validate_outputs: bool
     print_diffs: bool
@@ -89,7 +89,7 @@ def base_row(
     run: RunCase,
     backend: str,
     *,
-    cp_mode: str = 'auto',
+    cp_level: str = 'all',
     cp_pattern: str = 'auto',
     cp_enabled: bool | None = None,
     **extra,
@@ -107,7 +107,7 @@ def base_row(
         'hv': run.input.heads.hv,
         'chunk_size': run.chunk_size,
         'chunks': case_chunks(run),
-        'cp_mode': cp_mode,
+        'cp_level': cp_level,
         'cp_pattern': cp_pattern,
     }
     if cp_enabled is not None:
@@ -126,9 +126,9 @@ def format_row(row: dict[str, object]) -> str:
     return ','.join(parts)
 
 
-def _validate_cp_mode(cp_mode: str) -> None:
-    if cp_mode not in VALID_CP_MODES:
-        raise ValueError(f'unsupported_cp_mode {cp_mode}')
+def _validate_cp_level(cp_level: str) -> None:
+    if cp_level not in VALID_CP_LEVELS:
+        raise ValueError(f'unsupported_cp_level {cp_level}')
 
 
 def _validate_cp_pattern(cp_pattern: str) -> None:
@@ -136,20 +136,11 @@ def _validate_cp_pattern(cp_pattern: str) -> None:
         raise ValueError(f'unsupported_cp_pattern {cp_pattern}')
 
 
-def validate_cp_request(cp_mode: str, cp_pattern: str, backend: str) -> None:
-    _validate_cp_mode(cp_mode)
+def validate_cp_request(cp_level: str, cp_pattern: str, backend: str) -> None:
+    _validate_cp_level(cp_level)
     _validate_cp_pattern(cp_pattern)
     if cp_pattern != 'auto' and backend not in ('turbomind', 'flashqla'):
         raise ValueError('cp_pattern_requires_cp_backend')
-
-
-def enforce_cp_intent(row: dict[str, object], cp_mode: str) -> None:
-    _validate_cp_mode(cp_mode)
-    if cp_mode == 'auto':
-        return
-    cp_enabled = bool(row.get('cp_enabled', False))
-    if cp_mode == 'off' and cp_enabled:
-        raise ValueError('cp_selected')
 
 
 def apply_cp_pattern(
@@ -807,7 +798,6 @@ BACKEND_UNSUPPORTED_REASONS = (
     'flashqla_requires_chunk32',
     'flashqla_requires_chunk64',
     'fla_requires_chunk64',
-    'cp_selected',
     'cp_pattern_requires_cp_backend',
     'cp_not_selected',
     'cp_pattern_requires_multiple_segments',
@@ -826,7 +816,7 @@ def unavailable_row(run: RunCase, request: BenchmarkRequest) -> dict[str, object
     return base_row(
         run,
         request.backend,
-        cp_mode=request.cp_mode,
+        cp_level=request.cp_level,
         cp_pattern=request.cp_pattern,
         status='unavailable',
     )
@@ -836,7 +826,7 @@ def unsupported_row(run: RunCase, request: BenchmarkRequest, reason: str) -> dic
     return base_row(
         run,
         request.backend,
-        cp_mode=request.cp_mode,
+        cp_level=request.cp_level,
         cp_pattern=request.cp_pattern,
         status='unsupported',
         reason=reason,
@@ -845,7 +835,7 @@ def unsupported_row(run: RunCase, request: BenchmarkRequest, reason: str) -> dic
 
 def run_case(run: RunCase, request: BenchmarkRequest, device: torch.device) -> dict[str, object]:
     try:
-        validate_cp_request(request.cp_mode, request.cp_pattern, request.backend)
+        validate_cp_request(request.cp_level, request.cp_pattern, request.backend)
     except ValueError as exc:
         reason = str(exc)
         if reason not in BACKEND_UNSUPPORTED_REASONS:
@@ -874,15 +864,7 @@ def run_case(run: RunCase, request: BenchmarkRequest, device: torch.device) -> d
         if reason not in BACKEND_UNSUPPORTED_REASONS:
             raise
         return unsupported_row(run, request, reason)
-    row = time_task(task, request, device)
-    try:
-        enforce_cp_intent(row, request.cp_mode)
-    except ValueError as exc:
-        reason = str(exc)
-        if reason not in BACKEND_UNSUPPORTED_REASONS:
-            raise
-        return unsupported_row(run, request, reason)
-    return row
+    return time_task(task, request, device)
 
 
 CP_UNSUPPORTED_REASONS = BACKEND_UNSUPPORTED_REASONS
@@ -912,7 +894,7 @@ def request_from_args(args, *, backend: str, run: RunCase) -> BenchmarkRequest:
         backend=backend,
         state_dtype=run.state_dtype,
         chunk_size=args.chunk_size,
-        cp_mode=args.cp_mode,
+        cp_level=args.cp_level,
         cp_pattern=args.cp_pattern,
         validate_outputs=not args.skip_validate,
         print_diffs=args.print_diffs,
@@ -972,7 +954,7 @@ def make_parser() -> argparse.ArgumentParser:
     parser.add_argument('--batch-size', type=int, default=1)
     parser.add_argument('--backend', default='reference')
     parser.add_argument('--chunk-size', type=parse_chunk_size, default='auto')
-    parser.add_argument('--cp-mode', choices=VALID_CP_MODES, default='auto')
+    parser.add_argument('--cp-level', choices=VALID_CP_LEVELS, default='all')
     parser.add_argument('--cp-pattern', choices=VALID_CP_PATTERNS, default='auto')
     parser.add_argument('--print-diffs', action='store_true')
     parser.add_argument('--no-l2-flush', action='store_true')

--- a/tests/turbomind/linear_attn/fla_gated_delta_rule.py
+++ b/tests/turbomind/linear_attn/fla_gated_delta_rule.py
@@ -108,7 +108,7 @@ def make_benchmark_task(run: RunCase, inputs: InputTensors, request: BenchmarkRe
         base_row(
             run,
             'fla',
-            cp_mode=request.cp_mode,
+            cp_level=request.cp_level,
             cp_pattern=request.cp_pattern,
             cp_enabled=False,
         ),

--- a/tests/turbomind/linear_attn/flashqla_gated_delta_rule.py
+++ b/tests/turbomind/linear_attn/flashqla_gated_delta_rule.py
@@ -18,9 +18,6 @@ class FlashQlaUnsupported(ValueError):
     pass
 
 
-FLASHQLA_CHUNK_SIZE = 32
-
-
 @dataclass(frozen=True)
 class FlashQlaResult:
     out: torch.Tensor | None
@@ -31,17 +28,13 @@ class FlashQlaResult:
 @cache
 def _imports() -> dict[str, object]:
     from flash_qla.ops.gated_delta_rule import chunk as qla_chunk
-    from flash_qla.ops.gated_delta_rule.chunk.cp_context import (
-        _calc_cp_seqs,
-        intra_card_cp_preprocess,
-    )
+    from flash_qla.ops.gated_delta_rule.chunk.cp_context import intra_card_cp_preprocess
     from flash_qla.ops.utils import chunk_local_cumsum
 
     return {
         'chunk_local_cumsum': chunk_local_cumsum,
         'kkt_solve': qla_chunk.kkt_solve,
         'fused_gdr_fwd': qla_chunk.fused_gdr_fwd,
-        'calc_cp_seqs': _calc_cp_seqs,
         'intra_card_cp_preprocess': intra_card_cp_preprocess,
     }
 
@@ -62,17 +55,15 @@ def all_forward(q: torch.Tensor,
                 *,
                 initial_state: torch.Tensor | None = None,
                 cu_seqlens: torch.Tensor | None = None,
-                cp_mode: str = 'auto') -> FlashQlaResult:
+                cp_level: str = 'all') -> FlashQlaResult:
     imports = _imports()
-    g_cumsum = imports['chunk_local_cumsum'](
-        g,
-        chunk_size=FLASHQLA_CHUNK_SIZE,
-        cu_seqlens=cu_seqlens,
-    )
     a = imports['kkt_solve'](
         k=k,
         b=beta,
-        chunk_size=FLASHQLA_CHUNK_SIZE,
+        cu_seqlens=cu_seqlens,
+    )
+    g_cumsum = imports['chunk_local_cumsum'](
+        g,
         cu_seqlens=cu_seqlens,
     )
     run_initial_state = initial_state
@@ -81,8 +72,8 @@ def all_forward(q: torch.Tensor,
     raw_cu_seqlens = None
     cp_enabled = False
 
-    if cp_mode == 'auto':
-        run_initial_state, run_cu_seqlens, cp_seq_map, raw_cu_seqlens, _cp_cache = imports[
+    if cp_level == 'all':
+        run_initial_state, run_cu_seqlens, cp_seq_map, raw_cu_seqlens = imports[
             'intra_card_cp_preprocess'
         ](
             k=k,
@@ -96,8 +87,8 @@ def all_forward(q: torch.Tensor,
             enable_fwd_cp_cache=False,
         )
         cp_enabled = cp_seq_map is not None
-    elif cp_mode != 'off':
-        raise FlashQlaUnsupported(f'unsupported_cp_mode {cp_mode}')
+    elif cp_level != 'off':
+        raise FlashQlaUnsupported(f'unsupported_cp_level {cp_level}')
 
     out, _h, final_state = imports['fused_gdr_fwd'](
         q=q,
@@ -118,30 +109,31 @@ def all_forward(q: torch.Tensor,
     return FlashQlaResult(out=out, final_state=final_state, cp_enabled=cp_enabled)
 
 
-def validate_benchmark_case(run: RunCase, request: BenchmarkRequest) -> None:
-    if run.chunk_size != FLASHQLA_CHUNK_SIZE:
-        raise ValueError(f'flashqla_requires_chunk{FLASHQLA_CHUNK_SIZE}')
-
-
 def _cp_pattern_segment_tokens(inputs: InputTensors) -> int:
-    if inputs.q.shape[0] != 1:
-        raise ValueError('cp_not_selected')
-
-    raw_q_offsets = inputs.offsets
-    if raw_q_offsets is None:
-        raw_q_offsets = torch.tensor(
-            (0, inputs.q.shape[1]),
-            dtype=torch.int32,
-            device=inputs.q.device,
-        )
-    use_cp, cp_q_offsets, sequence_starts, _, _, _ = _imports()['calc_cp_seqs'](
-        raw_q_offsets,
-        FLASHQLA_CHUNK_SIZE,
-        inputs.v.shape[2],
+    imports = _imports()
+    a = imports['kkt_solve'](
+        k=inputs.k,
+        b=inputs.beta,
+        cu_seqlens=inputs.offsets,
     )
-    if not use_cp:
+    g_cumsum = imports['chunk_local_cumsum'](
+        inputs.g,
+        cu_seqlens=inputs.offsets,
+    )
+    _, cp_q_offsets, cp_seq_map, _ = imports['intra_card_cp_preprocess'](
+        k=inputs.k,
+        v=inputs.v,
+        a=a,
+        g=g_cumsum,
+        b=inputs.beta,
+        raw_h0=inputs.h0,
+        raw_cu_seqlens=inputs.offsets,
+        state_v_first=False,
+        enable_fwd_cp_cache=False,
+    )
+    if cp_seq_map is None:
         raise ValueError('cp_not_selected')
-    if not bool(((sequence_starts[1:] - sequence_starts[:-1]) > 1).any().item()):
+    if cp_seq_map.unique().numel() == cp_seq_map.numel():
         raise ValueError('cp_pattern_requires_multiple_segments')
     return int((cp_q_offsets[1:] - cp_q_offsets[:-1]).max().item())
 
@@ -151,9 +143,8 @@ def make_benchmark_task(run: RunCase, inputs: InputTensors, request: BenchmarkRe
     from .benchmark import base_row
     from .reference import chunk_gated_delta_rule_fwd
 
-    validate_benchmark_case(run, request)
     if request.cp_pattern != 'auto':
-        if request.cp_mode != 'auto':
+        if request.cp_level != 'all':
             raise ValueError('cp_not_selected')
         inputs = apply_cp_pattern(
             run.input,
@@ -164,7 +155,7 @@ def make_benchmark_task(run: RunCase, inputs: InputTensors, request: BenchmarkRe
     row = base_row(
         run,
         'flashqla',
-        cp_mode=request.cp_mode,
+        cp_level=request.cp_level,
         cp_pattern=request.cp_pattern,
     )
 
@@ -177,7 +168,7 @@ def make_benchmark_task(run: RunCase, inputs: InputTensors, request: BenchmarkRe
             inputs.beta,
             initial_state=inputs.h0,
             cu_seqlens=inputs.offsets,
-            cp_mode=request.cp_mode,
+            cp_level=request.cp_level,
         )
         row['cp_enabled'] = result.cp_enabled
         return result

--- a/tests/turbomind/linear_attn/reference.py
+++ b/tests/turbomind/linear_attn/reference.py
@@ -454,7 +454,7 @@ def make_benchmark_task(run: RunCase, inputs: InputTensors, request: BenchmarkRe
         base_row(
             run,
             'reference',
-            cp_mode=request.cp_mode,
+            cp_level=request.cp_level,
             cp_pattern=request.cp_pattern,
             cp_enabled=False,
         ),

--- a/tests/turbomind/linear_attn/test_gated_delta_rule.py
+++ b/tests/turbomind/linear_attn/test_gated_delta_rule.py
@@ -114,7 +114,7 @@ def _native_plan(run: RunCase, *, chunk_size):
         state_dtype=_native_state_dtype(run.state_dtype),
         mode='recurrent' if recurrent else 'chunked',
         chunk_size=chunk_size,
-        cp_mode='auto',
+        cp_level='all',
         num_head_groups=1,
         heads_per_block=run.input.heads.hv,
     )
@@ -219,7 +219,7 @@ def test_registered_arch_matrix_matches_reference(
         state_dtype=native_state_dtype,
         mode=mode,
         chunk_size=None,
-        cp_mode='off',
+        cp_level='off',
         q_offsets=q_offsets,
         num_head_groups=1,
         heads_per_block=10,
@@ -241,7 +241,7 @@ def test_registered_arch_matrix_matches_reference(
         native_inputs.g, native_inputs.beta,
         state_ptrs=state.ptrs[:, None], q_offsets=q_offsets,
         finished=finished,
-        state_dtype=native_state_dtype, mode=mode, cp_mode='off',
+        state_dtype=native_state_dtype, mode=mode, cp_level='off',
         num_head_groups=1, heads_per_block=10, plan=plan)
     torch.testing.assert_close(actual_o, expected_o, rtol=8e-2, atol=8e-2)
     torch.testing.assert_close(state.storage.float(), expected_state, rtol=8e-2, atol=8e-2)
@@ -282,6 +282,7 @@ def test_auto_plan_binds_one_complete_registered_operation():
 def test_benchmark_chunk_size_defaults_to_auto():
     args = make_parser().parse_args([])
     assert args.chunk_size is None
+    assert args.cp_level == 'all'
     assert args.cp_pattern == 'auto'
 
 
@@ -292,10 +293,16 @@ def test_benchmark_cp_pattern_choices(cp_pattern):
 
 
 def test_cp_pattern_supports_cp_backends():
-    validate_cp_request('auto', 'alternating', 'turbomind')
-    validate_cp_request('auto', 'alternating', 'flashqla')
+    validate_cp_request('all', 'alternating', 'turbomind')
+    validate_cp_request('all', 'alternating', 'flashqla')
     with pytest.raises(ValueError, match='cp_pattern_requires_cp_backend'):
-        validate_cp_request('auto', 'alternating', 'reference')
+        validate_cp_request('all', 'alternating', 'reference')
+
+
+@pytest.mark.parametrize('cp_level', ('all', 'exact', 'off'))
+def test_benchmark_cp_level_choices(cp_level):
+    args = make_parser().parse_args(['--cp-level', cp_level])
+    assert args.cp_level == cp_level
 
 
 def _cp_pattern_inputs(case):
@@ -456,7 +463,7 @@ def test_explicit_recurrent_chunk_one_matches_reference():
         finished=torch.zeros(run.input.real_batch_size, device='cuda', dtype=torch.bool),
         state_dtype=_native_state_dtype(run.state_dtype),
         chunk_size=1,
-        cp_mode='auto',
+        cp_level='all',
     )
 
     torch.testing.assert_close(actual_o, expected_o, rtol=8e-2, atol=8e-2)
@@ -481,7 +488,7 @@ def test_omitted_run_chunk_size_reuses_explicit_chunked_plan():
         state_dtype=_native_state_dtype(run.state_dtype),
         mode='chunked',
         chunk_size=run.chunk_size,
-        cp_mode='off',
+        cp_level='off',
         num_head_groups=1,
         heads_per_block=run.input.heads.hv,
     )
@@ -506,7 +513,7 @@ def test_omitted_run_chunk_size_reuses_explicit_chunked_plan():
         finished=finished,
         state_dtype=_native_state_dtype(run.state_dtype),
         chunk_size=None,
-        cp_mode='off',
+        cp_level='off',
         plan=plan,
     )
 
@@ -545,7 +552,7 @@ def test_bound_chunked_plan_ignores_conflicting_runtime_chunk_size(monkeypatch):
         finished=finished,
         state_dtype=_native_state_dtype(run.state_dtype),
         chunk_size=1,
-        cp_mode='off',
+        cp_level='off',
         out=out,
         state_tma_descs=torch.empty(0, device=device, dtype=torch.uint8),
         plan=plan,
@@ -596,7 +603,7 @@ def test_delta_rule_wrapper_all_generated_smoke_matches_reference(run):
         q_offsets=q_offsets,
         finished=finished,
         state_dtype=state_dtype,
-        cp_mode='auto',
+        cp_level='all',
         out=actual_o,
     )
 
@@ -770,7 +777,7 @@ def test_finished_sequence_produces_output_without_storing_state(mode):
         native_inputs.q, native_inputs.k, native_inputs.v,
         native_inputs.g, native_inputs.beta,
         state_ptrs=state.ptrs[:, None], q_offsets=q_offsets, finished=finished,
-        state_dtype='f32', mode=mode, cp_mode='off',
+        state_dtype='f32', mode=mode, cp_level='off',
         num_head_groups=1, heads_per_block=10)
     torch.testing.assert_close(actual_o, expected_o, rtol=8e-2, atol=8e-2)
     torch.testing.assert_close(state.storage[0].float(), initial[0], rtol=0, atol=0)
@@ -813,7 +820,7 @@ def test_one_chunked_plan_reuses_grouped_state_across_layer_offsets():
         state_dtype='f32',
         mode='chunked',
         chunk_size=None,
-        cp_mode='off',
+        cp_level='off',
         q_offsets=q_offsets,
         num_head_groups=3,
         heads_per_block=4,
@@ -848,7 +855,8 @@ def test_one_chunked_plan_reuses_grouped_state_across_layer_offsets():
 
 @cuda_required
 @pytest.mark.skipif(non_sm90_or_sm120, reason='optimized GDR target requires SM90 or SM120')
-def test_cp_matches_normalized_reference():
+@pytest.mark.parametrize('cp_level', ('exact', 'all'))
+def test_cp_matches_normalized_reference(cp_level):
     chunk_size = 32 if is_sm120 else 64
     seq_len = 513 * chunk_size if is_sm120 else 4096
     case = InputCase(
@@ -872,13 +880,14 @@ def test_cp_matches_normalized_reference():
         state_dtype='f32',
         mode='chunked',
         chunk_size=None,
-        cp_mode='auto',
+        cp_level=cp_level,
         q_offsets=q_offsets,
         num_head_groups=1,
         heads_per_block=8,
     )
     assert plan['problem']['chunk_size'] == chunk_size
     assert plan['cp']['enabled'] is True
+    assert plan['cp']['cp_level'] == cp_level
     expected_o, expected_state = chunk_gated_delta_rule_fwd(
         inputs.q, inputs.k, inputs.v, inputs.g, inputs.beta,
         initial_state=initial, chunk_size=chunk_size)
@@ -913,3 +922,16 @@ def test_cp_matches_normalized_reference():
     )
     torch.testing.assert_close(finished_o, expected_o, rtol=8e-2, atol=8e-2)
     torch.testing.assert_close(state.storage.float(), initial, rtol=0, atol=0)
+
+    disabled_plan = bridge.plan(
+        native_inputs,
+        state_dtype='f32',
+        mode='chunked',
+        chunk_size=None,
+        cp_level='off',
+        q_offsets=q_offsets,
+        num_head_groups=1,
+        heads_per_block=8,
+    )
+    assert disabled_plan['cp']['enabled'] is False
+    assert disabled_plan['cp']['cp_level'] == 'off'

--- a/tests/turbomind/linear_attn/turbomind_gated_delta_rule.py
+++ b/tests/turbomind/linear_attn/turbomind_gated_delta_rule.py
@@ -10,7 +10,6 @@ from .benchmark import (
     apply_cp_pattern,
     base_row,
     diff_metrics,
-    enforce_cp_intent,
 )
 from .cases import (
     Fixed,
@@ -66,7 +65,7 @@ class NativeBridge:
         state_dtype='f32',
         mode='chunked',
         chunk_size=None,
-        cp_mode='auto',
+        cp_level='all',
         num_head_groups=1,
         heads_per_block=0,
     ):
@@ -80,7 +79,7 @@ class NativeBridge:
             state_dtype=state_dtype,
             mode=mode,
             chunk_size=chunk_size,
-            cp_mode=cp_mode,
+            cp_level=cp_level,
             num_head_groups=num_head_groups,
             heads_per_block=heads_per_block,
         )
@@ -235,7 +234,7 @@ def chunk_gated_delta_rule_fwd(
     state_dtype: str = 'f32',
     mode: str | None = None,
     chunk_size: int | None = None,
-    cp_mode: str = 'auto',
+    cp_level: str = 'all',
     state_layer_offset: int = 0,
     num_head_groups: int = 1,
     heads_per_block: int = 0,
@@ -269,7 +268,7 @@ def chunk_gated_delta_rule_fwd(
             state_dtype=state_dtype,
             mode='recurrent' if recurrent else 'chunked',
             chunk_size=chunk_size,
-            cp_mode=cp_mode,
+            cp_level=cp_level,
             num_head_groups=num_head_groups,
             heads_per_block=heads_per_block or v.shape[2],
         )
@@ -341,7 +340,7 @@ def _turbomind_task(run: RunCase, inputs: InputTensors, request: BenchmarkReques
         state_dtype=state_arg,
         mode='recurrent' if recurrent else 'chunked',
         chunk_size=chunk_size,
-        cp_mode=request.cp_mode,
+        cp_level=request.cp_level,
         num_head_groups=1,
         heads_per_block=run.input.heads.hv,
     )
@@ -406,12 +405,10 @@ def _turbomind_task(run: RunCase, inputs: InputTensors, request: BenchmarkReques
         'turbomind',
         state_dtype=request.state_dtype,
         chunk_size=planned_chunk_size,
-        cp_mode=request.cp_mode,
+        cp_level=request.cp_level,
         cp_pattern=request.cp_pattern,
         cp_enabled=cp_enabled,
     )
-    enforce_cp_intent(row, request.cp_mode)
-
     def prepare():
         state.reset(inputs.h0)
 
@@ -427,7 +424,7 @@ def _turbomind_task(run: RunCase, inputs: InputTensors, request: BenchmarkReques
             finished=kwargs['finished'],
             state_dtype=state_arg,
             chunk_size=planned_chunk_size,
-            cp_mode=request.cp_mode,
+            cp_level=request.cp_level,
             out=out,
             workspace=workspace,
             state_tma_descs=kwargs.get('state_tma_descs'),


### PR DESCRIPTION
## Motivation

TurboMind GDR needs explicit controls for context-parallel execution and a way to force the legacy implementation on newer GPUs for debugging, validation, and performance comparison.

## Changes

- Add `ContextParallelLevel` with three supported levels:
  - `off`: disable context parallelism.
  - `exact`: allow exact CP only, without warmup CP.
  - `all`: allow both exact and warmup CP.
- Expose the CP level through:
  - Python `cp_level` values `off`, `exact`, and `all`.
  - `TM_GDR_CP_LEVEL` values `0`, `1`, and `2`.
- Propagate the selected CP level through GDR operation and plan metadata.
- Keep CP disabled for the legacy pre-SM90 implementation.
- Let FlashQLa use its architecture-specific default chunk size without passing or preparing an explicit chunk size.
- Compile the pre-SM90 recurrent and chunked GDR kernels for every configured CUDA target.
- Add `TM_GDR_FORCE_LEGACY`:
  - Unset or `0`: use native architecture dispatch.
  - `1`: force the pre-SM90 kernel family.
  - Other values: report an invalid configuration.
- Parse and cache `TM_GDR_FORCE_LEGACY` once per process.
- Make kernel-family selection explicit in the GDR registry.
- When legacy dispatch is forced, use chunk 1 for recurrent execution and chunk 16 for chunked execution.

## Validation

- Qwen3.5-27B model smoke tests passed for:
  - `TM_GDR_CP_LEVEL=0`
  - `TM_GDR_CP_LEVEL=1`
  - `TM_GDR_CP_LEVEL=2`
  - `TM_GDR_FORCE_LEGACY=1`