### PR TITLE
Ssm prefix cache non aligned

### DIFF
--- a/lmdeploy/pytorch/backends/base.py
+++ b/lmdeploy/pytorch/backends/base.py
@@ -38,6 +38,7 @@ class OpType(Enum):
     V4Compressor = auto()
     HcPrePost = auto()
     Embedding = auto()
+    CacheBlockCopy = auto()
 
     # MoE router
     RouterNoauxTC = auto()

--- a/lmdeploy/pytorch/backends/cache_block_copy.py
+++ b/lmdeploy/pytorch/backends/cache_block_copy.py
@@ -1,0 +1,30 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+from abc import ABC, abstractmethod
+from collections.abc import Sequence
+
+import torch
+
+
+class CacheBlockCopyImpl(ABC):
+    """Logical-block copy implementation owning its packed cache pools."""
+
+    @abstractmethod
+    def forward(self, src_block_offsets: torch.Tensor, dst_block_offsets: torch.Tensor) -> None:
+        """Copy complete logical blocks on the current stream.
+
+        Both offset tensors are one-dimensional ``torch.long`` device tensors
+        at scheduler block granularity. The caller owns plan semantic
+        validation and lifetime.
+        """
+        raise NotImplementedError
+
+
+class CacheBlockCopyBuilder(ABC):
+    """Logical-block copy implementation builder."""
+
+    @staticmethod
+    @abstractmethod
+    def build(packed_caches: Sequence[torch.Tensor], num_logical_blocks: int,
+              pages_per_block: int) -> CacheBlockCopyImpl:
+        """Build an implementation for stable logical/cache-page geometry."""
+        raise NotImplementedError

--- a/lmdeploy/pytorch/backends/cuda/cache_block_copy.py
+++ b/lmdeploy/pytorch/backends/cuda/cache_block_copy.py
@@ -1,0 +1,34 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+
+from collections.abc import Sequence
+
+import torch
+
+from lmdeploy.pytorch.kernels.cuda.copy_packed_cache import copy_packed_cache
+
+from ..cache_block_copy import CacheBlockCopyBuilder, CacheBlockCopyImpl
+
+
+class CudaCacheBlockCopyImpl(CacheBlockCopyImpl):
+    """Triton packed logical-block copy for CUDA cache pools."""
+
+    def __init__(self, packed_caches: Sequence[torch.Tensor], pages_per_block: int):
+        self.pages_per_block = pages_per_block
+        self._packed_caches = tuple(packed_caches)
+
+    def forward(self, src_block_offsets: torch.Tensor, dst_block_offsets: torch.Tensor) -> None:
+        if src_block_offsets.numel() == 0:
+            return
+
+        for packed_cache in self._packed_caches:
+            copy_packed_cache(packed_cache, src_block_offsets, dst_block_offsets, self.pages_per_block)
+
+
+class CudaCacheBlockCopyBuilder(CacheBlockCopyBuilder):
+    """Build the CUDA packed logical-block copy implementation."""
+
+    @staticmethod
+    def build(packed_caches: Sequence[torch.Tensor], num_logical_blocks: int,
+              pages_per_block: int) -> CacheBlockCopyImpl:
+        return CudaCacheBlockCopyImpl(packed_caches=packed_caches,
+                                      pages_per_block=pages_per_block)

--- a/lmdeploy/pytorch/backends/cuda/op_backend.py
+++ b/lmdeploy/pytorch/backends/cuda/op_backend.py
@@ -94,6 +94,9 @@ class CudaOpsBackend(DefaultOpsBackend):
         elif layer_type == OpType.GatedDeltaRule:
             from .gated_delta_rule import CudaGatedDeltaRuleBuilder
             return CudaGatedDeltaRuleBuilder
+        elif layer_type == OpType.CacheBlockCopy:
+            from .cache_block_copy import CudaCacheBlockCopyBuilder
+            return CudaCacheBlockCopyBuilder
         else:
             logger.debug(f'Op {layer_type} fallback to default implementation.')
             return super().get_layer_impl_builder(layer_type)

--- a/lmdeploy/pytorch/backends/default/cache_block_copy.py
+++ b/lmdeploy/pytorch/backends/default/cache_block_copy.py
@@ -1,0 +1,78 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+
+from collections.abc import Sequence
+
+import torch
+
+from ..cache_block_copy import CacheBlockCopyBuilder, CacheBlockCopyImpl
+
+
+class DefaultCacheBlockCopyImpl(CacheBlockCopyImpl):
+    """Batched torch fallback for copying opaque packed logical blocks."""
+
+    def __init__(self,
+                 packed_caches: Sequence[torch.Tensor],
+                 num_logical_blocks: int,
+                 pages_per_block: int,
+                 blocks_per_chunk: int):
+        packed_caches = tuple(packed_caches)
+        self.blocks_per_chunk = blocks_per_chunk
+        self._logical_caches = tuple(
+            packed_cache.unflatten(-2, (num_logical_blocks, pages_per_block))
+            for packed_cache in packed_caches)
+        self._workspaces: tuple[torch.Tensor, ...] | None = None
+
+    def forward(self, src_block_offsets: torch.Tensor, dst_block_offsets: torch.Tensor) -> None:
+        """Copy logical blocks with bounded gather/scatter batches."""
+        num_blocks = src_block_offsets.numel()
+        if len(self._logical_caches) == 0 or num_blocks == 0:
+            return
+
+        if self._workspaces is None:
+            self._workspaces = tuple(
+                torch.empty((*cache.shape[:-3], self.blocks_per_chunk, *cache.shape[-2:]),
+                            dtype=cache.dtype,
+                            device=cache.device) for cache in self._logical_caches)
+
+        for logical_cache, workspace in zip(self._logical_caches, self._workspaces):
+            for start in range(0, num_blocks, self.blocks_per_chunk):
+                end = min(start + self.blocks_per_chunk, num_blocks)
+                chunk_blocks = end - start
+                src_chunk = src_block_offsets[start:end]
+                dst_chunk = dst_block_offsets[start:end]
+                chunk_workspace = workspace.narrow(-3, 0, chunk_blocks)
+                torch.index_select(logical_cache, -3, src_chunk, out=chunk_workspace)
+
+                index_shape = [1] * logical_cache.dim()
+                index_shape[-3] = chunk_blocks
+                dst_index = dst_chunk.view(index_shape).expand_as(chunk_workspace)
+                logical_cache.scatter_(-3, dst_index, chunk_workspace)
+
+
+class DefaultCacheBlockCopyBuilder(CacheBlockCopyBuilder):
+    """Build the batched torch logical-block copy fallback."""
+
+    # Bound the total persistent gather workspace across all packed pools.
+    # One logical block remains the irreducible unit, so an unusually large
+    # block may exceed this target.
+    _TARGET_WORKSPACE_BYTES = 64 * 1024**2
+
+    @staticmethod
+    def build(packed_caches: Sequence[torch.Tensor], num_logical_blocks: int,
+              pages_per_block: int) -> CacheBlockCopyImpl:
+        packed_caches = tuple(packed_caches)
+        if num_logical_blocks == 0:
+            blocks_per_chunk = 1
+        else:
+            bytes_per_block = sum(cache.numel() * cache.element_size() // num_logical_blocks
+                                  for cache in packed_caches)
+            if bytes_per_block == 0:
+                blocks_per_chunk = num_logical_blocks
+            else:
+                blocks_per_chunk = max(1,
+                                       DefaultCacheBlockCopyBuilder._TARGET_WORKSPACE_BYTES // bytes_per_block)
+                blocks_per_chunk = min(blocks_per_chunk, num_logical_blocks)
+        return DefaultCacheBlockCopyImpl(packed_caches=packed_caches,
+                                         num_logical_blocks=num_logical_blocks,
+                                         pages_per_block=pages_per_block,
+                                         blocks_per_chunk=blocks_per_chunk)

--- a/lmdeploy/pytorch/backends/default/op_backend.py
+++ b/lmdeploy/pytorch/backends/default/op_backend.py
@@ -47,6 +47,9 @@ class DefaultOpsBackend(OpsBackend):
         elif layer_type == OpType.Embedding:
             from .embedding import DefaultEmbeddingBuilder
             return DefaultEmbeddingBuilder
+        elif layer_type == OpType.CacheBlockCopy:
+            from .cache_block_copy import DefaultCacheBlockCopyBuilder
+            return DefaultCacheBlockCopyBuilder
         elif layer_type == OpType.RouterNoauxTC:
             from .moe_router import DefaultRouterNoauxTCBuilder
             return DefaultRouterNoauxTCBuilder

--- a/lmdeploy/pytorch/engine/cache_engine.py
+++ b/lmdeploy/pytorch/engine/cache_engine.py
@@ -9,6 +9,7 @@ from operator import index as as_index
 import torch
 
 from lmdeploy.pytorch.backends import get_backend
+from lmdeploy.pytorch.backends.base import OpType
 from lmdeploy.pytorch.disagg.backend.backend import MIGRATION_BACKENDS
 from lmdeploy.pytorch.disagg.backend.base import MigrationBackendImpl
 from lmdeploy.pytorch.disagg.conn.protocol import DistServeInitRequest, DistServeKVTransferEndpointInfo
@@ -257,6 +258,7 @@ class CacheEngine:
         # Initialize the cache.
         self.local_gpu_cache = self.allocate_gpu_cache()
         self.local_cpu_cache = self.allocate_cpu_cache()
+        self._build_cache_block_copy()
 
         self.migration_backend_impl: MigrationBackendImpl | None = None
 
@@ -270,6 +272,22 @@ class CacheEngine:
 
         logger.debug(f'Initialize cache engine with {cache_config.num_gpu_blocks}'
                      f' gpu blocks and {cache_config.num_cpu_blocks} cpu blocks.')
+
+    def _build_cache_block_copy(self) -> None:
+        """Build the optional logical KV-block copy implementation."""
+        self._cache_block_copy_device = None
+        self._cache_block_copy_impl = None
+        if not (self.cache_config.enable_prefix_caching
+                and len(self.cache_config.states_shapes) > 0):
+            return
+
+        pages_per_block = self.cache_config.block_size // self.cache_config.kernel_block_size
+        packed_pools = self._as_mem_pools(self.full_gpu_cache)
+        self._cache_block_copy_device = packed_pools[0].device
+        block_copy_builder = get_backend().get_layer_impl_builder(OpType.CacheBlockCopy)
+        self._cache_block_copy_impl = block_copy_builder.build(packed_caches=packed_pools,
+                                                               num_logical_blocks=self.num_gpu_blocks,
+                                                               pages_per_block=pages_per_block)
 
     @property
     def cpu_cache(self):
@@ -644,7 +662,7 @@ class CacheEngine:
 
     @staticmethod
     def _as_mem_pools(mem_pool: torch.Tensor | list[torch.Tensor]) -> list[torch.Tensor]:
-        """Normalize one or many allocation pools."""
+        """Normalize one or many packed cache allocation pools."""
         if isinstance(mem_pool, torch.Tensor):
             return [mem_pool]
         return mem_pool
@@ -653,6 +671,34 @@ class CacheEngine:
     def _mem_pool_nbytes(mem_pool: torch.Tensor | list[torch.Tensor]) -> int:
         """Return memory size for one or many allocation pools."""
         return sum(pool.numel() * pool.element_size() for pool in CacheEngine._as_mem_pools(mem_pool))
+
+    @torch.inference_mode()
+    def copy_logical_blocks(self, copy_plan: torch.Tensor) -> None:
+        """Copy complete packed KV blocks on the current stream.
+
+        ``copy_plan`` has shape ``[2, num_pairs]`` and contains physical GPU
+        block-table entries at scheduler-block granularity, not allocator
+        logical block IDs.  It must already be on the cache device.  Host-side
+        plan construction validates values before forward-input H2D; this hot
+        path intentionally performs no device-value inspection.
+
+        The caller owns block lifetimes and must keep every source and
+        destination pinned until these stream-ordered copies are safe.
+        """
+        if not isinstance(copy_plan, torch.Tensor):
+            raise TypeError('copy_plan must be a torch.Tensor.')
+        if copy_plan.dim() != 2 or copy_plan.size(0) != 2:
+            raise ValueError('copy_plan must have shape [2, num_pairs].')
+        if copy_plan.dtype != torch.long:
+            raise TypeError('copy_plan must use torch.long indices.')
+        if self._cache_block_copy_impl is None:
+            raise RuntimeError('Logical KV-block copy is not enabled for this cache engine.')
+        if copy_plan.device != self._cache_block_copy_device:
+            raise ValueError('copy_plan must be on the packed cache device.')
+        if copy_plan.size(1) == 0:
+            return
+
+        self._cache_block_copy_impl.forward(copy_plan[0], copy_plan[1])
 
     @torch.inference_mode()
     def _swap(self, src: torch.Tensor | list[torch.Tensor], dst: torch.Tensor | list[torch.Tensor],
@@ -941,33 +987,16 @@ class StateCacheEngine:
         self.mem_pool.masked_fill_(reshaped_mask, 0)
 
     @staticmethod
-    def _index_list(idx: int | Sequence[int]):
-        """Normalize host-side cache indices."""
-        if isinstance(idx, torch.Tensor):
-            raise TypeError('State cache copy indices must be host integers, not torch.Tensor.')
-        if isinstance(idx, (str, bytes)):
-            raise TypeError('State cache copy indices must be an int or a sequence of ints.')
-        try:
-            return [as_index(idx)]
-        except TypeError:
-            pass
-        if not isinstance(idx, Sequence):
-            raise TypeError('State cache copy indices must be an int or a sequence of ints.')
-        if any(isinstance(item, torch.Tensor) for item in idx):
-            raise TypeError('State cache copy indices must be host integers, not torch.Tensor.')
-        return [as_index(item) for item in idx]
-
-    @staticmethod
-    def _validate_index_bounds(indices: Sequence[int], num_caches: int):
-        """Check normalized cache indices are valid state slots."""
+    def _validate_index_bounds(indices: tuple[int, ...], num_caches: int):
+        """Check state cache indices are valid slots."""
         for idx in indices:
             if idx < 0 or idx >= num_caches:
                 raise ValueError(f'State cache index {idx} is out of range [0, {num_caches}).')
 
     @staticmethod
-    def _copy_ranges(src_list: list[int], dst_list: list[int]):
+    def _copy_ranges(src_indices: tuple[int, ...], dst_indices: tuple[int, ...]):
         """Yield contiguous copy ranges as (src_start, dst_start, length)."""
-        pairs = sorted(zip(src_list, dst_list))
+        pairs = sorted(zip(src_indices, dst_indices))
         if len(pairs) == 0:
             return
         start_src = prev_src = pairs[0][0]
@@ -985,7 +1014,7 @@ class StateCacheEngine:
             length = 1
         yield start_src, start_dst, length
 
-    def copy_caches(self, src_idx: int | Sequence[int], dst_idx: int | Sequence[int]):
+    def copy_caches(self, src_indices: tuple[int, ...], dst_indices: tuple[int, ...]):
         """Copy state cache slots.
 
         This is the low-level primitive needed by SSM prefix caching: a frozen
@@ -995,22 +1024,20 @@ class StateCacheEngine:
         if len(self._state_caches) <= 0:
             return
 
-        src_list = self._index_list(src_idx)
-        dst_list = self._index_list(dst_idx)
-        if len(src_list) != len(dst_list):
-            raise ValueError('src_idx and dst_idx must have the same number of elements.')
-        if len(src_list) == 0:
+        if len(src_indices) != len(dst_indices):
+            raise ValueError('src_indices and dst_indices must have the same number of elements.')
+        if len(src_indices) == 0:
             return
         num_caches = self.mem_pool.size(0)
-        self._validate_index_bounds(src_list, num_caches)
-        self._validate_index_bounds(dst_list, num_caches)
-        dst_set = set(dst_list)
-        if len(dst_set) != len(dst_list):
-            raise ValueError('dst_idx must not contain duplicate entries.')
-        if not set(src_list).isdisjoint(dst_set):
-            raise ValueError('src_idx and dst_idx must not overlap for stream-ordered state copies.')
+        self._validate_index_bounds(src_indices, num_caches)
+        self._validate_index_bounds(dst_indices, num_caches)
+        dst_set = set(dst_indices)
+        if len(dst_set) != len(dst_indices):
+            raise ValueError('dst_indices must not contain duplicate entries.')
+        if not set(src_indices).isdisjoint(dst_set):
+            raise ValueError('src_indices and dst_indices must not overlap for stream-ordered state copies.')
 
-        for src, dst, length in self._copy_ranges(src_list, dst_list):
+        for src, dst, length in self._copy_ranges(src_indices, dst_indices):
             if length == 1:
                 self.mem_pool[dst].copy_(self.mem_pool[src], non_blocking=True)
             else:

--- a/lmdeploy/pytorch/engine/cache_inputs.py
+++ b/lmdeploy/pytorch/engine/cache_inputs.py
@@ -11,8 +11,9 @@ StateCacheCopyPlan = tuple[tuple[int, ...], tuple[int, ...]]
 class CacheCheckpointInputs:
     """One-forward cache restore and save plans.
 
-    KV plans are scheduler-block copy pairs with shape ``[2, N]``.  They are
-    transferred to the cache device with the rest of the forward payload.
+    KV plans contain physical GPU block-offset pairs at scheduler-block
+    granularity with shape ``[2, N]``. They are transferred to the cache device
+    with the rest of the forward payload.
     State plans stay as compact host integer sequences because
     ``StateCacheEngine`` schedules those copies from the host.
 

--- a/lmdeploy/pytorch/engine/cache_inputs.py
+++ b/lmdeploy/pytorch/engine/cache_inputs.py
@@ -1,0 +1,50 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+"""Per-forward prefix-cache checkpoint operations."""
+from dataclasses import dataclass
+
+import torch
+
+StateCacheCopyPlan = tuple[tuple[int, ...], tuple[int, ...]]
+
+
+@dataclass(frozen=True)
+class CacheCheckpointInputs:
+    """One-forward cache restore and save plans.
+
+    KV plans are scheduler-block copy pairs with shape ``[2, N]``.  They are
+    transferred to the cache device with the rest of the forward payload.
+    State plans stay as compact host integer sequences because
+    ``StateCacheEngine`` schedules those copies from the host.
+
+    This object is deliberately separate from ``ModelInputs``: checkpoint
+    operations are consumed once and must not participate in decode-step
+    merge, reindex, or advance logic.
+    """
+
+    kv_restore_plan: torch.Tensor | None = None
+    kv_save_plan: torch.Tensor | None = None
+    state_restore_plan: StateCacheCopyPlan | None = None
+    state_save_plan: StateCacheCopyPlan | None = None
+
+    @torch.inference_mode()
+    def to_device(self, device: str, non_blocking: bool = False):
+        """Move device-consumed plans while retaining host-scheduled plans."""
+        kv_restore_plan = self.kv_restore_plan
+        if kv_restore_plan is not None:
+            kv_restore_plan = kv_restore_plan.to(device, non_blocking=non_blocking)
+        kv_save_plan = self.kv_save_plan
+        if kv_save_plan is not None:
+            kv_save_plan = kv_save_plan.to(device, non_blocking=non_blocking)
+
+        return CacheCheckpointInputs(
+            kv_restore_plan=kv_restore_plan,
+            kv_save_plan=kv_save_plan,
+            state_restore_plan=self.state_restore_plan,
+            state_save_plan=self.state_save_plan,
+        )
+
+    def record_stream(self, stream: torch.cuda.Stream) -> None:
+        """Record forward-stream use of device-consumed plans."""
+        for plan in (self.kv_restore_plan, self.kv_save_plan):
+            if plan is not None and plan.is_cuda:
+                plan.record_stream(stream)

--- a/lmdeploy/pytorch/engine/engine_loop.py
+++ b/lmdeploy/pytorch/engine/engine_loop.py
@@ -406,12 +406,6 @@ class EngineLoop:
         self.scheduler.collect_migration_done()
         return await self.inputs_maker.send_next_inputs()
 
-    @staticmethod
-    def _has_state_checkpoint_save(model_inputs: 'ModelInputs | None', delta: 'ModelInputsDelta | None'):
-        """Check whether the current forward reserved SSM checkpoints."""
-        return ((model_inputs is not None and model_inputs.state_prefix_cache_save_offsets is not None)
-                or (delta is not None and delta.state_prefix_cache_save_offsets is not None))
-
     async def _prefetch_next_inputs(self):
         """Collect migration completions before prefetching the next batch."""
         if self._sleep_requested:
@@ -449,8 +443,10 @@ class EngineLoop:
         """Get outputs and prefetch."""
         model_inputs = forward_inputs['inputs']
         delta = forward_inputs['delta']
+        cache_inputs = forward_inputs['cache_inputs']
         self.inputs_maker.update_running_seqs(running, model_inputs)
-        has_state_checkpoint_save = self._has_state_checkpoint_save(model_inputs, delta)
+        has_state_checkpoint_save = (cache_inputs is not None
+                                     and cache_inputs.state_save_plan is not None)
 
         # ModelAgent executes queued forwards in send order.  Once the current
         # input is queued, matched checkpoints can be published before waiting

--- a/lmdeploy/pytorch/engine/inputs_maker.py
+++ b/lmdeploy/pytorch/engine/inputs_maker.py
@@ -27,6 +27,8 @@ from lmdeploy.pytorch.messages import MessageStatus
 from lmdeploy.pytorch.model_inputs import ModelInputs, ModelInputsDelta, VisionModelInputs
 from lmdeploy.utils import get_logger
 
+from .cache_inputs import CacheCheckpointInputs, StateCacheCopyPlan
+
 if TYPE_CHECKING:
     from lmdeploy.pytorch.adapter.adapter import AdapterManager
     from lmdeploy.pytorch.messages import SchedulerSequence
@@ -55,8 +57,9 @@ def _tensorlize_block_offsets(block_offsets, dtype=torch.int32):
     return torch.as_tensor(out, dtype=dtype)
 
 
-def _compact_state_prefix_cache_restore_offsets(messages: list['SchedulerSequence']):
-    """Build compact SSM restore src/dst index tensors."""
+def _make_state_prefix_cache_restore_plan(
+        messages: list['SchedulerSequence']) -> StateCacheCopyPlan | None:
+    """Build a compact host SSM state-restore plan."""
     src_offsets = []
     dst_offsets = []
     for msg in messages:
@@ -65,12 +68,13 @@ def _compact_state_prefix_cache_restore_offsets(messages: list['SchedulerSequenc
             src_offsets.append(restore.slot)
             dst_offsets.append(msg.logical_state)
     if len(src_offsets) == 0:
-        return None, None
+        return None
     return tuple(src_offsets), tuple(dst_offsets)
 
 
-def _compact_state_prefix_cache_save_offsets(messages: list['SchedulerSequence'], save_state_offsets: list[int]):
-    """Build compact SSM save src/dst index tensors."""
+def _make_state_prefix_cache_save_plan(messages: list['SchedulerSequence'],
+                                       save_state_offsets: list[int]) -> StateCacheCopyPlan | None:
+    """Build a compact host SSM state-save plan."""
     src_offsets = []
     dst_offsets = []
     for msg, state_idx in zip(messages, save_state_offsets):
@@ -78,7 +82,7 @@ def _compact_state_prefix_cache_save_offsets(messages: list['SchedulerSequence']
             src_offsets.append(msg.logical_state)
             dst_offsets.append(state_idx)
     if len(src_offsets) == 0:
-        return None, None
+        return None
     return tuple(src_offsets), tuple(dst_offsets)
 
 
@@ -254,6 +258,7 @@ class _ForwardInputsResult:
     running: 'SeqList' = field(default_factory=list)
     inputs: ModelInputs | None = None
     delta: ModelInputsDelta | None = None
+    cache_inputs: CacheCheckpointInputs | None = None
     extra_inputs: object | None = None
     swap_in_map: dict = field(default_factory=dict)
     swap_out_map: dict = field(default_factory=dict)
@@ -265,11 +270,13 @@ class _ForwardInputsResult:
                  running: 'SeqList',
                  inputs: ModelInputs | None,
                  delta: ModelInputsDelta | None,
-                 extra_inputs: object | None):
+                 extra_inputs: object | None,
+                 cache_inputs: CacheCheckpointInputs | None = None):
         """Replace forward work while preserving scheduler swap maps."""
         self.running = running
         self.inputs = inputs
         self.delta = delta
+        self.cache_inputs = cache_inputs
         self.extra_inputs = extra_inputs
 
 
@@ -460,14 +467,19 @@ class _ForwardInputsTask:
         self.state.tried_long_work = True
         result = self._build_active_chunk()
         self.state.active_chunk_blocked_by_kv = result.is_empty()
-        self.result.set_work(result.running, result.inputs, result.delta, result.extra_inputs)
+        self.result.set_work(result.running,
+                             result.inputs,
+                             result.delta,
+                             result.extra_inputs,
+                             cache_inputs=result.cache_inputs)
 
     def _try_decode(self):
         maker = self.maker
         self.state.prefill = False
         delta, running, invalid_seqs = maker.create_model_inputs_delta()
         maker.to_evict_seqs = invalid_seqs
-        self.result.set_work(running, None, delta, None)
+        cache_inputs = maker._make_decode_cache_inputs(running, delta)
+        self.result.set_work(running, None, delta, None, cache_inputs=cache_inputs)
 
     def _schedule_prefill(self,
                           allow_long_prefill: bool = True,
@@ -496,15 +508,18 @@ class _ForwardInputsTask:
                 # flags here: spec decoding uses them as a cross-chunk carry
                 # protocol.
                 maker.long_context_chunker.clear()
-                result.inputs, result.delta, result.extra_inputs = self._build_prefill_inputs(running)
+                (result.inputs, result.delta, result.extra_inputs,
+                 result.cache_inputs) = self._build_prefill_inputs(running)
             else:
                 chunk_size, multimodals = maker.long_context_chunker.next_chunk_size()
-                result.inputs, result.extra_inputs = self._build_chunk_inputs(running, chunk_size, multimodals)
+                (result.inputs, result.extra_inputs,
+                 result.cache_inputs) = self._build_chunk_inputs(running, chunk_size, multimodals)
                 result.inputs.is_first_chunk = True
                 result.inputs.is_chunk_multimodal = maker.long_context_chunker.has_multimodal
                 maker._short_prefill_turns_since_long_chunk = 0
         elif len(running) > 0:
-            result.inputs, result.delta, result.extra_inputs = self._build_prefill_inputs(running)
+            (result.inputs, result.delta, result.extra_inputs,
+             result.cache_inputs) = self._build_prefill_inputs(running)
         return result
 
     def _build_active_chunk(self):
@@ -518,12 +533,12 @@ class _ForwardInputsTask:
 
         running = [seq]
         if is_last_chunk:
-            inputs, delta, extra_inputs = self._build_prefill_inputs(running)
+            inputs, delta, extra_inputs, cache_inputs = self._build_prefill_inputs(running)
             inputs.is_chunk = True
             inputs.is_last_chunk = True
             maker.long_context_chunker.clear()
         else:
-            inputs, extra_inputs = self._build_chunk_inputs(running, chunk_size, multimodals)
+            inputs, extra_inputs, cache_inputs = self._build_chunk_inputs(running, chunk_size, multimodals)
             delta = None
         inputs.is_first_chunk = False
         inputs.is_chunk_multimodal = is_chunk_multimodal
@@ -531,6 +546,7 @@ class _ForwardInputsTask:
         return _ForwardInputsResult(running=running,
                                     inputs=inputs,
                                     delta=delta,
+                                    cache_inputs=cache_inputs,
                                     extra_inputs=extra_inputs)
 
     def _reserve_chunk(self,
@@ -552,10 +568,11 @@ class _ForwardInputsTask:
     def _build_prefill_inputs(self, seqs: 'SeqList'):
         maker = self.maker
         inputs = maker.create_model_inputs(seqs, True)
+        cache_inputs = maker._prepare_prefill_cache_inputs(seqs)
         delta, valid_seqs, _ = maker.create_model_inputs_delta_valid_only()
         maker.running_seqs = valid_seqs
         extra_inputs = maker.model_agent_strategy.make_extra_inputs(seqs, inputs)
-        return inputs, delta, extra_inputs
+        return inputs, delta, extra_inputs, cache_inputs
 
     def _build_chunk_inputs(self,
                             running: 'SeqList',
@@ -563,8 +580,10 @@ class _ForwardInputsTask:
                             multimodals: 'MultiModalInputs|None'):
         maker = self.maker
         inputs = maker.create_model_inputs_long_context(running[0], chunk_size, multimodals)
+        save_step = running[0].num_history_ids + chunk_size
+        cache_inputs = maker._prepare_prefill_cache_inputs(running, save_steps=(save_step, ))
         extra_inputs = maker.model_agent_strategy.make_extra_inputs(running, inputs)
-        return inputs, extra_inputs
+        return inputs, extra_inputs, cache_inputs
 
     def _need_logits(self):
         if self.maker.spec_decoding:
@@ -590,6 +609,7 @@ class _ForwardInputsTask:
             running=result.running,
             inputs=result.inputs,
             delta=result.delta,
+            cache_inputs=result.cache_inputs,
             swap_in_map=result.swap_in_map,
             swap_out_map=result.swap_out_map,
             sampling_inputs=sampling_inputs,
@@ -828,6 +848,75 @@ class InputsMakerAsync:
                          self.kernel_block_arange[None, None, :]).reshape(batch_size, -1)
         return block_offsets
 
+    def _make_kv_prefix_cache_copy_plan(
+            self, logical_pairs: list[tuple[int, int]]) -> torch.LongTensor:
+        """Resolve paging ids and build one host KV-block copy plan."""
+        logical_ids = np.asarray(logical_pairs, dtype=np.int64).reshape(-1, 2)
+        block_offsets = self.scheduler.resolve_gpu_block_offsets(logical_ids.reshape(-1))
+        block_offsets = block_offsets.reshape(-1, 2)
+        src_offsets = block_offsets[:, 0]
+        dst_offsets = block_offsets[:, 1]
+        if len(np.unique(dst_offsets)) != len(dst_offsets):
+            raise ValueError('KV copy destinations must be unique.')
+        if not set(src_offsets.tolist()).isdisjoint(dst_offsets.tolist()):
+            raise ValueError('KV copy sources and destinations must not overlap.')
+        return torch.from_numpy(block_offsets.T.copy())
+
+    def _ssm_prefix_cache_enabled(self):
+        """Check whether this input maker emits SSM checkpoint operations."""
+        return self.config.is_ssm and self.cache_config.enable_prefix_caching
+
+    def _prepare_prefill_cache_inputs(self,
+                                      messages: 'SeqList',
+                                      save_steps: tuple[int, ...] | None = None):
+        """Acquire and reserve one-forward prefill checkpoint operations."""
+        if not self._ssm_prefix_cache_enabled():
+            return None
+        if save_steps is not None and len(save_steps) != len(messages):
+            raise ValueError('save_steps must have one entry per prefill sequence.')
+
+        state_checkpoints = self.scheduler.block_trie.state_checkpoints
+        state_restore_plan = _make_state_prefix_cache_restore_plan(messages)
+        if state_restore_plan is not None:
+            # Pin restore checkpoints while the forward copies them into
+            # runtime state slots; otherwise checkpoint eviction could race
+            # with input prefetching for the next batch.
+            state_checkpoints.pin_restores(messages)
+            if any(msg.prefix_cache.restore.is_selected and not msg.prefix_cache.restore.pinned
+                   for msg in messages):
+                raise RuntimeError('Failed to acquire SSM prefix-cache restore checkpoint.')
+
+        # Prefill saves publish only after model_forward has copied the runtime
+        # state to these reserved checkpoint offsets.
+        if save_steps is None:
+            save_state_offsets = [state_checkpoints.reserve_save(msg) for msg in messages]
+        else:
+            save_state_offsets = [state_checkpoints.reserve_save(msg, step=step)
+                                  for msg, step in zip(messages, save_steps)]
+        state_save_plan = _make_state_prefix_cache_save_plan(messages, save_state_offsets)
+
+        if state_restore_plan is None and state_save_plan is None:
+            return None
+        return CacheCheckpointInputs(state_restore_plan=state_restore_plan,
+                                     state_save_plan=state_save_plan)
+
+    def _make_decode_cache_inputs(self, valid_seqs: 'SeqList', delta: ModelInputsDelta | None):
+        """Build one-forward checkpoint operations for a decode step."""
+        if delta is None or len(valid_seqs) == 0 or not self._ssm_prefix_cache_enabled():
+            return None
+
+        decode_state_interval = self.cache_config.prefix_cache_decode_state_interval
+        if (decode_state_interval <= 0 or self.spec_decoding or delta.max_q_seqlen != 1):
+            return None
+
+        state_checkpoints = self.scheduler.block_trie.state_checkpoints
+        save_state_offsets = [state_checkpoints.reserve_decode_save(seq, decode_state_interval)
+                              for seq in valid_seqs]
+        state_save_plan = _make_state_prefix_cache_save_plan(valid_seqs, save_state_offsets)
+        if state_save_plan is None:
+            return None
+        return CacheCheckpointInputs(state_save_plan=state_save_plan)
+
     @torch.inference_mode()
     @record_function('create_model_inputs')
     def create_model_inputs(self, messages: 'SeqList', is_prefill: bool):
@@ -892,29 +981,8 @@ class InputsMakerAsync:
 
         # ssm
         if self.config.is_ssm:
-            state_checkpoints = self.scheduler.block_trie.state_checkpoints
             state_offsets = torch.tensor([msg.logical_state for msg in messages])
             model_inputs.state_offsets = state_offsets
-            if (self.cache_config.enable_prefix_caching
-                    and any(msg.prefix_cache.restore.is_selected for msg in messages)):
-                # Pin restore checkpoints while the forward copies them into
-                # runtime state slots; otherwise checkpoint eviction could race
-                # with input prefetching for the next batch.
-                state_checkpoints.pin_restores(messages)
-                if any(msg.prefix_cache.restore.is_selected and not msg.prefix_cache.restore.pinned
-                       for msg in messages):
-                    raise RuntimeError('Failed to pin SSM prefix-cache restore checkpoint.')
-                restore_src_offsets, restore_dst_offsets = _compact_state_prefix_cache_restore_offsets(messages)
-                model_inputs.state_prefix_cache_offsets = restore_src_offsets
-                model_inputs.state_prefix_cache_dst_offsets = restore_dst_offsets
-            if self.cache_config.enable_prefix_caching and not is_decoding:
-                # Prefill saves publish only after model_forward has copied the
-                # runtime state to these reserved checkpoint offsets.
-                save_state_offsets = [state_checkpoints.reserve_save(msg) for msg in messages]
-                save_src_offsets, save_dst_offsets = _compact_state_prefix_cache_save_offsets(messages,
-                                                                                              save_state_offsets)
-                model_inputs.state_prefix_cache_save_src_offsets = save_src_offsets
-                model_inputs.state_prefix_cache_save_offsets = save_dst_offsets
 
         if self.config.use_mrope:
             mrope_pos_ids = [msg.mrope_pos_ids for msg in messages]
@@ -977,23 +1045,7 @@ class InputsMakerAsync:
 
         # ssm
         if self.config.is_ssm:
-            state_checkpoints = self.scheduler.block_trie.state_checkpoints
             model_inputs.state_offsets = torch.tensor([seq.logical_state])
-            if self.cache_config.enable_prefix_caching and seq.prefix_cache.restore.is_selected:
-                # Long-context chunks use the same restore pinning contract as
-                # normal prefill batches.
-                state_checkpoints.pin_restore(seq)
-                if not seq.prefix_cache.restore.pinned:
-                    raise RuntimeError('Failed to pin SSM prefix-cache restore checkpoint.')
-                model_inputs.state_prefix_cache_offsets = (seq.prefix_cache.restore.slot, )
-                model_inputs.state_prefix_cache_dst_offsets = (seq.logical_state, )
-            if self.cache_config.enable_prefix_caching:
-                # Save at the exact state step produced by this chunk forward.
-                checkpoint_step = seq.num_history_ids + chunk_size
-                save_state = state_checkpoints.reserve_save(seq, step=checkpoint_step)
-                if save_state >= 0:
-                    model_inputs.state_prefix_cache_save_src_offsets = (seq.logical_state, )
-                    model_inputs.state_prefix_cache_save_offsets = (save_state, )
 
         # mrope
         if self.config.use_mrope:
@@ -1054,18 +1106,6 @@ class InputsMakerAsync:
             sum_kv_seqlen=sum_kv_seqlen,
             num_ignored_history=num_ignored_history,
         )
-        decode_state_interval = self.cache_config.prefix_cache_decode_state_interval
-        if (self.cache_config.enable_prefix_caching and self.config.is_ssm and decode_state_interval > 0
-                and not self.spec_decoding and num_decode_tokens == 1):
-            state_checkpoints = self.scheduler.block_trie.state_checkpoints
-            save_state_offsets = [state_checkpoints.reserve_decode_save(seq, decode_state_interval)
-                                  for seq in valid_seqs]
-            if any(state_idx >= 0 for state_idx in save_state_offsets):
-                save_src_offsets, save_dst_offsets = _compact_state_prefix_cache_save_offsets(valid_seqs,
-                                                                                              save_state_offsets)
-                output.state_prefix_cache_save_src_offsets = save_src_offsets
-                output.state_prefix_cache_save_offsets = save_dst_offsets
-
         return output, valid_seqs, invalid_seqs
 
     def create_model_inputs_delta_valid_only(self):

--- a/lmdeploy/pytorch/engine/inputs_maker.py
+++ b/lmdeploy/pytorch/engine/inputs_maker.py
@@ -866,6 +866,70 @@ class InputsMakerAsync:
         """Check whether this input maker emits SSM checkpoint operations."""
         return self.config.is_ssm and self.cache_config.enable_prefix_caching
 
+    def _prepare_prefill_cache_restore(
+            self, messages: 'SeqList') -> tuple[torch.LongTensor | None, StateCacheCopyPlan | None]:
+        """Acquire checkpoints and build prefill restore plans."""
+        state_restore_plan = _make_state_prefix_cache_restore_plan(messages)
+        if state_restore_plan is None:
+            return None, None
+
+        state_checkpoints = self.scheduler.block_trie.state_checkpoints
+        # Keep checkpoint sources alive while the prefetched forward waits to
+        # copy them into request-owned KV and runtime state.
+        state_checkpoints.pin_restores(messages)
+        if any(msg.prefix_cache.restore.is_selected and not msg.prefix_cache.restore.pinned for msg in messages):
+            raise RuntimeError('Failed to acquire SSM prefix-cache restore checkpoint.')
+
+        logical_pairs = []
+        for msg in messages:
+            restore = msg.prefix_cache.restore
+            if not restore.is_selected:
+                continue
+            checkpoint = restore.node.state_checkpoint
+            if checkpoint.frozen_block_id < 0:
+                continue
+            dst_block_idx = checkpoint.step // self.cache_config.block_size
+            if dst_block_idx >= len(msg.logical_blocks):
+                raise RuntimeError('SSM prefix-cache restore destination block is missing.')
+            logical_pairs.append((checkpoint.frozen_block_id, msg.logical_blocks[dst_block_idx]))
+
+        kv_restore_plan = None
+        if logical_pairs:
+            kv_restore_plan = self._make_kv_prefix_cache_copy_plan(logical_pairs)
+        return kv_restore_plan, state_restore_plan
+
+    def _prepare_prefill_cache_save(
+        self,
+        messages: 'SeqList',
+        save_steps: tuple[int, ...] | None,
+    ) -> tuple[torch.LongTensor | None, StateCacheCopyPlan | None]:
+        """Reserve checkpoints and build prefill save plans."""
+        state_checkpoints = self.scheduler.block_trie.state_checkpoints
+        if save_steps is None:
+            save_state_offsets = [state_checkpoints.reserve_save(msg) for msg in messages]
+        else:
+            save_state_offsets = [state_checkpoints.reserve_save(msg, step=step)
+                                  for msg, step in zip(messages, save_steps)]
+        state_save_plan = _make_state_prefix_cache_save_plan(messages, save_state_offsets)
+
+        logical_pairs = []
+        for msg, state_idx in zip(messages, save_state_offsets):
+            if state_idx < 0:
+                continue
+            pending_save = msg.prefix_cache.pending_save
+            checkpoint = pending_save.node.state_checkpoint
+            if checkpoint.frozen_block_id < 0:
+                continue
+            src_block_idx = pending_save.step // self.cache_config.block_size
+            if src_block_idx >= len(msg.logical_blocks):
+                raise RuntimeError('SSM prefix-cache save source block is missing.')
+            logical_pairs.append((msg.logical_blocks[src_block_idx], checkpoint.frozen_block_id))
+
+        kv_save_plan = None
+        if logical_pairs:
+            kv_save_plan = self._make_kv_prefix_cache_copy_plan(logical_pairs)
+        return kv_save_plan, state_save_plan
+
     def _prepare_prefill_cache_inputs(self,
                                       messages: 'SeqList',
                                       save_steps: tuple[int, ...] | None = None):
@@ -875,29 +939,15 @@ class InputsMakerAsync:
         if save_steps is not None and len(save_steps) != len(messages):
             raise ValueError('save_steps must have one entry per prefill sequence.')
 
-        state_checkpoints = self.scheduler.block_trie.state_checkpoints
-        state_restore_plan = _make_state_prefix_cache_restore_plan(messages)
-        if state_restore_plan is not None:
-            # Pin restore checkpoints while the forward copies them into
-            # runtime state slots; otherwise checkpoint eviction could race
-            # with input prefetching for the next batch.
-            state_checkpoints.pin_restores(messages)
-            if any(msg.prefix_cache.restore.is_selected and not msg.prefix_cache.restore.pinned
-                   for msg in messages):
-                raise RuntimeError('Failed to acquire SSM prefix-cache restore checkpoint.')
+        kv_restore_plan, state_restore_plan = self._prepare_prefill_cache_restore(messages)
+        kv_save_plan, state_save_plan = self._prepare_prefill_cache_save(messages, save_steps)
 
-        # Prefill saves publish only after model_forward has copied the runtime
-        # state to these reserved checkpoint offsets.
-        if save_steps is None:
-            save_state_offsets = [state_checkpoints.reserve_save(msg) for msg in messages]
-        else:
-            save_state_offsets = [state_checkpoints.reserve_save(msg, step=step)
-                                  for msg, step in zip(messages, save_steps)]
-        state_save_plan = _make_state_prefix_cache_save_plan(messages, save_state_offsets)
-
-        if state_restore_plan is None and state_save_plan is None:
+        if (kv_restore_plan is None and kv_save_plan is None and state_restore_plan is None
+                and state_save_plan is None):
             return None
-        return CacheCheckpointInputs(state_restore_plan=state_restore_plan,
+        return CacheCheckpointInputs(kv_restore_plan=kv_restore_plan,
+                                     kv_save_plan=kv_save_plan,
+                                     state_restore_plan=state_restore_plan,
                                      state_save_plan=state_save_plan)
 
     def _make_decode_cache_inputs(self, valid_seqs: 'SeqList', delta: ModelInputsDelta | None):

--- a/lmdeploy/pytorch/engine/model_agent/agent.py
+++ b/lmdeploy/pytorch/engine/model_agent/agent.py
@@ -21,6 +21,7 @@ from lmdeploy.pytorch.devices import DeviceContext, get_device_manager
 from lmdeploy.pytorch.disagg.config import EngineRole
 from lmdeploy.pytorch.distributed import DistContext, get_dist_manager
 from lmdeploy.pytorch.engine.cache_engine import CacheEngine, StateCacheEngine
+from lmdeploy.pytorch.engine.cache_inputs import CacheCheckpointInputs
 from lmdeploy.pytorch.engine.guided_process import GuidedDecodingManager
 from lmdeploy.pytorch.engine.logits_process import FusedLogitsProcessor, SamplingInputs
 from lmdeploy.pytorch.memdecode import build_memdecode_agent
@@ -48,7 +49,7 @@ from .scoring import compute_input_ce_loss
 logger = get_logger('lmdeploy')
 
 _H2D_TRANSFER_KEY = '_h2d_transfer'
-_H2D_INPUT_KEYS = ('inputs', 'delta', 'sampling_inputs', 'stopping_criteria', 'extra_inputs')
+_H2D_INPUT_KEYS = ('inputs', 'delta', 'cache_inputs', 'sampling_inputs', 'stopping_criteria', 'extra_inputs')
 
 
 @dataclass
@@ -164,6 +165,30 @@ def cache_swapping(cache_engine: CacheEngine, swap_in_map: dict, swap_out_map: d
         cache_engine.events.wait()
 
 
+def _restore_cache_checkpoint(inputs: ModelInputs, cache_inputs: CacheCheckpointInputs | None,
+                              cache_engine: CacheEngine, state_cache_engine: StateCacheEngine) -> None:
+    """Restore one-forward KV and state checkpoints before model execution."""
+    if cache_inputs is None or inputs.is_dummy:
+        return
+
+    if cache_inputs.kv_restore_plan is not None:
+        cache_engine.copy_logical_blocks(cache_inputs.kv_restore_plan)
+    if cache_inputs.state_restore_plan is not None:
+        state_cache_engine.copy_caches(*cache_inputs.state_restore_plan)
+
+
+def _save_cache_checkpoint(inputs: ModelInputs, cache_inputs: CacheCheckpointInputs | None,
+                           cache_engine: CacheEngine, state_cache_engine: StateCacheEngine) -> None:
+    """Save one-forward KV and state checkpoints after model execution."""
+    if cache_inputs is None or inputs.is_dummy:
+        return
+
+    if cache_inputs.kv_save_plan is not None:
+        cache_engine.copy_logical_blocks(cache_inputs.kv_save_plan)
+    if cache_inputs.state_save_plan is not None:
+        state_cache_engine.copy_caches(*cache_inputs.state_save_plan)
+
+
 @torch.inference_mode()
 def model_forward(
     model: torch.nn.Module,
@@ -171,6 +196,7 @@ def model_forward(
     cache_engine: CacheEngine,
     state_cache_engine: StateCacheEngine,
     stream: torch.cuda.Stream = None,
+    cache_inputs: CacheCheckpointInputs | None = None,
 ):
     """Perform model forward."""
     stream = stream or torch.cuda.current_stream()
@@ -191,15 +217,11 @@ def model_forward(
         context.named_state_caches = state_cache_engine.named_state_caches
 
         with ctx_mgr.context(context):
-            if (not inputs.is_dummy and inputs.state_offsets is not None
-                    and inputs.state_prefix_cache_offsets is not None):
-                # Restore frozen SSM prefix state into this request's runtime
-                # slot on the forward stream.  The input maker already
-                # compacted valid src/dst pairs on CPU, so no CUDA boolean
-                # indexing/nonzero synchronization is needed here.
-                state_cache_engine.copy_caches(inputs.state_prefix_cache_offsets,
-                                               inputs.state_prefix_cache_dst_offsets)
-
+            # Some backends synchronize while building context. Queue restore
+            # afterward so that synchronization does not absorb copy latency;
+            # forward-stream ordering still keeps every model consumer behind
+            # the restore.
+            _restore_cache_checkpoint(inputs, cache_inputs, cache_engine, state_cache_engine)
             model_metas = model.update_model_metas(
                 past_key_values=cache_engine.gpu_cache,
                 context=context,
@@ -214,13 +236,7 @@ def model_forward(
             # InternVL-3.5-Flash will change the seqlen, model_metas during forward
             if getattr(context, 'is_model_meta_updated', False):
                 model_metas = context.model_metas
-            if (not inputs.is_dummy and inputs.state_offsets is not None
-                    and inputs.state_prefix_cache_save_offsets is not None):
-                # Save the post-forward runtime state into reserved checkpoint
-                # slots.  The scheduler publishes these slots only after the
-                # executor output boundary confirms the copy was enqueued.
-                state_cache_engine.copy_caches(inputs.state_prefix_cache_save_src_offsets,
-                                               inputs.state_prefix_cache_save_offsets)
+            _save_cache_checkpoint(inputs, cache_inputs, cache_engine, state_cache_engine)
             output['model_metas'] = model_metas
             output['seq_length'] = context.q_seqlens[:len(inputs.seq_length)]
             # for draft model reuse
@@ -508,12 +524,13 @@ class BaseModelAgent:
         self,
         inputs: ModelInputs,
         return_logits: bool,
+        cache_inputs: CacheCheckpointInputs | None = None,
     ):
         """Model forward."""
         if self.memdecode_agent is not None and return_logits:
             raise RuntimeError('MemDecode does not support returned prompt logits yet.')
 
-        ret = await self.async_forward(inputs)
+        ret = await self.async_forward(inputs, cache_inputs=cache_inputs)
 
         if not return_logits:
             ret = self._postprocess_forward_output(ret, inputs)
@@ -824,6 +841,7 @@ class BaseModelAgent:
         return_routed_experts: bool = False,
         return_ce_loss: bool = False,
         extra_inputs: ExtraInputs = None,
+        cache_inputs: CacheCheckpointInputs | None = None,
     ):
         """Asyc forward task."""
 
@@ -888,7 +906,8 @@ class BaseModelAgent:
         output = await self._async_model_forward(
             inputs,
             return_logits=return_logits or return_ce_loss,
-            )
+            cache_inputs=cache_inputs,
+        )
 
         if inputs.is_dummy and not self.spec_agent.is_enabled():
             # skip dummy forward output
@@ -1230,25 +1249,26 @@ class BaseModelAgent:
                 self.memdecode_agent.set_cache_config(self.cache_config)
                 self.memdecode_agent.build_cache_engine(self.cache_stream)
 
-    def _forward_impl(self, inputs: ModelInputs):
+    def _forward_impl(self, inputs: ModelInputs, cache_inputs: CacheCheckpointInputs | None = None):
         output = model_forward(
             self.patched_model,
             inputs,
             self.cache_engine,
             state_cache_engine=self.state_cache_engine,
             stream=self.stream,
+            cache_inputs=cache_inputs,
         )
         return output
 
-    async def async_forward(self, inputs: ModelInputs):
+    async def async_forward(self, inputs: ModelInputs, cache_inputs: CacheCheckpointInputs | None = None):
         """Model forward.
 
         Args:
-            inputs (dict): The input data comes from _make_inputs.
-            swap_in_map (SwapMap): Cache maps to swap in.
-            swap_out_map (SwapMap): Cache maps to swap out.
+            inputs (ModelInputs): Persistent model execution inputs.
+            cache_inputs (CacheCheckpointInputs | None): One-forward cache
+                checkpoint operations.
         """
-        output = self._forward_impl(inputs)
+        output = self._forward_impl(inputs, cache_inputs=cache_inputs)
         await asyncio.sleep(0)
         return output
 

--- a/lmdeploy/pytorch/kernels/cuda/copy_packed_cache.py
+++ b/lmdeploy/pytorch/kernels/cuda/copy_packed_cache.py
@@ -1,0 +1,62 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _copy_packed_cache_kernel(cache,
+                              src_block_offsets,
+                              dst_block_offsets,
+                              cache_stride_row,
+                              cache_stride_block,
+                              words_per_block: tl.constexpr,
+                              BLOCK_WORDS: tl.constexpr):
+    tile_id = tl.program_id(0)
+    row_id = tl.program_id(1)
+    pair_id = tl.program_id(2)
+
+    src_block = tl.load(src_block_offsets + pair_id).to(tl.int64)
+    dst_block = tl.load(dst_block_offsets + pair_id).to(tl.int64)
+    word_offsets = tile_id * BLOCK_WORDS + tl.arange(0, BLOCK_WORDS)
+    mask = word_offsets < words_per_block
+    row_offset = row_id.to(tl.int64) * cache_stride_row
+    src_offsets = row_offset + src_block * cache_stride_block + word_offsets
+    dst_offsets = row_offset + dst_block * cache_stride_block + word_offsets
+    values = tl.load(cache + src_offsets, mask=mask)
+    tl.store(cache + dst_offsets, values, mask=mask)
+
+
+def copy_packed_cache(packed_cache: torch.Tensor,
+                      src_block_offsets: torch.Tensor,
+                      dst_block_offsets: torch.Tensor,
+                      pages_per_block: int) -> None:
+    """Copy aligned packed logical blocks with one Triton launch.
+
+    Cache layout, logical/page geometry, and copy-plan semantics are internal backend invariants established before this
+    trusted launcher is called.
+    """
+    num_pairs = src_block_offsets.numel()
+    if num_pairs == 0:
+        return
+
+    physical_pages = packed_cache.size(-2)
+    num_logical_blocks = physical_pages // pages_per_block
+    words_per_block = packed_cache.size(-1) * pages_per_block // torch.int64.itemsize
+    block_words = min(1024, triton.next_power_of_2(words_per_block))
+    num_warps = 8 if block_words >= 1024 else 4
+    num_rows = packed_cache.numel() // (physical_pages * packed_cache.size(-1))
+    packed_words = packed_cache.view(torch.int64).reshape(num_rows, num_logical_blocks, words_per_block)
+    num_tiles = triton.cdiv(words_per_block, block_words)
+    grid = (num_tiles, num_rows, num_pairs)
+    _copy_packed_cache_kernel[grid](
+        packed_words,
+        src_block_offsets,
+        dst_block_offsets,
+        packed_words.stride(0),
+        packed_words.stride(1),
+        words_per_block=words_per_block,
+        BLOCK_WORDS=block_words,
+        num_warps=num_warps,
+    )

--- a/lmdeploy/pytorch/kernels/cuda/copy_packed_cache.py
+++ b/lmdeploy/pytorch/kernels/cuda/copy_packed_cache.py
@@ -32,7 +32,7 @@ def copy_packed_cache(packed_cache: torch.Tensor,
                       src_block_offsets: torch.Tensor,
                       dst_block_offsets: torch.Tensor,
                       pages_per_block: int) -> None:
-    """Copy aligned packed logical blocks with one Triton launch.
+    """Copy complete packed logical blocks with one Triton launch.
 
     Cache layout, logical/page geometry, and copy-plan semantics are internal backend invariants established before this
     trusted launcher is called.

--- a/lmdeploy/pytorch/messages.py
+++ b/lmdeploy/pytorch/messages.py
@@ -925,6 +925,12 @@ class SchedulerSequence:
             clamped = next_step
         return clamped
 
+    def is_prefix_cache_boundary_safe(self, step: int):
+        """Check that an exact cache boundary is outside multimodal spans."""
+        if any(span.start < step < span.end for span in self.prefix_cache.multimodal_spans):
+            return False
+        return not any(emb.start < step < emb.end for emb in self.history_embeddings.embeddings)
+
     def get_prefix_cache_max_match_step(self):
         """Get the deepest prefix step allowed for a cache hit."""
         block_size = self.block_size

--- a/lmdeploy/pytorch/model_inputs.py
+++ b/lmdeploy/pytorch/model_inputs.py
@@ -1,5 +1,5 @@
 # Copyright (c) OpenMMLab. All rights reserved.
-from collections.abc import Mapping, Sequence
+from collections.abc import Mapping
 from dataclasses import dataclass, field, fields
 from typing import TYPE_CHECKING, Any
 
@@ -165,9 +165,6 @@ class ModelInputsDelta:
     is_decoding: bool = True
     # sliding window
     num_ignored_history: torch.Tensor | None = None
-    # Compact SSM prefix-cache checkpoint save pairs for decode forwards.
-    state_prefix_cache_save_src_offsets: Sequence[int] | None = None
-    state_prefix_cache_save_offsets: Sequence[int] | None = None
 
     @property
     def seq_length(self):
@@ -229,14 +226,6 @@ class ModelInputs:
     is_dummy: bool = False
     # Runtime SSM state slot ids for each sequence in the batch.
     state_offsets: torch.Tensor | None = None
-    # Frozen checkpoint slot ids to restore from before forward. Compact, no sentinels.
-    state_prefix_cache_offsets: Sequence[int] | None = None
-    # Runtime state slot ids to restore into before forward. Compact, no sentinels.
-    state_prefix_cache_dst_offsets: Sequence[int] | None = None
-    # Runtime state slot ids to save from after forward. Compact, no sentinels.
-    state_prefix_cache_save_src_offsets: Sequence[int] | None = None
-    # Reserved checkpoint slot ids to save into after forward. Compact, no sentinels.
-    state_prefix_cache_save_offsets: Sequence[int] | None = None
     target_hidden_states: torch.Tensor | None = None
     target_position_ids: torch.Tensor | None = None
     target_inputs_embeds: torch.Tensor | None = None
@@ -266,10 +255,6 @@ class ModelInputs:
             history_lengths=self.history_lengths + step_seqlens,
             max_kv_seqlen=self.max_kv_seqlen + self.max_q_seqlen,
             sum_kv_seqlen=self.sum_kv_seqlen + self.max_q_seqlen * self.seq_length.numel(),
-            state_prefix_cache_offsets=None,
-            state_prefix_cache_dst_offsets=None,
-            state_prefix_cache_save_src_offsets=None,
-            state_prefix_cache_save_offsets=None,
             mrope_pos_ids=mrope_pos_ids,
         )
 

--- a/lmdeploy/pytorch/paging/block_manager/base_block_manager.py
+++ b/lmdeploy/pytorch/paging/block_manager/base_block_manager.py
@@ -249,6 +249,20 @@ class BaseBlockManager:
         logical_blocks = msg.logical_blocks
         return self.allocator.get_physical_blocks(logical_blocks.get_real_blocks())
 
+    def resolve_gpu_block_offsets(self, logical_block_ids: np.ndarray):
+        """Resolve allocated logical ids to resident GPU block offsets."""
+        allocator = self.allocator
+        num_logical_blocks = self.num_gpu_blocks + self.num_cpu_blocks
+        if np.any(logical_block_ids < 0) or np.any(logical_block_ids >= num_logical_blocks):
+            raise ValueError('logical_block_ids contains an out-of-range allocator id.')
+        if np.any(allocator.get_ref_count(logical_block_ids) <= 0):
+            raise ValueError('logical_block_ids contains an unallocated allocator id.')
+
+        block_offsets = allocator.get_physical_blocks(logical_block_ids)
+        if np.any(block_offsets < 0) or np.any(block_offsets >= self.num_gpu_blocks):
+            raise ValueError('logical_block_ids contains a block that is not GPU-resident.')
+        return block_offsets
+
     def allocate(self, data: SchedulerSequence, prealloc_size: int = 0):
         """Allocate stuff."""
         return self.allocate_msg(data, prealloc_size)

--- a/lmdeploy/pytorch/paging/block_trie/README.md
+++ b/lmdeploy/pytorch/paging/block_trie/README.md
@@ -7,7 +7,7 @@ nodes.
 
 Prefix caching is an end-to-end protocol rather than an isolated trie lookup.
 The scheduler performs tentative matching and resource admission, the input
-maker describes state copies, the model agent queues those copies on the
+maker describes checkpoint copies, the model agent queues those copies on the
 forward stream, and the engine loop publishes or unpins checkpoints at safe
 asynchronous boundaries.
 
@@ -31,18 +31,18 @@ writes tentative state directly to `SchedulerSequence`.
 
 ## Ownership Map
 
-| Component                  | Owns                                                                                                         | Does not own                                |
-| -------------------------- | ------------------------------------------------------------------------------------------------------------ | ------------------------------------------- |
-| `BlockTrie`                | Adapter roots, block identity, match/application policy, routed-expert replay, prefix-cache statistics       | Scheduler admission, concrete cache tensors |
-| `Node`                     | One trie edge, one trie-owned KV block reference, parent/children topology, optional state-checkpoint record | State-slot allocation policy                |
-| `KVBlockLifecycle`         | KV reference transactions, leaf-candidate bookkeeping, KV leaf eviction                                      | Token or multimodal identity                |
-| `StateCheckpointIndex`     | Sparse checkpoint candidates and exact host verification                                                     | State slots or trie topology                |
-| `StateCheckpointLifecycle` | State-slot reservation, publication, pins, state-only eviction, stale cleanup                                | KV references or scheduler policy           |
-| `StateManager`             | Runtime and checkpoint state slots                                                                           | Prefix identity                             |
-| `Scheduler`                | Tentative-match admission, rollback, and sequence resource allocation                                        | Exact matching and device copies            |
-| `InputsMakerAsync`         | Compact host source/destination copy plans for one forward                                                   | Concrete state-cache storage                |
-| `ModelAgent`               | Stream-ordered restore and save copies around model forward                                                  | Checkpoint publication and eviction         |
-| `EngineLoop`               | Publication and pin release at asynchronous forward boundaries                                               | Prefix identity                             |
+| Component                  | Owns                                                                                                         | Does not own                                  |
+| -------------------------- | ------------------------------------------------------------------------------------------------------------ | --------------------------------------------- |
+| `BlockTrie`                | Adapter roots, block identity, match/application policy, routed-expert replay, prefix-cache statistics       | Scheduler admission, concrete cache tensors   |
+| `Node`                     | One trie edge, one trie-owned KV block reference, parent/children topology, optional cache-checkpoint record | Checkpoint allocation policy                  |
+| `KVBlockLifecycle`         | KV reference transactions, leaf-candidate bookkeeping, KV leaf eviction                                      | Token or multimodal identity                  |
+| `StateCheckpointIndex`     | Sparse checkpoint candidates and exact host verification                                                     | State slots or trie topology                  |
+| `StateCheckpointLifecycle` | State slot and frozen-tail reservation, publication, pins, release, checkpoint eviction, stale cleanup       | Normal trie KV references or scheduler policy |
+| `StateManager`             | Runtime and checkpoint state slots                                                                           | Prefix identity                               |
+| `Scheduler`                | Tentative-match admission, rollback, and sequence resource allocation                                        | Exact matching and device copies              |
+| `InputsMakerAsync`         | Compact host KV/state source-destination plans for one forward                                               | Concrete cache storage                        |
+| `ModelAgent`               | Stream-ordered restore and save copies around model forward                                                  | Checkpoint publication and eviction           |
+| `EngineLoop`               | Publication and pin release at asynchronous forward boundaries                                               | Prefix identity                               |
 
 `BlockTrie` is the composition root for the lower-level trie collaborators. The
 dependencies point downward: lower modules do not hold a `Scheduler` or general
@@ -198,14 +198,15 @@ state checkpoints rather than treating a KV walk as the source of truth.
 `StateCheckpointIndex` uses a coarse key:
 
 ```text
-(adapter_name, checkpoint_step, last_block_hash)
+(adapter_name, checkpoint_step, tail_hash)
 ```
 
 Candidate steps are searched from deepest to shallowest. The exact verifier,
 `verify_candidate()`, then checks that:
 
 - the node still owns a published checkpoint;
-- the checkpoint path is current and has the expected length;
+- the checkpoint owner remains attached and its canonical path has the
+  expected length;
 - the sparse key and adapter still match the node;
 - the step is valid for this request and outside multimodal interiors; and
 - the immutable full-prefix token and multimodal identities match exactly.
@@ -219,6 +220,12 @@ miss.
 the canonical logical KV path at publication. This makes lookup independent of
 later sequence mutation and avoids a Python ancestor walk on every hit, at the
 cost of metadata proportional to the saved prefix length.
+
+For `step = q * block_size + r`, the checkpoint stays on the full-block anchor
+at `q * block_size`. When `r > 0`, it owns one frozen logical KV block and
+indexes the exact tail token and multimodal identity from that final partial
+range. Matching attaches only the `q` canonical trie blocks; the frozen tail is
+copied into a request-owned private block before forward.
 
 ## SSM Checkpoint Lifecycle
 
@@ -234,20 +241,24 @@ A node checkpoint has three ownership states:
 cannot be evicted or released because an asynchronous restore or save copy may
 still reference its slot.
 
-The current implementation reserves checkpoints only at positive,
-block-aligned steps that are safe multimodal boundaries.
+Prefill checkpoints may use any positive model-forward boundary outside a
+multimodal span. Decode checkpoints remain block-aligned. One checkpoint is
+kept per full-block anchor; a later unpinned checkpoint at that anchor may
+replace the older one.
 
 ### Save path
 
 ```text
 InputsMakerAsync
   reserve_save(seq)
-  runtime slot -> checkpoint slot copy plan
+  producer partial block -> frozen block, if needed
+  runtime slot -> checkpoint slot
         |
         v
 ModelAgent.model_forward()
   run model
-  queue runtime state -> checkpoint copy on the forward stream
+  queue partial KV -> frozen KV
+  queue runtime state -> checkpoint state
         |
         v
 EngineLoop
@@ -261,7 +272,8 @@ forward output/event boundary
 
 Publication is transactional. It revalidates node attachment, slot ownership,
 save step, and producer identity before adding exact metadata to the sparse
-index. An abandoned or invalid reservation releases its state slot.
+index. An abandoned or invalid reservation releases both its state slot and
+optional frozen block.
 
 ### Restore path
 
@@ -272,11 +284,13 @@ BlockTrie.match()
         v
 Scheduler / InputsMakerAsync
   pin_restore(seq) before checkpoint eviction can run
-  checkpoint slot -> runtime slot copy plan
+  frozen block -> private request block, if needed
+  checkpoint slot -> runtime slot
         |
         v
 ModelAgent.model_forward()
-  queue checkpoint -> runtime state copy before model execution
+  queue frozen KV -> private KV
+  queue checkpoint -> runtime state before model execution
         |
         v
 EngineLoop
@@ -289,9 +303,11 @@ clears a selected restore.
 
 ## Device-copy Contract
 
-The input maker stores compact host integer source/destination sequences in
-`ModelInputs` or `ModelInputsDelta`. `ModelAgent` passes them directly to the
-state cache engine before or after model execution on the same forward stream.
+The input maker stores one-forward KV and state plans in
+`CacheCheckpointInputs`. KV plans are transferred with the forward payload;
+state plans stay as compact host integer sequences. `ModelAgent` executes both
+through their cache owners before or after model execution on the same forward
+stream.
 
 Keep these rules:
 
@@ -305,14 +321,17 @@ Keep these rules:
 
 ## Eviction
 
-KV and state pressure are related but independently accounted:
+KV and state pressure share the checkpoint lifecycle but remain explicitly
+accounted:
 
+- `StateCheckpointLifecycle.evict_frozen_checkpoints()` releases published,
+  unpinned partial checkpoints before normal trie KV eviction.
 - `KVBlockLifecycle.evict()` removes attached leaf nodes whose KV reference
   count proves that no sequence still shares them. Removing a KV leaf also
   releases its unpinned state checkpoint.
-- `StateCheckpointLifecycle.evict()` may release a published, unpinned state
-  checkpoint while retaining the node and its KV block. It uses
-  `last_access_time` as state-only LRU order.
+- `StateCheckpointLifecycle.evict()` may release any published, unpinned
+  checkpoint while retaining the node and its trie KV block. Both checkpoint
+  eviction paths use `last_access_time` as LRU order.
 
 Both paths revalidate candidates because their heaps and indexes are auxiliary
 state that may contain stale entries.
@@ -327,9 +346,11 @@ state that may contain stale entries.
 - A hash match is never sufficient without exact identity verification.
 - SSM reuse requires both the canonical KV path and an exact published state
   checkpoint.
+- A partial checkpoint's frozen block and its consumer destination are distinct
+  from trie-owned blocks and remain private while forward writes them.
 - Trie nodes attach once, and eviction detaches leaves only; attached ancestor
   paths never change.
-- Pinned state checkpoints and shared KV nodes are not evictable.
+- Pinned checkpoints and shared KV nodes are not evictable.
 - Blocks in `recompute_overlap` must remain sequence-owned and writable through
   `BlockTrie.allocate()`.
 - `block_size` is the scheduler/trie identity unit. `kernel_block_size` is a
@@ -340,18 +361,18 @@ state that may contain stale entries.
 
 ## Where to Make Changes
 
-| Change                                                  | Primary owner                                              |
-| ------------------------------------------------------- | ---------------------------------------------------------- |
-| Token, adapter, or multimodal identity                  | `trie.py`                                                  |
-| Monotonic trie attachment or leaf detachment            | `node.py`                                                  |
-| Sparse checkpoint keys or exact verification            | `checkpoint.py`                                            |
-| State reservation, publication, pins, or state eviction | `checkpoint_lifecycle.py`                                  |
-| KV references, leaf bookkeeping, or KV eviction         | `kv_lifecycle.py`                                          |
-| Admission order or tentative-match rollback             | `../scheduler.py`                                          |
-| Per-sequence prefix-cache protocol state                | `../../prefix_cache_state.py`                              |
-| Host restore/save copy plans                            | `../../engine/inputs_maker.py` and `../../model_inputs.py` |
-| Stream ordering around model execution                  | `../../engine/model_agent/agent.py`                        |
-| Publication and unpin timing                            | `../../engine/engine_loop.py`                              |
+| Change                                                 | Primary owner                                                     |
+| ------------------------------------------------------ | ----------------------------------------------------------------- |
+| Token, adapter, or multimodal identity                 | `trie.py`                                                         |
+| Monotonic trie attachment or leaf detachment           | `node.py`                                                         |
+| Sparse checkpoint keys or exact verification           | `checkpoint.py`                                                   |
+| Checkpoint reservation, publication, pins, or eviction | `checkpoint_lifecycle.py`                                         |
+| KV references, leaf bookkeeping, or KV eviction        | `kv_lifecycle.py`                                                 |
+| Admission order or tentative-match rollback            | `../scheduler.py`                                                 |
+| Per-sequence prefix-cache protocol state               | `../../prefix_cache_state.py`                                     |
+| Host restore/save copy plans                           | `../../engine/inputs_maker.py` and `../../engine/cache_inputs.py` |
+| Stream ordering around model execution                 | `../../engine/model_agent/agent.py`                               |
+| Publication and unpin timing                           | `../../engine/engine_loop.py`                                     |
 
 Avoid moving behavior merely to shorten a file. Split only when one component
 can own a mutable resource and its invariants without a reverse dependency on

--- a/lmdeploy/pytorch/paging/block_trie/checkpoint.py
+++ b/lmdeploy/pytorch/paging/block_trie/checkpoint.py
@@ -60,6 +60,16 @@ class StateCheckpointVerifyResult:
     matched_block_ids: np.ndarray | None = None
 
 
+def checkpoint_anchor_step(step: int, block_size: int):
+    """Return the full-block trie boundary owning an exact checkpoint."""
+    return step - step % block_size
+
+
+def checkpoint_tail_start(step: int, block_size: int):
+    """Return the start of the final nonempty range used by the sparse key."""
+    return ((step - 1) // block_size) * block_size
+
+
 def freeze_state_checkpoint_match_data(token_ids: np.ndarray,
                                        extra_identity: PrefixCacheExtraIdentity,
                                        block_ids: np.ndarray,
@@ -94,7 +104,7 @@ class StateCheckpointIndex:
 
     def make_request_key(self, seq: SchedulerSequence, step: int) -> StateCheckpointKey:
         """Make the sparse lookup key for one request checkpoint step."""
-        tail_start = ((step - 1) // self.block_size) * self.block_size
+        tail_start = checkpoint_tail_start(step, self.block_size)
         token_ids = seq.history_cache[tail_start:step]
         extra_identity = seq.get_prefix_cache_extra_identity(tail_start, step)
         return (seq.adapter_name, step, self._hash_block(token_ids, extra_identity))
@@ -177,7 +187,7 @@ class StateCheckpointIndex:
         if step <= 0:
             return StateCheckpointVerifyResult(StateCheckpointVerifyStatus.STALE_CHECKPOINT,
                                                reason=f'invalid checkpoint step: {step}')
-        anchor_step = step - step % self.block_size
+        anchor_step = checkpoint_anchor_step(step, self.block_size)
         is_partial = anchor_step != step
         if is_partial and checkpoint.frozen_block_id < 0:
             return StateCheckpointVerifyResult(StateCheckpointVerifyStatus.STALE_CHECKPOINT,

--- a/lmdeploy/pytorch/paging/block_trie/checkpoint.py
+++ b/lmdeploy/pytorch/paging/block_trie/checkpoint.py
@@ -7,11 +7,11 @@ publication/pinning lifecycle.  This module owns the auxiliary sparse index
 used to find checkpoint candidates and the immutable metadata used to verify a
 candidate exactly.
 
-The sparse key ``(adapter, step, last_block_hash)`` is only a coarse lookup.
+The sparse key ``(adapter, step, tail_hash)`` is only a coarse lookup.
 ``verify_candidate()`` compares the complete token and multimodal identities
-before a checkpoint may be restored. Keeping that distinction inside one small class
-makes the matching contract visible without mixing it with cache allocation
-and checkpoint lifecycle code.
+before a checkpoint may be restored. Keeping both operations here makes the
+matching contract visible without mixing it with cache allocation or
+checkpoint lifecycle code.
 """
 
 import enum
@@ -48,6 +48,7 @@ class StateCheckpointMatchData:
     token_ids: np.ndarray
     extra_identity: PrefixCacheExtraIdentity
     block_ids: np.ndarray
+    tail_hash: int
 
 
 @dataclass
@@ -61,13 +62,15 @@ class StateCheckpointVerifyResult:
 
 def freeze_state_checkpoint_match_data(token_ids: np.ndarray,
                                        extra_identity: PrefixCacheExtraIdentity,
-                                       block_ids: np.ndarray):
+                                       block_ids: np.ndarray,
+                                       tail_hash: int):
     """Make already-owned checkpoint identity arrays read-only."""
     token_ids.flags.writeable = False
     block_ids.flags.writeable = False
     return StateCheckpointMatchData(token_ids=token_ids,
                                     extra_identity=extra_identity,
-                                    block_ids=block_ids)
+                                    block_ids=block_ids,
+                                    tail_hash=tail_hash)
 
 
 def make_request_multimodal_identity(seq: SchedulerSequence, step: int):
@@ -91,15 +94,20 @@ class StateCheckpointIndex:
 
     def make_request_key(self, seq: SchedulerSequence, step: int) -> StateCheckpointKey:
         """Make the sparse lookup key for one request checkpoint step."""
-        start = step - self.block_size
-        token_ids = seq.history_cache[start:step]
-        extra_identity = seq.get_prefix_cache_extra_identity(start, step)
+        tail_start = ((step - 1) // self.block_size) * self.block_size
+        token_ids = seq.history_cache[tail_start:step]
+        extra_identity = seq.get_prefix_cache_extra_identity(tail_start, step)
         return (seq.adapter_name, step, self._hash_block(token_ids, extra_identity))
 
-    @staticmethod
-    def make_node_key(node: 'Node') -> StateCheckpointKey:
+    def make_node_key(self, node: 'Node') -> StateCheckpointKey:
         """Make the sparse-index key stored for a checkpoint node."""
-        return (node.adapter_name, node.prefix_len, node.block_hash)
+        checkpoint = node.state_checkpoint
+        if checkpoint is None:
+            raise RuntimeError('Cannot key a node without a state checkpoint.')
+        match_data = checkpoint.exact_match_data
+        if match_data is None:
+            raise RuntimeError('Cannot key a checkpoint without exact-match metadata.')
+        return (node.adapter_name, checkpoint.step, match_data.tail_hash)
 
     def add(self, node: 'Node'):
         """Add a prevalidated published checkpoint node."""
@@ -107,7 +115,7 @@ class StateCheckpointIndex:
         nodes = self._buckets.setdefault(key, [])
         if not any(indexed_node is node for indexed_node in nodes):
             nodes.append(node)
-        self._steps_by_adapter.setdefault(node.adapter_name, set()).add(node.prefix_len)
+        self._steps_by_adapter.setdefault(node.adapter_name, set()).add(key[1])
 
     def remove_entry(self, node: 'Node', key: StateCheckpointKey):
         """Remove a node from one sparse-index bucket."""
@@ -165,19 +173,33 @@ class StateCheckpointIndex:
             return StateCheckpointVerifyResult(StateCheckpointVerifyStatus.STALE_CHECKPOINT,
                                                reason='checkpoint is not published')
 
-        step = node.prefix_len
+        step = checkpoint.step
         if step <= 0:
             return StateCheckpointVerifyResult(StateCheckpointVerifyStatus.STALE_CHECKPOINT,
                                                reason=f'invalid checkpoint step: {step}')
+        anchor_step = step - step % self.block_size
+        is_partial = anchor_step != step
+        if is_partial and checkpoint.frozen_block_id < 0:
+            return StateCheckpointVerifyResult(StateCheckpointVerifyStatus.STALE_CHECKPOINT,
+                                               reason='checkpoint partial KV block is missing')
+        if not is_partial and checkpoint.frozen_block_id >= 0:
+            return StateCheckpointVerifyResult(StateCheckpointVerifyStatus.STALE_CHECKPOINT,
+                                               reason='aligned checkpoint unexpectedly owns a partial KV block')
 
         match_data = checkpoint.exact_match_data
         if match_data is None:
             return StateCheckpointVerifyResult(StateCheckpointVerifyStatus.STALE_CHECKPOINT,
                                                reason='checkpoint exact-match metadata is missing')
-        if len(match_data.block_ids) * self.block_size != step:
+        if node.prefix_len != anchor_step:
+            return StateCheckpointVerifyResult(StateCheckpointVerifyStatus.STALE_CHECKPOINT,
+                                               reason='checkpoint owner is not its full-block anchor')
+        if len(match_data.block_ids) * self.block_size != anchor_step:
             return StateCheckpointVerifyResult(StateCheckpointVerifyStatus.STALE_CHECKPOINT,
                                                reason='checkpoint exact-match path has the wrong length')
-        if not node.is_attached():
+        if len(match_data.token_ids) != step:
+            return StateCheckpointVerifyResult(StateCheckpointVerifyStatus.STALE_CHECKPOINT,
+                                               reason='checkpoint exact token identity has the wrong length')
+        if not node.is_attached_or_root():
             return StateCheckpointVerifyResult(StateCheckpointVerifyStatus.STALE_CHECKPOINT,
                                                reason='checkpoint owner is detached from its cached path')
 
@@ -191,13 +213,16 @@ class StateCheckpointIndex:
             return StateCheckpointVerifyResult(StateCheckpointVerifyStatus.STALE_INDEX_ENTRY,
                                                reason='checkpoint adapter differs from lookup adapter')
 
-        max_step = ((seq.num_valid_ids - 1) // self.block_size) * self.block_size
+        max_step = seq.num_valid_ids - 1
         if step > max_step:
             return StateCheckpointVerifyResult(StateCheckpointVerifyStatus.REQUEST_MISMATCH,
                                                reason='checkpoint is longer than this request')
-        if seq.clamp_prefix_cache_match_step(step) != step:
+        if not seq.is_prefix_cache_boundary_safe(step):
             return StateCheckpointVerifyResult(StateCheckpointVerifyStatus.REQUEST_MISMATCH,
                                                reason='checkpoint would stop inside a multimodal span')
+        if is_partial and seq.return_routed_experts:
+            return StateCheckpointVerifyResult(StateCheckpointVerifyStatus.REQUEST_MISMATCH,
+                                               reason='partial checkpoint has no routed-expert tail history')
         if not np.array_equal(seq.history_cache[:step], match_data.token_ids):
             return StateCheckpointVerifyResult(StateCheckpointVerifyStatus.REQUEST_MISMATCH,
                                                reason='checkpoint token identity differs from this request')

--- a/lmdeploy/pytorch/paging/block_trie/checkpoint_lifecycle.py
+++ b/lmdeploy/pytorch/paging/block_trie/checkpoint_lifecycle.py
@@ -1,19 +1,22 @@
 # Copyright (c) OpenMMLab. All rights reserved.
-"""Ownership lifecycle for node-backed SSM state checkpoints.
+"""Ownership lifecycle for node-backed SSM cache checkpoints.
 
-The lifecycle owns state-slot reservation, publication, async-copy pins, and
-checkpoint-only eviction. It deliberately does not own trie topology or KV
-blocks. :class:`BlockTrie` supplies the exact-identity builder needed while
-publishing a checkpoint, while ``KVBlockLifecycle`` consults this owner before
-evicting a checkpoint-bearing KV leaf.
+The lifecycle owns state-slot reservation, optional frozen partial KV blocks,
+publication, async-copy pins, and checkpoint-only eviction. It deliberately
+does not own trie topology or normal trie KV blocks. :class:`BlockTrie`
+supplies the exact-identity builder needed while publishing a checkpoint,
+while ``KVBlockLifecycle`` consults this owner before evicting a
+checkpoint-bearing KV leaf.
 """
 
 from __future__ import annotations
 
 import heapq
 import time
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 from typing import TYPE_CHECKING
+
+import numpy as np
 
 from lmdeploy.pytorch.messages import SchedulerSequence
 from lmdeploy.utils import get_logger
@@ -22,6 +25,7 @@ from .checkpoint import StateCheckpointIndex
 from .node import Node, NodeStateCheckpoint
 
 if TYPE_CHECKING:
+    from ..block_manager.base_block_manager import LogicalAllocator
     from ..state_manager import StateManager
     from .checkpoint import StateCheckpointKey, StateCheckpointMatchData
 
@@ -31,14 +35,14 @@ SequenceMatchDataBuilder = Callable[['Node', SchedulerSequence], 'StateCheckpoin
 
 
 class StateCheckpointLifecycle:
-    """Manage recurrent-state checkpoint ownership independently of KV.
+    """Manage node-owned state and optional frozen partial-KV checkpoints.
 
-    Trie nodes remain the source of truth: a node with state ownership holds a
-    lazily allocated :class:`NodeStateCheckpoint`. This component coordinates
-    that record with ``StateManager`` and ``StateCheckpointIndex``. Nodes own
-    their monotonic attachment invariant; the injected builder keeps
-    exact-identity policy in ``BlockTrie`` without giving the lifecycle a
-    back-reference to the whole trie.
+    Trie nodes remain the source of truth: a node with checkpoint ownership
+    holds a lazily allocated :class:`NodeStateCheckpoint`. This component
+    coordinates that record with ``StateManager``, ``LogicalAllocator``, and
+    ``StateCheckpointIndex``. Nodes own their monotonic attachment invariant;
+    the injected builder keeps exact-identity policy in ``BlockTrie`` without
+    giving the lifecycle a back-reference to the whole trie.
     """
 
     def __init__(self,
@@ -46,18 +50,20 @@ class StateCheckpointLifecycle:
                  prefix_cache_enabled: bool,
                  state_checkpoints_enabled: bool,
                  block_size: int,
+                 allocator: LogicalAllocator,
                  state_manager: StateManager | None,
                  index: StateCheckpointIndex,
                  make_sequence_match_data: SequenceMatchDataBuilder):
         self._prefix_cache_enabled = prefix_cache_enabled
         self._state_checkpoints_enabled = state_checkpoints_enabled
         self._block_size = block_size
+        self._allocator = allocator
         self._state_manager = state_manager
         self._index = index
         self._make_sequence_match_data = make_sequence_match_data
 
     def reserve_save(self, seq: SchedulerSequence, step: int = None, is_decode: bool = False):
-        """Reserve a checkpoint at an attached, block-aligned trie step."""
+        """Reserve a checkpoint at an exact safe prefill boundary."""
         self.discard_save(seq)
 
         if not self._prefix_cache_enabled or not self._state_checkpoints_enabled:
@@ -65,19 +71,22 @@ class StateCheckpointLifecycle:
 
         if step is None:
             step = seq.num_valid_ids
-        if step <= 0 or step % self._block_size != 0:
+        if step <= 0 or (is_decode and step % self._block_size != 0):
             return -1
         if step > seq.num_valid_ids:
             return -1
-        if seq.clamp_prefix_cache_match_step(step) != step:
+        if not seq.is_prefix_cache_boundary_safe(step):
             return -1
 
-        node = self._find_checkpoint_node(seq, step)
-        if node is None or self._node_has_slot(node):
+        anchor_step = step - step % self._block_size
+        node = self._find_checkpoint_node(seq, anchor_step)
+        if node is None:
             return -1
 
         try:
-            slot = self._reserve_slot(node)
+            slot = self._reserve_slot(node, step)
+        except MemoryError:
+            return -1
         except RuntimeError as e:
             if 'No free states' not in str(e):
                 raise
@@ -121,6 +130,7 @@ class StateCheckpointLifecycle:
             pending_save.clear()
             return False
         slot = pending_save.slot
+        save_step = pending_save.step
         node = pending_save.node
         is_decode = pending_save.is_decode
         pending_save.clear()
@@ -128,7 +138,7 @@ class StateCheckpointLifecycle:
             if is_decode and prefix_cache.decode_checkpoint_node is node:
                 prefix_cache.decode_checkpoint_node = None
             logger.debug('Discard SSM prefix-cache checkpoint reservation: session_id=%s seq_id=%s step=%s '
-                         'state_idx=%s is_decode=%s', seq.session_id, seq.seq_id, node.prefix_len, slot,
+                         'state_idx=%s is_decode=%s', seq.session_id, seq.seq_id, save_step, slot,
                          is_decode)
             self.release_checkpoint(node)
             return True
@@ -190,7 +200,7 @@ class StateCheckpointLifecycle:
         checkpoint.last_access_time = time.perf_counter()
         restore.pinned = True
         logger.debug('Pin SSM prefix-cache restore checkpoint: session_id=%s seq_id=%s step=%s state_idx=%s '
-                     'pin_count=%s', seq.session_id, seq.seq_id, node.prefix_len, checkpoint.slot,
+                     'pin_count=%s', seq.session_id, seq.seq_id, checkpoint.step, checkpoint.slot,
                      checkpoint.pin_count)
         return True
 
@@ -211,7 +221,7 @@ class StateCheckpointLifecycle:
         )
         checkpoint = node.state_checkpoint
         logger.debug('Unpin SSM prefix-cache restore checkpoint: session_id=%s seq_id=%s step=%s state_idx=%s '
-                     'pin_count=%s', seq.session_id, seq.seq_id, node.prefix_len, checkpoint.slot,
+                     'pin_count=%s', seq.session_id, seq.seq_id, checkpoint.step, checkpoint.slot,
                      checkpoint.pin_count)
         restore.clear()
         return True
@@ -235,7 +245,7 @@ class StateCheckpointLifecycle:
         )
         checkpoint = node.state_checkpoint
         logger.debug('Unpin SSM prefix-cache save checkpoint: session_id=%s seq_id=%s step=%s state_idx=%s '
-                     'pin_count=%s', seq.session_id, seq.seq_id, node.prefix_len, checkpoint.slot,
+                     'pin_count=%s', seq.session_id, seq.seq_id, checkpoint.step, checkpoint.slot,
                      checkpoint.pin_count)
         producer_pin.clear()
         return True
@@ -254,45 +264,33 @@ class StateCheckpointLifecycle:
         return checkpoint is not None and checkpoint.pin_count > 0
 
     def release_checkpoint(self, node: Node):
-        """Release a node-owned state checkpoint while keeping its KV node."""
+        """Release a node-owned checkpoint while keeping its trie KV node."""
         checkpoint = node.state_checkpoint
         if checkpoint is None:
             return
         if checkpoint.pin_count > 0:
             raise RuntimeError('Cannot release a pinned SSM prefix-cache checkpoint.')
+        self._unindex_checkpoint(node)
+        if checkpoint.frozen_block_id >= 0:
+            self._allocator.free(np.array([checkpoint.frozen_block_id], dtype=np.int64))
         if checkpoint.slot < 0:
             if checkpoint.published:
                 self._warn_unexpected_state(
                     f'published SSM checkpoint has no state slot: adapter={node.adapter_name} '
-                    f'step={node.prefix_len}')
-                self._unindex_checkpoint(node)
-            node.state_checkpoint = None
-            return
-        if checkpoint.published:
-            self._unindex_checkpoint(node)
-        self._state_manager.free_checkpoint_state(checkpoint.slot)
+                    f'step={checkpoint.step}')
+        else:
+            self._state_manager.free_checkpoint_state(checkpoint.slot)
         node.state_checkpoint = None
 
-    def evict(self, max_num_states: int):
-        """Evict published state checkpoints without removing KV trie nodes."""
-        if not self._state_checkpoints_enabled or max_num_states <= 0:
-            return 0
+    def evict(self, max_num_checkpoints: int):
+        """Evict published checkpoints without removing trie nodes."""
+        return self._evict_checkpoints(self._index.unique_nodes(), max_num_checkpoints)
 
-        candidates = [(node.state_checkpoint.last_access_time, id(node), node) for node in self._index.unique_nodes()
-                      if self._is_evictable_checkpoint(node)]
-        heapq.heapify(candidates)
-
-        evicted = 0
-        while candidates and evicted < max_num_states:
-            _, _, node = heapq.heappop(candidates)
-            if not self._is_evictable_checkpoint(node):
-                continue
-            checkpoint = node.state_checkpoint
-            logger.debug('Evict SSM prefix-cache checkpoint: adapter=%s step=%s state_idx=%s', node.adapter_name,
-                         node.prefix_len, checkpoint.slot)
-            self.release_checkpoint(node)
-            evicted += 1
-        return evicted
+    def evict_frozen_checkpoints(self, max_num_blocks: int):
+        """Evict checkpoints that each release one frozen KV block."""
+        nodes = (node for node in self._index.unique_nodes()
+                 if node.state_checkpoint is not None and node.state_checkpoint.frozen_block_id >= 0)
+        return self._evict_checkpoints(nodes, max_num_blocks)
 
     def discard_stale_index_entry(self, node: Node, key: StateCheckpointKey, reason: str):
         """Remove a stale index entry without releasing a valid checkpoint."""
@@ -320,23 +318,21 @@ class StateCheckpointLifecycle:
             self._unindex_checkpoint(node)
             return False
         slot = checkpoint.slot
+        step = checkpoint.step
         was_published = checkpoint.published
-        self._unindex_checkpoint(node)
-        if slot >= 0:
-            self._state_manager.free_checkpoint_state(slot)
-        node.state_checkpoint = None
+        self.release_checkpoint(node)
         logger.debug('Release stale SSM prefix-cache checkpoint candidate: adapter=%s step=%s state_idx=%s '
-                     'was_published=%s reason=%s', node.adapter_name, node.prefix_len, slot, was_published,
+                     'was_published=%s reason=%s', node.adapter_name, step, slot, was_published,
                      reason)
         return slot >= 0 or was_published
 
     @staticmethod
     def _find_checkpoint_node(seq: SchedulerSequence, step: int):
-        """Find the attached trie node at an exact sequence step."""
+        """Find the attached trie anchor at a full-block step."""
         node = seq.prefix_cache.trie_cursor
         while node is not None and node.prefix_len > step:
             node = node.parent
-        if node is None or not node.is_attached() or node.prefix_len != step:
+        if node is None or not node.is_attached_or_root() or node.prefix_len != step:
             return None
         return node
 
@@ -350,41 +346,85 @@ class StateCheckpointLifecycle:
         if old_checkpoint is None or old_checkpoint.slot < 0:
             prefix_cache.decode_checkpoint_node = None
             return True
-        if old_node.prefix_len == new_step and old_checkpoint.published:
+        if old_checkpoint.step == new_step and old_checkpoint.published:
             return False
 
         if old_checkpoint.pin_count > 0:
             return False
         logger.debug('Release previous decode SSM prefix-cache checkpoint: session_id=%s seq_id=%s '
-                     'old_step=%s old_state_idx=%s new_step=%s', seq.session_id, seq.seq_id, old_node.prefix_len,
+                     'old_step=%s old_state_idx=%s new_step=%s', seq.session_id, seq.seq_id, old_checkpoint.step,
                      old_checkpoint.slot, new_step)
         self.release_checkpoint(old_node)
         prefix_cache.decode_checkpoint_node = None
         return True
 
-    def _reserve_slot(self, node: Node):
-        """Reserve a state-cache slot owned by a trie node.
+    def _evict_checkpoints(self, nodes: Iterable[Node], limit: int):
+        if not self._state_checkpoints_enabled or limit <= 0:
+            return 0
 
-        Replacing a published checkpoint is allowed only while no async copy pins it. If the shared state pool is full,
-        one old unpinned checkpoint may be evicted without removing its trie/KV node.
+        candidates = [(node.state_checkpoint.last_access_time, id(node), node) for node in nodes
+                      if self._is_evictable_checkpoint(node)]
+        heapq.heapify(candidates)
+        evicted = 0
+        while candidates and evicted < limit:
+            _, _, node = heapq.heappop(candidates)
+            if not self._is_evictable_checkpoint(node):
+                continue
+            checkpoint = node.state_checkpoint
+            logger.debug('Evict SSM prefix-cache checkpoint: adapter=%s step=%s state_idx=%s block_id=%s',
+                         node.adapter_name, checkpoint.step, checkpoint.slot, checkpoint.frozen_block_id)
+            self.release_checkpoint(node)
+            evicted += 1
+        return evicted
+
+    def _reserve_slot(self, node: Node, step: int = None):
+        """Reserve state and optional frozen KV owned by one trie anchor.
+
+        Replacing a published checkpoint at the same anchor is allowed only while no async copy pins it. If the shared
+        state pool is full, one old unpinned checkpoint may be evicted without removing its trie/KV node.
         """
-        if not self._state_checkpoints_enabled or node.parent is None:
+        if step is None:
+            step = node.prefix_len
+        anchor_step = step - step % self._block_size
+        is_partial = anchor_step != step
+        if (not self._state_checkpoints_enabled or not node.is_attached_or_root()
+                or node.prefix_len != anchor_step):
             return -1
         checkpoint = node.state_checkpoint
         if checkpoint is not None and checkpoint.published:
             if checkpoint.pin_count > 0:
                 return -1
+            if checkpoint.step == step:
+                return -1
+            frozen_block_id = checkpoint.frozen_block_id
+            if is_partial and frozen_block_id < 0:
+                frozen_block_id = int(self._allocator.allocate(1, 'gpu')[0])
             logger.debug('Replace SSM prefix-cache checkpoint: adapter=%s step=%s state_idx=%s', node.adapter_name,
-                         node.prefix_len, checkpoint.slot)
+                         checkpoint.step, checkpoint.slot)
             self._unindex_checkpoint(node)
+            if not is_partial and checkpoint.frozen_block_id >= 0:
+                self._allocator.free(np.array([checkpoint.frozen_block_id], dtype=np.int64))
+                frozen_block_id = -1
         elif checkpoint is not None:
             return -1
         if checkpoint is None:
             if self._state_manager.get_num_free_checkpoint() == 0 and self.evict(1) == 0:
                 return -1
             slot = self._state_manager.allocate_checkpoint_state()
-            checkpoint = NodeStateCheckpoint(slot=slot)
+            try:
+                frozen_block_id = -1
+                if is_partial:
+                    frozen_block_id = int(self._allocator.allocate(1, 'gpu')[0])
+            except Exception:
+                self._state_manager.free_checkpoint_state(slot)
+                raise
+            checkpoint = NodeStateCheckpoint(slot=slot,
+                                             step=step,
+                                             frozen_block_id=frozen_block_id)
             node.state_checkpoint = checkpoint
+        else:
+            checkpoint.step = step
+            checkpoint.frozen_block_id = frozen_block_id
         checkpoint.published = False
         checkpoint.exact_match_data = None
         checkpoint.last_access_time = 0.0
@@ -397,7 +437,7 @@ class StateCheckpointLifecycle:
             raise RuntimeError('Cannot publish an unreserved state checkpoint.')
         if checkpoint.pin_count != 0:
             raise RuntimeError('Cannot publish a pinned SSM prefix-cache checkpoint.')
-        if not node.is_attached():
+        if not node.is_attached_or_root():
             raise RuntimeError('Cannot publish a detached SSM prefix-cache checkpoint node.')
         if checkpoint.published:
             if checkpoint.exact_match_data is None:
@@ -430,7 +470,7 @@ class StateCheckpointLifecycle:
         checkpoint.last_access_time = time.perf_counter()
         producer_pin.acquire(slot, node)
         logger.debug('Pin SSM prefix-cache save checkpoint: session_id=%s seq_id=%s step=%s state_idx=%s '
-                     'pin_count=%s', seq.session_id, seq.seq_id, node.prefix_len, slot, checkpoint.pin_count)
+                     'pin_count=%s', seq.session_id, seq.seq_id, checkpoint.step, slot, checkpoint.pin_count)
         return True
 
     @classmethod
@@ -456,15 +496,18 @@ class StateCheckpointLifecycle:
     def _publication_invalid_reason(self, node: Node | None, slot: int, save_step: int):
         if node is None:
             return 'missing node'
-        if not node.is_attached():
+        if not node.is_attached_or_root():
             return 'detached node'
         checkpoint = node.state_checkpoint
         if checkpoint is None:
             return 'missing state checkpoint'
         if checkpoint.slot != slot:
             return f'slot changed: expected={slot} actual={checkpoint.slot}'
-        if node.prefix_len != save_step:
-            return f'step changed: expected={save_step} actual={node.prefix_len}'
+        if checkpoint.step != save_step:
+            return f'step changed: expected={save_step} actual={checkpoint.step}'
+        anchor_step = save_step - save_step % self._block_size
+        if node.prefix_len != anchor_step:
+            return f'anchor changed: expected={anchor_step} actual={node.prefix_len}'
         return None
 
     @staticmethod

--- a/lmdeploy/pytorch/paging/block_trie/checkpoint_lifecycle.py
+++ b/lmdeploy/pytorch/paging/block_trie/checkpoint_lifecycle.py
@@ -21,7 +21,7 @@ import numpy as np
 from lmdeploy.pytorch.messages import SchedulerSequence
 from lmdeploy.utils import get_logger
 
-from .checkpoint import StateCheckpointIndex
+from .checkpoint import StateCheckpointIndex, checkpoint_anchor_step
 from .node import Node, NodeStateCheckpoint
 
 if TYPE_CHECKING:
@@ -78,7 +78,7 @@ class StateCheckpointLifecycle:
         if not seq.is_prefix_cache_boundary_safe(step):
             return -1
 
-        anchor_step = step - step % self._block_size
+        anchor_step = checkpoint_anchor_step(step, self._block_size)
         node = self._find_checkpoint_node(seq, anchor_step)
         if node is None:
             return -1
@@ -383,7 +383,7 @@ class StateCheckpointLifecycle:
         Replacing a published checkpoint at the same anchor is allowed only while no async copy pins it. If the shared
         state pool is full, one old unpinned checkpoint may be evicted without removing its trie/KV node.
         """
-        anchor_step = step - step % self._block_size
+        anchor_step = checkpoint_anchor_step(step, self._block_size)
         if (not self._state_checkpoints_enabled or not node.is_attached_or_root()
                 or node.prefix_len != anchor_step):
             return -1
@@ -403,7 +403,7 @@ class StateCheckpointLifecycle:
         slot = self._state_manager.allocate_checkpoint_state()
         try:
             frozen_block_id = -1
-            if step % self._block_size != 0:
+            if checkpoint_anchor_step(step, self._block_size) != step:
                 frozen_block_id = int(self._allocator.allocate(1, 'gpu')[0])
         except Exception:
             self._state_manager.free_checkpoint_state(slot)
@@ -416,7 +416,7 @@ class StateCheckpointLifecycle:
 
     def _replace_checkpoint(self, node: Node, checkpoint: NodeStateCheckpoint, step: int):
         """Reuse an unpinned checkpoint while changing its exact step."""
-        is_partial = step % self._block_size != 0
+        is_partial = checkpoint_anchor_step(step, self._block_size) != step
         frozen_block_id = checkpoint.frozen_block_id
         if is_partial and frozen_block_id < 0:
             frozen_block_id = int(self._allocator.allocate(1, 'gpu')[0])
@@ -510,7 +510,7 @@ class StateCheckpointLifecycle:
             return f'slot changed: expected={slot} actual={checkpoint.slot}'
         if checkpoint.step != save_step:
             return f'step changed: expected={save_step} actual={checkpoint.step}'
-        anchor_step = save_step - save_step % self._block_size
+        anchor_step = checkpoint_anchor_step(save_step, self._block_size)
         if node.prefix_len != anchor_step:
             return f'anchor changed: expected={anchor_step} actual={node.prefix_len}'
         return None

--- a/lmdeploy/pytorch/paging/block_trie/checkpoint_lifecycle.py
+++ b/lmdeploy/pytorch/paging/block_trie/checkpoint_lifecycle.py
@@ -31,8 +31,6 @@ if TYPE_CHECKING:
 
 logger = get_logger('lmdeploy')
 
-SequenceMatchDataBuilder = Callable[['Node', SchedulerSequence], 'StateCheckpointMatchData']
-
 
 class StateCheckpointLifecycle:
     """Manage node-owned state and optional frozen partial-KV checkpoints.
@@ -41,8 +39,9 @@ class StateCheckpointLifecycle:
     holds a lazily allocated :class:`NodeStateCheckpoint`. This component
     coordinates that record with ``StateManager``, ``LogicalAllocator``, and
     ``StateCheckpointIndex``. Nodes own their monotonic attachment invariant;
-    the injected builder keeps exact-identity policy in ``BlockTrie`` without
-    giving the lifecycle a back-reference to the whole trie.
+    the injected snapshot operation keeps exact-identity policy in
+    ``BlockTrie`` without giving the lifecycle a back-reference to the whole
+    trie.
     """
 
     def __init__(self,
@@ -53,14 +52,14 @@ class StateCheckpointLifecycle:
                  allocator: LogicalAllocator,
                  state_manager: StateManager | None,
                  index: StateCheckpointIndex,
-                 make_sequence_match_data: SequenceMatchDataBuilder):
+                 snapshot_match_data: Callable[[Node, SchedulerSequence], StateCheckpointMatchData]):
         self._prefix_cache_enabled = prefix_cache_enabled
         self._state_checkpoints_enabled = state_checkpoints_enabled
         self._block_size = block_size
         self._allocator = allocator
         self._state_manager = state_manager
         self._index = index
-        self._make_sequence_match_data = make_sequence_match_data
+        self._snapshot_match_data = snapshot_match_data
 
     def reserve_save(self, seq: SchedulerSequence, step: int = None, is_decode: bool = False):
         """Reserve a checkpoint at an exact safe prefill boundary."""
@@ -299,7 +298,7 @@ class StateCheckpointLifecycle:
             checkpoint = node.state_checkpoint
             slot = -1 if checkpoint is None else checkpoint.slot
             logger.debug('Drop stale SSM prefix-cache checkpoint index entry: adapter=%s step=%s node_adapter=%s '
-                         'node_step=%s state_idx=%s reason=%s', key[0], key[1], node.adapter_name, node.prefix_len,
+                         'node_anchor=%s state_idx=%s reason=%s', key[0], key[1], node.adapter_name, node.prefix_len,
                          slot, reason)
         return removed
 
@@ -309,7 +308,7 @@ class StateCheckpointLifecycle:
         if self.is_pinned(node):
             checkpoint = node.state_checkpoint
             logger.debug('Skip pinned stale SSM prefix-cache checkpoint candidate: adapter=%s step=%s '
-                         'state_idx=%s pin_count=%s reason=%s', node.adapter_name, node.prefix_len, checkpoint.slot,
+                         'state_idx=%s pin_count=%s reason=%s', node.adapter_name, checkpoint.step, checkpoint.slot,
                          checkpoint.pin_count, reason)
             return False
 
@@ -449,7 +448,7 @@ class StateCheckpointLifecycle:
                 raise RuntimeError('Cannot republish an SSM checkpoint with missing exact-match metadata.')
             return
 
-        match_data = self._make_sequence_match_data(node, seq)
+        match_data = self._snapshot_match_data(node, seq)
         checkpoint.exact_match_data = match_data
         checkpoint.published = True
         checkpoint.last_access_time = time.perf_counter()

--- a/lmdeploy/pytorch/paging/block_trie/checkpoint_lifecycle.py
+++ b/lmdeploy/pytorch/paging/block_trie/checkpoint_lifecycle.py
@@ -4,7 +4,7 @@
 The lifecycle owns state-slot reservation, optional frozen partial KV blocks,
 publication, async-copy pins, and checkpoint-only eviction. It deliberately
 does not own trie topology or normal trie KV blocks. :class:`BlockTrie`
-supplies the exact-identity builder needed while publishing a checkpoint,
+supplies the exact-identity snapshot operation used during publication,
 while ``KVBlockLifecycle`` consults this owner before evicting a
 checkpoint-bearing KV leaf.
 """

--- a/lmdeploy/pytorch/paging/block_trie/checkpoint_lifecycle.py
+++ b/lmdeploy/pytorch/paging/block_trie/checkpoint_lifecycle.py
@@ -84,7 +84,7 @@ class StateCheckpointLifecycle:
             return -1
 
         try:
-            slot = self._reserve_slot(node, step)
+            slot = self._reserve_checkpoint(node, step)
         except MemoryError:
             return -1
         except RuntimeError as e:
@@ -377,54 +377,59 @@ class StateCheckpointLifecycle:
             evicted += 1
         return evicted
 
-    def _reserve_slot(self, node: Node, step: int = None):
-        """Reserve state and optional frozen KV owned by one trie anchor.
+    def _reserve_checkpoint(self, node: Node, step: int):
+        """Reserve or replace the checkpoint owned by one trie anchor.
 
         Replacing a published checkpoint at the same anchor is allowed only while no async copy pins it. If the shared
         state pool is full, one old unpinned checkpoint may be evicted without removing its trie/KV node.
         """
-        if step is None:
-            step = node.prefix_len
         anchor_step = step - step % self._block_size
-        is_partial = anchor_step != step
         if (not self._state_checkpoints_enabled or not node.is_attached_or_root()
                 or node.prefix_len != anchor_step):
             return -1
+
         checkpoint = node.state_checkpoint
-        if checkpoint is not None and checkpoint.published:
-            if checkpoint.pin_count > 0:
-                return -1
-            if checkpoint.step == step:
-                return -1
-            frozen_block_id = checkpoint.frozen_block_id
-            if is_partial and frozen_block_id < 0:
-                frozen_block_id = int(self._allocator.allocate(1, 'gpu')[0])
-            logger.debug('Replace SSM prefix-cache checkpoint: adapter=%s step=%s state_idx=%s', node.adapter_name,
-                         checkpoint.step, checkpoint.slot)
-            self._unindex_checkpoint(node)
-            if not is_partial and checkpoint.frozen_block_id >= 0:
-                self._allocator.free(np.array([checkpoint.frozen_block_id], dtype=np.int64))
-                frozen_block_id = -1
-        elif checkpoint is not None:
-            return -1
         if checkpoint is None:
-            if self._state_manager.get_num_free_checkpoint() == 0 and self.evict(1) == 0:
-                return -1
-            slot = self._state_manager.allocate_checkpoint_state()
-            try:
-                frozen_block_id = -1
-                if is_partial:
-                    frozen_block_id = int(self._allocator.allocate(1, 'gpu')[0])
-            except Exception:
-                self._state_manager.free_checkpoint_state(slot)
-                raise
-            checkpoint = NodeStateCheckpoint(slot=slot,
-                                             step=step,
-                                             frozen_block_id=frozen_block_id)
-            node.state_checkpoint = checkpoint
-        else:
-            checkpoint.step = step
-            checkpoint.frozen_block_id = frozen_block_id
+            return self._create_checkpoint(node, step)
+        if not checkpoint.published or checkpoint.pin_count > 0 or checkpoint.step == step:
+            return -1
+        return self._replace_checkpoint(node, checkpoint, step)
+
+    def _create_checkpoint(self, node: Node, step: int):
+        """Allocate a new checkpoint, rolling back state on KV failure."""
+        if self._state_manager.get_num_free_checkpoint() == 0 and self.evict(1) == 0:
+            return -1
+
+        slot = self._state_manager.allocate_checkpoint_state()
+        try:
+            frozen_block_id = -1
+            if step % self._block_size != 0:
+                frozen_block_id = int(self._allocator.allocate(1, 'gpu')[0])
+        except Exception:
+            self._state_manager.free_checkpoint_state(slot)
+            raise
+
+        node.state_checkpoint = NodeStateCheckpoint(slot=slot,
+                                                    step=step,
+                                                    frozen_block_id=frozen_block_id)
+        return slot
+
+    def _replace_checkpoint(self, node: Node, checkpoint: NodeStateCheckpoint, step: int):
+        """Reuse an unpinned checkpoint while changing its exact step."""
+        is_partial = step % self._block_size != 0
+        frozen_block_id = checkpoint.frozen_block_id
+        if is_partial and frozen_block_id < 0:
+            frozen_block_id = int(self._allocator.allocate(1, 'gpu')[0])
+
+        logger.debug('Replace SSM prefix-cache checkpoint: adapter=%s step=%s state_idx=%s', node.adapter_name,
+                     checkpoint.step, checkpoint.slot)
+        self._unindex_checkpoint(node)
+        if not is_partial and checkpoint.frozen_block_id >= 0:
+            self._allocator.free(np.array([checkpoint.frozen_block_id], dtype=np.int64))
+            frozen_block_id = -1
+
+        checkpoint.step = step
+        checkpoint.frozen_block_id = frozen_block_id
         checkpoint.published = False
         checkpoint.exact_match_data = None
         checkpoint.last_access_time = 0.0

--- a/lmdeploy/pytorch/paging/block_trie/node.py
+++ b/lmdeploy/pytorch/paging/block_trie/node.py
@@ -16,16 +16,19 @@ if TYPE_CHECKING:
 
 @dataclass(slots=True)
 class NodeStateCheckpoint:
-    """State-checkpoint metadata allocated only for checkpoint owners.
+    """State and optional partial-KV checkpoint owned by one trie anchor.
 
-    ``slot`` describes the reservation. ``published`` exposes it to exact
-    matching, while ``exact_match_data`` caches the immutable prefix identity
-    and logical KV path used after sparse lookup. ``pin_count`` protects async
-    save/restore copies, and ``last_access_time`` drives state-only LRU
-    eviction.
+    ``step`` is the exact model-forward boundary. ``frozen_block_id`` owns a
+    copy of the partial logical block when ``step`` is not block-aligned.
+    ``published`` exposes the reservation to exact matching, while
+    ``exact_match_data`` caches the immutable prefix identity and logical KV
+    path used after sparse lookup. ``pin_count`` protects async save/restore
+    copies, and ``last_access_time`` drives checkpoint LRU eviction.
     """
 
     slot: int
+    step: int
+    frozen_block_id: int = -1
     published: bool = False
     exact_match_data: StateCheckpointMatchData | None = None
     pin_count: int = 0
@@ -101,6 +104,12 @@ class Node:
         """Check whether this node is still linked from its parent."""
         parent = self.parent
         return parent is not None and parent.children.get(self.block_hash) is self
+
+    def is_attached_or_root(self):
+        """Check whether this node is attached or is an adapter root."""
+        if self.parent is None:
+            return self.block_id < 0
+        return self.is_attached()
 
     def path_from_root(self):
         """Return non-root nodes from the adapter root to this node."""

--- a/lmdeploy/pytorch/paging/block_trie/node.py
+++ b/lmdeploy/pytorch/paging/block_trie/node.py
@@ -20,7 +20,7 @@ class NodeStateCheckpoint:
 
     ``step`` is the exact model-forward boundary. ``frozen_block_id`` owns a
     copy of the partial logical block when ``step`` is not block-aligned.
-    ``published`` exposes the reservation to exact matching, while
+    ``published`` exposes the checkpoint to exact matching, while
     ``exact_match_data`` caches the immutable prefix identity and logical KV
     path used after sparse lookup. ``pin_count`` protects async save/restore
     copies, and ``last_access_time`` drives checkpoint LRU eviction.

--- a/lmdeploy/pytorch/paging/block_trie/trie.py
+++ b/lmdeploy/pytorch/paging/block_trie/trie.py
@@ -165,7 +165,7 @@ class BlockTrie:
             allocator=self.allocator,
             state_manager=checkpoint_state_manager,
             index=self._checkpoint_index,
-            make_sequence_match_data=self._make_state_checkpoint_match_data_from_seq,
+            snapshot_match_data=self._snapshot_checkpoint_match_data,
         )
         self._kv_lifecycle = KVBlockLifecycle(self.allocator, self._state_checkpoints)
         self.stats = PrefixCacheStats()
@@ -297,39 +297,48 @@ class BlockTrie:
         for seq in seqs:
             self.cache_routed_experts_for_seq(seq)
 
-    def _make_state_checkpoint_match_data_from_seq(self, node: Node, seq: SchedulerSequence):
+    def _snapshot_checkpoint_match_data(self, node: Node, seq: SchedulerSequence):
         """Snapshot exact match data from a checkpoint producer.
+
+        The lifecycle already proved that ``node`` owns an unpublished
+        reservation. This method proves that the producer still matches that
+        owner before freezing its exact identity.
 
         ``BlockTrie.allocate()`` already made the producer cursor authoritative
         for this prefix. Its recompute-overlap substitutions turn the
         contiguous logical-block copy back into the shared trie path
         without rebuilding thousands of Python ``Node`` objects per save.
         """
-        checkpoint = node.state_checkpoint
-        if checkpoint is None:
-            raise RuntimeError('Cannot publish an SSM checkpoint without a reservation.')
-        step = checkpoint.step
+        step = node.state_checkpoint.step
         anchor_step = checkpoint_anchor_step(step, self.block_size)
         num_full_blocks = anchor_step // self.block_size
+        mismatch = 'Cannot publish an SSM checkpoint from a mismatched sequence cursor'
+        if not self._cursor_belongs_to_trie(node):
+            raise RuntimeError(f'{mismatch}: checkpoint owner does not belong to this trie.')
+        if seq.adapter_name != node.adapter_name:
+            raise RuntimeError(f'{mismatch}: adapter does not match the checkpoint owner.')
+        if node.prefix_len != anchor_step:
+            raise RuntimeError(f'{mismatch}: checkpoint owner is not the expected block anchor.')
+
         token_ids = seq.history_cache[:step].copy()
+        if len(token_ids) != step:
+            raise RuntimeError(f'{mismatch}: token identity is incomplete.')
         block_ids = seq.logical_blocks.get_real_blocks()[:num_full_blocks].copy()
+        if len(block_ids) != num_full_blocks:
+            raise RuntimeError(f'{mismatch}: logical block path is incomplete.')
         seq.prefix_cache.recompute_overlap.apply_trie_blocks(block_ids)
+        if num_full_blocks > 0:
+            owner_start = anchor_step - self.block_size
+            block_extra_identity = seq.get_prefix_cache_extra_identity(owner_start, anchor_step)
+            if block_ids[-1] != node.block_id:
+                raise RuntimeError(f'{mismatch}: last logical block is not owned by the checkpoint node.')
+            if not self._node_matches_block(node, token_ids[owner_start:anchor_step], block_extra_identity):
+                raise RuntimeError(f'{mismatch}: last block identity does not match the checkpoint owner.')
+
         prefix_extra_identity = make_request_multimodal_identity(seq, step)
         tail_start = checkpoint_tail_start(step, self.block_size)
         tail_extra_identity = seq.get_prefix_cache_extra_identity(tail_start, step)
         tail_hash = self._hash_block(token_ids[tail_start:step], tail_extra_identity)
-        if num_full_blocks > 0:
-            owner_start = anchor_step - self.block_size
-            block_extra_identity = seq.get_prefix_cache_extra_identity(owner_start, anchor_step)
-        owner_matches = (self._cursor_belongs_to_trie(node) and seq.adapter_name == node.adapter_name
-                         and node.prefix_len == anchor_step)
-        if owner_matches and num_full_blocks > 0:
-            owner_matches = (block_ids[-1] == node.block_id
-                             and self._node_matches_block(node, token_ids[owner_start:anchor_step],
-                                                          block_extra_identity))
-        has_complete_identity = len(token_ids) == step and len(block_ids) == num_full_blocks
-        if not has_complete_identity or not owner_matches:
-            raise RuntimeError('Cannot publish an SSM checkpoint from a mismatched sequence cursor.')
         return freeze_state_checkpoint_match_data(token_ids, prefix_extra_identity, block_ids, tail_hash)
 
     def _cursor_belongs_to_trie(self, node: Node):
@@ -338,18 +347,18 @@ class BlockTrie:
             return node.block_id < 0 and self._roots.get(node.adapter_name) is node
         return node.is_attached()
 
-    def _handle_state_checkpoint_rejection(self, seq: SchedulerSequence, node: Node, key, match_result):
-        """Clean up a rejected sparse candidate according to its status."""
-        if match_result.status == StateCheckpointVerifyStatus.STALE_INDEX_ENTRY:
-            self.state_checkpoints.discard_stale_index_entry(node, key, match_result.reason)
-        elif match_result.status == StateCheckpointVerifyStatus.STALE_CHECKPOINT:
-            self.state_checkpoints.release_stale_checkpoint(node, match_result.reason)
+    def _reject_state_checkpoint_candidate(self, seq: SchedulerSequence, node: Node, key, verification):
+        """Clean up and log a rejected sparse candidate."""
         checkpoint = node.state_checkpoint
         state_idx = -1 if checkpoint is None else checkpoint.slot
-        step = node.prefix_len if checkpoint is None else checkpoint.step
+        candidate_step = key[1]
+        if verification.status == StateCheckpointVerifyStatus.STALE_INDEX_ENTRY:
+            self.state_checkpoints.discard_stale_index_entry(node, key, verification.reason)
+        elif verification.status == StateCheckpointVerifyStatus.STALE_CHECKPOINT:
+            self.state_checkpoints.release_stale_checkpoint(node, verification.reason)
         logger.debug('Reject SSM prefix-cache checkpoint candidate: session_id=%s seq_id=%s step=%s '
-                     'state_idx=%s status=%s reason=%s', seq.session_id, seq.seq_id, step, state_idx,
-                     match_result.status.name, match_result.reason)
+                     'state_idx=%s status=%s reason=%s', seq.session_id, seq.seq_id, candidate_step, state_idx,
+                     verification.status.name, verification.reason)
 
     def _find_recompute_overlap_end(self, seq: SchedulerSequence, node: Node, step: int, recompute_blocks: int):
         """Return the cached overlap end, or ``-1`` when it is too short."""
@@ -418,9 +427,9 @@ class BlockTrie:
                 continue
             key = self._checkpoint_index.make_request_key(seq, step)
             for node in self._checkpoint_index.candidates(key):
-                match_result = self._checkpoint_index.verify_candidate(seq, node, key)
-                if match_result.status != StateCheckpointVerifyStatus.HIT:
-                    self._handle_state_checkpoint_rejection(seq, node, key, match_result)
+                verification = self._checkpoint_index.verify_candidate(seq, node, key)
+                if verification.status != StateCheckpointVerifyStatus.HIT:
+                    self._reject_state_checkpoint_candidate(seq, node, key, verification)
                     continue
 
                 if recompute_blocks > 0:
@@ -428,7 +437,7 @@ class BlockTrie:
                     if overlap_end_step < 0:
                         continue
 
-                self._apply_state_checkpoint_hit(seq, node, match_result.matched_block_ids, initial_step,
+                self._apply_state_checkpoint_hit(seq, node, verification.matched_block_ids, initial_step,
                                                  overlap_end_step)
                 return
 

--- a/lmdeploy/pytorch/paging/block_trie/trie.py
+++ b/lmdeploy/pytorch/paging/block_trie/trie.py
@@ -86,6 +86,8 @@ from ..state_manager import StateManager
 from .checkpoint import (
     StateCheckpointIndex,
     StateCheckpointVerifyStatus,
+    checkpoint_anchor_step,
+    checkpoint_tail_start,
     freeze_state_checkpoint_match_data,
     make_request_multimodal_identity,
 )
@@ -307,25 +309,25 @@ class BlockTrie:
         if checkpoint is None:
             raise RuntimeError('Cannot publish an SSM checkpoint without a reservation.')
         step = checkpoint.step
-        anchor_step = step - step % self.block_size
-        num_blocks = anchor_step // self.block_size
+        anchor_step = checkpoint_anchor_step(step, self.block_size)
+        num_full_blocks = anchor_step // self.block_size
         token_ids = seq.history_cache[:step].copy()
-        block_ids = seq.logical_blocks.get_real_blocks()[:num_blocks].copy()
+        block_ids = seq.logical_blocks.get_real_blocks()[:num_full_blocks].copy()
         seq.prefix_cache.recompute_overlap.apply_trie_blocks(block_ids)
         prefix_extra_identity = make_request_multimodal_identity(seq, step)
-        tail_start = ((step - 1) // self.block_size) * self.block_size
+        tail_start = checkpoint_tail_start(step, self.block_size)
         tail_extra_identity = seq.get_prefix_cache_extra_identity(tail_start, step)
         tail_hash = self._hash_block(token_ids[tail_start:step], tail_extra_identity)
-        if num_blocks > 0:
-            block_start = anchor_step - self.block_size
-            block_extra_identity = seq.get_prefix_cache_extra_identity(block_start, anchor_step)
+        if num_full_blocks > 0:
+            owner_start = anchor_step - self.block_size
+            block_extra_identity = seq.get_prefix_cache_extra_identity(owner_start, anchor_step)
         owner_matches = (self._cursor_belongs_to_trie(node) and seq.adapter_name == node.adapter_name
                          and node.prefix_len == anchor_step)
-        if owner_matches and num_blocks > 0:
+        if owner_matches and num_full_blocks > 0:
             owner_matches = (block_ids[-1] == node.block_id
-                             and self._node_matches_block(node, token_ids[block_start:anchor_step],
+                             and self._node_matches_block(node, token_ids[owner_start:anchor_step],
                                                           block_extra_identity))
-        has_complete_identity = len(token_ids) == step and len(block_ids) == num_blocks
+        has_complete_identity = len(token_ids) == step and len(block_ids) == num_full_blocks
         if not has_complete_identity or not owner_matches:
             raise RuntimeError('Cannot publish an SSM checkpoint from a mismatched sequence cursor.')
         return freeze_state_checkpoint_match_data(token_ids, prefix_extra_identity, block_ids, tail_hash)
@@ -380,14 +382,15 @@ class BlockTrie:
         prefix_cache = seq.prefix_cache
         prefix_cache.restore.select(checkpoint.slot, node)
         prefix_cache.trie_cursor = node
-        fresh_end_block = (step + self.block_size - 1) // self.block_size
+        fresh_start_idx = step // self.block_size
+        fresh_end_idx = (step + self.block_size - 1) // self.block_size
         if checkpoint.frozen_block_id >= 0:
             # Forward resumes inside a private partial block. Complete suffix
             # blocks already present in the request must remain private too.
-            fresh_end_block = max(fresh_end_block, seq.num_valid_ids // self.block_size)
+            fresh_end_idx = max(fresh_end_idx, seq.num_valid_ids // self.block_size)
         if overlap_end_step >= 0:
-            fresh_end_block = max(fresh_end_block, overlap_end_step // self.block_size)
-        prefix_cache.recompute_overlap.set_fresh_block_range(step // self.block_size, fresh_end_block)
+            fresh_end_idx = max(fresh_end_idx, overlap_end_step // self.block_size)
+        prefix_cache.recompute_overlap.set_fresh_block_range(fresh_start_idx, fresh_end_idx)
 
         self._record_match_stats(seq,
                                  query_tokens=seq.num_all_ids - initial_step,

--- a/lmdeploy/pytorch/paging/block_trie/trie.py
+++ b/lmdeploy/pytorch/paging/block_trie/trie.py
@@ -20,9 +20,10 @@ Pipeline summary:
 3. Text/VLM matching walks trie blocks by adapter root.  Each block key is
    token ids plus multimodal extra hashes; matches are clamped so forward never
    starts inside a multimodal span.
-4. SSM matching cannot reuse KV alone. It uses sparse published-checkpoint lookup,
-   verifies the full ancestor chain, then asks ``ModelAgent`` to copy the
-   frozen checkpoint state into the request runtime state on the forward stream.
+4. SSM matching cannot reuse KV alone. It uses sparse published-checkpoint
+   lookup, verifies exact host identity, then asks ``ModelAgent`` to restore
+   any frozen partial KV block before the checkpoint state on the forward
+   stream.
 5. SSM checkpoint saves are reserved through ``state_checkpoints``, copied by
    ``ModelAgent`` after forward, and published by ``EngineLoop`` once the
    producer forward is queued.
@@ -39,14 +40,15 @@ SSM checkpoint detail:
   slots stored in a trie's optional ``Node.state_checkpoint`` record. A trie
   node may own KV only, KV plus an unpublished checkpoint reservation, or KV
   plus a published checkpoint.
-* Saving a checkpoint starts from an already-attached block-aligned trie node.
-  ``state_checkpoints.reserve_save()`` records a ``pending_save`` reservation
-  on ``seq.prefix_cache``.  Prefill and
-  long-context chunks save at the produced chunk end; decode saves are optional
-  and bounded by ``prefix_cache_decode_state_interval``.
-* ``InputsMaker`` converts those pending saves into compact host integer
-  src/dst pairs.  ``ModelAgent`` then copies ``runtime_state -> checkpoint`` on
-  the model forward stream after the model has produced the new SSM state.
+* Saving a checkpoint starts from the full-block trie node at or before the
+  exact save step. A partial step also reserves one checkpoint-owned frozen KV
+  block. ``state_checkpoints.reserve_save()`` records a ``pending_save``
+  reservation on ``seq.prefix_cache``. Prefill and long-context chunks save at
+  the produced chunk end; decode saves remain block-aligned and bounded by
+  ``prefix_cache_decode_state_interval``.
+* ``InputsMaker`` converts pending saves into compact host copy plans.
+  ``ModelAgent`` copies a partial producer block into its frozen destination,
+  then copies ``runtime_state -> checkpoint`` after forward on the same stream.
   ``EngineLoop`` calls ``state_checkpoints.publish_save()`` after the forward
   is queued; only then is the checkpoint published into the sparse
   match index. The producing forward holds a producer pin
@@ -55,18 +57,20 @@ SSM checkpoint detail:
   Abandoned reservations are discarded.
 * Matching a SSM prefix never walks KV blocks as the source of truth.
   ``_match_state_checkpoint_prefix()`` searches published checkpoint steps, filters by
-  ``(adapter, step, last_block_hash)``, then proves the complete prefix against
+  ``(adapter, step, tail_hash)``, then proves the complete prefix against
   immutable exact-match metadata built when the checkpoint is published.  A
   hit appends trie-owned KV blocks, advances ``seq.num_history_ids``, records a
   selected ``restore``, and may replay routed experts.
 * Restore is two-phase. The scheduler/input maker pins the published checkpoint
-  by incrementing its pin count. ``ModelAgent`` copies
-  ``checkpoint -> runtime_state`` before the suffix forward.  ``EngineLoop``
+  by incrementing its pin count. For a partial checkpoint, ``ModelAgent`` first
+  copies the frozen tail into the request's private writable block, then copies
+  ``checkpoint -> runtime_state`` before the suffix forward. ``EngineLoop``
   releases the pin once the copy has been queued, so LRU eviction cannot reuse
   the checkpoint source slot too early.
-* Checkpoint eviction is state-only LRU over published, unpinned nodes. KV leaf
-  eviction also releases any checkpoint owned by that leaf.  A KV match without
-  an exact published SSM checkpoint is intentionally a miss.
+* State pressure uses checkpoint LRU. KV pressure first releases unpinned
+  checkpoints with frozen blocks, then evicts trie leaves. A KV leaf eviction
+  also releases any checkpoint owned by that leaf. A KV match without an exact
+  published SSM checkpoint is intentionally a miss.
 """
 
 from dataclasses import dataclass
@@ -156,6 +160,7 @@ class BlockTrie:
             prefix_cache_enabled=self.enabled,
             state_checkpoints_enabled=self._use_checkpoints,
             block_size=self.block_size,
+            allocator=self.allocator,
             state_manager=checkpoint_state_manager,
             index=self._checkpoint_index,
             make_sequence_match_data=self._make_state_checkpoint_match_data_from_seq,
@@ -298,24 +303,35 @@ class BlockTrie:
         contiguous logical-block copy back into the shared trie path
         without rebuilding thousands of Python ``Node`` objects per save.
         """
-        step = node.prefix_len
-        num_blocks = step // self.block_size
+        checkpoint = node.state_checkpoint
+        if checkpoint is None:
+            raise RuntimeError('Cannot publish an SSM checkpoint without a reservation.')
+        step = checkpoint.step
+        anchor_step = step - step % self.block_size
+        num_blocks = anchor_step // self.block_size
         token_ids = seq.history_cache[:step].copy()
         block_ids = seq.logical_blocks.get_real_blocks()[:num_blocks].copy()
         seq.prefix_cache.recompute_overlap.apply_trie_blocks(block_ids)
         prefix_extra_identity = make_request_multimodal_identity(seq, step)
-        start = step - self.block_size
-        block_extra_identity = seq.get_prefix_cache_extra_identity(start, step)
+        tail_start = ((step - 1) // self.block_size) * self.block_size
+        tail_extra_identity = seq.get_prefix_cache_extra_identity(tail_start, step)
+        tail_hash = self._hash_block(token_ids[tail_start:step], tail_extra_identity)
+        if num_blocks > 0:
+            block_start = anchor_step - self.block_size
+            block_extra_identity = seq.get_prefix_cache_extra_identity(block_start, anchor_step)
+        owner_matches = (self._cursor_belongs_to_trie(node) and seq.adapter_name == node.adapter_name
+                         and node.prefix_len == anchor_step)
+        if owner_matches and num_blocks > 0:
+            owner_matches = (block_ids[-1] == node.block_id
+                             and self._node_matches_block(node, token_ids[block_start:anchor_step],
+                                                          block_extra_identity))
         has_complete_identity = len(token_ids) == step and len(block_ids) == num_blocks
-        has_matching_owner = (seq.adapter_name == node.adapter_name and len(block_ids) > 0
-                              and block_ids[-1] == node.block_id
-                              and self._node_matches_block(node, token_ids[start:], block_extra_identity))
-        if not has_complete_identity or not has_matching_owner:
+        if not has_complete_identity or not owner_matches:
             raise RuntimeError('Cannot publish an SSM checkpoint from a mismatched sequence cursor.')
-        return freeze_state_checkpoint_match_data(token_ids, prefix_extra_identity, block_ids)
+        return freeze_state_checkpoint_match_data(token_ids, prefix_extra_identity, block_ids, tail_hash)
 
-    def _cursor_is_attached(self, node: Node):
-        """Check a cursor under the monotonic attach/detach contract."""
+    def _cursor_belongs_to_trie(self, node: Node):
+        """Check whether a cursor is an attached node or registered root."""
         if node.parent is None:
             return node.block_id < 0 and self._roots.get(node.adapter_name) is node
         return node.is_attached()
@@ -328,13 +344,13 @@ class BlockTrie:
             self.state_checkpoints.release_stale_checkpoint(node, match_result.reason)
         checkpoint = node.state_checkpoint
         state_idx = -1 if checkpoint is None else checkpoint.slot
+        step = node.prefix_len if checkpoint is None else checkpoint.step
         logger.debug('Reject SSM prefix-cache checkpoint candidate: session_id=%s seq_id=%s step=%s '
-                     'state_idx=%s status=%s reason=%s', seq.session_id, seq.seq_id, node.prefix_len, state_idx,
+                     'state_idx=%s status=%s reason=%s', seq.session_id, seq.seq_id, step, state_idx,
                      match_result.status.name, match_result.reason)
 
-    def _find_recompute_overlap_end(self, seq: SchedulerSequence, node: Node, recompute_blocks: int):
+    def _find_recompute_overlap_end(self, seq: SchedulerSequence, node: Node, step: int, recompute_blocks: int):
         """Return the cached overlap end, or ``-1`` when it is too short."""
-        step = node.prefix_len
         cached_end_step = self._find_deepest_block_match_step(seq, node)
         required_step = step + recompute_blocks * self.block_size
         if cached_end_step >= required_step:
@@ -352,7 +368,8 @@ class BlockTrie:
                                     initial_step: int,
                                     overlap_end_step: int):
         """Apply a verified checkpoint hit to sequence state."""
-        step = node.prefix_len
+        checkpoint = node.state_checkpoint
+        step = checkpoint.step
         new_blocks = matched_block_ids[initial_step // self.block_size:]
         self.allocator.update_access_time(new_blocks)
         self.allocator.add_ref_count(new_blocks, 1)
@@ -361,12 +378,16 @@ class BlockTrie:
         self._append_state_checkpoint_routed_experts(seq, node, initial_step)
 
         prefix_cache = seq.prefix_cache
-        checkpoint = node.state_checkpoint
         prefix_cache.restore.select(checkpoint.slot, node)
         prefix_cache.trie_cursor = node
+        fresh_end_block = (step + self.block_size - 1) // self.block_size
+        if checkpoint.frozen_block_id >= 0:
+            # Forward resumes inside a private partial block. Complete suffix
+            # blocks already present in the request must remain private too.
+            fresh_end_block = max(fresh_end_block, seq.num_valid_ids // self.block_size)
         if overlap_end_step >= 0:
-            prefix_cache.recompute_overlap.set_fresh_block_range(step // self.block_size,
-                                                                 overlap_end_step // self.block_size)
+            fresh_end_block = max(fresh_end_block, overlap_end_step // self.block_size)
+        prefix_cache.recompute_overlap.set_fresh_block_range(step // self.block_size, fresh_end_block)
 
         self._record_match_stats(seq,
                                  query_tokens=seq.num_all_ids - initial_step,
@@ -387,11 +408,10 @@ class BlockTrie:
 
         recompute_blocks = max(0, seq.prefix_cache.recompute_overlap.recompute_blocks)
         overlap_end_step = -1
-        max_step = ((seq.num_valid_ids - 1) // self.block_size) * self.block_size
-        max_step = seq.clamp_prefix_cache_match_step(max_step)
+        max_step = seq.num_valid_ids - 1
         candidate_steps = self._checkpoint_index.candidate_steps(seq.adapter_name, initial_step, max_step)
         for step in candidate_steps:
-            if seq.clamp_prefix_cache_match_step(step) != step:
+            if not seq.is_prefix_cache_boundary_safe(step):
                 continue
             key = self._checkpoint_index.make_request_key(seq, step)
             for node in self._checkpoint_index.candidates(key):
@@ -401,7 +421,7 @@ class BlockTrie:
                     continue
 
                 if recompute_blocks > 0:
-                    overlap_end_step = self._find_recompute_overlap_end(seq, node, recompute_blocks)
+                    overlap_end_step = self._find_recompute_overlap_end(seq, node, step, recompute_blocks)
                     if overlap_end_step < 0:
                         continue
 
@@ -503,7 +523,7 @@ class BlockTrie:
         node = seq.prefix_cache.trie_cursor
         if node is None:
             node = self._get_or_create_root(seq.adapter_name)
-        elif not self._cursor_is_attached(node):
+        elif not self._cursor_belongs_to_trie(node):
             logger.debug('Reset detached prefix-cache sequence cursor: session_id=%s seq_id=%s adapter=%s '
                          'cursor_step=%s', seq.session_id, seq.seq_id, seq.adapter_name, node.prefix_len)
             node = self._get_or_create_root(seq.adapter_name)
@@ -534,9 +554,12 @@ class BlockTrie:
             if child is not None and not self._node_matches_block(child, token_ids, extra_identity):
                 break
 
-            if child is not None and fresh_block_range is not None and block_idx in fresh_block_range:
-                # Traverse the shared identity path while retaining the fresh,
-                # writable sequence block needed to recompute bridge state.
+            if fresh_block_range is not None and block_idx in fresh_block_range:
+                # Traverse an existing identity path while retaining the fresh,
+                # writable sequence block. A missing child ends path extension:
+                # the private block must not become trie-owned before forward.
+                if child is None:
+                    break
                 trie_block_map[block_idx] = child.block_id
                 node = child
                 continue
@@ -570,7 +593,7 @@ class BlockTrie:
         """Attach newly allocated full blocks to the prefix-cache trie.
 
         Allocation starts from ``seq.prefix_cache.trie_cursor`` when that
-        cursor still reaches the current trie.  Existing identical children are
+        cursor remains attached to this trie. Existing identical children are
         deduplicated back to the trie-owned block, except for the recompute
         overlap where the sequence must keep fresh writable KV.
         New nodes take one trie-owned allocator ref. The facade decides the
@@ -597,12 +620,17 @@ class BlockTrie:
         recompute_overlap.clear_fresh_block_range()
 
     def evict(self, max_num_blocks: int):
-        """Evict trie-owned KV leaf blocks.
+        """Evict checkpoint-frozen and trie-owned KV blocks.
 
-        ``KVBlockLifecycle`` owns the auxiliary leaf index and rechecks every
-        candidate against topology, allocator refs, and checkpoint pins.
+        Frozen partial blocks are cheaper to release because their trie anchor
+        remains cached. ``KVBlockLifecycle`` then owns normal leaf eviction and
+        rechecks every candidate against topology, allocator refs, and
+        checkpoint pins.
         """
         if not self.enabled:
             return 0
 
-        return self._kv_lifecycle.evict(max_num_blocks)
+        evicted = self._state_checkpoints.evict_frozen_checkpoints(max_num_blocks)
+        if evicted < max_num_blocks:
+            evicted += self._kv_lifecycle.evict(max_num_blocks - evicted)
+        return evicted

--- a/lmdeploy/pytorch/paging/scheduler.py
+++ b/lmdeploy/pytorch/paging/scheduler.py
@@ -922,6 +922,10 @@ class Scheduler:
         """Get block tables for the sequences."""
         return [self.block_manager.get_block_table(seq) for seq in seqs]
 
+    def resolve_gpu_block_offsets(self, logical_block_ids):
+        """Resolve paging-owned logical ids for a forward cache-copy plan."""
+        return self.block_manager.resolve_gpu_block_offsets(logical_block_ids)
+
     def evict_seqs(self, running: SeqList):
         """Evict running sequences."""
         for seq in running:

--- a/lmdeploy/pytorch/strategies/ar/model_inputs.py
+++ b/lmdeploy/pytorch/strategies/ar/model_inputs.py
@@ -1,7 +1,5 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 
-from collections.abc import Sequence
-
 import numpy as np
 import torch
 
@@ -131,9 +129,7 @@ def index_select_model_inputs(inputs: ModelInputs,
                               max_q_seqlen: int | None = None,
                               max_kv_seqlen: int | None = None,
                               sum_kv_seqlen: int | None = None,
-                              num_ignored_history: torch.Tensor | None = None,
-                              state_prefix_cache_save_src_offsets: Sequence[int] | None = None,
-                              state_prefix_cache_save_offsets: Sequence[int] | None = None):
+                              num_ignored_history: torch.Tensor | None = None):
     """Index select model inputs by indices."""
     assert inputs.is_decoding, 'Only support index_select in decoding.'
 
@@ -196,8 +192,6 @@ def index_select_model_inputs(inputs: ModelInputs,
         local_adapter_ids=local_adapter_ids,
         model_metas=model_metas,
         state_offsets=state_offsets,
-        state_prefix_cache_save_src_offsets=state_prefix_cache_save_src_offsets,
-        state_prefix_cache_save_offsets=state_prefix_cache_save_offsets,
         target_hidden_states=target_hidden_states,
         target_position_ids=target_position_ids,
         mrope_pos_ids=mrope_pos_ids,

--- a/lmdeploy/pytorch/strategies/ar/step_inputs.py
+++ b/lmdeploy/pytorch/strategies/ar/step_inputs.py
@@ -105,8 +105,6 @@ def _reindex_model_inputs(inputs: ModelInputs, delta: ModelInputsDelta) -> Model
         max_kv_seqlen=delta.max_kv_seqlen,
         sum_kv_seqlen=delta.sum_kv_seqlen,
         num_ignored_history=delta.num_ignored_history,
-        state_prefix_cache_save_src_offsets=delta.state_prefix_cache_save_src_offsets,
-        state_prefix_cache_save_offsets=delta.state_prefix_cache_save_offsets,
     )
 
 

--- a/lmdeploy/pytorch/strategies/ar_spec/step_inputs.py
+++ b/lmdeploy/pytorch/strategies/ar_spec/step_inputs.py
@@ -41,8 +41,6 @@ def _reindex_model_inputs_arspec(
     max_kv_seqlen = delta.max_kv_seqlen
     sum_kv_seqlen = delta.sum_kv_seqlen
     num_ignored_history = delta.num_ignored_history
-    state_prefix_cache_save_src_offsets = delta.state_prefix_cache_save_src_offsets
-    state_prefix_cache_save_offsets = delta.state_prefix_cache_save_offsets
 
     # required inputs — reshape by num_spec_tokens+1 for spec decoding
     inputs_ids = inputs.input_ids.reshape(1, -1, num_spec_tokens + 1)
@@ -91,8 +89,6 @@ def _reindex_model_inputs_arspec(
         local_adapter_ids=local_adapter_ids,
         model_metas=model_metas,
         state_offsets=state_offsets,
-        state_prefix_cache_save_src_offsets=state_prefix_cache_save_src_offsets,
-        state_prefix_cache_save_offsets=state_prefix_cache_save_offsets,
         mrope_pos_ids=mrope_pos_ids,
     )
 

--- a/lmdeploy/pytorch/strategies/dllm/step_inputs.py
+++ b/lmdeploy/pytorch/strategies/dllm/step_inputs.py
@@ -134,8 +134,6 @@ def _reindex_model_inputs_dllm(
     max_kv_seqlen = delta.max_kv_seqlen
     sum_kv_seqlen = delta.sum_kv_seqlen
     num_ignored_history = delta.num_ignored_history
-    state_prefix_cache_save_src_offsets = delta.state_prefix_cache_save_src_offsets
-    state_prefix_cache_save_offsets = delta.state_prefix_cache_save_offsets
 
     # required inputs — reshape by block_size for DLLM
     inputs_ids = inputs.input_ids.reshape(1, -1, block_size)
@@ -178,8 +176,6 @@ def _reindex_model_inputs_dllm(
         local_adapter_ids=local_adapter_ids,
         model_metas=model_metas,
         state_offsets=state_offsets,
-        state_prefix_cache_save_src_offsets=state_prefix_cache_save_src_offsets,
-        state_prefix_cache_save_offsets=state_prefix_cache_save_offsets,
     )
 
 

--- a/tests/pytorch/engine/test_cache_block_copy.py
+++ b/tests/pytorch/engine/test_cache_block_copy.py
@@ -1,0 +1,308 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+import pytest
+import torch
+
+import lmdeploy.pytorch.engine.cache_engine as cache_engine_module
+from lmdeploy.messages import QuantPolicy
+from lmdeploy.pytorch.backends.base import OpType
+from lmdeploy.pytorch.backends.default.cache_block_copy import (
+    DefaultCacheBlockCopyBuilder,
+    DefaultCacheBlockCopyImpl,
+)
+from lmdeploy.pytorch.backends.default.op_backend import DefaultOpsBackend
+from lmdeploy.pytorch.config import CacheConfig, ModelConfig
+from lmdeploy.pytorch.engine.cache_engine import CacheEngine
+
+
+def test_default_backend_registers_cache_block_copy_builder():
+    assert DefaultOpsBackend.get_layer_impl_builder(OpType.CacheBlockCopy) is DefaultCacheBlockCopyBuilder
+
+
+def test_cache_engine_build_cache_block_copy_routes_stable_list_pools(monkeypatch):
+    cache_config = CacheConfig(max_batches=1,
+                               block_size=6,
+                               kernel_block_size=2,
+                               num_cpu_blocks=0,
+                               num_gpu_blocks=4,
+                               enable_prefix_caching=True,
+                               states_shapes=[((2, 3), torch.float32)])
+    physical_pages = cache_config.num_gpu_blocks * (cache_config.block_size // cache_config.kernel_block_size)
+    packed_pools = [
+        torch.empty((2, physical_pages, 8), dtype=torch.uint8),
+        torch.empty((2, 3, physical_pages, 16), dtype=torch.uint8),
+    ]
+    build_calls = []
+    requested_ops = []
+    copy_impl = object()
+
+    class _RecordingBuilder:
+
+        @staticmethod
+        def build(**kwargs):
+            build_calls.append(kwargs)
+            return copy_impl
+
+    class _RecordingBackend:
+
+        @staticmethod
+        def get_layer_impl_builder(op_type):
+            requested_ops.append(op_type)
+            return _RecordingBuilder
+
+    monkeypatch.setattr(cache_engine_module, 'get_backend', lambda: _RecordingBackend())
+    cache_engine = object.__new__(CacheEngine)
+    cache_engine.cache_config = cache_config
+    cache_engine.full_gpu_cache = packed_pools
+
+    cache_engine._build_cache_block_copy()
+
+    assert requested_ops == [OpType.CacheBlockCopy]
+    assert len(build_calls) == 1
+    build_args = build_calls[0]
+    assert [id(pool) for pool in build_args['packed_caches']] == [id(pool) for pool in packed_pools]
+    assert build_args['num_logical_blocks'] == cache_config.num_gpu_blocks
+    assert build_args['pages_per_block'] == 3
+    assert cache_engine._cache_block_copy_device == packed_pools[0].device
+    assert cache_engine._cache_block_copy_impl is copy_impl
+
+
+@pytest.mark.parametrize(
+    ('enable_prefix_caching', 'states_shapes'),
+    [
+        pytest.param(False, [((2, 3), torch.float32)], id='prefix-cache-disabled'),
+        pytest.param(True, [], id='non-ssm'),
+    ],
+)
+def test_cache_engine_build_cache_block_copy_skips_disabled(monkeypatch, enable_prefix_caching,
+                                                            states_shapes):
+    cache_config = CacheConfig(max_batches=1,
+                               block_size=4,
+                               kernel_block_size=2,
+                               num_cpu_blocks=0,
+                               num_gpu_blocks=1,
+                               enable_prefix_caching=enable_prefix_caching,
+                               states_shapes=states_shapes)
+    cache_engine = object.__new__(CacheEngine)
+    cache_engine.cache_config = cache_config
+    cache_engine.full_gpu_cache = object()
+    monkeypatch.setattr(cache_engine_module, 'get_backend',
+                        lambda: (_ for _ in ()).throw(AssertionError('disabled copy must not request a backend')))
+
+    cache_engine._build_cache_block_copy()
+
+    assert cache_engine._cache_block_copy_device is None
+    assert cache_engine._cache_block_copy_impl is None
+
+
+def _make_cache_engine(quant_policy: QuantPolicy = QuantPolicy.NONE,
+                       cache_shapes: list[tuple[list[int], torch.dtype]] | None = None,
+                       num_blocks: int = 5):
+    cache_config = CacheConfig(max_batches=1,
+                               block_size=4,
+                               kernel_block_size=2,
+                               num_cpu_blocks=0,
+                               num_gpu_blocks=num_blocks,
+                               quant_policy=quant_policy)
+    model_config = ModelConfig(hidden_size=16,
+                               num_layers=2,
+                               num_attention_heads=2,
+                               num_key_value_heads=1,
+                               bos_token_id=1,
+                               eos_token_id=[2],
+                               head_dim=8,
+                               cache_shapes=cache_shapes or [])
+    cache_engine = object.__new__(CacheEngine)
+    cache_engine.cache_config = cache_config
+    cache_engine.model_config = model_config
+    cache_engine.full_gpu_cache, caches = CacheEngine.allocate_caches(num_blocks=num_blocks,
+                                                                      model_config=model_config,
+                                                                      cache_config=cache_config,
+                                                                      world_size=1,
+                                                                      device='cpu')
+    cache_engine._cache_block_copy_device = cache_engine.full_gpu_cache.device
+    cache_engine._cache_block_copy_impl = DefaultCacheBlockCopyImpl(
+        packed_caches=[cache_engine.full_gpu_cache],
+        num_logical_blocks=num_blocks,
+        pages_per_block=2,
+        blocks_per_chunk=num_blocks,
+    )
+    return cache_engine, caches
+
+
+class _RecordingCacheBlockCopy:
+
+    def __init__(self):
+        self.calls = []
+
+    def forward(self, src_block_offsets, dst_block_offsets):
+        self.calls.append((src_block_offsets.clone(), dst_block_offsets.clone()))
+
+
+def _make_copy_plan(src_block_offsets, dst_block_offsets):
+    return torch.tensor((src_block_offsets, dst_block_offsets), dtype=torch.long)
+
+
+def test_default_cache_block_copy_chunks_and_reuses_workspaces():
+    packed_cache = torch.full((2, 3, 12, 8), 99, dtype=torch.uint8)
+    copy_impl = DefaultCacheBlockCopyImpl(packed_caches=[packed_cache],
+                                          num_logical_blocks=6,
+                                          pages_per_block=2,
+                                          blocks_per_chunk=2)
+    logical_cache = packed_cache.unflatten(-2, (6, 2))
+    src_blocks = torch.tensor([0, 1, 0])
+    dst_blocks = torch.tensor([3, 4, 5])
+    for block_id in set(src_blocks.tolist()):
+        logical_cache.select(-3, block_id).fill_(block_id + 1)
+    expected = logical_cache.index_select(-3, src_blocks).clone()
+
+    copy_impl.forward(src_blocks, dst_blocks)
+
+    assert torch.equal(logical_cache.index_select(-3, dst_blocks), expected)
+    workspace_ptrs = tuple(workspace.data_ptr() for workspace in copy_impl._workspaces)
+    copy_impl.forward(src_blocks, dst_blocks)
+    assert tuple(workspace.data_ptr() for workspace in copy_impl._workspaces) == workspace_ptrs
+
+
+def test_default_cache_block_copy_builder_uses_total_byte_budget(monkeypatch):
+    packed_pools = [
+        torch.empty((2, 12, 8), dtype=torch.uint8),
+        torch.empty((2, 3, 12, 16), dtype=torch.uint8),
+    ]
+    bytes_per_block = sum(pool.numel() * pool.element_size() // 6 for pool in packed_pools)
+    monkeypatch.setattr(DefaultCacheBlockCopyBuilder, '_TARGET_WORKSPACE_BYTES', bytes_per_block * 2)
+
+    copy_impl = DefaultCacheBlockCopyBuilder.build(packed_caches=packed_pools,
+                                                   num_logical_blocks=6,
+                                                   pages_per_block=2)
+
+    assert copy_impl.blocks_per_chunk == 2
+    assert copy_impl._workspaces is None
+    copy_impl.forward(torch.tensor([0]), torch.tensor([1]))
+    assert sum(workspace.nbytes for workspace in copy_impl._workspaces) == bytes_per_block * 2
+
+
+def test_default_cache_block_copy_does_not_allocate_workspace_for_empty_plan():
+    packed_cache = torch.empty((2, 12, 8), dtype=torch.uint8)
+    copy_impl = DefaultCacheBlockCopyBuilder.build(packed_caches=[packed_cache],
+                                                   num_logical_blocks=6,
+                                                   pages_per_block=2)
+
+    copy_impl.forward(torch.empty(0, dtype=torch.long), torch.empty(0, dtype=torch.long))
+
+    assert copy_impl._workspaces is None
+
+
+def test_default_cache_block_copy_groups_kernel_pages_without_expanding_plan():
+    pages_per_block = 3
+    packed_cache = torch.full((2, 18, 10), 99, dtype=torch.uint8)
+    copy_impl = DefaultCacheBlockCopyImpl(packed_caches=[packed_cache],
+                                          num_logical_blocks=6,
+                                          pages_per_block=pages_per_block,
+                                          blocks_per_chunk=2)
+    src_blocks = torch.tensor([0, 2, 0])
+    dst_blocks = torch.tensor([3, 1, 4])
+    logical_cache = packed_cache.unflatten(-2, (6, pages_per_block))
+    for block_id in set(src_blocks.tolist()):
+        logical_cache.select(-3, block_id).fill_(block_id + 1)
+    expected = logical_cache.index_select(-3, src_blocks).clone()
+
+    copy_impl.forward(src_blocks, dst_blocks)
+
+    assert torch.equal(logical_cache.index_select(-3, dst_blocks), expected)
+
+
+@pytest.mark.parametrize(
+    ('quant_policy', 'cache_shapes', 'expected_num_cache_views'),
+    [
+        pytest.param(QuantPolicy.NONE, [], 2, id='standard'),
+        pytest.param(QuantPolicy.INT8, [], 4, id='quantized'),
+        pytest.param(QuantPolicy.NONE, [([3], torch.float32)], 3, id='custom'),
+    ],
+)
+def test_cache_engine_copy_logical_blocks_copies_complete_packed_blocks(quant_policy, cache_shapes,
+                                                                        expected_num_cache_views):
+    cache_engine, caches = _make_cache_engine(quant_policy=quant_policy, cache_shapes=cache_shapes)
+    packed_cache = cache_engine.full_gpu_cache
+    pages_per_block = 2
+    src_block_offsets = (0, 2, 0)
+    dst_block_offsets = (3, 1, 4)
+    assert len(caches) == expected_num_cache_views
+
+    for block_id in set(src_block_offsets):
+        page_start = block_id * pages_per_block
+        for page_offset in range(pages_per_block):
+            packed_cache[:, page_start + page_offset].fill_(block_id * 20 + page_offset + 1)
+            for cache_id, cache in enumerate(caches):
+                cache[:, page_start + page_offset].fill_(cache_id * 20 + block_id * 2 + page_offset + 1)
+
+    packed_sources = [
+        packed_cache[:, src * pages_per_block:(src + 1) * pages_per_block].clone()
+        for src in src_block_offsets
+    ]
+    copy_plan = _make_copy_plan(src_block_offsets, dst_block_offsets)
+    cache_engine.copy_logical_blocks(copy_plan)
+
+    for pair_idx, dst in enumerate(dst_block_offsets):
+        dst_start = dst * pages_per_block
+        dst_end = (dst + 1) * pages_per_block
+        assert torch.equal(packed_cache[:, dst_start:dst_end], packed_sources[pair_idx])
+
+
+def test_cache_engine_copy_logical_blocks_dispatches_one_batched_plan():
+    cache_engine, _ = _make_cache_engine(num_blocks=6)
+    copy_impl = _RecordingCacheBlockCopy()
+    cache_engine._cache_block_copy_impl = copy_impl
+    copy_plan = _make_copy_plan((0, 2, 0), (3, 1, 4))
+
+    cache_engine.copy_logical_blocks(copy_plan)
+
+    assert len(copy_impl.calls) == 1
+    assert torch.equal(copy_impl.calls[0][0], copy_plan[0])
+    assert torch.equal(copy_impl.calls[0][1], copy_plan[1])
+
+
+def test_cache_engine_copy_logical_blocks_copies_heterogeneous_raw_pools():
+    cache_engine, _ = _make_cache_engine(num_blocks=6)
+    physical_pages = 2 * cache_engine.num_gpu_blocks
+    packed_pools = [
+        torch.full((2, physical_pages, 8), 99, dtype=torch.uint8),
+        torch.full((2, 3, physical_pages, 16), 99, dtype=torch.uint8),
+    ]
+    cache_engine.full_gpu_cache = packed_pools
+    cache_engine._cache_block_copy_device = packed_pools[0].device
+    cache_engine._cache_block_copy_impl = DefaultCacheBlockCopyImpl(packed_caches=packed_pools,
+                                                                     num_logical_blocks=6,
+                                                                     pages_per_block=2,
+                                                                     blocks_per_chunk=6)
+    src_block_offsets = (0, 2, 0)
+    dst_block_offsets = (3, 1, 4)
+    src_pages = torch.tensor([0, 1, 4, 5, 0, 1])
+    dst_pages = torch.tensor([6, 7, 2, 3, 8, 9])
+    for pool_id, packed_pool in enumerate(packed_pools):
+        for page_id in set(src_pages.tolist()):
+            packed_pool.select(-2, page_id).fill_(pool_id * 40 + page_id + 1)
+    expected_sources = [packed_pool.index_select(-2, src_pages).clone() for packed_pool in packed_pools]
+
+    copy_plan = _make_copy_plan(src_block_offsets, dst_block_offsets)
+    cache_engine.copy_logical_blocks(copy_plan)
+
+    for packed_pool, expected_source in zip(packed_pools, expected_sources):
+        assert torch.equal(packed_pool.index_select(-2, dst_pages), expected_source)
+
+
+@pytest.mark.parametrize(
+    ('copy_plan', 'error_type', 'error'),
+    [
+        pytest.param([[0], [2]], TypeError, 'torch.Tensor', id='not-a-tensor'),
+        pytest.param(torch.tensor([0, 2]), ValueError, r'\[2, num_pairs\]', id='wrong-shape'),
+        pytest.param(torch.tensor([[0.0], [2.0]]), TypeError, 'torch.long', id='wrong-dtype'),
+        pytest.param(torch.empty((2, 1), dtype=torch.long, device='meta'),
+                     ValueError,
+                     'packed cache device',
+                     id='wrong-device'),
+    ],
+)
+def test_cache_engine_copy_logical_blocks_rejects_invalid_device_plan(copy_plan, error_type, error):
+    cache_engine, _ = _make_cache_engine()
+    with pytest.raises(error_type, match=error):
+        cache_engine.copy_logical_blocks(copy_plan)

--- a/tests/pytorch/engine/test_cache_block_copy.py
+++ b/tests/pytorch/engine/test_cache_block_copy.py
@@ -3,7 +3,6 @@ import pytest
 import torch
 
 import lmdeploy.pytorch.engine.cache_engine as cache_engine_module
-from lmdeploy.messages import QuantPolicy
 from lmdeploy.pytorch.backends.base import OpType
 from lmdeploy.pytorch.backends.default.cache_block_copy import (
     DefaultCacheBlockCopyBuilder,
@@ -94,23 +93,19 @@ def test_cache_engine_build_cache_block_copy_skips_disabled(monkeypatch, enable_
     assert cache_engine._cache_block_copy_impl is None
 
 
-def _make_cache_engine(quant_policy: QuantPolicy = QuantPolicy.NONE,
-                       cache_shapes: list[tuple[list[int], torch.dtype]] | None = None,
-                       num_blocks: int = 5):
+def _make_cache_engine(num_blocks: int = 5):
     cache_config = CacheConfig(max_batches=1,
                                block_size=4,
                                kernel_block_size=2,
                                num_cpu_blocks=0,
-                               num_gpu_blocks=num_blocks,
-                               quant_policy=quant_policy)
+                               num_gpu_blocks=num_blocks)
     model_config = ModelConfig(hidden_size=16,
                                num_layers=2,
                                num_attention_heads=2,
                                num_key_value_heads=1,
                                bos_token_id=1,
                                eos_token_id=[2],
-                               head_dim=8,
-                               cache_shapes=cache_shapes or [])
+                               head_dim=8)
     cache_engine = object.__new__(CacheEngine)
     cache_engine.cache_config = cache_config
     cache_engine.model_config = model_config
@@ -142,13 +137,14 @@ def _make_copy_plan(src_block_offsets, dst_block_offsets):
     return torch.tensor((src_block_offsets, dst_block_offsets), dtype=torch.long)
 
 
-def test_default_cache_block_copy_chunks_and_reuses_workspaces():
-    packed_cache = torch.full((2, 3, 12, 8), 99, dtype=torch.uint8)
+@pytest.mark.parametrize(('shape', 'pages_per_block'), [((2, 3, 12, 8), 2), ((2, 18, 10), 3)])
+def test_default_cache_block_copy_chunks_pages_and_reuses_workspaces(shape, pages_per_block):
+    packed_cache = torch.full(shape, 99, dtype=torch.uint8)
     copy_impl = DefaultCacheBlockCopyImpl(packed_caches=[packed_cache],
                                           num_logical_blocks=6,
-                                          pages_per_block=2,
+                                          pages_per_block=pages_per_block,
                                           blocks_per_chunk=2)
-    logical_cache = packed_cache.unflatten(-2, (6, 2))
+    logical_cache = packed_cache.unflatten(-2, (6, pages_per_block))
     src_blocks = torch.tensor([0, 1, 0])
     dst_blocks = torch.tensor([3, 4, 5])
     for block_id in set(src_blocks.tolist()):
@@ -181,71 +177,30 @@ def test_default_cache_block_copy_builder_uses_total_byte_budget(monkeypatch):
     assert sum(workspace.nbytes for workspace in copy_impl._workspaces) == bytes_per_block * 2
 
 
-def test_default_cache_block_copy_does_not_allocate_workspace_for_empty_plan():
-    packed_cache = torch.empty((2, 12, 8), dtype=torch.uint8)
-    copy_impl = DefaultCacheBlockCopyBuilder.build(packed_caches=[packed_cache],
-                                                   num_logical_blocks=6,
-                                                   pages_per_block=2)
-
-    copy_impl.forward(torch.empty(0, dtype=torch.long), torch.empty(0, dtype=torch.long))
-
-    assert copy_impl._workspaces is None
-
-
-def test_default_cache_block_copy_groups_kernel_pages_without_expanding_plan():
-    pages_per_block = 3
-    packed_cache = torch.full((2, 18, 10), 99, dtype=torch.uint8)
-    copy_impl = DefaultCacheBlockCopyImpl(packed_caches=[packed_cache],
-                                          num_logical_blocks=6,
-                                          pages_per_block=pages_per_block,
-                                          blocks_per_chunk=2)
-    src_blocks = torch.tensor([0, 2, 0])
-    dst_blocks = torch.tensor([3, 1, 4])
-    logical_cache = packed_cache.unflatten(-2, (6, pages_per_block))
-    for block_id in set(src_blocks.tolist()):
-        logical_cache.select(-3, block_id).fill_(block_id + 1)
-    expected = logical_cache.index_select(-3, src_blocks).clone()
-
-    copy_impl.forward(src_blocks, dst_blocks)
-
-    assert torch.equal(logical_cache.index_select(-3, dst_blocks), expected)
-
-
-@pytest.mark.parametrize(
-    ('quant_policy', 'cache_shapes', 'expected_num_cache_views'),
-    [
-        pytest.param(QuantPolicy.NONE, [], 2, id='standard'),
-        pytest.param(QuantPolicy.INT8, [], 4, id='quantized'),
-        pytest.param(QuantPolicy.NONE, [([3], torch.float32)], 3, id='custom'),
-    ],
-)
-def test_cache_engine_copy_logical_blocks_copies_complete_packed_blocks(quant_policy, cache_shapes,
-                                                                        expected_num_cache_views):
-    cache_engine, caches = _make_cache_engine(quant_policy=quant_policy, cache_shapes=cache_shapes)
-    packed_cache = cache_engine.full_gpu_cache
+def test_cache_engine_copy_logical_blocks_copies_allocated_cache_views():
+    cache_engine, caches = _make_cache_engine()
     pages_per_block = 2
     src_block_offsets = (0, 2, 0)
     dst_block_offsets = (3, 1, 4)
-    assert len(caches) == expected_num_cache_views
 
-    for block_id in set(src_block_offsets):
-        page_start = block_id * pages_per_block
-        for page_offset in range(pages_per_block):
-            packed_cache[:, page_start + page_offset].fill_(block_id * 20 + page_offset + 1)
-            for cache_id, cache in enumerate(caches):
+    for cache_id, cache in enumerate(caches):
+        for block_id in set(src_block_offsets):
+            page_start = block_id * pages_per_block
+            for page_offset in range(pages_per_block):
                 cache[:, page_start + page_offset].fill_(cache_id * 20 + block_id * 2 + page_offset + 1)
 
-    packed_sources = [
-        packed_cache[:, src * pages_per_block:(src + 1) * pages_per_block].clone()
-        for src in src_block_offsets
+    expected_sources = [
+        [cache[:, src * pages_per_block:(src + 1) * pages_per_block].clone()
+         for src in src_block_offsets] for cache in caches
     ]
     copy_plan = _make_copy_plan(src_block_offsets, dst_block_offsets)
     cache_engine.copy_logical_blocks(copy_plan)
 
-    for pair_idx, dst in enumerate(dst_block_offsets):
-        dst_start = dst * pages_per_block
-        dst_end = (dst + 1) * pages_per_block
-        assert torch.equal(packed_cache[:, dst_start:dst_end], packed_sources[pair_idx])
+    for cache, cache_sources in zip(caches, expected_sources):
+        for pair_idx, dst in enumerate(dst_block_offsets):
+            dst_start = dst * pages_per_block
+            dst_end = (dst + 1) * pages_per_block
+            assert torch.equal(cache[:, dst_start:dst_end], cache_sources[pair_idx])
 
 
 def test_cache_engine_copy_logical_blocks_dispatches_one_batched_plan():

--- a/tests/pytorch/engine/test_cache_engine.py
+++ b/tests/pytorch/engine/test_cache_engine.py
@@ -2,7 +2,6 @@
 import asyncio
 from types import SimpleNamespace
 
-import numpy as np
 import pytest
 import torch
 
@@ -265,7 +264,7 @@ def test_state_cache_engine_copy_caches_copies_all_state_views():
     conv_state[1].fill_(3.0)
     recurrent_state[1].fill_(5.0)
 
-    cache_engine.copy_caches(1, 2)
+    cache_engine.copy_caches((1, ), (2, ))
 
     assert torch.equal(conv_state[2], conv_state[1])
     assert torch.equal(recurrent_state[2], recurrent_state[1])
@@ -288,66 +287,39 @@ def test_state_cache_engine_copy_caches_supports_batched_indices():
     assert torch.equal(recurrent_state[3], recurrent_state[1])
 
 
-def test_state_cache_engine_copy_caches_accepts_host_integer_scalars():
-    cache_engine = _make_state_cache_engine()
-    conv_state, recurrent_state = cache_engine.state_caches
-
-    conv_state[1].fill_(7.0)
-    recurrent_state[1].fill_(9.0)
-
-    cache_engine.copy_caches(np.int64(1), np.int64(2))
-
-    assert torch.equal(conv_state[2], conv_state[1])
-    assert torch.equal(recurrent_state[2], recurrent_state[1])
-
-
 def test_state_cache_engine_copy_caches_coalesces_contiguous_ranges():
-    ranges = list(StateCacheEngine._copy_ranges([4, 1, 5, 0, 6, 9], [20, 11, 21, 10, 22, 30]))
+    ranges = list(StateCacheEngine._copy_ranges((4, 1, 5, 0, 6, 9), (20, 11, 21, 10, 22, 30)))
 
     assert ranges == [(0, 10, 2), (4, 20, 3), (9, 30, 1)]
-    assert list(StateCacheEngine._copy_ranges([], [])) == []
+    assert list(StateCacheEngine._copy_ranges((), ())) == []
 
 
 def test_state_cache_engine_copy_caches_rejects_mismatched_indices():
     cache_engine = _make_state_cache_engine()
 
     with pytest.raises(ValueError, match='same number of elements'):
-        cache_engine.copy_caches([0, 1], [2])
-
-
-def test_state_cache_engine_copy_caches_rejects_tensor_indices():
-    cache_engine = _make_state_cache_engine()
-
-    with pytest.raises(TypeError, match='host integers'):
-        cache_engine.copy_caches(torch.tensor([0, 1]), torch.tensor([2, 3]))
-
-
-def test_state_cache_engine_copy_caches_rejects_tensor_sequence_items():
-    cache_engine = _make_state_cache_engine()
-
-    with pytest.raises(TypeError, match='host integers'):
-        cache_engine.copy_caches([torch.tensor(0)], [2])
+        cache_engine.copy_caches((0, 1), (2, ))
 
 
 def test_state_cache_engine_copy_caches_rejects_out_of_range_indices():
     cache_engine = _make_state_cache_engine()
 
     with pytest.raises(ValueError, match='out of range'):
-        cache_engine.copy_caches([-1], [2])
+        cache_engine.copy_caches((-1, ), (2, ))
 
     with pytest.raises(ValueError, match='out of range'):
-        cache_engine.copy_caches([0], [4])
+        cache_engine.copy_caches((0, ), (4, ))
 
 
 def test_state_cache_engine_copy_caches_rejects_overlapping_indices():
     cache_engine = _make_state_cache_engine()
 
     with pytest.raises(ValueError, match='must not overlap'):
-        cache_engine.copy_caches([0, 1], [1, 2])
+        cache_engine.copy_caches((0, 1), (1, 2))
 
 
 def test_state_cache_engine_copy_caches_rejects_duplicate_destinations():
     cache_engine = _make_state_cache_engine()
 
     with pytest.raises(ValueError, match='duplicate'):
-        cache_engine.copy_caches([0, 1], [2, 2])
+        cache_engine.copy_caches((0, 1), (2, 2))

--- a/tests/pytorch/engine/test_cache_inputs.py
+++ b/tests/pytorch/engine/test_cache_inputs.py
@@ -1,0 +1,59 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+import torch
+
+from lmdeploy.pytorch.engine.cache_inputs import CacheCheckpointInputs
+
+
+def test_cache_checkpoint_inputs_to_device_moves_only_kv_plans():
+    kv_restore_plan = torch.tensor([[1, 2], [3, 4]])
+    kv_save_plan = torch.tensor([[5], [6]])
+    state_restore_plan = ((7, 8), (9, 10))
+    state_save_plan = ((11, ), (12, ))
+    cache_inputs = CacheCheckpointInputs(
+        kv_restore_plan=kv_restore_plan,
+        kv_save_plan=kv_save_plan,
+        state_restore_plan=state_restore_plan,
+        state_save_plan=state_save_plan,
+    )
+
+    device_inputs = cache_inputs.to_device('meta', non_blocking=True)
+
+    assert device_inputs is not cache_inputs
+    assert device_inputs.kv_restore_plan.device.type == 'meta'
+    assert device_inputs.kv_save_plan.device.type == 'meta'
+    assert device_inputs.state_restore_plan is state_restore_plan
+    assert device_inputs.state_save_plan is state_save_plan
+
+
+def test_cache_checkpoint_inputs_record_stream_records_only_kv_plans():
+    recorded = []
+
+    class _CudaTensor(torch.Tensor):
+
+        @staticmethod
+        def __new__(cls):
+            return torch.Tensor._make_subclass(cls, torch.empty(1), False)
+
+        @property
+        def is_cuda(self):
+            return True
+
+        def record_stream(self, stream):
+            recorded.append((id(self), stream))
+
+    stream = object()
+    restore_plan = _CudaTensor()
+    save_plan = _CudaTensor()
+    cache_inputs = CacheCheckpointInputs(
+        kv_restore_plan=restore_plan,
+        kv_save_plan=save_plan,
+        state_restore_plan=((1, ), (2, )),
+        state_save_plan=((3, ), (4, )),
+    )
+
+    cache_inputs.record_stream(stream)
+
+    assert recorded == [
+        (id(restore_plan), stream),
+        (id(save_plan), stream),
+    ]

--- a/tests/pytorch/engine/test_inputs_maker.py
+++ b/tests/pytorch/engine/test_inputs_maker.py
@@ -3,17 +3,20 @@ import asyncio
 from dataclasses import dataclass
 from types import SimpleNamespace
 
+import numpy as np
 import pytest
+import torch
 
 import lmdeploy.pytorch.engine.inputs_maker as inputs_maker_module
 from lmdeploy.pytorch.disagg.config import EngineRole
+from lmdeploy.pytorch.engine.cache_inputs import CacheCheckpointInputs
 from lmdeploy.pytorch.engine.engine_loop import EngineLoop, RunableEventAsync
 from lmdeploy.pytorch.engine.inputs_maker import (
     InputsMakerAsync,
     InputsMakerConfig,
     LongContextChunker,
-    _compact_state_prefix_cache_restore_offsets,
-    _compact_state_prefix_cache_save_offsets,
+    _make_state_prefix_cache_restore_plan,
+    _make_state_prefix_cache_save_plan,
 )
 from lmdeploy.pytorch.messages import MessageStatus, StateCheckpointRestore
 
@@ -62,6 +65,50 @@ class _DummySeq:
 def _state_seq(logical_state: int, restore_state: int = -1):
     return SimpleNamespace(logical_state=logical_state,
                            prefix_cache=SimpleNamespace(restore=StateCheckpointRestore(slot=restore_state)))
+
+
+class _CopyPlanScheduler:
+
+    def __init__(self, mapping=None):
+        self.mapping = mapping
+        self.calls = []
+
+    def resolve_gpu_block_offsets(self, logical_block_ids):
+        logical_block_ids = np.asarray(logical_block_ids)
+        self.calls.append(logical_block_ids.copy())
+        if self.mapping is None:
+            return logical_block_ids.copy()
+        return np.asarray([self.mapping[int(block_id)] for block_id in logical_block_ids])
+
+
+def _copy_plan_maker(scheduler):
+    maker = object.__new__(InputsMakerAsync)
+    maker.scheduler = scheduler
+    return maker
+
+
+def test_make_kv_prefix_cache_copy_plan_resolves_paging_ids_and_preserves_pairs():
+    scheduler = _CopyPlanScheduler({10: 4, 20: 1, 21: 3, 11: 0, 22: 5})
+    maker = _copy_plan_maker(scheduler)
+
+    copy_plan = maker._make_kv_prefix_cache_copy_plan([(10, 20), (10, 21), (11, 22)])
+
+    assert torch.equal(copy_plan, torch.tensor([[4, 4, 0], [1, 3, 5]]))
+    assert np.array_equal(scheduler.calls[0], np.array([10, 20, 10, 21, 11, 22]))
+
+
+@pytest.mark.parametrize(
+    ('logical_pairs', 'error'),
+    [
+        pytest.param([(0, 2), (1, 2)], 'destinations must be unique', id='duplicate-dst'),
+        pytest.param([(0, 1), (1, 2)], 'must not overlap', id='overlap'),
+    ],
+)
+def test_make_kv_prefix_cache_copy_plan_rejects_invalid_relationships(logical_pairs, error):
+    maker = _copy_plan_maker(_CopyPlanScheduler())
+
+    with pytest.raises(ValueError, match=error):
+        maker._make_kv_prefix_cache_copy_plan(logical_pairs)
 
 
 class _FakeScheduler:
@@ -172,8 +219,9 @@ def test_engine_loop_keeps_state_save_pinned_until_output_boundary():
     loop.inputs_maker = _InputsMaker(state_checkpoints)
     loop.executor = _Executor(state_checkpoints)
     loop._sleep_requested = False
-    model_inputs = SimpleNamespace(state_prefix_cache_save_offsets=[1])
-    forward_inputs = dict(inputs=model_inputs, delta=None)
+    model_inputs = SimpleNamespace()
+    cache_inputs = CacheCheckpointInputs(state_save_plan=((0, ), (1, )))
+    forward_inputs = dict(inputs=model_inputs, delta=None, cache_inputs=cache_inputs)
 
     forward_inputs, next_running = asyncio.run(loop._main_loop_get_outputs([object()], forward_inputs))
 
@@ -228,8 +276,9 @@ def test_engine_loop_skips_prefetch_when_sleep_requested_but_unpins_state_save()
     loop.inputs_maker = _InputsMaker()
     loop.executor = _Executor()
     loop._sleep_requested = True
-    model_inputs = SimpleNamespace(state_prefix_cache_save_offsets=[1])
-    forward_inputs = dict(inputs=model_inputs, delta=None)
+    model_inputs = SimpleNamespace()
+    cache_inputs = CacheCheckpointInputs(state_save_plan=((0, ), (1, )))
+    forward_inputs = dict(inputs=model_inputs, delta=None, cache_inputs=cache_inputs)
 
     forward_inputs, next_running = asyncio.run(loop._main_loop_get_outputs([object()], forward_inputs))
 
@@ -295,7 +344,7 @@ def test_engine_loop_reset_runtime_state_delegates_to_inputs_maker():
 
 def _make_policy_maker(long_seq, decode_seq=None):
     maker = InputsMakerAsync.__new__(InputsMakerAsync)
-    maker.config = SimpleNamespace(role=EngineRole.Decode)
+    maker.config = SimpleNamespace(role=EngineRole.Decode, is_ssm=False)
     maker.spec_decoding = False
     maker.scheduler = _FakeScheduler([])
     maker.engine_strategy = _FakeEngineStrategy()
@@ -437,8 +486,9 @@ def test_single_forward_multimodal_long_context_stays_normal_prefill_for_spec_de
                                    is_first_chunk=False,
                                    is_last_chunk=False,
                                    is_chunk_multimodal=False)
+    cache_inputs = CacheCheckpointInputs(state_save_plan=((1, ), (2, )))
     maker = InputsMakerAsync.__new__(InputsMakerAsync)
-    maker.config = SimpleNamespace(role=EngineRole.Decode)
+    maker.config = SimpleNamespace(role=EngineRole.Decode, is_ssm=False)
     maker.spec_decoding = True
     maker.scheduler = _FakeScheduler([seq])
     maker.engine_strategy = _FakeEngineStrategy()
@@ -449,11 +499,13 @@ def test_single_forward_multimodal_long_context_stays_normal_prefill_for_spec_de
     maker.to_evict_seqs = []
     maker._decode_count = 0
     maker.create_model_inputs = lambda seqs, is_prefill: model_inputs
+    maker._prepare_prefill_cache_inputs = lambda seqs, save_steps=None: cache_inputs
     maker.create_model_inputs_delta_valid_only = lambda: (None, [], [])
 
     forward_inputs = maker._make_forward_inputs(prefill=True)
 
     assert forward_inputs['inputs'] is model_inputs
+    assert forward_inputs['cache_inputs'] is cache_inputs
     assert not model_inputs.is_chunk
     assert not model_inputs.is_first_chunk
     assert not model_inputs.is_last_chunk
@@ -474,7 +526,7 @@ def test_spec_decoding_text_turn_ignores_previous_multimodal_chunk_limit():
                                    is_last_chunk=False,
                                    is_chunk_multimodal=False)
     maker = InputsMakerAsync.__new__(InputsMakerAsync)
-    maker.config = SimpleNamespace(role=EngineRole.Decode)
+    maker.config = SimpleNamespace(role=EngineRole.Decode, is_ssm=False)
     maker.spec_decoding = True
     maker.scheduler = _FakeScheduler([seq])
     maker.engine_strategy = _FakeEngineStrategy()
@@ -506,8 +558,9 @@ def test_prefix_resumed_long_context_suffix_starts_new_chunk_chain():
                                    is_first_chunk=False,
                                    is_last_chunk=False,
                                    is_chunk_multimodal=False)
+    cache_inputs = CacheCheckpointInputs(state_save_plan=((1, ), (2, )))
     maker = InputsMakerAsync.__new__(InputsMakerAsync)
-    maker.config = SimpleNamespace(role=EngineRole.Decode)
+    maker.config = SimpleNamespace(role=EngineRole.Decode, is_ssm=False)
     maker.spec_decoding = False
     maker.scheduler = _FakeScheduler([seq])
     maker.engine_strategy = _FakeEngineStrategy()
@@ -525,15 +578,24 @@ def test_prefix_resumed_long_context_suffix_starts_new_chunk_chain():
         captured['multimodals'] = multimodals
         return model_inputs
 
+    def _prepare_prefill_cache_inputs(seqs, save_steps=None):
+        captured['cache_seqs'] = seqs
+        captured['save_steps'] = save_steps
+        return cache_inputs
+
     maker.create_model_inputs_long_context = _create_model_inputs_long_context
+    maker._prepare_prefill_cache_inputs = _prepare_prefill_cache_inputs
 
     forward_inputs = maker._make_forward_inputs(prefill=True)
 
     assert forward_inputs['inputs'] is model_inputs
+    assert forward_inputs['cache_inputs'] is cache_inputs
     assert captured == {
         'seq': seq,
         'chunk_size': 512,
         'multimodals': None,
+        'cache_seqs': [seq],
+        'save_steps': (1536, ),
     }
     assert model_inputs.is_first_chunk
     assert not model_inputs.is_last_chunk
@@ -555,7 +617,7 @@ def test_long_context_final_chunk_preserves_multimodal_flag_for_spec_decoding():
                                    is_last_chunk=False,
                                    is_chunk_multimodal=False)
     maker = InputsMakerAsync.__new__(InputsMakerAsync)
-    maker.config = SimpleNamespace(role=EngineRole.Decode)
+    maker.config = SimpleNamespace(role=EngineRole.Decode, is_ssm=False)
     maker.spec_decoding = True
     maker.scheduler = _FakeScheduler([])
     maker.engine_strategy = _FakeEngineStrategy()
@@ -586,9 +648,11 @@ def test_long_context_chunk_defers_to_decode_after_chunk_forward():
     long_seq = _DummySeq(history_ids=0, token_ids=1024, all_multimodals={}, input_multimodals={})
     decode_seq = _DummySeq(history_ids=0, token_ids=1, all_multimodals={}, input_multimodals={})
     delta = SimpleNamespace(is_decoding=True)
+    cache_inputs = CacheCheckpointInputs(state_save_plan=((1, ), (2, )))
     maker = _make_policy_maker(long_seq, decode_seq)
     maker._last_forward_kind = 'long_context_chunk'
     maker.create_model_inputs_delta = lambda: (delta, [decode_seq], [])
+    maker._make_decode_cache_inputs = lambda running, delta: cache_inputs
     maker.create_model_inputs_long_context = lambda *args, **kwargs: (_ for _ in ()).throw(
         AssertionError('long chunk should wait behind decode'))
 
@@ -596,6 +660,7 @@ def test_long_context_chunk_defers_to_decode_after_chunk_forward():
 
     assert forward_inputs['inputs'] is None
     assert forward_inputs['delta'] is delta
+    assert forward_inputs['cache_inputs'] is cache_inputs
     assert maker.to_evict_seqs == []
 
 
@@ -983,7 +1048,7 @@ def test_waiting_long_context_first_chunk_gets_round_robin_turn_after_short_pref
             return True
 
     maker = InputsMakerAsync.__new__(InputsMakerAsync)
-    maker.config = SimpleNamespace(role=EngineRole.Decode)
+    maker.config = SimpleNamespace(role=EngineRole.Decode, is_ssm=False)
     maker.spec_decoding = False
     maker.scheduler = _RoundRobinScheduler()
     maker.engine_strategy = _FakeEngineStrategy()
@@ -1045,7 +1110,7 @@ def test_waiting_long_context_admission_failure_falls_back_to_short_prefill():
             return True
 
     maker = InputsMakerAsync.__new__(InputsMakerAsync)
-    maker.config = SimpleNamespace(role=EngineRole.Decode)
+    maker.config = SimpleNamespace(role=EngineRole.Decode, is_ssm=False)
     maker.spec_decoding = False
     maker.scheduler = _WaitingLongFailScheduler()
     maker.engine_strategy = _FakeEngineStrategy()
@@ -1135,22 +1200,138 @@ def test_do_prefill_default_forces_pending_last_chunk_prefill():
     assert maker.do_prefill_default()
 
 
-def test_state_prefix_cache_restore_offsets_are_compact():
+def test_state_prefix_cache_restore_plan_is_compact():
     messages = [_state_seq(4, 11), _state_seq(5, -1), _state_seq(6, 13)]
 
-    src_offsets, dst_offsets = _compact_state_prefix_cache_restore_offsets(messages)
+    plan = _make_state_prefix_cache_restore_plan(messages)
 
-    assert src_offsets == (11, 13)
-    assert dst_offsets == (4, 6)
+    assert plan == ((11, 13), (4, 6))
+    assert _make_state_prefix_cache_restore_plan([_state_seq(4)]) is None
 
 
-def test_state_prefix_cache_save_offsets_are_compact():
+def test_state_prefix_cache_save_plan_is_compact():
     messages = [_state_seq(4), _state_seq(5), _state_seq(6)]
 
-    src_offsets, dst_offsets = _compact_state_prefix_cache_save_offsets(messages, [-1, 21, 22])
+    plan = _make_state_prefix_cache_save_plan(messages, [-1, 21, 22])
 
-    assert src_offsets == (5, 6)
-    assert dst_offsets == (21, 22)
+    assert plan == ((5, 6), (21, 22))
+    assert _make_state_prefix_cache_save_plan(messages, [-1, -1, -1]) is None
+
+
+def test_prepare_prefill_cache_inputs_groups_state_restore_and_save_plans():
+    messages = [_state_seq(4, 11), _state_seq(5)]
+    events = []
+
+    class _StateCheckpoints:
+
+        def pin_restores(self, seqs):
+            events.append('pin_restores')
+            for seq in seqs:
+                if seq.prefix_cache.restore.is_selected:
+                    seq.prefix_cache.restore.pinned = True
+
+        def reserve_save(self, seq, step=None):
+            assert step is None
+            return {4: 21, 5: -1}[seq.logical_state]
+
+    maker = InputsMakerAsync.__new__(InputsMakerAsync)
+    maker.config = SimpleNamespace(is_ssm=True)
+    maker.cache_config = SimpleNamespace(enable_prefix_caching=True)
+    maker.scheduler = SimpleNamespace(block_trie=SimpleNamespace(state_checkpoints=_StateCheckpoints()))
+
+    cache_inputs = maker._prepare_prefill_cache_inputs(messages)
+
+    assert events == ['pin_restores']
+    assert cache_inputs.state_restore_plan == ((11, ), (4, ))
+    assert cache_inputs.state_save_plan == ((4, ), (21, ))
+
+
+def test_prepare_prefill_cache_inputs_uses_explicit_chunk_end_step():
+    seq = _state_seq(4, 11)
+    seq.num_history_ids = 128
+    reserve_steps = []
+
+    class _StateCheckpoints:
+
+        def pin_restores(self, seqs):
+            for seq in seqs:
+                seq.prefix_cache.restore.pinned = True
+
+        def reserve_save(self, seq, step=None):
+            reserve_steps.append(step)
+            return 21
+
+    maker = InputsMakerAsync.__new__(InputsMakerAsync)
+    maker.config = SimpleNamespace(is_ssm=True)
+    maker.cache_config = SimpleNamespace(enable_prefix_caching=True)
+    maker.scheduler = SimpleNamespace(block_trie=SimpleNamespace(state_checkpoints=_StateCheckpoints()))
+
+    cache_inputs = maker._prepare_prefill_cache_inputs([seq], save_steps=(160, ))
+
+    assert reserve_steps == [160]
+    assert cache_inputs.state_restore_plan == ((11, ), (4, ))
+    assert cache_inputs.state_save_plan == ((4, ), (21, ))
+
+
+def test_prepare_prefill_cache_inputs_rejects_mismatched_save_steps():
+    maker = InputsMakerAsync.__new__(InputsMakerAsync)
+    maker.config = SimpleNamespace(is_ssm=True)
+    maker.cache_config = SimpleNamespace(enable_prefix_caching=True)
+
+    with pytest.raises(ValueError, match='one entry per prefill sequence'):
+        maker._prepare_prefill_cache_inputs([_state_seq(4)], save_steps=())
+
+
+def test_make_decode_cache_inputs_compacts_valid_state_saves():
+    valid_seqs = [_state_seq(4), _state_seq(5)]
+
+    class _StateCheckpoints:
+
+        def reserve_decode_save(self, seq, interval):
+            assert interval == 16
+            return {4: 31, 5: -1}[seq.logical_state]
+
+    maker = InputsMakerAsync.__new__(InputsMakerAsync)
+    maker.config = SimpleNamespace(is_ssm=True)
+    maker.cache_config = SimpleNamespace(enable_prefix_caching=True,
+                                         prefix_cache_decode_state_interval=16)
+    maker.scheduler = SimpleNamespace(block_trie=SimpleNamespace(state_checkpoints=_StateCheckpoints()))
+    maker.spec_decoding = False
+    delta = SimpleNamespace(max_q_seqlen=1)
+
+    cache_inputs = maker._make_decode_cache_inputs(valid_seqs, delta)
+
+    assert cache_inputs.state_restore_plan is None
+    assert cache_inputs.state_save_plan == ((4, ), (31, ))
+
+
+@pytest.mark.parametrize(
+    ('is_ssm', 'enabled', 'interval', 'spec_decoding', 'max_q_seqlen'),
+    [
+        (False, True, 16, False, 1),
+        (True, False, 16, False, 1),
+        (True, True, 0, False, 1),
+        (True, True, 16, True, 1),
+        (True, True, 16, False, 2),
+    ],
+)
+def test_make_decode_cache_inputs_respects_feature_gates(is_ssm, enabled, interval, spec_decoding,
+                                                         max_q_seqlen):
+
+    class _StateCheckpoints:
+
+        def reserve_decode_save(self, seq, interval):
+            raise AssertionError('disabled decode checkpoint path must not reserve state')
+
+    maker = InputsMakerAsync.__new__(InputsMakerAsync)
+    maker.config = SimpleNamespace(is_ssm=is_ssm)
+    maker.cache_config = SimpleNamespace(enable_prefix_caching=enabled,
+                                         prefix_cache_decode_state_interval=interval)
+    maker.scheduler = SimpleNamespace(block_trie=SimpleNamespace(state_checkpoints=_StateCheckpoints()))
+    maker.spec_decoding = spec_decoding
+    delta = SimpleNamespace(max_q_seqlen=max_q_seqlen)
+
+    assert maker._make_decode_cache_inputs([_state_seq(4)], delta) is None
 
 
 @pytest.mark.parametrize('max_q_seqlen', [1, 4])  # standard decode, then spec/MTP

--- a/tests/pytorch/engine/test_inputs_maker.py
+++ b/tests/pytorch/engine/test_inputs_maker.py
@@ -18,7 +18,7 @@ from lmdeploy.pytorch.engine.inputs_maker import (
     _make_state_prefix_cache_restore_plan,
     _make_state_prefix_cache_save_plan,
 )
-from lmdeploy.pytorch.messages import MessageStatus, StateCheckpointRestore
+from lmdeploy.pytorch.messages import MessageStatus, StateCheckpointRestore, StateCheckpointSaveReservation
 
 
 @dataclass
@@ -63,8 +63,14 @@ class _DummySeq:
 
 
 def _state_seq(logical_state: int, restore_state: int = -1):
+    restore = StateCheckpointRestore()
+    if restore_state >= 0:
+        checkpoint = SimpleNamespace(step=0, frozen_block_id=-1)
+        restore.select(restore_state, SimpleNamespace(state_checkpoint=checkpoint))
     return SimpleNamespace(logical_state=logical_state,
-                           prefix_cache=SimpleNamespace(restore=StateCheckpointRestore(slot=restore_state)))
+                           logical_blocks=np.empty((0, ), dtype=np.int64),
+                           prefix_cache=SimpleNamespace(restore=restore,
+                                                        pending_save=StateCheckpointSaveReservation()))
 
 
 class _CopyPlanScheduler:
@@ -1232,7 +1238,12 @@ def test_prepare_prefill_cache_inputs_groups_state_restore_and_save_plans():
 
         def reserve_save(self, seq, step=None):
             assert step is None
-            return {4: 21, 5: -1}[seq.logical_state]
+            state_idx = {4: 21, 5: -1}[seq.logical_state]
+            if state_idx >= 0:
+                checkpoint = SimpleNamespace(step=0, frozen_block_id=-1)
+                node = SimpleNamespace(state_checkpoint=checkpoint)
+                seq.prefix_cache.pending_save.reserve(state_idx, 0, node, False)
+            return state_idx
 
     maker = InputsMakerAsync.__new__(InputsMakerAsync)
     maker.config = SimpleNamespace(is_ssm=True)
@@ -1259,6 +1270,9 @@ def test_prepare_prefill_cache_inputs_uses_explicit_chunk_end_step():
 
         def reserve_save(self, seq, step=None):
             reserve_steps.append(step)
+            checkpoint = SimpleNamespace(step=step, frozen_block_id=-1)
+            node = SimpleNamespace(state_checkpoint=checkpoint)
+            seq.prefix_cache.pending_save.reserve(21, step, node, False)
             return 21
 
     maker = InputsMakerAsync.__new__(InputsMakerAsync)
@@ -1273,13 +1287,51 @@ def test_prepare_prefill_cache_inputs_uses_explicit_chunk_end_step():
     assert cache_inputs.state_save_plan == ((4, ), (21, ))
 
 
+def test_prepare_prefill_cache_inputs_groups_partial_kv_restore_and_save_plans():
+    messages = [_state_seq(4, 11), _state_seq(5, 12)]
+    for msg, dst_block in zip(messages, (20, 21)):
+        checkpoint = SimpleNamespace(step=17, frozen_block_id=70)
+        msg.prefix_cache.restore.node = SimpleNamespace(state_checkpoint=checkpoint)
+        msg.logical_blocks = np.array([10, dst_block], dtype=np.int64)
+
+    class _StateCheckpoints:
+
+        def pin_restores(self, seqs):
+            for seq in seqs:
+                seq.prefix_cache.restore.pinned = True
+
+        def reserve_save(self, seq, step=None):
+            state_idx = {4: 21, 5: 22}[seq.logical_state]
+            frozen_block = {4: 80, 5: 81}[seq.logical_state]
+            checkpoint = SimpleNamespace(step=17, frozen_block_id=frozen_block)
+            node = SimpleNamespace(state_checkpoint=checkpoint)
+            seq.prefix_cache.pending_save.reserve(state_idx, 17, node, False)
+            return state_idx
+
+    scheduler = _CopyPlanScheduler()
+    scheduler.block_trie = SimpleNamespace(state_checkpoints=_StateCheckpoints())
+    maker = InputsMakerAsync.__new__(InputsMakerAsync)
+    maker.config = SimpleNamespace(is_ssm=True)
+    maker.cache_config = SimpleNamespace(enable_prefix_caching=True, block_size=16)
+    maker.scheduler = scheduler
+
+    cache_inputs = maker._prepare_prefill_cache_inputs(messages)
+
+    assert torch.equal(cache_inputs.kv_restore_plan, torch.tensor([[70, 70], [20, 21]]))
+    assert torch.equal(cache_inputs.kv_save_plan, torch.tensor([[20, 21], [80, 81]]))
+    assert cache_inputs.state_restore_plan == ((11, 12), (4, 5))
+    assert cache_inputs.state_save_plan == ((4, 5), (21, 22))
+    assert np.array_equal(scheduler.calls[0], np.array([70, 20, 70, 21]))
+    assert np.array_equal(scheduler.calls[1], np.array([20, 80, 21, 81]))
+
+
 def test_prepare_prefill_cache_inputs_rejects_mismatched_save_steps():
     maker = InputsMakerAsync.__new__(InputsMakerAsync)
     maker.config = SimpleNamespace(is_ssm=True)
     maker.cache_config = SimpleNamespace(enable_prefix_caching=True)
 
     with pytest.raises(ValueError, match='one entry per prefill sequence'):
-        maker._prepare_prefill_cache_inputs([_state_seq(4)], save_steps=())
+        maker._prepare_prefill_cache_inputs([_state_seq(4, 11)], save_steps=())
 
 
 def test_make_decode_cache_inputs_compacts_valid_state_saves():

--- a/tests/pytorch/engine/test_model_agent.py
+++ b/tests/pytorch/engine/test_model_agent.py
@@ -186,6 +186,149 @@ def test_spec_agent_reset_runtime_state_discards_chunk_carry():
     assert agent._prev_chunk_last == {}
 
 
+@pytest.mark.parametrize(
+    ('is_dummy', 'expected_events'),
+    [
+        pytest.param(False, [
+            'build_context',
+            'kv_restore',
+            'state_restore',
+            'update_model_metas',
+            'prepare_inputs',
+            'model_forward',
+            'kv_save',
+            'state_save',
+        ], id='real-forward'),
+        pytest.param(True, [
+            'build_context',
+            'update_model_metas',
+            'prepare_inputs',
+            'model_forward',
+        ], id='dummy-forward'),
+    ],
+)
+def test_model_forward_orders_kv_and_state_checkpoint_copies(monkeypatch, is_dummy, expected_events):
+    from lmdeploy.pytorch.engine.cache_inputs import CacheCheckpointInputs
+    from lmdeploy.pytorch.engine.model_agent import agent as agent_module
+
+    events = []
+    copy_calls = []
+    restore_plan = torch.tensor([[1], [2]])
+    save_plan = torch.tensor([[3], [4]])
+
+    class _ContextManager:
+
+        def build_context(self, **kwargs):
+            events.append('build_context')
+            return SimpleNamespace(q_seqlens=torch.tensor([1]),
+                                   position_ids=torch.tensor([0]),
+                                   is_model_meta_updated=False)
+
+        def context(self, context):
+            return nullcontext()
+
+    class _Model:
+        ctx_mgr = _ContextManager()
+
+        def update_model_metas(self, **kwargs):
+            events.append('update_model_metas')
+            return []
+
+        def prepare_inputs_for_generation(self, **kwargs):
+            events.append('prepare_inputs')
+            return {}
+
+        def __call__(self, **kwargs):
+            events.append('model_forward')
+            return {'hidden_states': torch.tensor([0])}
+
+    class _CacheEngine:
+        model_config = object()
+        cache_config = SimpleNamespace(quant_policy=0)
+        gpu_cache = object()
+        block_caches = {}
+
+        def copy_logical_blocks(self, plan):
+            copy_calls.append(('kv', plan))
+            events.append('kv_restore' if plan is restore_plan else 'kv_save')
+
+    class _StateCacheEngine:
+        state_caches = object()
+        named_state_caches = {}
+
+        def copy_caches(self, src, dst):
+            copy_calls.append(('state', src, dst))
+            events.append('state_restore' if src == (5, ) else 'state_save')
+
+    inputs = SimpleNamespace(
+        is_dummy=is_dummy,
+        state_offsets=None,
+        seq_length=torch.tensor([1]),
+    )
+    cache_inputs = CacheCheckpointInputs(
+        kv_restore_plan=restore_plan,
+        kv_save_plan=save_plan,
+        state_restore_plan=((5, ), (6, )),
+        state_save_plan=((7, ), (8, )),
+    )
+
+    monkeypatch.setattr(agent_module, 'step_ctx_manager', lambda ctx_mgr: nullcontext())
+    monkeypatch.setattr(agent_module.torch.cuda, 'stream', lambda stream: nullcontext())
+
+    agent_module.model_forward(_Model(),
+                               inputs,
+                               _CacheEngine(),
+                               _StateCacheEngine(),
+                               stream=object(),
+                               cache_inputs=cache_inputs)
+
+    assert events == expected_events
+    if is_dummy:
+        assert copy_calls == []
+    else:
+        assert copy_calls[0][0] == 'kv'
+        assert copy_calls[0][1] is restore_plan
+        assert copy_calls[1] == ('state', (5, ), (6, ))
+        assert copy_calls[2][0] == 'kv'
+        assert copy_calls[2][1] is save_plan
+        assert copy_calls[3] == ('state', (7, ), (8, ))
+
+
+def test_inputs_preprocess_transfers_cache_inputs_and_keeps_host_ref(monkeypatch, event_loop):
+    from lmdeploy.pytorch.engine.model_agent import agent as agent_module
+
+    calls = []
+    device_cache_inputs = object()
+
+    class _HostCacheInputs:
+
+        def to_device(self, device, non_blocking=False):
+            calls.append((device, non_blocking))
+            return device_cache_inputs
+
+    class _Event:
+
+        def record(self):
+            calls.append('record')
+
+    model_agent = _make_agent_with_queues()
+    model_agent.out_stream = object()
+    host_cache_inputs = _HostCacheInputs()
+    monkeypatch.setattr(agent_module.torch.cuda, 'stream', lambda stream: nullcontext())
+    monkeypatch.setattr(agent_module.torch.cuda, 'Event', _Event)
+
+    task = event_loop.create_task(model_agent._async_loop_inputs_preprocess())
+    model_agent._pre_in_que.put_nowait({'cache_inputs': host_cache_inputs})
+    forward_inputs = event_loop.run_until_complete(asyncio.wait_for(model_agent._in_que.get(), timeout=1))
+    task.cancel()
+    event_loop.run_until_complete(asyncio.gather(task, return_exceptions=True))
+
+    transfer = forward_inputs.pop(agent_module._H2D_TRANSFER_KEY)
+    assert calls == [('cuda', True), 'record']
+    assert forward_inputs['cache_inputs'] is device_cache_inputs
+    assert transfer.refs['cache_inputs'] is host_cache_inputs
+
+
 def test_record_forward_input_stream_uses_payload_protocol():
     from lmdeploy.pytorch.engine.model_agent.agent import _record_forward_input_stream
 
@@ -217,6 +360,7 @@ def test_record_forward_input_stream_uses_payload_protocol():
         'inputs': payload,
         'delta': tensor,
         'unowned_container': {'tensor': nested_tensor},
+        'cache_inputs': torch.empty(1),
     }
 
     _record_forward_input_stream(forward_inputs, stream)
@@ -356,6 +500,36 @@ def test_record_forward_input_stream_defers_origin_stream_reuse():
     forward_stream.synchronize()
     h2d_stream.synchronize()
     assert torch.all(observed == 7)
+
+
+def test_async_model_forward_preserves_cache_inputs_through_forward_impl():
+    from lmdeploy.pytorch.engine.cache_inputs import CacheCheckpointInputs
+    from lmdeploy.pytorch.engine.model_agent.agent import BaseModelAgent
+
+    model_inputs = SimpleNamespace()
+    cache_inputs = CacheCheckpointInputs(kv_restore_plan=torch.tensor([[1], [2]]))
+    hidden_states = torch.ones(1, 1, 2)
+    seen = []
+
+    class _SpecAgent:
+
+        def update_main_model_outputs(self, output, inputs):
+            assert inputs is model_inputs
+            return output['hidden_states'], output
+
+    agent = BaseModelAgent.__new__(BaseModelAgent)
+    agent.memdecode_agent = None
+    agent.spec_agent = _SpecAgent()
+    agent._forward_impl = lambda inputs, cache_inputs=None: (
+        seen.append((inputs, cache_inputs)) or {
+            'hidden_states': hidden_states
+        })
+    agent.get_logits = lambda hidden: hidden
+
+    output = asyncio.run(agent._async_model_forward(model_inputs, return_logits=True, cache_inputs=cache_inputs))
+
+    assert seen == [(model_inputs, cache_inputs)]
+    assert output['logits'] is hidden_states
 
 
 class TestDrainQueues:
@@ -945,7 +1119,8 @@ class TestMemDecodeModelAgentLifecycle:
                 indices = seq_length.cumsum(0) - 1
                 return hidden_states[indices]
 
-        async def _base_forward(forward_inputs):
+        async def _base_forward(forward_inputs, cache_inputs=None):
+            assert cache_inputs is None
             calls.append(('base_forward', forward_inputs))
             return {'hidden_states': base_hidden.clone(), 'seq_length': forward_inputs.seq_length}
 
@@ -1012,7 +1187,8 @@ class TestMemDecodeModelAgentLifecycle:
         def _cache_swapping(cache_engine, swap_in_map=None, swap_out_map=None):
             calls.append((cache_engine, swap_in_map, swap_out_map))
 
-        async def _async_model_forward(_inputs, return_logits):
+        async def _async_model_forward(_inputs, return_logits, cache_inputs=None):
+            assert cache_inputs is None
             raise _StopAfterSwap
 
         monkeypatch.setattr(agent_module, 'get_dist_manager', lambda: _DistManager())

--- a/tests/pytorch/kernel/test_copy_packed_cache.py
+++ b/tests/pytorch/kernel/test_copy_packed_cache.py
@@ -1,0 +1,129 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+
+import pytest
+import torch
+
+pytest.importorskip('triton')
+
+from lmdeploy.pytorch.backends.base import OpType
+from lmdeploy.pytorch.backends.cuda.op_backend import CudaOpsBackend
+from lmdeploy.pytorch.config import CacheConfig
+from lmdeploy.pytorch.engine.cache_engine import CacheEngine
+from lmdeploy.pytorch.engine.cache_inputs import CacheCheckpointInputs
+
+if torch.cuda.is_available():
+    from lmdeploy.pytorch.backends.cuda.cache_block_copy import CudaCacheBlockCopyImpl
+    from lmdeploy.pytorch.kernels.cuda.copy_packed_cache import copy_packed_cache
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason='requires CUDA backend import')
+def test_cuda_backend_registers_cache_block_copy_builder():
+    from lmdeploy.pytorch.backends.cuda.cache_block_copy import CudaCacheBlockCopyBuilder
+
+    assert CudaOpsBackend.get_layer_impl_builder(OpType.CacheBlockCopy) is CudaCacheBlockCopyBuilder
+
+
+def _logical_view(packed_cache: torch.Tensor, pages_per_block: int):
+    num_logical_blocks = packed_cache.size(-2) // pages_per_block
+    return packed_cache.unflatten(-2, (num_logical_blocks, pages_per_block))
+
+
+def _seed_logical_blocks(packed_cache: torch.Tensor, block_offsets: tuple[int, ...], pages_per_block: int,
+                         value_offset: int = 0):
+    for block_offset in set(block_offsets):
+        for page_offset in range(pages_per_block):
+            page_id = block_offset * pages_per_block + page_offset
+            packed_cache.select(-2, page_id).fill_(value_offset + block_offset * 20 + page_offset + 1)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason='requires CUDA')
+@pytest.mark.parametrize(('shape', 'pages_per_block'), [((3, 12, 1280), 2), ((2, 3, 18, 8448), 3)])
+def test_copy_packed_cache_copies_logical_blocks(shape, pages_per_block):
+    src_blocks_tuple = (0, 2, 0)
+    dst_blocks_tuple = (3, 1, 4)
+    stream = torch.cuda.Stream()
+    with torch.cuda.stream(stream):
+        packed_cache = torch.full(shape, 99, dtype=torch.uint8, device='cuda')
+        src_blocks = torch.tensor(src_blocks_tuple, dtype=torch.long, device='cuda')
+        dst_blocks = torch.tensor(dst_blocks_tuple, dtype=torch.long, device='cuda')
+        _seed_logical_blocks(packed_cache, src_blocks_tuple, pages_per_block)
+        logical_cache = _logical_view(packed_cache, pages_per_block)
+        expected = logical_cache.index_select(-3, src_blocks).clone()
+        expected_sources = expected.clone()
+        untouched = logical_cache.select(-3, 5).clone()
+
+        copy_packed_cache(packed_cache, src_blocks, dst_blocks, pages_per_block)
+
+    stream.synchronize()
+    assert torch.equal(logical_cache.index_select(-3, dst_blocks), expected)
+    assert torch.equal(logical_cache.index_select(-3, src_blocks), expected_sources)
+    assert torch.equal(logical_cache.select(-3, 5), untouched)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason='requires CUDA')
+def test_cuda_cache_block_copy_uses_one_device_plan_for_multiple_pools():
+    device = torch.device('cuda')
+    pages_per_block = 2
+    packed_pools = [
+        torch.full((3, 12, 1280), 99, dtype=torch.uint8, device=device),
+        torch.full((2, 12, 8448), 99, dtype=torch.uint8, device=device),
+    ]
+    copy_impl = CudaCacheBlockCopyImpl(pages_per_block=pages_per_block,
+                                       packed_caches=packed_pools)
+    src_blocks_tuple = (0, 2, 0)
+    dst_blocks_tuple = (3, 1, 4)
+    src_blocks = torch.tensor(src_blocks_tuple, device=device)
+    dst_blocks = torch.tensor(dst_blocks_tuple, device=device)
+    stream = torch.cuda.Stream()
+    with torch.cuda.stream(stream):
+        expected = []
+        for pool_id, packed_cache in enumerate(packed_pools):
+            _seed_logical_blocks(packed_cache, src_blocks_tuple, pages_per_block, value_offset=pool_id * 100)
+            logical_cache = _logical_view(packed_cache, pages_per_block)
+            expected.append(logical_cache.index_select(-3, src_blocks).clone())
+
+        copy_impl.forward(src_blocks, dst_blocks)
+
+    stream.synchronize()
+    for packed_cache, expected_blocks in zip(packed_pools, expected):
+        logical_cache = _logical_view(packed_cache, pages_per_block)
+        assert torch.equal(logical_cache.index_select(-3, dst_blocks), expected_blocks)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason='requires CUDA')
+def test_cache_engine_dispatches_cache_checkpoint_device_plan():
+    device = torch.device('cuda')
+    pages_per_block = 2
+    packed_cache = torch.zeros((2, 12, 256), dtype=torch.uint8, device=device)
+    _seed_logical_blocks(packed_cache, (0, 2), pages_per_block)
+    cache_engine = object.__new__(CacheEngine)
+    cache_engine.cache_config = CacheConfig(max_batches=3,
+                                            block_size=4,
+                                            kernel_block_size=2,
+                                            num_cpu_blocks=0,
+                                            num_gpu_blocks=6,
+                                            enable_prefix_caching=True,
+                                            states_shapes=[((1, ), torch.float32)])
+    cache_engine.full_gpu_cache = packed_cache
+    cache_engine._cache_block_copy_device = packed_cache.device
+    cache_engine._cache_block_copy_impl = CudaCacheBlockCopyImpl(pages_per_block=pages_per_block,
+                                                                 packed_caches=[packed_cache])
+    host_plan = torch.tensor(((0, 2, 0), (3, 1, 4)), dtype=torch.long).pin_memory()
+    host_cache_inputs = CacheCheckpointInputs(kv_restore_plan=host_plan)
+    h2d_stream = torch.cuda.Stream()
+    forward_stream = torch.cuda.Stream()
+    h2d_event = torch.cuda.Event()
+    logical_cache = _logical_view(packed_cache, pages_per_block)
+    torch.cuda.current_stream().synchronize()
+
+    with torch.cuda.stream(h2d_stream):
+        device_cache_inputs = host_cache_inputs.to_device(device, non_blocking=True)
+        h2d_event.record()
+    forward_stream.wait_event(h2d_event)
+    with torch.cuda.stream(forward_stream):
+        copy_plan = device_cache_inputs.kv_restore_plan
+        expected = logical_cache.index_select(-3, copy_plan[0]).clone()
+        cache_engine.copy_logical_blocks(copy_plan)
+
+    forward_stream.synchronize()
+    assert torch.equal(logical_cache.index_select(-3, copy_plan[1]), expected)

--- a/tests/pytorch/paging/test_block_manager.py
+++ b/tests/pytorch/paging/test_block_manager.py
@@ -1,4 +1,5 @@
 # yapf: disable
+import numpy as np
 import pytest
 import torch
 
@@ -142,6 +143,33 @@ class TestDefaultBlockManager:
         token_ids = torch.zeros((num_gpu_blocks * block_size + 1, ), dtype=torch.int64)
         msg = sess.add_sequence(token_ids)
         assert not block_mgr.can_allocate(msg)
+
+    def test_resolve_gpu_block_offsets(self, block_mgr):
+        allocator = block_mgr.allocator
+        logical_ids = allocator.allocate(3, 'gpu')
+        expected = allocator.get_physical_blocks(logical_ids)
+
+        block_offsets = block_mgr.resolve_gpu_block_offsets(logical_ids[[0, 2, 0]])
+
+        assert np.array_equal(block_offsets, expected[[0, 2, 0]])
+
+    @pytest.mark.parametrize(
+        ('logical_ids', 'error'),
+        [
+            pytest.param(np.array([-1]), 'out-of-range', id='negative'),
+            pytest.param(np.array([8]), 'out-of-range', id='too-large'),
+            pytest.param(np.array([0]), 'unallocated', id='unallocated'),
+        ],
+    )
+    def test_resolve_gpu_block_offsets_rejects_invalid_logical_ids(self, block_mgr, logical_ids, error):
+        with pytest.raises(ValueError, match=error):
+            block_mgr.resolve_gpu_block_offsets(logical_ids)
+
+    def test_resolve_gpu_block_offsets_rejects_cpu_resident_blocks(self, block_mgr):
+        logical_ids = block_mgr.allocator.allocate(1, 'cpu')
+
+        with pytest.raises(ValueError, match='not GPU-resident'):
+            block_mgr.resolve_gpu_block_offsets(logical_ids)
 
     def test_num_required_blocks(self, scheduler, block_mgr):
         from lmdeploy.pytorch.messages import InputEmbeddings

--- a/tests/pytorch/paging/test_block_trie/test_checkpoint.py
+++ b/tests/pytorch/paging/test_block_trie/test_checkpoint.py
@@ -488,16 +488,22 @@ class TestStateCheckpointMatching(BlockTrieTestMixin):
         assert node.state_checkpoint.published
         assert ssm_scheduler.state_manager.get_num_free_checkpoint() == free_states
 
-    def test_match_ssm_releases_detached_stale_checkpoint_candidate(self, ssm_scheduler):
+    def test_match_ssm_releases_detached_partial_checkpoint(self, ssm_scheduler, monkeypatch):
         block_size = ssm_scheduler.seq_meta.block_size
-        token_ids = [1] * block_size + [2] * block_size
-        _, node, _ = self._add_published_ssm_checkpoint(ssm_scheduler, token_ids)
+        token_ids = [1] * block_size + [2] * block_size + [3]
+        _, node, state_idx = self._add_published_ssm_checkpoint(ssm_scheduler, token_ids)
         block_trie = ssm_scheduler.block_trie
         key = block_trie._checkpoint_index.make_node_key(node)
         free_states = ssm_scheduler.state_manager.get_num_free_checkpoint()
+        logs = []
+
+        def capture_log(message, *args):
+            logs.append(message % args)
+
+        monkeypatch.setattr('lmdeploy.pytorch.paging.block_trie.trie.logger.debug', capture_log)
 
         node.detach_leaf()
-        seq = ssm_scheduler.add_session(100).add_sequence(token_ids + [3])
+        seq = ssm_scheduler.add_session(100).add_sequence(token_ids + [4])
         block_trie.match(seq)
 
         assert len(seq.logical_blocks) == 0
@@ -506,6 +512,9 @@ class TestStateCheckpointMatching(BlockTrieTestMixin):
         assert node.adapter_name not in block_trie._checkpoint_index._steps_by_adapter
         assert node.state_checkpoint is None
         assert ssm_scheduler.state_manager.get_num_free_checkpoint() == free_states + 1
+        rejection = next(message for message in logs
+                         if message.startswith('Reject SSM prefix-cache checkpoint candidate'))
+        assert f'step={len(token_ids)} state_idx={state_idx}' in rejection
 
     def test_match_ssm_keeps_pinned_stale_checkpoint_candidate(self, ssm_scheduler):
         block_size = ssm_scheduler.seq_meta.block_size

--- a/tests/pytorch/paging/test_block_trie/test_checkpoint.py
+++ b/tests/pytorch/paging/test_block_trie/test_checkpoint.py
@@ -2,8 +2,26 @@ import numpy as np
 import pytest
 
 from lmdeploy.pytorch.messages import SamplingParam
+from lmdeploy.pytorch.paging.block_trie.checkpoint import (
+    checkpoint_anchor_step,
+    checkpoint_tail_start,
+)
 
 from ._utils import BlockTrieTestMixin
+
+
+@pytest.mark.parametrize(('step', 'anchor_step', 'tail_start'), [
+    (1, 0, 0),
+    (15, 0, 0),
+    (16, 16, 0),
+    (17, 16, 16),
+    (32, 32, 16),
+])
+def test_checkpoint_step_geometry(step, anchor_step, tail_start):
+    block_size = 16
+
+    assert checkpoint_anchor_step(step, block_size) == anchor_step
+    assert checkpoint_tail_start(step, block_size) == tail_start
 
 
 class TestStateCheckpointMatching(BlockTrieTestMixin):

--- a/tests/pytorch/paging/test_block_trie/test_checkpoint.py
+++ b/tests/pytorch/paging/test_block_trie/test_checkpoint.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 
 from lmdeploy.pytorch.messages import SamplingParam
 
@@ -6,6 +7,180 @@ from ._utils import BlockTrieTestMixin
 
 
 class TestStateCheckpointMatching(BlockTrieTestMixin):
+
+    @pytest.mark.parametrize(('num_full_blocks', 'remainder'), [(0, 1), (1, 1), (1, -1)])
+    def test_match_ssm_partial_checkpoint_uses_private_destination(self, ssm_scheduler, num_full_blocks,
+                                                                   remainder):
+        block_mgr = ssm_scheduler.block_manager
+        block_trie = ssm_scheduler.block_trie
+        block_size = ssm_scheduler.seq_meta.block_size
+        if remainder < 0:
+            remainder = block_size - 1
+        step = num_full_blocks * block_size + remainder
+        token_ids = np.arange(step, dtype=np.int64).tolist()
+
+        producer = ssm_scheduler.add_session(0).add_sequence(token_ids)
+        block_mgr.allocate(producer)
+        block_trie.allocate(producer)
+        state_idx = block_trie.state_checkpoints.reserve_save(producer)
+        node = producer.prefix_cache.pending_save.node
+        frozen_block = node.state_checkpoint.frozen_block_id
+        assert block_trie.state_checkpoints.publish_save(producer)
+
+        matched = ssm_scheduler.add_session(1).add_sequence(token_ids + [999])
+        block_trie.match(matched)
+
+        assert matched.num_history_ids == step
+        assert matched.prefix_cache.restore.slot == state_idx
+        assert matched.prefix_cache.restore.node is node
+        assert len(matched.logical_blocks) == num_full_blocks
+        assert matched.prefix_cache.recompute_overlap.fresh_block_range == range(num_full_blocks,
+                                                                                 num_full_blocks + 1)
+
+        block_mgr.allocate(matched)
+        private_block = matched.logical_blocks[num_full_blocks]
+        assert private_block != frozen_block
+        block_trie.allocate(matched)
+
+        assert matched.logical_blocks[num_full_blocks] == private_block
+        assert matched.prefix_cache.trie_cursor is node
+
+    def test_match_ssm_partial_checkpoint_verifies_full_prefix_and_tail(self, ssm_scheduler):
+        block_mgr = ssm_scheduler.block_manager
+        block_trie = ssm_scheduler.block_trie
+        block_size = ssm_scheduler.seq_meta.block_size
+        token_ids = [1] * block_size + [2, 3, 4]
+
+        producer = ssm_scheduler.add_session(0).add_sequence(token_ids)
+        block_mgr.allocate(producer)
+        block_trie.allocate(producer)
+        state_idx = block_trie.state_checkpoints.reserve_save(producer)
+        node = producer.prefix_cache.pending_save.node
+        assert block_trie.state_checkpoints.publish_save(producer)
+
+        full_prefix_mismatch = ssm_scheduler.add_session(1).add_sequence([9] * block_size + [2, 3, 4, 5])
+        block_trie.match(full_prefix_mismatch)
+        tail_mismatch = ssm_scheduler.add_session(2).add_sequence([1] * block_size + [2, 3, 8, 5])
+        block_trie.match(tail_mismatch)
+
+        assert full_prefix_mismatch.num_history_ids == 0
+        assert not full_prefix_mismatch.prefix_cache.restore.is_selected
+        assert tail_mismatch.num_history_ids == 0
+        assert not tail_mismatch.prefix_cache.restore.is_selected
+        assert node.state_checkpoint.slot == state_idx
+        assert node.state_checkpoint.published
+
+    def test_match_ssm_partial_checkpoint_does_not_skip_requested_routed_experts(self, ssm_scheduler):
+        block_mgr = ssm_scheduler.block_manager
+        block_trie = ssm_scheduler.block_trie
+        block_size = ssm_scheduler.seq_meta.block_size
+        token_ids = [1] * block_size + [2]
+
+        producer = ssm_scheduler.add_session(0).add_sequence(token_ids)
+        block_mgr.allocate(producer)
+        block_trie.allocate(producer)
+        assert block_trie.state_checkpoints.reserve_save(producer) >= 0
+        assert block_trie.state_checkpoints.publish_save(producer)
+
+        sampling_param = SamplingParam(return_routed_experts=True)
+        matched = ssm_scheduler.add_session(1).add_sequence(token_ids + [3], sampling_param=sampling_param)
+        block_trie.match(matched)
+
+        assert matched.num_history_ids == 0
+        assert not matched.prefix_cache.restore.is_selected
+
+    def test_match_ssm_partial_checkpoint_verifies_multimodal_boundary_and_content(self, ssm_scheduler):
+        block_mgr = ssm_scheduler.block_manager
+        block_trie = ssm_scheduler.block_trie
+        block_size = ssm_scheduler.seq_meta.block_size
+        image_start = block_size
+        image_end = block_size + 4
+        token_ids = [1] * block_size + [99] * 4
+
+        producer = ssm_scheduler.add_session(0).add_sequence(
+            token_ids,
+            multimodals=self._image_multimodals(image_start, image_end, 1.0, content_hash='image-a'),
+        )
+        block_mgr.allocate(producer)
+        block_trie.allocate(producer)
+        state_idx = block_trie.state_checkpoints.reserve_save(producer)
+        assert state_idx >= 0
+        assert block_trie.state_checkpoints.publish_save(producer)
+        assert block_trie.state_checkpoints.reserve_save(producer, step=image_start + 2) == -1
+
+        matched = ssm_scheduler.add_session(1).add_sequence(
+            token_ids + [3],
+            multimodals=self._image_multimodals(image_start, image_end, 2.0, content_hash='image-a'),
+        )
+        block_trie.match(matched)
+        mismatched = ssm_scheduler.add_session(2).add_sequence(
+            token_ids + [3],
+            multimodals=self._image_multimodals(image_start, image_end, 1.0, content_hash='image-b'),
+        )
+        block_trie.match(mismatched)
+
+        assert matched.num_history_ids == image_end
+        assert matched.prefix_cache.restore.slot == state_idx
+        assert mismatched.num_history_ids == 0
+        assert not mismatched.prefix_cache.restore.is_selected
+
+    def test_match_ssm_partial_checkpoint_preserves_mtp_recompute_overlap(self, ssm_scheduler):
+        block_mgr = ssm_scheduler.block_manager
+        block_trie = ssm_scheduler.block_trie
+        block_size = ssm_scheduler.seq_meta.block_size
+        token_ids = [token for token in range(1, 5) for _ in range(block_size)] + [9]
+
+        producer = ssm_scheduler.add_session(0).add_sequence(token_ids)
+        block_mgr.allocate(producer)
+        block_trie.allocate(producer)
+        producer_blocks = producer.logical_blocks.get_real_blocks().copy()
+        step = block_size * 2 + 1
+        state_idx = block_trie.state_checkpoints.reserve_save(producer, step=step)
+        assert state_idx >= 0
+        assert block_trie.state_checkpoints.publish_save(producer)
+
+        matched = ssm_scheduler.add_session(1).add_sequence(token_ids)
+        matched.prefix_cache.recompute_overlap.recompute_blocks = 1
+        block_trie.match(matched)
+
+        assert matched.num_history_ids == step
+        assert matched.prefix_cache.restore.slot == state_idx
+        assert matched.prefix_cache.recompute_overlap.fresh_block_range == range(2, 4)
+
+        block_mgr.allocate(matched)
+        private_blocks = matched.logical_blocks.get_real_blocks()[2:4].copy()
+        block_trie.allocate(matched)
+
+        assert np.all(private_blocks != producer_blocks[2:4])
+        assert np.array_equal(matched.logical_blocks.get_real_blocks()[2:4], private_blocks)
+        assert matched.prefix_cache.trie_cursor.prefix_len == block_size * 4
+
+    def test_match_ssm_partial_checkpoint_keeps_cached_continuation_writable(self, ssm_scheduler):
+        block_mgr = ssm_scheduler.block_manager
+        block_trie = ssm_scheduler.block_trie
+        block_size = ssm_scheduler.seq_meta.block_size
+        token_ids = [token for token in range(1, 5) for _ in range(block_size)] + [9]
+
+        producer = ssm_scheduler.add_session(0).add_sequence(token_ids)
+        block_mgr.allocate(producer)
+        block_trie.allocate(producer)
+        producer_blocks = producer.logical_blocks.get_real_blocks().copy()
+        step = block_size * 2 + 1
+        assert block_trie.state_checkpoints.reserve_save(producer, step=step) >= 0
+        assert block_trie.state_checkpoints.publish_save(producer)
+
+        matched = ssm_scheduler.add_session(1).add_sequence(token_ids)
+        block_trie.match(matched)
+
+        assert matched.num_history_ids == step
+        assert matched.prefix_cache.recompute_overlap.fresh_block_range == range(2, 4)
+
+        block_mgr.allocate(matched)
+        private_blocks = matched.logical_blocks.get_real_blocks()[2:4].copy()
+        block_trie.allocate(matched)
+
+        assert np.all(private_blocks != producer_blocks[2:4])
+        assert np.array_equal(matched.logical_blocks.get_real_blocks()[2:4], private_blocks)
 
     def test_match_ssm_requires_published_state_checkpoint(self, ssm_scheduler):
         block_mgr = ssm_scheduler.block_manager
@@ -349,7 +524,7 @@ class TestStateCheckpointMatching(BlockTrieTestMixin):
         state_idx = block_trie.state_checkpoints._reserve_slot(node)
         assert state_idx >= 0
         assert not node.state_checkpoint.published
-        key = block_trie._checkpoint_index.make_node_key(node)
+        key = (node.adapter_name, node.prefix_len, node.block_hash)
         block_trie._checkpoint_index._buckets.setdefault(key, []).append(node)
         block_trie._checkpoint_index._steps_by_adapter.setdefault(node.adapter_name, set()).add(node.prefix_len)
         free_states = ssm_scheduler.state_manager.get_num_free_checkpoint()

--- a/tests/pytorch/paging/test_block_trie/test_checkpoint.py
+++ b/tests/pytorch/paging/test_block_trie/test_checkpoint.py
@@ -200,7 +200,7 @@ class TestStateCheckpointMatching(BlockTrieTestMixin):
         assert seq.num_history_ids == 0
         assert seq.prefix_cache.restore.slot == -1
 
-        state_idx = block_trie.state_checkpoints._reserve_slot(node)
+        state_idx = block_trie.state_checkpoints._reserve_checkpoint(node, node.prefix_len)
         block_trie.state_checkpoints._publish_checkpoint(node, producer)
 
         seq = sess.add_sequence(token_ids)
@@ -221,7 +221,7 @@ class TestStateCheckpointMatching(BlockTrieTestMixin):
         block_trie.allocate(seq)
         leaf = seq.prefix_cache.trie_cursor
         checkpoint_node = leaf.parent
-        state_idx = block_trie.state_checkpoints._reserve_slot(checkpoint_node)
+        state_idx = block_trie.state_checkpoints._reserve_checkpoint(checkpoint_node, checkpoint_node.prefix_len)
         block_trie.state_checkpoints._publish_checkpoint(checkpoint_node, seq)
 
         seq = sess.add_sequence(token_ids)
@@ -293,7 +293,7 @@ class TestStateCheckpointMatching(BlockTrieTestMixin):
         block_mgr.allocate(seq)
         block_trie.allocate(seq)
         node = seq.prefix_cache.trie_cursor
-        block_trie.state_checkpoints._reserve_slot(node)
+        block_trie.state_checkpoints._reserve_checkpoint(node, node.prefix_len)
         block_trie.state_checkpoints._publish_checkpoint(node, seq)
 
         miss_token_ids = token_ids.copy()
@@ -325,7 +325,7 @@ class TestStateCheckpointMatching(BlockTrieTestMixin):
         block_mgr.allocate(seq)
         block_trie.allocate(seq)
         node = seq.prefix_cache.trie_cursor
-        block_trie.state_checkpoints._reserve_slot(node)
+        block_trie.state_checkpoints._reserve_checkpoint(node, node.prefix_len)
         block_trie.state_checkpoints._publish_checkpoint(node, seq)
 
         miss_token_ids = [1] * block_size + [4] * block_size + [3]
@@ -521,7 +521,7 @@ class TestStateCheckpointMatching(BlockTrieTestMixin):
         block_mgr.allocate(seq)
         block_trie.allocate(seq)
         node = seq.prefix_cache.trie_cursor
-        state_idx = block_trie.state_checkpoints._reserve_slot(node)
+        state_idx = block_trie.state_checkpoints._reserve_checkpoint(node, node.prefix_len)
         assert state_idx >= 0
         assert not node.state_checkpoint.published
         key = (node.adapter_name, node.prefix_len, node.block_hash)

--- a/tests/pytorch/paging/test_block_trie/test_checkpoint_lifecycle.py
+++ b/tests/pytorch/paging/test_block_trie/test_checkpoint_lifecycle.py
@@ -139,7 +139,7 @@ class TestStateCheckpointLifecycle(BlockTrieTestMixin):
         block_mgr.allocate(seq)
         block_trie.allocate(seq)
         node = seq.prefix_cache.trie_cursor
-        block_trie.state_checkpoints._reserve_slot(node)
+        block_trie.state_checkpoints._reserve_checkpoint(node, node.prefix_len)
 
         block_trie.state_checkpoints._publish_checkpoint(node, seq)
         match_data = node.state_checkpoint.exact_match_data
@@ -161,7 +161,7 @@ class TestStateCheckpointLifecycle(BlockTrieTestMixin):
         block_mgr.allocate(seq)
         block_trie.allocate(seq)
         node = seq.prefix_cache.trie_cursor
-        block_trie.state_checkpoints._reserve_slot(node)
+        block_trie.state_checkpoints._reserve_checkpoint(node, node.prefix_len)
         block_trie.state_checkpoints._publish_checkpoint(node, seq)
         key = block_trie._checkpoint_index.make_node_key(node)
         block_trie._checkpoint_index._buckets[key].extend([node, node])
@@ -732,7 +732,7 @@ class TestStateCheckpointLifecycle(BlockTrieTestMixin):
         block_mgr.allocate(seq)
         block_trie.allocate(seq)
         node = seq.prefix_cache.trie_cursor
-        block_trie.state_checkpoints._reserve_slot(node)
+        block_trie.state_checkpoints._reserve_checkpoint(node, node.prefix_len)
         block_trie.state_checkpoints._publish_checkpoint(node, seq)
         assert node.state_checkpoint.exact_match_data is not None
         free_states = ssm_scheduler.state_manager.get_num_free_checkpoint()

--- a/tests/pytorch/paging/test_block_trie/test_checkpoint_lifecycle.py
+++ b/tests/pytorch/paging/test_block_trie/test_checkpoint_lifecycle.py
@@ -177,11 +177,12 @@ class TestStateCheckpointLifecycle(BlockTrieTestMixin):
         block_trie = ssm_scheduler.block_trie
         sess = ssm_scheduler.add_session(0)
         block_size = sess.seq_meta.block_size
-        token_ids = [1] * block_size * 2
+        token_ids = [1] * block_size * 2 + [2]
 
         seq = sess.add_sequence(token_ids)
         block_mgr.allocate(seq)
         block_trie.allocate(seq)
+        free_blocks = block_mgr.get_num_free_gpu_blocks()
         free_states = ssm_scheduler.state_manager.get_num_free_checkpoint()
         state_idx = block_trie.state_checkpoints.reserve_save(seq)
         node = seq.prefix_cache.trie_cursor
@@ -189,6 +190,8 @@ class TestStateCheckpointLifecycle(BlockTrieTestMixin):
         assert state_idx >= 0
         assert node.state_checkpoint.slot == state_idx
         assert not node.state_checkpoint.published
+        assert node.state_checkpoint.frozen_block_id >= 0
+        assert block_mgr.get_num_free_gpu_blocks() == free_blocks - 1
         assert ssm_scheduler.state_manager.get_num_free_checkpoint() == free_states - 1
 
         assert block_trie.state_checkpoints.discard_save(seq)
@@ -196,6 +199,7 @@ class TestStateCheckpointLifecycle(BlockTrieTestMixin):
         assert seq.prefix_cache.pending_save.step == 0
         assert seq.prefix_cache.pending_save.node is None
         assert node.state_checkpoint is None
+        assert block_mgr.get_num_free_gpu_blocks() == free_blocks
         assert ssm_scheduler.state_manager.get_num_free_checkpoint() == free_states
 
     def test_ssm_checkpoint_publish_allows_sequence_to_advance_past_save_step(self, ssm_scheduler):
@@ -283,7 +287,7 @@ class TestStateCheckpointLifecycle(BlockTrieTestMixin):
         free_states = ssm_scheduler.state_manager.get_num_free_checkpoint()
         state_idx = block_trie.state_checkpoints.reserve_save(seq)
         node = seq.prefix_cache.trie_cursor
-        key = block_trie._checkpoint_index.make_node_key(node)
+        key = (node.adapter_name, node.prefix_len, node.block_hash)
         checkpoint_lifecycle = block_trie.state_checkpoints
         add_to_index = checkpoint_lifecycle._index.add
 
@@ -458,7 +462,7 @@ class TestStateCheckpointLifecycle(BlockTrieTestMixin):
         assert seq.num_history_ids == checkpoint_step
         assert seq.prefix_cache.restore.slot == state_idx
 
-    def test_ssm_checkpoint_save_skips_partial_tail(self, ssm_scheduler):
+    def test_ssm_checkpoint_save_owns_and_releases_partial_tail(self, ssm_scheduler):
         block_mgr = ssm_scheduler.block_manager
         block_trie = ssm_scheduler.block_trie
         sess = ssm_scheduler.add_session(0)
@@ -468,9 +472,97 @@ class TestStateCheckpointLifecycle(BlockTrieTestMixin):
         seq = sess.add_sequence(token_ids)
         block_mgr.allocate(seq)
         block_trie.allocate(seq)
+        source_block = seq.logical_blocks[2]
+        free_blocks = block_mgr.get_num_free_gpu_blocks()
+        free_states = ssm_scheduler.state_manager.get_num_free_checkpoint()
 
-        assert block_trie.state_checkpoints.reserve_save(seq) == -1
+        state_idx = block_trie.state_checkpoints.reserve_save(seq)
+        node = seq.prefix_cache.pending_save.node
+
+        assert state_idx >= 0
+        checkpoint = node.state_checkpoint
+        assert checkpoint.step == block_size * 2 + 1
+        assert checkpoint.frozen_block_id >= 0
+        assert checkpoint.frozen_block_id != source_block
+        assert block_mgr.get_num_free_gpu_blocks() == free_blocks - 1
+        assert ssm_scheduler.state_manager.get_num_free_checkpoint() == free_states - 1
+
+        assert block_trie.state_checkpoints.publish_save(seq)
+        block_trie.state_checkpoints.release_checkpoint(node)
+
+        assert node.state_checkpoint is None
+        assert block_mgr.get_num_free_gpu_blocks() == free_blocks
+        assert ssm_scheduler.state_manager.get_num_free_checkpoint() == free_states
+
+    def test_ssm_checkpoint_partial_tail_allocation_failure_rolls_back_state(self, ssm_cache_config,
+                                                                             scheduler_config, seq_meta):
+        ssm_cache_config.num_gpu_blocks = 3
+        scheduler = Scheduler(scheduler_config=scheduler_config,
+                              cache_config=ssm_cache_config,
+                              seq_meta=seq_meta)
+        block_size = scheduler.seq_meta.block_size
+        seq = scheduler.add_session(0).add_sequence([1] * (block_size * 2 + 1))
+        scheduler.block_manager.allocate(seq)
+        scheduler.block_trie.allocate(seq)
+        node = seq.prefix_cache.trie_cursor
+        free_states = scheduler.state_manager.get_num_free_checkpoint()
+
+        assert scheduler.block_manager.get_num_free_gpu_blocks() == 0
+        assert scheduler.block_trie.state_checkpoints.reserve_save(seq) == -1
         assert seq.prefix_cache.pending_save.slot == -1
+        assert node.state_checkpoint is None
+        assert scheduler.state_manager.get_num_free_checkpoint() == free_states
+
+    def test_ssm_checkpoint_replaces_partial_variant_at_same_anchor(self, ssm_scheduler):
+        block_mgr = ssm_scheduler.block_manager
+        block_trie = ssm_scheduler.block_trie
+        block_size = ssm_scheduler.seq_meta.block_size
+        seq = ssm_scheduler.add_session(0).add_sequence([1] * (block_size * 2 + 5))
+        block_mgr.allocate(seq)
+        block_trie.allocate(seq)
+        first_step = block_size * 2 + 1
+        second_step = block_size * 2 + 3
+
+        first_state = block_trie.state_checkpoints.reserve_save(seq, step=first_step)
+        node = seq.prefix_cache.pending_save.node
+        assert block_trie.state_checkpoints.publish_save(seq)
+        first_key = block_trie._checkpoint_index.make_node_key(node)
+        frozen_block = node.state_checkpoint.frozen_block_id
+        free_blocks = block_mgr.get_num_free_gpu_blocks()
+
+        second_state = block_trie.state_checkpoints.reserve_save(seq, step=second_step)
+
+        assert second_state == first_state
+        assert first_key not in block_trie._checkpoint_index._buckets
+        assert node.state_checkpoint.step == second_step
+        assert node.state_checkpoint.frozen_block_id == frozen_block
+        assert not node.state_checkpoint.published
+        assert block_mgr.get_num_free_gpu_blocks() == free_blocks
+
+        assert block_trie.state_checkpoints.publish_save(seq)
+        second_key = block_trie._checkpoint_index.make_node_key(node)
+        assert second_key in block_trie._checkpoint_index._buckets
+
+    def test_kv_pressure_evicts_unpinned_frozen_tail(self, ssm_scheduler):
+        block_mgr = ssm_scheduler.block_manager
+        block_trie = ssm_scheduler.block_trie
+        seq = ssm_scheduler.add_session(0).add_sequence([1])
+        block_mgr.allocate(seq)
+        block_trie.allocate(seq)
+        assert block_trie.state_checkpoints.reserve_save(seq) >= 0
+        node = seq.prefix_cache.pending_save.node
+        assert node.parent is None
+        assert block_trie.state_checkpoints.publish_save(seq, pin_save=True)
+        free_blocks = block_mgr.get_num_free_gpu_blocks()
+
+        assert block_trie.evict(1) == 0
+        assert node.state_checkpoint is not None
+        assert block_mgr.get_num_free_gpu_blocks() == free_blocks
+
+        assert block_trie.state_checkpoints.unpin_save(seq)
+        assert block_trie.evict(1) == 1
+        assert node.state_checkpoint is None
+        assert block_mgr.get_num_free_gpu_blocks() == free_blocks + 1
 
     def test_ssm_checkpoint_save_skips_when_no_state_slot(self, ssm_cache_config, scheduler_config, seq_meta):
         cache_config = ssm_cache_config

--- a/tests/pytorch/paging/test_block_trie/test_node.py
+++ b/tests/pytorch/paging/test_block_trie/test_node.py
@@ -16,20 +16,24 @@ def test_state_checkpoint_is_allocated_lazily():
 
     assert node.state_checkpoint is None
 
-    node.state_checkpoint = NodeStateCheckpoint(slot=3)
+    node.state_checkpoint = NodeStateCheckpoint(slot=3, step=16)
 
     assert node.state_checkpoint.slot == 3
     assert not node.state_checkpoint.published
 
 
 def test_attach_and_detach_leaf_maintain_both_sides():
-    root = _make_node(0)
+    root = _make_node(-1)
     child = _make_node(1)
+
+    assert root.is_attached_or_root()
+    assert not child.is_attached_or_root()
 
     child.attach_to(root)
 
     assert child.parent is root
     assert child.is_attached()
+    assert child.is_attached_or_root()
     assert root.children == {child.block_hash: child}
     assert child.path_from_root() == [child]
 
@@ -37,6 +41,7 @@ def test_attach_and_detach_leaf_maintain_both_sides():
 
     assert child.parent is None
     assert not child.is_attached()
+    assert not child.is_attached_or_root()
     assert root.children == {}
 
 

--- a/tests/pytorch/paging/test_block_trie/test_trie.py
+++ b/tests/pytorch/paging/test_block_trie/test_trie.py
@@ -151,7 +151,7 @@ class TestBlockTrie(BlockTrieTestMixin):
         new_node = seq.prefix_cache.trie_cursor
         assert new_node.prefix_len == block_size * 4
         assert new_node.parent is not cached_overlap_leaf
-        assert block_trie._cursor_is_attached(new_node)
+        assert block_trie._cursor_belongs_to_trie(new_node)
 
     @pytest.mark.parametrize('raw_match_blocks', [1, 2, 5])
     def test_match_recompute_overlap_boundary_cases(self, block_trie, block_mgr, scheduler, raw_match_blocks):

--- a/tests/pytorch/paging/test_scheduler.py
+++ b/tests/pytorch/paging/test_scheduler.py
@@ -6,7 +6,7 @@ import torch
 import lmdeploy.pytorch.paging.scheduler as scheduler_module
 from lmdeploy.pytorch.config import CacheConfig, SchedulerConfig
 from lmdeploy.pytorch.disagg.conn.protocol import MigrationProtocol, MigrationRequest
-from lmdeploy.pytorch.engine.inputs_maker import _compact_state_prefix_cache_save_offsets
+from lmdeploy.pytorch.engine.inputs_maker import _make_state_prefix_cache_save_plan
 from lmdeploy.pytorch.messages import MessageStatus, SequenceMeta, UpdateTokenMode
 from lmdeploy.pytorch.paging.scheduler import Scheduler
 from lmdeploy.pytorch.paging.state_manager import StateManager
@@ -351,8 +351,9 @@ def test_ssm_same_batch_duplicate_checkpoint_save_has_unique_dst_offsets():
     save_state_offsets = [
         scheduler.block_trie.state_checkpoints.reserve_save(seq) for seq in output.running
     ]
-    save_src_offsets, save_dst_offsets = _compact_state_prefix_cache_save_offsets(output.running,
-                                                                                  save_state_offsets)
+    save_plan = _make_state_prefix_cache_save_plan(output.running, save_state_offsets)
+    assert save_plan is not None
+    save_src_offsets, save_dst_offsets = save_plan
 
     assert save_src_offsets == (seq_a.logical_state, )
     assert save_dst_offsets == (save_state_offsets[0], )


### PR DESCRIPTION
## Requirement

- [x] #4788 
- [x] #4792 

## Motivation

SSM prefix caching currently saves and restores recurrent-state checkpoints only at scheduler block boundaries. This prevents reuse when prefill or chunked prefill ends at a safe but non-block-aligned step, which is common for long-context and multimodal requests.

This PR allows SSM checkpoints at exact prefill boundaries while preserving the existing full-block trie ownership model and keeping decode checkpoints block-aligned.

This PR is temporarily based on `ssm-prefix-cache-readability` and will be rebased onto `main` after that branch is merged.

## Modification

- Store the exact checkpoint step and an optional frozen partial KV block on each checkpoint record.
- Keep trie nodes responsible only for canonical full blocks. A non-aligned checkpoint copies its partial KV block into checkpoint-owned storage.
- Restore the frozen partial block into a request-owned writable block before model execution.
- Add ordered logical KV-block copy support for packed cache pools, including scheduler-block to kernel-block geometry.
- Carry KV and recurrent-state restore/save plans through a dedicated one-forward `CacheCheckpointInputs` object.
- Execute restore copies before the model forward and save copies afterward on the forward stream.
- Index candidates by adapter, exact step, and partial-tail hash, followed by full token, multimodal identity, block-path, and ownership verification.
- Pin checkpoints while asynchronous restore or save copies are pending.
- Release frozen partial blocks through checkpoint lifecycle management and prefer them during KV-pressure eviction.
- Keep partial hits disabled when routed-expert tail history cannot be reconstructed.
- Preserve writable suffix blocks for normal continuation and MTP recompute overlap.

No public API or configuration behavior is changed.

## BC-breaking

No.

## Use cases

- Reuse an SSM prefix ending at steps such as `B - 1`, `B + 1`, or other safe prefill boundaries.
- Cache non-block-aligned long-context chunks.
- Cache multimodal prefill checkpoints when the boundary is outside multimodal spans.
- Restore the same frozen checkpoint concurrently into multiple request-owned blocks.
