### PR TITLE
docs: remove non-existent `--enable-metrics` flag from metrics/spec_decoding guides

### DIFF
--- a/docs/en/advance/metrics.md
+++ b/docs/en/advance/metrics.md
@@ -22,7 +22,7 @@ This section describes how to set up the monitoring stack (Prometheus + Grafana)
 1. **Start your LMDeploy server with metrics enabled**
 
 ```
-lmdeploy serve api_server Qwen/Qwen2.5-7B-Instruct --enable-metrics
+lmdeploy serve api_server Qwen/Qwen2.5-7B-Instruct
 ```
 
 Replace the model path according to your needs.
@@ -78,8 +78,7 @@ lmdeploy serve api_server \
     --dp 2 \
     --proxy-url http://0.0.0.0:8000 \
     --nnodes 1 \
-    --node-rank 0 \
-    --enable-metrics
+    --node-rank 0
 ```
 
 You should be able to see multiple API servers added to the proxy server list. Details can be found in `lmdeploy/serve/proxy/proxy_config.json`.

--- a/docs/en/advance/spec_decoding.md
+++ b/docs/en/advance/spec_decoding.md
@@ -53,8 +53,7 @@ meta-llama/Llama-3.1-8B-Instruct \
 --speculative-draft-model yuhuili/EAGLE3-LLaMA3.1-Instruct-8B \
 --speculative-algorithm eagle3 \
 --speculative-num-draft-tokens 3 \
---max-batch-size 128 \
---enable-metrics
+--max-batch-size 128
 ```
 
 ### Deepseek MTP
@@ -102,8 +101,7 @@ deepseek-ai/DeepSeek-V3 \
 --tp 16 \
 --speculative-algorithm deepseek_mtp \
 --speculative-num-draft-tokens 3 \
---max-batch-size 128 \
---enable-metrics
+--max-batch-size 128
 ```
 
 ## Guided Decoding with Speculative Decoding

--- a/docs/zh_cn/advance/metrics.md
+++ b/docs/zh_cn/advance/metrics.md
@@ -21,7 +21,7 @@ LMDeploy 通过 Prometheus 暴露监控指标，并通过 Grafana 提供可视�
 1. **启动已启用指标的 LMDeploy 服务**
 
 ```
-lmdeploy serve api_server Qwen/Qwen2.5-7B-Instruct --enable-metrics
+lmdeploy serve api_server Qwen/Qwen2.5-7B-Instruct
 ```
 
 请根据需求替换模型路径。默认 metrics endpoint 位于 `http://<lmdeploy_server_host>:23333/metrics`。
@@ -76,8 +76,7 @@ lmdeploy serve api_server \
     --dp 2 \
     --proxy-url http://0.0.0.0:8000 \
     --nnodes 1 \
-    --node-rank 0 \
-    --enable-metrics
+    --node-rank 0
 ```
 
 您应该能在代理服务器列表中看到多个 API 服务实例。详细信息可以在 `lmdeploy/serve/proxy/proxy_config.json` 中找到。

--- a/docs/zh_cn/advance/spec_decoding.md
+++ b/docs/zh_cn/advance/spec_decoding.md
@@ -53,8 +53,7 @@ meta-llama/Llama-3.1-8B-Instruct \
 --speculative-draft-model yuhuili/EAGLE3-LLaMA3.1-Instruct-8B \
 --speculative-algorithm eagle3 \
 --speculative-num-draft-tokens 3 \
---max-batch-size 128 \
---enable-metrics
+--max-batch-size 128
 ```
 
 ### Deepseek MTP
@@ -101,8 +100,7 @@ deepseek-ai/DeepSeek-V3 \
 --tp 16 \
 --speculative-algorithm deepseek_mtp \
 --speculative-num-draft-tokens 3 \
---max-batch-size 128 \
---enable-metrics
+--max-batch-size 128
 ```
 
 ## 投机解码与结构化输出


### PR DESCRIPTION
## Motivation

The metrics guide and the speculative-decoding guide instruct users to start the API server with `--enable-metrics`:

```
lmdeploy serve api_server Qwen/Qwen2.5-7B-Instruct --enable-metrics
```

That flag does not exist. The CLI only defines `--disable-metrics` (`lmdeploy/cli/utils.py`):

```python
def disable_metrics(parser):
    return parser.add_argument("--disable-metrics", action="store_true", default=False, ...)
```

and it is wired as `enable_metrics = not args.disable_metrics` (`lmdeploy/cli/serve.py`), with `--disable-metrics` defaulting to `False`. So **metrics are already enabled by default**, and the metrics guide itself says the endpoint is available *"by default"*.

Because the server uses a strict argument parser, copy-pasting the documented command fails before startup:

```
error: unrecognized arguments: --enable-metrics
```
(exit code 2)

## Modification

Removed the redundant, non-existent `--enable-metrics` flag from the example commands in:

- `docs/en/advance/metrics.md` (2 commands)
- `docs/en/advance/spec_decoding.md` (2 commands)
- `docs/zh_cn/advance/metrics.md` (2 commands)
- `docs/zh_cn/advance/spec_decoding.md` (2 commands)

For the multi-line commands, the trailing `\` on the preceding line was also removed so the continuation stays valid. Docs-only; metrics behavior is unchanged (still on by default).

## BC-breaking (Optional)

No.

## Checklist

1. Docs-only change; no lint-relevant code touched.
2. N/A (documentation).
4. This PR is the documentation fix.