### PR TITLE
fix: skip interns2 preview time-series weights

### DIFF
--- a/lmdeploy/pytorch/models/qwen3_5_moe.py
+++ b/lmdeploy/pytorch/models/qwen3_5_moe.py
@@ -362,6 +362,8 @@ class Qwen3_5MoeForConditionalGeneration(Qwen3_5ForConditionalGeneration):
 
             if 'mtp.' in name:
                 continue
+            if name.startswith(('model.time_series.', 'time_series_forecaster.')):
+                continue
             if 'rotary_emb.inv_freq' in name:
                 continue
             if ('rotary_emb.cos_cached' in name or 'rotary_emb.sin_cached' in name):


### PR DESCRIPTION
## Summary

- Skip Intern-S2 Preview time-series encoder and forecaster checkpoint tensors in the Qwen3.5 MoE loader.
- Keep strict unexpected-key handling for all other checkpoint weights.
- Allow main-branch non-time-series serving to load checkpoints that package time-series weights.

## Validation

- `python -m py_compile lmdeploy/pytorch/models/qwen3_5_moe.py`
- Focused loader check: time-series encoder and forecaster keys are skipped; unrelated unexpected keys still raise.
- Local non-time-series smoke: model loaded successfully with PyTorch TP8.
- Local text smoke: OpenAI-compatible chat request returned `OK`.
- Local image smoke: OpenAI-compatible image request returned a short image description.

## Assistance

Assisted with Codex + GPT-5.6-Sol xHigh, reviewed manually
