### PR TITLE
feat(turbomind): enable SM90 GDR PDL and fix CP matrix layout

### DIFF
--- a/src/turbomind/kernels/linear_attn/kernel/CMakeLists.txt
+++ b/src/turbomind/kernels/linear_attn/kernel/CMakeLists.txt
@@ -66,6 +66,7 @@ if(LINEAR_ATTN_GDR_SM90_ARCHS)
     add_library(linear_attn_kernels_sm90 STATIC ${LINEAR_ATTN_GDR_SM90_KERNEL_SOURCES})
     set_property(TARGET linear_attn_kernels_sm90 PROPERTY
             CUDA_ARCHITECTURES "${LINEAR_ATTN_GDR_SM90_ARCHS}")
+    target_compile_definitions(linear_attn_kernels_sm90 PRIVATE CUTLASS_ENABLE_GDC_FOR_SM90=1)
     configure_linear_attn_kernel_target(linear_attn_kernels_sm90)
     list(APPEND LINEAR_ATTN_GDR_KERNEL_TARGETS linear_attn_kernels_sm90)
 endif()

--- a/src/turbomind/kernels/linear_attn/kernel/sm_90/common.h
+++ b/src/turbomind/kernels/linear_attn/kernel/sm_90/common.h
@@ -68,6 +68,26 @@ CUTE_HOST_DEVICE constexpr auto FusedGdrGmmaQkKLayout()
 }
 
 template<class Element>
+CUTE_HOST_DEVICE constexpr auto FusedGdrGmmaSegmentMatrixLayout()
+{
+    // segment_m is row-major [DK, DK]. Its TMA producer copies two
+    // 128-row-by-64-column SW128 boxes into consecutive shared-memory slabs.
+    // Layout_K_SW128 tiled to [DK, DK] is the matching GMMA-A view.
+    return cute::tile_to_shape(cute::SM90::GMMA::Layout_K_SW128_Atom<Element>{},
+                               cute::make_shape(cute::Int<kHeadDim>{}, cute::Int<kHeadDim>{}));
+}
+
+static_assert(cute::cosize_v<decltype(FusedGdrGmmaSegmentMatrixLayout<cute::bfloat16_t>())>
+              == kHeadDim * kHeadDim);
+static_assert(FusedGdrGmmaSegmentMatrixLayout<cute::bfloat16_t>()(
+                  cute::Int<0>{}, cute::Int<kHeadDim / 2>{})
+              == (kHeadDim / 2) * kHeadDim);
+static_assert(FusedGdrGmmaSegmentMatrixLayout<cute::bfloat16_t>()(
+                  cute::Int<kHeadDim - 1>{}, cute::Int<kHeadDim - 1>{})
+              == (kHeadDim / 2) * kHeadDim
+                     + cute::Swizzle<3, 4, 3>{}((kHeadDim - 1) * (kHeadDim / 2) + (kHeadDim / 2 - 1)));
+
+template<class Element>
 CUTE_HOST_DEVICE constexpr auto FusedGdrGmmaQkTransposeALayout()
 {
     static_assert(sizeof(Element) == 2);

--- a/src/turbomind/kernels/linear_attn/kernel/sm_90/common.h
+++ b/src/turbomind/kernels/linear_attn/kernel/sm_90/common.h
@@ -77,13 +77,10 @@ CUTE_HOST_DEVICE constexpr auto FusedGdrGmmaSegmentMatrixLayout()
                                cute::make_shape(cute::Int<kHeadDim>{}, cute::Int<kHeadDim>{}));
 }
 
-static_assert(cute::cosize_v<decltype(FusedGdrGmmaSegmentMatrixLayout<cute::bfloat16_t>())>
-              == kHeadDim * kHeadDim);
-static_assert(FusedGdrGmmaSegmentMatrixLayout<cute::bfloat16_t>()(
-                  cute::Int<0>{}, cute::Int<kHeadDim / 2>{})
+static_assert(cute::cosize_v<decltype(FusedGdrGmmaSegmentMatrixLayout<cute::bfloat16_t>())> == kHeadDim * kHeadDim);
+static_assert(FusedGdrGmmaSegmentMatrixLayout<cute::bfloat16_t>()(cute::Int<0>{}, cute::Int<kHeadDim / 2>{})
               == (kHeadDim / 2) * kHeadDim);
-static_assert(FusedGdrGmmaSegmentMatrixLayout<cute::bfloat16_t>()(
-                  cute::Int<kHeadDim - 1>{}, cute::Int<kHeadDim - 1>{})
+static_assert(FusedGdrGmmaSegmentMatrixLayout<cute::bfloat16_t>()(cute::Int<kHeadDim - 1>{}, cute::Int<kHeadDim - 1>{})
               == (kHeadDim / 2) * kHeadDim
                      + cute::Swizzle<3, 4, 3>{}((kHeadDim - 1) * (kHeadDim / 2) + (kHeadDim / 2 - 1)));
 

--- a/src/turbomind/kernels/linear_attn/kernel/sm_90/cp_fwd.h
+++ b/src/turbomind/kernels/linear_attn/kernel/sm_90/cp_fwd.h
@@ -18,7 +18,7 @@ struct Sm90CorrectInitialStates {
         kCorrectInitialStatesSegmentMDesc,
     };
 
-    static constexpr int kCorrectInitialStatesMRowsPerTma = 64;
+    static constexpr int kCorrectInitialStatesMColumnsPerTma = 64;
 
     static constexpr int kCorrectInitialStatesKTile                = 128;
     static constexpr int kCorrectInitialStatesStoreStages          = 2;
@@ -203,7 +203,7 @@ struct Sm90CorrectInitialStates {
 
         constexpr int kPrefixHBytes = kHeadDim * BlockDv * static_cast<int>(sizeof(__nv_bfloat16));
         constexpr int kPrefixMBytes = kHeadDim * kCorrectInitialStatesKTile * static_cast<int>(sizeof(__nv_bfloat16));
-        static_assert(kCorrectInitialStatesMRowsPerTma == 64);
+        static_assert(kCorrectInitialStatesMColumnsPerTma == 64);
 
         if (tid >= kCorrectInitialStatesProducerTid0) {
             // Register deallocation is WG1-collective, while the h_free/m_free
@@ -238,12 +238,12 @@ struct Sm90CorrectInitialStates {
                 // Acquire: thread 128 receives this M stage after all 128 consumers
                 // release it; first use also uses complementary free parity.
                 cute::wait_barrier(m_free_bar[stage], free_phase);
-                // Release: arm a kPrefixMBytes transaction. Completion of both 64-row TMA
+                // Release: arm a kPrefixMBytes transaction. Completion of both 64-column TMA
                 // boxes releases the full BF16 M tile through m_ready_mbar.
                 cutlass::arch::ClusterTransactionBarrier::arrive_and_expect_tx(&m_ready_mbar[stage], kPrefixMBytes);
                 auto* m_stage = &smem.m_stage[stage][0][0];
 #pragma unroll
-                for (int col = 0; col < kHeadDim; col += kCorrectInitialStatesMRowsPerTma) {
+                for (int col = 0; col < kHeadDim; col += kCorrectInitialStatesMColumnsPerTma) {
                     cute::SM90_TMA_LOAD_4D::copy(segment_m_tma_desc,
                                                  &m_ready_mbar[stage],
                                                  kTmaNoCacheHint,
@@ -266,7 +266,7 @@ struct Sm90CorrectInitialStates {
                                                                            Element,
                                                                            float,
                                                                            FallbackTileShape,
-                                                                           cute::SM90::GMMA::Major::MN,
+                                                                           cute::SM90::GMMA::Major::K,
                                                                            cute::SM90::GMMA::Major::MN>());
         auto  fallback_mma      = cute::make_tiled_mma(FallbackGmmaAtom{});
         auto  fallback_thr_mma  = fallback_mma.get_thread_slice(tid);
@@ -358,7 +358,7 @@ struct Sm90CorrectInitialStates {
             if (fallback) {
                 auto s_m =
                     cute::make_tensor(cute::make_smem_ptr(reinterpret_cast<Element*>(&smem.m_stage[stage][0][0])),
-                                      FusedGdrGmmaStateTLayout<Element, kWideGdrBlockDv>());
+                                      FusedGdrGmmaSegmentMatrixLayout<Element>());
                 auto s_h_prev = cute::make_tensor(cute::make_smem_ptr(reinterpret_cast<Element*>(&smem.h_prev[0][0])),
                                                   FusedGdrGmmaStateTLayout<Element, BlockDv>());
                 FusedGdrGmmaSs(fallback_mma, tid, s_m, s_h_prev, tCrH, cute::SM90::GMMA::ScaleOut::One);

--- a/src/turbomind/kernels/linear_attn/kernel/sm_90/cp_fwd.h
+++ b/src/turbomind/kernels/linear_attn/kernel/sm_90/cp_fwd.h
@@ -6,6 +6,8 @@
 #include "src/turbomind/kernels/linear_attn/kernel/sm_90/common.h"
 #include "src/turbomind/kernels/linear_attn/kernel/sm_90/pdl.h"
 
+#include <cutlass/arch/grid_dependency_control.h>
+
 namespace turbomind::linear_attn::delta_rule {
 namespace {
 
@@ -214,7 +216,7 @@ struct Sm90CorrectInitialStates {
             if (tid != kCorrectInitialStatesProducerTid0) {
                 return;
             }
-            detail::WaitForPdlDependency();
+            cutlass::arch::wait_on_dependent_grids();
             for (int segment_id = first_segment_id; segment_id + 1 < last_segment_id; ++segment_id) {
                 const int iter       = segment_id - first_segment_id;
                 const int stage      = iter & 1;
@@ -254,7 +256,7 @@ struct Sm90CorrectInitialStates {
                                                  segment_id);
                 }
             }
-            detail::TriggerPdlDependents();
+            cutlass::arch::launch_dependent_grids();
             return;
         }
 
@@ -322,7 +324,7 @@ struct Sm90CorrectInitialStates {
             }
 
             if (store_iter == 0) {
-                detail::WaitForPdlDependency();
+                cutlass::arch::wait_on_dependent_grids();
             }
             const int  iter     = segment_id - first_segment_id;
             const int  stage    = iter & 1;

--- a/src/turbomind/kernels/linear_attn/kernel/sm_90/cp_fwd.h
+++ b/src/turbomind/kernels/linear_attn/kernel/sm_90/cp_fwd.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "src/turbomind/kernels/linear_attn/kernel/sm_90/common.h"
+#include "src/turbomind/kernels/linear_attn/kernel/sm_90/pdl.h"
 
 namespace turbomind::linear_attn::delta_rule {
 namespace {
@@ -213,6 +214,7 @@ struct Sm90CorrectInitialStates {
             if (tid != kCorrectInitialStatesProducerTid0) {
                 return;
             }
+            detail::WaitForPdlDependency();
             for (int segment_id = first_segment_id; segment_id + 1 < last_segment_id; ++segment_id) {
                 const int iter       = segment_id - first_segment_id;
                 const int stage      = iter & 1;
@@ -252,6 +254,7 @@ struct Sm90CorrectInitialStates {
                                                  segment_id);
                 }
             }
+            detail::TriggerPdlDependents();
             return;
         }
 
@@ -318,6 +321,9 @@ struct Sm90CorrectInitialStates {
                 break;
             }
 
+            if (store_iter == 0) {
+                detail::WaitForPdlDependency();
+            }
             const int  iter     = segment_id - first_segment_id;
             const int  stage    = iter & 1;
             const int  phase    = (iter >> 1) & 1;
@@ -447,20 +453,23 @@ void LaunchSm90CorrectInitialStatesTyped(core::Tensor&              cp_state,
     static_cast<void>(cp);
     SetCorrectInitialStatesSharedMemoryLimit<StateT, block_dv>(smem_bytes);
 
-    Sm90CorrectInitialStatesKernel<StateT, block_dv>
-        <<<grid, block, smem_bytes, stream>>>(reinterpret_cast<CUtensorMap*>(tma_desc_workspace),
-                                              reinterpret_cast<const int64_t*>(state_ptrs.raw_data()),
-                                              cp_sequence_starts.data<int32_t>(),
-                                              finished.data<bool>(),
-                                              cp_fallback.data<bool>(),
-                                              segment_state.data<__nv_bfloat16>(),
-                                              segment_m.data<__nv_bfloat16>(),
-                                              cp_state.data<float>(),
-                                              state_layer_offset,
-                                              problem.num_head_groups,
-                                              problem.heads_per_block,
-                                              problem.sequence_num);
-    TM_CUDA_CHECK(cudaGetLastError());
+    detail::LaunchPdlKernel(grid,
+                            block,
+                            smem_bytes,
+                            stream,
+                            Sm90CorrectInitialStatesKernel<StateT, block_dv>,
+                            reinterpret_cast<CUtensorMap*>(tma_desc_workspace),
+                            reinterpret_cast<const int64_t*>(state_ptrs.raw_data()),
+                            cp_sequence_starts.data<int32_t>(),
+                            finished.data<bool>(),
+                            cp_fallback.data<bool>(),
+                            segment_state.data<__nv_bfloat16>(),
+                            segment_m.data<__nv_bfloat16>(),
+                            cp_state.data<float>(),
+                            state_layer_offset,
+                            problem.num_head_groups,
+                            problem.heads_per_block,
+                            problem.sequence_num);
 }
 
 }  // namespace

--- a/src/turbomind/kernels/linear_attn/kernel/sm_90/fused_fwd.h
+++ b/src/turbomind/kernels/linear_attn/kernel/sm_90/fused_fwd.h
@@ -949,7 +949,7 @@ struct Sm90FusedGdrFwd {
                 auto* cp_state_base = reinterpret_cast<float*>(static_cast<uintptr_t>(cp_state_ptrs[segment_id]));
                 auto* state_base    = cp_state_base + static_cast<int64_t>(value_head) * kHeadDim * kHeadDim + dv0;
                 detail::WaitForPdlDependency();
-                auto  g_state       = cute::make_tensor(cute::make_gmem_ptr(state_base), state_tile_layout);
+                auto g_state = cute::make_tensor(cute::make_gmem_ptr(state_base), state_tile_layout);
                 FusedGdrLoadStateFragmentGlobal<float>(tCrState, g_state, thr_mma, role_tid);
             }
             else {

--- a/src/turbomind/kernels/linear_attn/kernel/sm_90/fused_fwd.h
+++ b/src/turbomind/kernels/linear_attn/kernel/sm_90/fused_fwd.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "src/turbomind/kernels/linear_attn/kernel/sm_90/common.h"
+#include "src/turbomind/kernels/linear_attn/kernel/sm_90/pdl.h"
 
 #include <cute/algorithm/tuple_algorithms.hpp>
 #include <cute/arch/copy_sm80.hpp>
@@ -844,6 +845,20 @@ struct Sm90FusedGdrFwd {
                         // bytes; resolvent TMA completion releases them to stage_ready_mbar.
                         cutlass::arch::ClusterTransactionBarrier::expect_transaction(&smem.stage_ready_mbar[stage],
                                                                                      kSquareTmaBytes);
+                    }
+                    IssueGateStageCpAsync(smem.gate_stage[stage][0],
+                                          g_cumsum,
+                                          role_tid - 64,
+                                          valid,
+                                          token0,
+                                          gate_sequence_offset,
+                                          gate_stride);
+                    if (role_tid == 64) {
+                        if constexpr (!ContextParallel) {
+                            if (chunk == 0) {
+                                detail::WaitForPdlDependency();
+                            }
+                        }
                         cute::SM90_TMA_LOAD_4D::copy(resolvent_desc,
                                                      &smem.stage_ready_mbar[stage],
                                                      kTmaNoCacheHint,
@@ -853,13 +868,6 @@ struct Sm90FusedGdrFwd {
                                                      token0,
                                                      0);
                     }
-                    IssueGateStageCpAsync(smem.gate_stage[stage][0],
-                                          g_cumsum,
-                                          role_tid - 64,
-                                          valid,
-                                          token0,
-                                          gate_sequence_offset,
-                                          gate_stride);
                     // Release: each resolvent/g lane attaches its pre-counted arrival to
                     // completion of both per-head g cp.async copies. Consumers acquire
                     // g together with completion of the resolvent transaction bytes.
@@ -940,6 +948,7 @@ struct Sm90FusedGdrFwd {
             if constexpr (ContextParallel) {
                 auto* cp_state_base = reinterpret_cast<float*>(static_cast<uintptr_t>(cp_state_ptrs[segment_id]));
                 auto* state_base    = cp_state_base + static_cast<int64_t>(value_head) * kHeadDim * kHeadDim + dv0;
+                detail::WaitForPdlDependency();
                 auto  g_state       = cute::make_tensor(cute::make_gmem_ptr(state_base), state_tile_layout);
                 FusedGdrLoadStateFragmentGlobal<float>(tCrState, g_state, thr_mma, role_tid);
             }
@@ -1425,28 +1434,31 @@ void LaunchSm90FusedGdrFwdTyped(const core::Tensor& q,
     auto*         tma_desc_ptr = reinterpret_cast<CUtensorMap*>(tma_desc_workspace);
 
     SetFusedGdrFwdSharedMemoryLimit<StateT, block_dv, ContextParallel>(smem_bytes);
-    Sm90FusedGdrFwdKernel<__nv_bfloat16, StateT, block_dv, ContextParallel>
-        <<<grid, block, smem_bytes, stream>>>(tma_desc_ptr,
-                                              g_cumsum.data<float>(),
-                                              beta.data<float>(),
-                                              problem.gate_batch_stride,
-                                              problem.gate_stride,
-                                              problem.beta_batch_stride,
-                                              problem.beta_stride,
-                                              problem.token_num,
-                                              q_offsets_ptr,
-                                              finished_ptr,
-                                              data_q_offsets_ptr,
-                                              cp_source_indices_ptr,
-                                              cp_state_ptrs_ptr,
-                                              reinterpret_cast<const int64_t*>(state_ptrs.raw_data()),
-                                              state_layer_offset,
-                                              descriptor_sequence_num,
-                                              problem.hq,
-                                              problem.hv,
-                                              problem.num_head_groups,
-                                              problem.heads_per_block);
-    TM_CUDA_CHECK(cudaGetLastError());
+    detail::LaunchPdlKernel(grid,
+                            block,
+                            smem_bytes,
+                            stream,
+                            Sm90FusedGdrFwdKernel<__nv_bfloat16, StateT, block_dv, ContextParallel>,
+                            tma_desc_ptr,
+                            g_cumsum.data<float>(),
+                            beta.data<float>(),
+                            problem.gate_batch_stride,
+                            problem.gate_stride,
+                            problem.beta_batch_stride,
+                            problem.beta_stride,
+                            problem.token_num,
+                            q_offsets_ptr,
+                            finished_ptr,
+                            data_q_offsets_ptr,
+                            cp_source_indices_ptr,
+                            cp_state_ptrs_ptr,
+                            reinterpret_cast<const int64_t*>(state_ptrs.raw_data()),
+                            state_layer_offset,
+                            descriptor_sequence_num,
+                            problem.hq,
+                            problem.hv,
+                            problem.num_head_groups,
+                            problem.heads_per_block);
 }
 
 template<class StateT, int BlockDv>

--- a/src/turbomind/kernels/linear_attn/kernel/sm_90/fused_fwd.h
+++ b/src/turbomind/kernels/linear_attn/kernel/sm_90/fused_fwd.h
@@ -8,6 +8,7 @@
 
 #include <cute/algorithm/tuple_algorithms.hpp>
 #include <cute/arch/copy_sm80.hpp>
+#include <cutlass/arch/grid_dependency_control.h>
 #include <cutlass/pipeline/sm90_pipeline.hpp>
 
 namespace turbomind::linear_attn::delta_rule {
@@ -856,7 +857,7 @@ struct Sm90FusedGdrFwd {
                     if (role_tid == 64) {
                         if constexpr (!ContextParallel) {
                             if (chunk == 0) {
-                                detail::WaitForPdlDependency();
+                                cutlass::arch::wait_on_dependent_grids();
                             }
                         }
                         cute::SM90_TMA_LOAD_4D::copy(resolvent_desc,
@@ -948,7 +949,7 @@ struct Sm90FusedGdrFwd {
             if constexpr (ContextParallel) {
                 auto* cp_state_base = reinterpret_cast<float*>(static_cast<uintptr_t>(cp_state_ptrs[segment_id]));
                 auto* state_base    = cp_state_base + static_cast<int64_t>(value_head) * kHeadDim * kHeadDim + dv0;
-                detail::WaitForPdlDependency();
+                cutlass::arch::wait_on_dependent_grids();
                 auto g_state = cute::make_tensor(cute::make_gmem_ptr(state_base), state_tile_layout);
                 FusedGdrLoadStateFragmentGlobal<float>(tCrState, g_state, thr_mma, role_tid);
             }

--- a/src/turbomind/kernels/linear_attn/kernel/sm_90/kkt_solve.cu
+++ b/src/turbomind/kernels/linear_attn/kernel/sm_90/kkt_solve.cu
@@ -521,10 +521,10 @@ struct Sm90KktSolve {
         uint64_t* k_ready0 = &smem.k_ready0;
         uint64_t* k_ready1 = &smem.k_ready1;
 
-        using MmaElement       = Element;
-        MmaElement* k_tile0    = smem.k_tile;
-        MmaElement* k_tile1    = smem.k_tile + kKTilePlaneElems;
-        float*      beta_stage = smem.beta_stage;
+        using MmaElement            = Element;
+        MmaElement* k_tile0         = smem.k_tile;
+        MmaElement* k_tile1         = smem.k_tile + kKTilePlaneElems;
+        float*      beta_stage      = smem.beta_stage;
         const int   first_beta_quad = value_head_base / 4;
         IssueBetaQuadAsync(beta_stage,
                            beta,
@@ -535,7 +535,7 @@ struct Sm90KktSolve {
                            local_beta_token0,
                            beta_stride,
                            beta_batch_stride);
-        const auto* gmem_desc  = tma_desc_workspace + sequence_id * kKktTmaDescCount;
+        const auto* gmem_desc = tma_desc_workspace + sequence_id * kKktTmaDescCount;
         AcquireAndPrefetchTmaDescriptors(gmem_desc, tx);
         const CUtensorMap* k_desc         = &gmem_desc[kKktKDesc];
         const CUtensorMap* resolvent_desc = &gmem_desc[kKktResolventDesc];

--- a/src/turbomind/kernels/linear_attn/kernel/sm_90/kkt_solve.cu
+++ b/src/turbomind/kernels/linear_attn/kernel/sm_90/kkt_solve.cu
@@ -20,6 +20,7 @@
 #include <cute/swizzle_layout.hpp>
 #include <cute/tensor.hpp>
 #include <cute/underscore.hpp>
+#include <cutlass/arch/grid_dependency_control.h>
 
 #include <cute/algorithm/clear.hpp>
 #include <cute/algorithm/cooperative_gemm.hpp>
@@ -152,7 +153,7 @@ struct Sm90KktSolve {
     static __device__ __forceinline__ void AcquireAndPrefetchTmaDescriptors(const CUtensorMap* desc, int tid)
     {
         if (tid == kKktKDesc || tid == kKktResolventDesc) {
-            detail::WaitForPdlDependency();
+            cutlass::arch::wait_on_dependent_grids();
             cute::tma_descriptor_fence_acquire(reinterpret_cast<const cute::TmaDescriptor*>(&desc[tid]));
             cute::prefetch_tma_descriptor(&desc[tid]);
         }
@@ -1010,7 +1011,7 @@ struct Sm90KktSolve {
                     }
                 }
                 if (role_tid == 0) {
-                    detail::TriggerPdlDependents();
+                    cutlass::arch::launch_dependent_grids();
                     // Acquire/drain all remaining output stores. The leader keeps the CTA
                     // alive until the final TMA store has completed.
                     cute::tma_store_wait<0>();

--- a/src/turbomind/kernels/linear_attn/kernel/sm_90/kkt_solve.cu
+++ b/src/turbomind/kernels/linear_attn/kernel/sm_90/kkt_solve.cu
@@ -2,6 +2,7 @@
 // https://github.com/QwenLM/FlashQLA/blob/60f81453143e724bcaf3fc7921e71e7328f6ebcd/flash_qla/ops/gated_delta_rule/chunk/hopper/kkt_solve.py
 
 #include "src/turbomind/kernels/linear_attn/kernel/sm_90/internal.h"
+#include "src/turbomind/kernels/linear_attn/kernel/sm_90/pdl.h"
 
 #include "src/turbomind/kernels/core/math.h"
 #include "src/turbomind/kernels/core/smem.h"
@@ -151,6 +152,7 @@ struct Sm90KktSolve {
     static __device__ __forceinline__ void AcquireAndPrefetchTmaDescriptors(const CUtensorMap* desc, int tid)
     {
         if (tid == kKktKDesc || tid == kKktResolventDesc) {
+            detail::WaitForPdlDependency();
             cute::tma_descriptor_fence_acquire(reinterpret_cast<const cute::TmaDescriptor*>(&desc[tid]));
             cute::prefetch_tma_descriptor(&desc[tid]);
         }
@@ -523,6 +525,16 @@ struct Sm90KktSolve {
         MmaElement* k_tile0    = smem.k_tile;
         MmaElement* k_tile1    = smem.k_tile + kKTilePlaneElems;
         float*      beta_stage = smem.beta_stage;
+        const int   first_beta_quad = value_head_base / 4;
+        IssueBetaQuadAsync(beta_stage,
+                           beta,
+                           role_tid,
+                           valid,
+                           first_beta_quad,
+                           physical_batch,
+                           local_beta_token0,
+                           beta_stride,
+                           beta_batch_stride);
         const auto* gmem_desc  = tma_desc_workspace + sequence_id * kKktTmaDescCount;
         AcquireAndPrefetchTmaDescriptors(gmem_desc, tx);
         const CUtensorMap* k_desc         = &gmem_desc[kKktKDesc];
@@ -572,8 +584,7 @@ struct Sm90KktSolve {
                     cute::make_tensor(cute::make_rmem_ptr(gram_fragment),
                                       cute::partition_shape_C(gmma64, cute::Shape<cute::_64, cute::_64>{}));
 
-                constexpr int k_tma_box_rows  = kChunkSize;
-                const int     first_beta_quad = value_head_base / 4;
+                constexpr int k_tma_box_rows = kChunkSize;
                 if (role_tid == 0) {
                     // Transaction bytes match the fixed descriptor box; TMA zero-fills OOB rows.
                     cute::set_barrier_transaction_bytes(*k_ready0, k_tma_box_rows * kKTileTmaDim * sizeof(MmaElement));
@@ -585,15 +596,6 @@ struct Sm90KktSolve {
                     cute::SM90_TMA_LOAD_5D::copy(
                         k_desc, k_ready1, kTmaNoCacheHint, k_tile1, 0, 1, qk_head, token0, batch_id);
                 }
-                IssueBetaQuadAsync(beta_stage,
-                                   beta,
-                                   role_tid,
-                                   valid,
-                                   first_beta_quad,
-                                   physical_batch,
-                                   local_beta_token0,
-                                   beta_stride,
-                                   beta_batch_stride);
                 // Acquire both K halves from TMA completion at phase 0; all expected
                 // bytes are visible to the consumer WG before asynchronous SM90 GMMA.
                 cute::wait_barrier(*k_ready0, 0);
@@ -1008,6 +1010,7 @@ struct Sm90KktSolve {
                     }
                 }
                 if (role_tid == 0) {
+                    detail::TriggerPdlDependents();
                     // Acquire/drain all remaining output stores. The leader keeps the CTA
                     // alive until the final TMA store has completed.
                     cute::tma_store_wait<0>();
@@ -1081,19 +1084,22 @@ void LaunchKktSolveTyped(const K*            k_ptr,
     const int32_t* offsets_ptr    = q_offsets.data<int32_t>();
     const bool*    finished_ptr   = finished.data<bool>();
     auto*          desc_workspace = reinterpret_cast<CUtensorMap*>(tma_desc_workspace);
-    Sm90KktSolveKernel<K, ConsumerThreads, ConsumerRegisters>
-        <<<grid, Kernel::kKktSolveConsumerWgs * ConsumerThreads, shared_bytes, stream>>>(beta_ptr,
-                                                                                         offsets_ptr,
-                                                                                         finished_ptr,
-                                                                                         desc_workspace,
-                                                                                         problem.token_num,
-                                                                                         problem.sequence_num,
-                                                                                         problem.hq,
-                                                                                         problem.hv,
-                                                                                         problem.beta_stride,
-                                                                                         problem.beta_batch_stride,
-                                                                                         groups_per_k_head);
-    TM_CUDA_CHECK(cudaGetLastError());
+    detail::LaunchPdlKernel(grid,
+                            dim3(Kernel::kKktSolveConsumerWgs * ConsumerThreads),
+                            shared_bytes,
+                            stream,
+                            Sm90KktSolveKernel<K, ConsumerThreads, ConsumerRegisters>,
+                            beta_ptr,
+                            offsets_ptr,
+                            finished_ptr,
+                            desc_workspace,
+                            problem.token_num,
+                            problem.sequence_num,
+                            problem.hq,
+                            problem.hv,
+                            problem.beta_stride,
+                            problem.beta_batch_stride,
+                            groups_per_k_head);
 }
 
 void LaunchSm90KktSolveImpl(const core::Tensor& k,

--- a/src/turbomind/kernels/linear_attn/kernel/sm_90/pdl.h
+++ b/src/turbomind/kernels/linear_attn/kernel/sm_90/pdl.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include "src/turbomind/utils/cuda_utils.h"
+
+#include <cuda_runtime.h>
+
+#include <cstddef>
+#include <utility>
+
+#include <cutlass/arch/grid_dependency_control.h>
+
+namespace turbomind::linear_attn::delta_rule::detail {
+
+__device__ __forceinline__ void WaitForPdlDependency()
+{
+    cutlass::arch::wait_on_dependent_grids();
+}
+
+__device__ __forceinline__ void TriggerPdlDependents()
+{
+    cutlass::arch::launch_dependent_grids();
+}
+
+template<class... KernelArgs, class... CallArgs>
+void LaunchPdlKernel(dim3                         grid,
+                     dim3                         block,
+                     size_t                       dynamic_smem_bytes,
+                     cudaStream_t                 stream,
+                     void (*kernel)(KernelArgs...),
+                     CallArgs&&... args)
+{
+    cudaLaunchAttribute attribute{};
+    attribute.id                                           = cudaLaunchAttributeProgrammaticStreamSerialization;
+    attribute.val.programmaticStreamSerializationAllowed = 1;
+
+    cudaLaunchConfig_t config{};
+    config.gridDim          = grid;
+    config.blockDim         = block;
+    config.dynamicSmemBytes = dynamic_smem_bytes;
+    config.stream           = stream;
+    config.attrs            = &attribute;
+    config.numAttrs         = 1;
+
+    TM_CUDA_CHECK(cudaLaunchKernelEx(&config, kernel, std::forward<CallArgs>(args)...));
+}
+
+}  // namespace turbomind::linear_attn::delta_rule::detail

--- a/src/turbomind/kernels/linear_attn/kernel/sm_90/pdl.h
+++ b/src/turbomind/kernels/linear_attn/kernel/sm_90/pdl.h
@@ -7,19 +7,7 @@
 #include <cstddef>
 #include <utility>
 
-#include <cutlass/arch/grid_dependency_control.h>
-
 namespace turbomind::linear_attn::delta_rule::detail {
-
-__device__ __forceinline__ void WaitForPdlDependency()
-{
-    cutlass::arch::wait_on_dependent_grids();
-}
-
-__device__ __forceinline__ void TriggerPdlDependents()
-{
-    cutlass::arch::launch_dependent_grids();
-}
 
 template<class... KernelArgs, class... CallArgs>
 void LaunchPdlKernel(dim3         grid,

--- a/src/turbomind/kernels/linear_attn/kernel/sm_90/pdl.h
+++ b/src/turbomind/kernels/linear_attn/kernel/sm_90/pdl.h
@@ -22,15 +22,15 @@ __device__ __forceinline__ void TriggerPdlDependents()
 }
 
 template<class... KernelArgs, class... CallArgs>
-void LaunchPdlKernel(dim3                         grid,
-                     dim3                         block,
-                     size_t                       dynamic_smem_bytes,
-                     cudaStream_t                 stream,
+void LaunchPdlKernel(dim3         grid,
+                     dim3         block,
+                     size_t       dynamic_smem_bytes,
+                     cudaStream_t stream,
                      void (*kernel)(KernelArgs...),
                      CallArgs&&... args)
 {
     cudaLaunchAttribute attribute{};
-    attribute.id                                           = cudaLaunchAttributeProgrammaticStreamSerialization;
+    attribute.id                                         = cudaLaunchAttributeProgrammaticStreamSerialization;
     attribute.val.programmaticStreamSerializationAllowed = 1;
 
     cudaLaunchConfig_t config{};

--- a/src/turbomind/kernels/linear_attn/kernel/sm_90/prepare_h.h
+++ b/src/turbomind/kernels/linear_attn/kernel/sm_90/prepare_h.h
@@ -7,6 +7,7 @@
 #include "src/turbomind/kernels/linear_attn/kernel/sm_90/pdl.h"
 
 #include <cute/arch/copy_sm80.hpp>
+#include <cutlass/arch/grid_dependency_control.h>
 
 namespace turbomind::linear_attn::delta_rule {
 namespace {
@@ -322,7 +323,7 @@ struct Sm90FusedGdrH {
                                                      token0,
                                                      0);
                         if (chunk == 0) {
-                            detail::WaitForPdlDependency();
+                            cutlass::arch::wait_on_dependent_grids();
                         }
                         cute::SM90_TMA_LOAD_4D::copy(resolvent_tma_desc,
                                                      &smem.stage_ready_mbar[stage],
@@ -361,7 +362,7 @@ struct Sm90FusedGdrH {
                     }
                 }
                 if (role_tid == 32) {
-                    detail::TriggerPdlDependents();
+                    cutlass::arch::launch_dependent_grids();
                 }
             }
             else {

--- a/src/turbomind/kernels/linear_attn/kernel/sm_90/prepare_h.h
+++ b/src/turbomind/kernels/linear_attn/kernel/sm_90/prepare_h.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "src/turbomind/kernels/linear_attn/kernel/sm_90/common.h"
+#include "src/turbomind/kernels/linear_attn/kernel/sm_90/pdl.h"
 
 #include <cute/arch/copy_sm80.hpp>
 
@@ -320,6 +321,9 @@ struct Sm90FusedGdrH {
                                                      value_head,
                                                      token0,
                                                      0);
+                        if (chunk == 0) {
+                            detail::WaitForPdlDependency();
+                        }
                         cute::SM90_TMA_LOAD_4D::copy(resolvent_tma_desc,
                                                      &smem.stage_ready_mbar[stage],
                                                      kTmaNoCacheHint,
@@ -355,6 +359,9 @@ struct Sm90FusedGdrH {
                         // registered transaction bytes complete asynchronously.
                         cute::arrive_barrier(smem.stage_ready_mbar[stage]);
                     }
+                }
+                if (role_tid == 32) {
+                    detail::TriggerPdlDependents();
                 }
             }
             else {
@@ -957,27 +964,30 @@ void LaunchSm90FusedGdrHTyped(const core::Tensor&        k,
     const size_t smem_bytes = Kernel::SharedBytes();
 
     SetFusedGdrHSharedMemoryLimit(smem_bytes);
-    Sm90FusedGdrHKernel<__nv_bfloat16>
-        <<<grid, block, smem_bytes, stream>>>(reinterpret_cast<CUtensorMap*>(tma_desc_workspace),
-                                              g_cumsum.data<float>(),
-                                              beta.data<float>(),
-                                              segment_state.data<__nv_bfloat16>(),
-                                              segment_m.data<__nv_bfloat16>(),
-                                              q_offsets.data<int32_t>(),
-                                              cp_source_indices.data<int32_t>(),
-                                              cp_q_offsets.data<int32_t>(),
-                                              cp_finished.data<bool>(),
-                                              cp_fallback.data<bool>(),
-                                              problem.token_num,
-                                              problem.sequence_num,
-                                              problem.hq,
-                                              problem.hv,
-                                              problem.gate_stride,
-                                              problem.gate_batch_stride,
-                                              problem.beta_stride,
-                                              problem.beta_batch_stride,
-                                              cp.cp_level == ContextParallelLevel::kAll);
-    TM_CUDA_CHECK(cudaGetLastError());
+    detail::LaunchPdlKernel(grid,
+                            block,
+                            smem_bytes,
+                            stream,
+                            Sm90FusedGdrHKernel<__nv_bfloat16>,
+                            reinterpret_cast<CUtensorMap*>(tma_desc_workspace),
+                            g_cumsum.data<float>(),
+                            beta.data<float>(),
+                            segment_state.data<__nv_bfloat16>(),
+                            segment_m.data<__nv_bfloat16>(),
+                            q_offsets.data<int32_t>(),
+                            cp_source_indices.data<int32_t>(),
+                            cp_q_offsets.data<int32_t>(),
+                            cp_finished.data<bool>(),
+                            cp_fallback.data<bool>(),
+                            problem.token_num,
+                            problem.sequence_num,
+                            problem.hq,
+                            problem.hv,
+                            problem.gate_stride,
+                            problem.gate_batch_stride,
+                            problem.beta_stride,
+                            problem.beta_batch_stride,
+                            cp.cp_level == ContextParallelLevel::kAll);
 }
 
 }  // namespace

--- a/src/turbomind/kernels/linear_attn/kernel/sm_90/tma_desc_prepare.h
+++ b/src/turbomind/kernels/linear_attn/kernel/sm_90/tma_desc_prepare.h
@@ -2,6 +2,7 @@
 
 #include "src/turbomind/kernels/linear_attn/kernel/sm_90/common.h"
 #include "src/turbomind/kernels/linear_attn/kernel/sm_90/internal.h"
+#include "src/turbomind/kernels/linear_attn/kernel/sm_90/pdl.h"
 
 #include <stdexcept>
 #include <string>
@@ -1267,6 +1268,9 @@ __global__ __launch_bounds__(
                          output_gate_stride,
                          output_gate_batch_stride,
                          smem);
+        if (threadIdx.x == 0) {
+            detail::TriggerPdlDependents();
+        }
     }
 #endif
 }

--- a/src/turbomind/kernels/linear_attn/kernel/sm_90/tma_desc_prepare.h
+++ b/src/turbomind/kernels/linear_attn/kernel/sm_90/tma_desc_prepare.h
@@ -317,8 +317,8 @@ CUtensorMap MakeContextParallelStateTmaDesc(StateT* ptr, int total_segments, int
 template<class T>
 CUtensorMap MakeCorrectInitialStatesSegmentMatrixTmaDesc(T* ptr, int total_segments, int hv)
 {
-    constexpr int kRowsPerTma = 64;
-    static_assert(kHeadDim % kRowsPerTma == 0);
+    constexpr int kColumnsPerTma = 64;
+    static_assert(kHeadDim % kColumnsPerTma == 0);
 
     const uint64_t global_dim[4] = {
         static_cast<uint64_t>(kHeadDim),
@@ -332,7 +332,7 @@ CUtensorMap MakeCorrectInitialStatesSegmentMatrixTmaDesc(T* ptr, int total_segme
         static_cast<uint64_t>(hv) * kHeadDim * kHeadDim * sizeof(T),
     };
     const uint32_t box_dim[4] = {
-        static_cast<uint32_t>(kRowsPerTma),
+        static_cast<uint32_t>(kColumnsPerTma),
         static_cast<uint32_t>(kHeadDim),
         1u,
         1u,

--- a/src/turbomind/kernels/linear_attn/kernel/sm_90/tma_desc_prepare.h
+++ b/src/turbomind/kernels/linear_attn/kernel/sm_90/tma_desc_prepare.h
@@ -2,7 +2,8 @@
 
 #include "src/turbomind/kernels/linear_attn/kernel/sm_90/common.h"
 #include "src/turbomind/kernels/linear_attn/kernel/sm_90/internal.h"
-#include "src/turbomind/kernels/linear_attn/kernel/sm_90/pdl.h"
+
+#include <cutlass/arch/grid_dependency_control.h>
 
 #include <stdexcept>
 #include <string>
@@ -1269,7 +1270,7 @@ __global__ __launch_bounds__(
                          output_gate_batch_stride,
                          smem);
         if (threadIdx.x == 0) {
-            detail::TriggerPdlDependents();
+            cutlass::arch::launch_dependent_grids();
         }
     }
 #endif


### PR DESCRIPTION
## Motivation

Reduce serialization between dependent SM90 gated delta rule (GDR) kernels while preserving the required data dependencies. Also correct the context-parallel segment matrix layout used by the SM90 fallback path.

## Modification

- Enable CUTLASS grid dependency control for SM90 GDR kernels.
- Add a common PDL launcher using CUDA programmatic stream serialization.
- Convert the SM90 descriptor preparation, KKT solve, fused state preparation, context-parallel state correction, and fused forward kernels to PDL launches.
- Add dependency waits immediately before consuming predecessor outputs, including:
  - TMA descriptors
  - resolvent data
  - context-parallel state
  - segment matrices
- Signal dependent grids once each producer has completed the required work, allowing independent work and final TMA-store draining to overlap.
- Move the KKT beta prefetch ahead of the dependency wait so it can overlap with descriptor preparation.
- Correct the context-parallel segment matrix contract:
  - Use a K-major SW128 GMMA layout matching the TMA producer.
  - Treat the matrix as two 64-column TMA slabs.
  - Add compile-time checks for the shared-memory layout.

## BC-breaking (Optional)

No backward compatibility break is expected.