### PR TITLE
[Fix] generate: propagate the disconnect 400 instead of returning null

### DIFF
--- a/lmdeploy/serve/openai/api_server.py
+++ b/lmdeploy/serve/openai/api_server.py
@@ -1081,7 +1081,9 @@ async def generate(request: GenerateReqInput, raw_request: Request = None):
                                      completion_tokens=res.generate_token_len)
         response = GenerateReqOutput(text=text, output_ids=output_ids, meta_info=meta)
 
-    await _inner_call()
+    inner_result = await _inner_call()
+    if inner_result is not None:
+        return inner_result
     return response
 
 

--- a/tests/test_lmdeploy/serve/test_session_cleanup.py
+++ b/tests/test_lmdeploy/serve/test_session_cleanup.py
@@ -257,3 +257,48 @@ async def _run_max_new_tokens_zero_cleans_up_session():
 
 def test_max_new_tokens_zero_cleans_up_session():
     asyncio.run(_run_max_new_tokens_zero_cleans_up_session())
+
+
+async def _run_generate_disconnect_returns_client_disconnected_response():
+    from types import SimpleNamespace
+
+    from fastapi.responses import JSONResponse
+
+    from lmdeploy.serve.core.async_engine import GenOut
+    from lmdeploy.serve.openai.api_server import VariableInterface, generate
+    from lmdeploy.serve.openai.protocol import GenerateReqInput
+
+    class _FakeAsyncEngine:
+        epoch = 0
+
+        def __init__(self):
+            self.backend_config = SimpleNamespace()
+            self.session_mgr = SessionManager()
+
+        async def generate(self, **kwargs):
+            yield GenOut(response='hi', input_token_len=1, generate_token_len=1, finish_reason=None)
+            await asyncio.Event().wait()
+
+    class _FakeRawRequest:
+
+        async def json(self):
+            return {}
+
+        async def is_disconnected(self):
+            return True
+
+    origin_async_engine = VariableInterface.async_engine
+    VariableInterface.async_engine = _FakeAsyncEngine()
+    try:
+        request = GenerateReqInput(prompt='hello', stream=False)
+        result = await generate(request, _FakeRawRequest())
+    finally:
+        VariableInterface.async_engine = origin_async_engine
+
+    assert isinstance(result, JSONResponse)
+    assert result.status_code == 400
+    assert b'Client disconnected' in result.body
+
+
+def test_generate_disconnect_returns_client_disconnected_response():
+    asyncio.run(_run_generate_disconnect_returns_client_disconnected_response())


### PR DESCRIPTION
## Motivation

Fixes #4781. The non-streaming `/generate` endpoint aborts the session on client disconnect but discards the `400` response it computed, so the caller gets `HTTP 200` with a `null` body instead. Same discard-the-inner-return shape as #4776/#4777, in the sibling `/generate` endpoint.

## Modification

`generate`'s `_inner_call()` returns the disconnect error response from inside its `async with` block, but the call site (`await _inner_call()`) never captured it, and the `nonlocal response` it otherwise sets is only reachable on the non-disconnect path. Capture `_inner_call()`'s return value and return it directly when not `None`, falling back to `response` only on the normal completion path:

```python
inner_result = await _inner_call()
if inner_result is not None:
    return inner_result
return response
```

## Verification

Docker (`python:3.11-slim`, CPU-only deps, no GPU), current `main` (`9140d372`). Added `test_generate_disconnect_returns_client_disconnected_response` to `tests/test_lmdeploy/serve/test_session_cleanup.py`, mirroring the existing `test_completions_v1_disconnect_returns_client_disconnected_response` in the same file: a fake `AsyncEngine.generate()` yields one item then blocks, and a fake `raw_request.is_disconnected()` returns `True`. Confirmed the test fails on unmodified `main` (`result` is `None`) and passes with this change. The full `tests/test_lmdeploy/serve/test_session_cleanup.py` file (10 tests) stays green, and `pre-commit run --files` on both changed files passes.

Not verified: the CUDA/GPU CI legs (no GPU on this machine) and the pre-existing failures in `tests/test_lmdeploy/serve/openai/responses/` (unrelated `pydantic` validation errors in the `/responses` API, reproduced as already red on unmodified `main`, untouched by this change).

## BC-breaking

None.

## Checklist

1. Pre-commit run on the changed files.
2. Covered by a new unit test (fails on main, passes here).

Refs #4811: `completions_v1` has the same discard-the-return-value bug (via `asyncio.gather`), scoped out of this PR at the reporter's own suggestion; see the thread there.