### PR TITLE
refactor: report cache usage directly

### DIFF
--- a/lmdeploy/messages.py
+++ b/lmdeploy/messages.py
@@ -694,9 +694,7 @@ class EngineEvent:
 class ScheduleMetrics:
     active_seqs: int = 0
     waiting_seqs: int = 0
-    total_blocks: int = 0
-    free_blocks: int = 0
-    cache_usage: float | None = None
+    cache_usage: float = 0.0
     prefix_cache_hit_rate: float = 0
     scheduler_tick: int = 0
 

--- a/lmdeploy/metrics/stats.py
+++ b/lmdeploy/metrics/stats.py
@@ -37,7 +37,7 @@ class SchedulerStats:
         # Engine core
         num_running_reqs: Engine core, currently executing requests.
         num_waiting_reqs: Engine core, requests queued waiting for execution.
-        gpu_cache_usage: Fraction of GPU KV blocks utilized (0.0 to 1.0).
+        gpu_cache_usage: Fraction of GPU KV cache utilized (0.0 to 1.0).
         prefix_cache_hit_rate: Prefix caching hit rate.
     """
 
@@ -90,10 +90,7 @@ class SchedulerStats:
     def update_from_schedule_metrics(self, scheduled_metrics: ScheduleMetrics):
         self.num_running_reqs = scheduled_metrics.active_seqs
         self.num_waiting_reqs = scheduled_metrics.waiting_seqs
-        if scheduled_metrics.cache_usage is None:
-            self.gpu_cache_usage = 1.0 - (scheduled_metrics.free_blocks / scheduled_metrics.total_blocks)
-        else:
-            self.gpu_cache_usage = scheduled_metrics.cache_usage
+        self.gpu_cache_usage = scheduled_metrics.cache_usage
         self.prefix_cache_hit_rate = scheduled_metrics.prefix_cache_hit_rate
 
 

--- a/lmdeploy/pytorch/paging/scheduler.py
+++ b/lmdeploy/pytorch/paging/scheduler.py
@@ -1059,11 +1059,13 @@ class Scheduler:
 
     @property
     def schedule_metrics(self):
+        total_blocks = self.block_manager.num_gpu_blocks
+        free_blocks = self.block_manager.get_num_free_gpu_blocks()
+        cache_usage = 1.0 - free_blocks / total_blocks if total_blocks else 0.0
         return ScheduleMetrics(
             active_seqs=self.num_running(),
             waiting_seqs=self.num_waiting() + self.num_ready(),
-            total_blocks=self.block_manager.num_gpu_blocks,
-            free_blocks=self.block_manager.get_num_free_gpu_blocks(),
+            cache_usage=cache_usage,
             prefix_cache_hit_rate=self.block_trie.hit_rate(),
             scheduler_tick=self.scheduler_tick,
         )

--- a/lmdeploy/turbomind/turbomind.py
+++ b/lmdeploy/turbomind/turbomind.py
@@ -399,8 +399,6 @@ class TurboMind:
         tm_metrics = self.model_comm.get_schedule_metrics(0)
         return ScheduleMetrics(active_seqs=tm_metrics.active_seqs,
                                waiting_seqs=tm_metrics.waiting_seqs,
-                               total_blocks=tm_metrics.total_blocks,
-                               free_blocks=tm_metrics.free_blocks,
                                cache_usage=tm_metrics.cache_usage,
                                prefix_cache_hit_rate=tm_metrics.prefix_cache_hit_rate,
                                scheduler_tick=tm_metrics.scheduler_tick)

--- a/src/turbomind/engine/engine.cc
+++ b/src/turbomind/engine/engine.cc
@@ -957,8 +957,6 @@ void Engine::Impl::UpdateScheduleMetrics(bool advance_scheduler)
     m->total_seqs   = total_seqs;
     m->active_seqs  = active_seqs;
     m->waiting_seqs = total_seqs - active_seqs;
-    m->total_blocks = static_cast<int64_t>(memory.live_allocations);
-    m->free_blocks  = 0;
     m->cache_usage  = memory.region_bytes ? static_cast<double>(memory.live_bytes) / memory.region_bytes : 0.;
     m->prefix_cache_hit_rate =
         prefix_query_tokens_ ? static_cast<double>(prefix_hit_tokens_) / prefix_query_tokens_ : 0.;

--- a/src/turbomind/python/bind.cpp
+++ b/src/turbomind/python/bind.cpp
@@ -484,8 +484,6 @@ PYBIND11_MODULE(_turbomind, m)
         .def_readonly("total_seqs", &ft::ScheduleMetrics::total_seqs)
         .def_readonly("active_seqs", &ft::ScheduleMetrics::active_seqs)
         .def_readonly("waiting_seqs", &ft::ScheduleMetrics::waiting_seqs)
-        .def_readonly("total_blocks", &ft::ScheduleMetrics::total_blocks)
-        .def_readonly("free_blocks", &ft::ScheduleMetrics::free_blocks)
         .def_readonly("cache_usage", &ft::ScheduleMetrics::cache_usage)
         .def_readonly("prefix_cache_hit_rate", &ft::ScheduleMetrics::prefix_cache_hit_rate)
         .def_readonly("scheduler_tick", &ft::ScheduleMetrics::scheduler_tick);

--- a/src/turbomind/utils/metrics.h
+++ b/src/turbomind/utils/metrics.h
@@ -13,10 +13,6 @@ struct ScheduleMetrics {
     int active_seqs{};   // the number of active sequences
     int waiting_seqs{};  // the number of waiting sequences
 
-    // Cache-object counts. The heterogeneous allocator has no fixed-size free-block pool.
-    int64_t total_blocks{};  // the number of live cache objects
-    int64_t free_blocks{};   // always zero for the heterogeneous allocator
-
     double cache_usage{};            // live cache-object bytes / cache region bytes
     double prefix_cache_hit_rate{};  // skipped prompt tokens / queried prompt tokens
 
@@ -47,8 +43,6 @@ inline std::ostream& operator<<(std::ostream& os, const ScheduleMetrics& m)
     os << ", scheduler_tick=" << m.scheduler_tick;
     os << ", cache_usage=" << m.cache_usage;
     os << ", prefix_cache_hit_rate=" << m.prefix_cache_hit_rate;
-    os << ", total_blocks=" << m.total_blocks;
-    os << ", free_blocks=" << m.free_blocks;
     os << " }";
     return os;
 }

--- a/tests/pytorch/paging/test_scheduler.py
+++ b/tests/pytorch/paging/test_scheduler.py
@@ -56,6 +56,8 @@ class TestScheduler:
 
     def test_schedule_base(self, scheduler, block_size, num_gpu_blocks):
         block_manager = scheduler.block_manager
+        assert scheduler.schedule_metrics.cache_usage == 0.0
+
         session_id = 0
         session = scheduler.add_session(session_id)
         assert session_id in scheduler.sessions
@@ -76,8 +78,15 @@ class TestScheduler:
         assert len(block_tables) == 1
         assert len(block_tables[0]) == num_blocks
         assert block_manager.get_num_free_gpu_blocks() == num_gpu_blocks - num_blocks
+        assert scheduler.schedule_metrics.cache_usage == num_blocks / num_gpu_blocks
 
         assert scheduler.has_unfinished()
+
+    def test_schedule_metrics_without_gpu_blocks(self, cache_config, scheduler_config, seq_meta):
+        cache_config.num_gpu_blocks = 0
+        scheduler = Scheduler(scheduler_config=scheduler_config, cache_config=cache_config, seq_meta=seq_meta)
+
+        assert scheduler.schedule_metrics.cache_usage == 0.0
 
     def test_update(self, scheduler, block_size, num_gpu_blocks):
         block_manager = scheduler.block_manager


### PR DESCRIPTION
## Motivation

`ScheduleMetrics.total_blocks` and `free_blocks` expose allocator-specific details to the upper metrics layer. 

Having the upper layer derive cache utilization from these fields couples it to a particular allocation strategy. Each engine should instead calculate cache utilization according to its own memory model and report a backend-independent value.

  ## Modification

  - Removed `total_blocks` and `free_blocks` from `ScheduleMetrics`.
  - Changed `cache_usage` to a concrete float with a default of 0.0.
  - Updated the PyTorch scheduler to calculate and report cache usage directly, including handling zero GPU-cache capacity.
