### PR TITLE
[Fix] Reject LoRA adapters on non-PyTorch backend

### DIFF
--- a/lmdeploy/cli/serve.py
+++ b/lmdeploy/cli/serve.py
@@ -13,6 +13,14 @@ from .utils import (
 )
 
 
+def _validate_lora_backend(adapters, backend):
+    """Validate LoRA adapters against the selected backend."""
+    if adapters and backend != 'pytorch':
+        raise ValueError(
+            'LoRA adapters are only supported by the PyTorch backend. '
+            'Please set --backend pytorch when using --adapters.')
+
+
 class SubCliServe:
     """Serve LLMs and interact on terminal."""
     _help = 'Serve LLMs with openai API'
@@ -231,6 +239,7 @@ class SubCliServe:
         if backend != 'pytorch':
             # set auto backend mode
             backend = autoget_backend(args.model_path, trust_remote_code=args.trust_remote_code)
+        _validate_lora_backend(args.adapters, backend)
 
         if backend == 'pytorch':
             from lmdeploy.messages import PytorchEngineConfig

--- a/tests/test_lmdeploy/cli/test_serve.py
+++ b/tests/test_lmdeploy/cli/test_serve.py
@@ -1,0 +1,30 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+from types import SimpleNamespace
+
+import pytest
+
+from lmdeploy.cli.serve import SubCliServe, _validate_lora_backend
+
+
+def test_validate_lora_backend_rejects_turbomind():
+    with pytest.raises(ValueError, match='LoRA adapters are only supported by the PyTorch backend'):
+        _validate_lora_backend(['adapter=/path/to/lora'], 'turbomind')
+
+
+def test_validate_lora_backend_allows_pytorch():
+    _validate_lora_backend(['adapter=/path/to/lora'], 'pytorch')
+
+
+def test_api_server_rejects_lora_adapters_after_backend_resolution(monkeypatch):
+    import lmdeploy.archs
+
+    monkeypatch.setattr(lmdeploy.archs, 'autoget_backend', lambda *args, **kwargs: 'turbomind')
+    args = SimpleNamespace(max_batch_size=1,
+                           device='cuda',
+                           backend='turbomind',
+                           model_path='model',
+                           trust_remote_code=False,
+                           adapters=['adapter=/path/to/lora'])
+
+    with pytest.raises(ValueError, match='LoRA adapters are only supported by the PyTorch backend'):
+        SubCliServe.api_server(args)


### PR DESCRIPTION
## Motivation

When `lmdeploy serve api_server` resolves to the TurboMind backend, `--adapters` is currently accepted but not applied because LoRA adapters are PyTorch-backend only. This can make the server start successfully while adapter model names are unavailable, which matches the confusion reported in #3594.

Refs #3594

## Modification

- Add an early CLI validation for `serve api_server`: if adapters are provided after backend resolution and the selected backend is not `pytorch`, raise a clear `ValueError` asking the user to set `--backend pytorch`.
- Add CLI unit coverage for both rejecting TurboMind and allowing PyTorch.

## BC-breaking (Optional)

No supported behavior is removed. Invalid `--adapters` + non-PyTorch backend combinations now fail early with an explicit message instead of being silently ignored.

## Use cases (Optional)

Users serving LoRA adapters should launch with `--backend pytorch`, for example:

```shell
lmdeploy serve api_server /path/to/model --backend pytorch --adapters mylora=/path/to/lora
```

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
   - `python -m pre_commit run --files lmdeploy/cli/serve.py tests/test_lmdeploy/cli/test_serve.py`
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
   - `python -m pytest tests/test_lmdeploy/cli/test_serve.py tests/test_lmdeploy/serve/test_generation_config.py -q`
3. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
   - N/A
4. The documentation has been modified accordingly, like docstring or example tutorials.
   - N/A; this is a CLI validation/error-message fix.
