### PR TITLE
[Fix] Validate final cache block size

### DIFF
--- a/lmdeploy/pytorch/engine/executor/base.py
+++ b/lmdeploy/pytorch/engine/executor/base.py
@@ -271,6 +271,19 @@ class ExecutorBase:
                 f'Update `block_size={self.cache_config.block_size}` for large `head_dim={self.model_config.k_head_dim}`.'  # noqa
             )
 
+    def _validate_block_size(self):
+        """Validate final cache block sizes before building cache kernels."""
+        block_size = self.cache_config.block_size
+        kernel_block_size = self.cache_config.kernel_block_size
+        if block_size < 16 or (block_size & (block_size - 1)) != 0:
+            raise ValueError(f'block_size must be >= 16 and a power of 2, but got {block_size}')
+        if kernel_block_size < 16 or (kernel_block_size & (kernel_block_size - 1)) != 0:
+            raise ValueError(f'kernel_block_size must be >= 16 and a power of 2, but got {kernel_block_size}')
+        if block_size < kernel_block_size or block_size % kernel_block_size != 0:
+            raise ValueError(
+                f'block_size must be >= kernel_block_size and an integer multiple of kernel_block_size, but got '
+                f'block_size {block_size} and kernel_block_size {kernel_block_size}')
+
     def _get_state_cache_mem(self, states_shapes=None, cache_config=None, model_config=None):
         """Get state cache mem usage."""
         cache_config = cache_config or self.cache_config
@@ -429,6 +442,7 @@ class ExecutorBase:
     def update_configs(self) -> None:
         """Update cache config."""
         self._adjust_block_size()
+        self._validate_block_size()
         self._maybe_disable_unsupported_prefix_caching()
         self._sync_spec_cache_block_size()
         self._validate_memdecode_configs()

--- a/tests/pytorch/engine/test_executor_base.py
+++ b/tests/pytorch/engine/test_executor_base.py
@@ -131,6 +131,19 @@ def test_adjust_block_size_uses_deepseek_v4_cache_hook_before_large_head_dim_rul
     assert executor.cache_config.window_size == -1
 
 
+def test_update_configs_rejects_non_power_of_two_block_size():
+    executor = object.__new__(ExecutorBase)
+    executor.cache_config = CacheConfig(max_batches=1,
+                                        block_size=48,
+                                        kernel_block_size=16,
+                                        num_cpu_blocks=0,
+                                        num_gpu_blocks=0)
+    executor.model_config = SimpleNamespace(k_head_dim=128, use_flash_mla=False, update_cache_config_func=None)
+
+    with pytest.raises(ValueError, match='block_size must be >= 16 and a power of 2'):
+        executor.update_configs()
+
+
 def test_executor_disables_prefix_cache_with_generic_sliding_window():
     cache_config = CacheConfig(max_batches=1,
                                block_size=64,


### PR DESCRIPTION
## Motivation

Issue #3781 reports that `fill_kv_cache` / paged-attention kernels assume the cache `block_size` is a power of 2. Existing `PytorchEngineConfig` validation catches the common default path where `kernel_block_size == block_size`, but a final executor cache config can still keep a non-power-of-two `block_size` when split kernel blocks are used, for example `block_size=48` and `kernel_block_size=16`.

Refs #3781

## Modification

- Add final cache block-size validation in `ExecutorBase.update_configs()` after model-specific block-size adjustment.
- Reject final `block_size` / `kernel_block_size` values that are below 16, not powers of 2, or incompatible with each other.
- Add a regression test covering `update_configs()` rejecting a non-power-of-two final `block_size`.

## BC-breaking (Optional)

No. Invalid cache block configurations now fail earlier with a clear `ValueError` before cache kernels are built.

## Use cases (Optional)

N/A

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
   - `python -m pre_commit run --files lmdeploy/pytorch/engine/executor/base.py tests/pytorch/engine/test_executor_base.py`
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
   - `python -m pytest tests/pytorch/engine/test_executor_base.py tests/pytorch/engine/test_engine_checker.py tests/pytorch/engine/test_cache_engine.py tests/pytorch/config/test_model_config.py -q`
3. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
   - N/A
4. The documentation has been modified accordingly, like docstring or example tutorials.
   - N/A; this is an internal validation fix.
