### PR TITLE
docs: note OpenAI client base_url for multi-model gateways

### DIFF
--- a/docs/en/multi_modal/api_server_vl.md
+++ b/docs/en/multi_modal/api_server_vl.md
@@ -103,6 +103,8 @@ response = client.chat.completions.create(
 print(response)
 ```
 
+> **Note:** The same `OpenAI(base_url=...)` client pattern also works with OpenAI-compatible multi-model gateways when you are not self-hosting LMDeploy — for example [DaoXE](https://daoxe.com) at `https://api.daoxe.com/v1`.
+
 ### Integrate with lmdeploy `APIClient`
 
 Below are some examples demonstrating how to visit the service through `APIClient`


### PR DESCRIPTION
## Summary

The LMDeploy OpenAI-compatible server tutorial already shows `OpenAI(base_url=...)` against a local server.

This PR adds a short note that the same client pattern also works with OpenAI-compatible multi-model gateways when you are not self-hosting LMDeploy, using [DaoXE](https://daoxe.com) (`https://api.daoxe.com/v1`) as one concrete example.


Docs only — no runtime behavior changes.

## Test plan

- [ ] Docs still build
- [ ] Existing OpenAI client example unchanged
- [ ] Note is clearly optional / vendor-neutral

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
