### PR TITLE
[Fix] Load memdecode router checkpoints with weights_only

### DIFF
--- a/lmdeploy/pytorch/memdecode/fusion.py
+++ b/lmdeploy/pytorch/memdecode/fusion.py
@@ -297,7 +297,7 @@ class MemDecodeFusion(nn.Module):
     def _router_config_from_checkpoint(checkpoint_path: Path) -> dict[str, Any]:
         if checkpoint_path.suffix == '.safetensors':
             return {}
-        checkpoint = torch.load(checkpoint_path, map_location='cpu')
+        checkpoint = torch.load(checkpoint_path, map_location='cpu', weights_only=True)
         if not isinstance(checkpoint, dict):
             return {}
         config = checkpoint.get('router_config', checkpoint.get('config', {}))
@@ -315,7 +315,7 @@ class MemDecodeFusion(nn.Module):
                 raise ValueError('router checkpoint must contain a non-empty state dict.')
             return state_dict
 
-        checkpoint = torch.load(checkpoint_path, map_location='cpu')
+        checkpoint = torch.load(checkpoint_path, map_location='cpu', weights_only=True)
         if not isinstance(checkpoint, dict):
             raise ValueError('router checkpoint must be a state-dict checkpoint.')
 

--- a/tests/pytorch/memdecode/test_fusion.py
+++ b/tests/pytorch/memdecode/test_fusion.py
@@ -439,3 +439,23 @@ def test_router_checkpoint_without_state_dict_fails(tmp_path):
             base_hidden_size=2,
             memory_hidden_size=3,
         )
+
+
+def test_router_checkpoint_torch_load_uses_weights_only(monkeypatch, tmp_path):
+    import lmdeploy.pytorch.memdecode.fusion as fusion_module
+
+    router_path = tmp_path / 'router.pt'
+    router_path.write_bytes(b'not-used')
+    loads = []
+
+    def fake_load(path, **kwargs):
+        loads.append((path, kwargs))
+        if len(loads) == 1:
+            return {'config': {'hidden_dim': 4}}
+        return {'state_dict': {'weight': torch.tensor([1.0])}}
+
+    monkeypatch.setattr(fusion_module.torch, 'load', fake_load)
+
+    assert MemDecodeFusion._router_config_from_checkpoint(router_path) == {'hidden_dim': 4}
+    assert MemDecodeFusion._load_router_state_dict(router_path) == {'weight': torch.tensor([1.0])}
+    assert [kwargs.get('weights_only') for _, kwargs in loads] == [True, True]


### PR DESCRIPTION
## Motivation

Issue #3255 reports unsafe `torch.load(...)` usage for `.pt` checkpoint loading. The original `load_weight_ckpt` helper no longer exists on current `main`, but the memdecode adaptive-router path still loads user-provided `.pt` router checkpoints without explicitly setting `weights_only=True`.

Refs #3255

## Modification

- Load memdecode router checkpoint metadata with `torch.load(..., weights_only=True)`.
- Load memdecode router state dicts with `torch.load(..., weights_only=True)`.
- Add regression coverage to ensure both router checkpoint load paths pass `weights_only=True` explicitly.

## BC-breaking (Optional)

No. Supported router checkpoints using tensors and primitive dict metadata continue to load; unsafe pickle globals are rejected earlier by PyTorch's weights-only loader.

## Use cases (Optional)

N/A

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
   - `python -m pre_commit run --files lmdeploy/pytorch/memdecode/fusion.py tests/pytorch/memdecode/test_fusion.py`
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
   - `python -m pytest tests/pytorch/memdecode/test_fusion.py -q`
3. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
   - N/A
4. The documentation has been modified accordingly, like docstring or example tutorials.
   - N/A; this is an internal checkpoint-loading hardening change.
