### PR TITLE
fix(benchmark): seed NumPy RNG so --seed controls random-mode lengths (#4784)

### DIFF
--- a/benchmark/benchmark_guided.py
+++ b/benchmark/benchmark_guided.py
@@ -527,6 +527,7 @@ def run_once(engine: Engine, requests, temperature, top_p, top_k,
 def main():
     args = parse_args()
     random.seed(args.seed)
+    np.random.seed(args.seed)
     os.environ['TM_LOG_LEVEL'] = args.log_level
 
     json_schema = None

--- a/benchmark/profile_pipeline_api.py
+++ b/benchmark/profile_pipeline_api.py
@@ -294,6 +294,7 @@ def parse_args():
 def main():
     args = parse_args()
     random.seed(args.seed)
+    np.random.seed(args.seed)
     os.environ['TM_LOG_LEVEL'] = args.log_level
     if args.backend == 'turbomind':
         engine_config = TurbomindEngineConfig(max_batch_size=args.concurrency,

--- a/benchmark/profile_throughput.py
+++ b/benchmark/profile_throughput.py
@@ -347,6 +347,7 @@ def parse_args():
 def main():
     args = parse_args()
     random.seed(args.seed)
+    np.random.seed(args.seed)
     if args.backend == 'turbomind':
         engine_config = TurbomindEngineConfig(
             max_batch_size=args.concurrency // args.dp,


### PR DESCRIPTION
## Summary

Three benchmark entry points seed Python's `random` module but build their random-mode input/output lengths with NumPy's **global** RNG, which is never seeded. As a result `--seed` does not make the sampled benchmark workload reproducible:

- `benchmark/profile_pipeline_api.py` — `random.seed(args.seed)` only; lengths via `np.random.randint` (input/output/offsets)
- `benchmark/profile_throughput.py` — same
- `benchmark/benchmark_guided.py` — same

`benchmark/profile_restful_api.py` already seeds **both** (`random.seed` + `np.random.seed`), so this simply brings the other three in line with the existing correct pattern.

## Fix

Add `np.random.seed(args.seed)` immediately after the existing `random.seed(args.seed)` in each of the three scripts (`numpy` is already imported as `np` in all of them).

```python
    random.seed(args.seed)
    np.random.seed(args.seed)
```

## Scope

This makes the **sampled random-mode workload** (`--dataset-name random`) reproducible for a given `--seed`. It does **not** claim deterministic model outputs, GPU kernels, scheduling, or end-to-end latency/throughput. The ShareGPT sampler path is unaffected.

Fixes #4784

🤖 Generated with [Claude Code](https://claude.com/claude-code)
