### PR TITLE
fix(disagg): use JSON instead of pickle for P2P ZMQ requests (#4804)

### DIFF
--- a/lmdeploy/pytorch/disagg/conn/engine_conn.py
+++ b/lmdeploy/pytorch/disagg/conn/engine_conn.py
@@ -6,6 +6,7 @@ from urllib.parse import urlparse
 
 import zmq
 import zmq.asyncio
+from pydantic import ValidationError
 
 from lmdeploy.logger import get_logger
 from lmdeploy.pytorch.disagg.conn.protocol import (
@@ -71,20 +72,30 @@ class EngineP2PConnection:
         return {'success': True}
 
     async def zmq_send(self, remote_engine_id: str, remote_session_id: int):
-        await self.p2p_sender[remote_engine_id].send_pyobj(
-            DistServeCacheFreeRequest(remote_engine_id=remote_engine_id, remote_session_id=remote_session_id))
+        req = DistServeCacheFreeRequest(remote_engine_id=remote_engine_id, remote_session_id=remote_session_id)
+        # Use JSON rather than pickle on the wire: recv_pyobj()/send_pyobj() call
+        # pickle.loads() on peer-supplied bytes, which is remote code execution.
+        await self.p2p_sender[remote_engine_id].send_json(req.model_dump())
 
     async def handle_zmq_recv(self, remote_engine_id: str):
+        receiver = self.p2p_receiver[remote_engine_id]
         while True:
-            req: DistServeCacheFreeRequest = await self.p2p_receiver[remote_engine_id].recv_pyobj()
-            if isinstance(req, DistServeCacheFreeRequest):
-                session_id = req.remote_session_id
-                if session_id in self.engine.scheduler.sessions:
-                    self.engine.end_session(session_id=session_id)
-                else:
-                    logger.error(f'invalid free, {remote_engine_id}, {session_id}')
+            # recv_json() decodes with json.loads (no code execution); model_validate
+            # then enforces the DistServeCacheFreeRequest schema before the payload is
+            # used, replacing the old recv_pyobj() -> pickle.loads() RCE path. Malformed
+            # or off-schema payloads are logged and skipped so a single bad message
+            # cannot tear down the receive loop.
+            try:
+                raw = await receiver.recv_json()
+                req = DistServeCacheFreeRequest.model_validate(raw)
+            except (ValueError, ValidationError) as e:
+                logger.error(f'invalid zmq request from {remote_engine_id}: {e}')
+                continue
+            session_id = req.remote_session_id
+            if session_id in self.engine.scheduler.sessions:
+                self.engine.end_session(session_id=session_id)
             else:
-                raise ValueError(f'Unsupported zmq request {type(req)}')
+                logger.error(f'invalid free, {remote_engine_id}, {session_id}')
 
     async def zmq_disconnect(self, remote_engine_id: str):
         self.p2p_receiver[remote_engine_id].close()

--- a/lmdeploy/pytorch/disagg/conn/engine_conn.py
+++ b/lmdeploy/pytorch/disagg/conn/engine_conn.py
@@ -73,8 +73,8 @@ class EngineP2PConnection:
 
     async def zmq_send(self, remote_engine_id: str, remote_session_id: int):
         req = DistServeCacheFreeRequest(remote_engine_id=remote_engine_id, remote_session_id=remote_session_id)
-        # Use JSON rather than pickle on the wire: recv_pyobj()/send_pyobj() call
-        # pickle.loads() on peer-supplied bytes, which is remote code execution.
+        # Use JSON rather than pickle on the wire: recv_pyobj() uses pickle.loads() on
+        # peer-supplied bytes (RCE risk), and send_pyobj() produces that pickle format.
         await self.p2p_sender[remote_engine_id].send_json(req.model_dump())
 
     async def handle_zmq_recv(self, remote_engine_id: str):


### PR DESCRIPTION
### Motivation

Fixes #4804.

The disaggregated-serving P2P connector deserializes peer-supplied bytes with `pickle`:

```python
# lmdeploy/pytorch/disagg/conn/engine_conn.py
req = await self.p2p_receiver[remote_engine_id].recv_pyobj()   # = pickle.loads()
if isinstance(req, DistServeCacheFreeRequest):                 # check runs *after* loads
```

`recv_pyobj()` calls `pickle.loads()` on the raw frame, so the `isinstance` guard runs only after any `__reduce__` payload has already executed. As analysed in the issue, the reachable path is not the bound `PUSH` socket but the HTTP endpoint: an unauthenticated `POST /distserve/p2p_connect` supplies `zmq_address`, the engine's `PULL` socket `connect()`s to that caller-chosen address, and `handle_zmq_recv` then `pickle.loads()` whatever that address sends → remote code execution on the engine node (`AuthenticationMiddleware` is only installed when `api_keys` is set, and the `/distserve/*` routes carry no auth dependency).

### Modification

The connector's only wire message is `DistServeCacheFreeRequest`, a pydantic model with two scalar fields (`remote_engine_id: str`, `remote_session_id: int`). Both send and receive live in the same class and upgrade together, so switching the codec has no protocol-mismatch risk:

- `zmq_send`: `send_pyobj(...)` → `send_json(req.model_dump())`
- `handle_zmq_recv`: `recv_pyobj()` → `recv_json()` + `DistServeCacheFreeRequest.model_validate(...)`

`recv_json()` decodes with `json.loads` (no code execution) and `model_validate` enforces the schema **before** the payload is used, making the old `isinstance` check redundant. Malformed or off-schema messages are now logged and skipped rather than raising out of the bare `while True` in the detached task (which previously surfaced only as a task-destroyed warning).

No wire-format compatibility break beyond the coordinated both-ends change here.

### Checklist

- [x] Pre-commit / code style aligned with the existing file
- [x] Reproduced the deserialization path against `main`
- [x] Change is confined to `engine_conn.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
