### PR TITLE
fix(serve): handle missing logprobs attrs on TurbomindEngineConfig in Anthropic messages

### DIFF
--- a/lmdeploy/serve/anthropic/endpoints/messages.py
+++ b/lmdeploy/serve/anthropic/endpoints/messages.py
@@ -44,15 +44,16 @@ def _is_tool_choice_auto(tool_choice):
 
 
 def _validate_extended_outputs(request: MessagesRequest, server_context):
+    # TurbomindEngineConfig has neither field; treat missing attrs as disabled.
     engine_config = server_context.get_engine_config()
-    logprobs_mode = engine_config.logprobs_mode
+    logprobs_mode = getattr(engine_config, 'logprobs_mode', None)
     if request.return_logprob and logprobs_mode is None:
         return create_error_response(
             HTTPStatus.BAD_REQUEST,
             f'return_logprob={request.return_logprob} was requested, but '
             'logprobs_mode is not enabled in the engine configuration.')
 
-    if request.return_routed_experts and not engine_config.enable_return_routed_experts:
+    if request.return_routed_experts and not getattr(engine_config, 'enable_return_routed_experts', False):
         return create_error_response(
             HTTPStatus.BAD_REQUEST,
             ('routed experts requested but not configured in engine configuration. '


### PR DESCRIPTION
Fix the following issue:

<img width="1204" height="1206" alt="img_v3_02142_a48a63a9-f481-4541-abc1-f60f8908964g" src="https://github.com/user-attachments/assets/433e6f57-9804-4d67-af35-88b3b40fd4b6" />
