### PR TITLE
[Bugfix] Return the client-disconnect error instead of discarding it in completions_v1

### DIFF
--- a/lmdeploy/serve/openai/api_server.py
+++ b/lmdeploy/serve/openai/api_server.py
@@ -1088,12 +1088,7 @@ async def generate(request: GenerateReqInput, raw_request: Request = None):
                                      completion_tokens=res.generate_token_len)
         response = GenerateReqOutput(text=text, output_ids=output_ids, meta_info=meta)
 
-    # `_inner_call` returns the error response from inside the `async with`, so the disconnect
-    # branch never reaches the `response` assignment below it. Take its return value instead of
-    # discarding it, or the caller gets 200 with a null body.
-    error_response = await _inner_call()
-    if error_response is not None:
-        return error_response
+    await _inner_call()
     return response
 
 

--- a/lmdeploy/serve/openai/api_server.py
+++ b/lmdeploy/serve/openai/api_server.py
@@ -960,7 +960,14 @@ async def completions_v1(request: CompletionRequest, raw_request: Request = None
         usage.completion_tokens += final_res.generate_token_len
         usage.total_tokens += total_tokens
 
-    await asyncio.gather(*[_inner_call(i, generators[i], sessions[i]) for i in range(len(generators))])
+    # Same as `generate` below: each `_inner_call` returns its error response from inside the
+    # `async with`, and `gather` collects those into a list. Without this check a disconnect on
+    # one entry leaves `final_res` unset for it and the response is built from the rest.
+    inner_results = await asyncio.gather(
+        *[_inner_call(i, generators[i], sessions[i]) for i in range(len(generators))])
+    for inner_result in inner_results:
+        if inner_result is not None:
+            return inner_result
 
     response = CompletionResponse(
         id=request_id,
@@ -1081,7 +1088,12 @@ async def generate(request: GenerateReqInput, raw_request: Request = None):
                                      completion_tokens=res.generate_token_len)
         response = GenerateReqOutput(text=text, output_ids=output_ids, meta_info=meta)
 
-    await _inner_call()
+    # `_inner_call` returns the error response from inside the `async with`, so the disconnect
+    # branch never reaches the `response` assignment below it. Take its return value instead of
+    # discarding it, or the caller gets 200 with a null body.
+    error_response = await _inner_call()
+    if error_response is not None:
+        return error_response
     return response
 
 


### PR DESCRIPTION
Fixes #4781.

## Motivation

`generate()` and `completions_v1()` both moved their streaming loop into a nested `_inner_call`, which signals client disconnect by returning `create_error_response(HTTPStatus.BAD_REQUEST, 'Client disconnected')` from inside an `async with`. Neither call site used that return value.

**`generate()`** — the disconnect branch returns from inside the `async with`, so the `response = GenerateReqOutput(...)` assignment below it is never reached, and `await _inner_call()` throws the error response away. The endpoint returns the still-`None` `response`, which FastAPI serialises as `200` with a `null` body. Running the pattern in isolation:

```
disconnect=False  before -> '200 GenerateReqOutput'  after -> '200 GenerateReqOutput'
disconnect=True   before -> None                     after -> '400 Client disconnected'
```

**`completions_v1()`** — same shape, reached through `asyncio.gather`, which collects the return values into a list that was discarded. This one degrades more quietly: after the early return, `final_res` stays `None` for the disconnected index, so `assert final_res is not None` never runs for it and the response is built from the choices that did finish.

```
disconnect_idx=None  before -> 200 choices=[0, 1, 2]  after -> 200 choices=[0, 1, 2]
disconnect_idx=1     before -> 200 choices=[0, 2]     after -> 400 (idx 1)
```

For contrast, `/v1/chat/completions` is correct and shows the intended shape: its `async with` and `return create_error_response(...)` sit directly in the endpoint body, so the return leaves the endpoint.

## Modification

Take the return value at both call sites. `generate()` returns it when it isn't `None`; `completions_v1()` scans the `gather` results and returns the first non-`None` entry. The normal path is untouched in both — when no client disconnects every `_inner_call` returns `None` and the existing `response` is built and returned as before.

## Checklist

- [x] Pre-commit or other linting tools are used to fix the potential lint issues. `ruff check` reports one `I001` on this file, and reports the same on an unmodified checkout, so it is pre-existing; `ruff format --check` likewise wants to reformat the file on both. Neither is touched here. The only line over the 120 limit (line 320) is also pre-existing.
- [x] The modification is covered by complete unit tests. Not added: both paths need a live server plus a client that disconnects mid-stream, and there is no existing harness in `tests/` for the disconnect branch of these endpoints. The numbers above come from running the control-flow pattern rather than the server, so I would rather say so than add a test I could not run. Happy to add one if you can point me at the right fixture.
- [x] If this PR introduces a new feature, docs are updated. Not a feature.
