### PR TITLE
[Docs] Explain prompt hidden states in pipeline

### DIFF
--- a/docs/en/llm/pipeline.md
+++ b/docs/en/llm/pipeline.md
@@ -144,6 +144,30 @@ response = pipe(['Hi, pls intro yourself', 'Shanghai is'],
 hidden_states = [x.last_hidden_state for x in response]
 ```
 
+### Get last layer's hidden states for prompt and generated tokens
+
+Set `output_last_hidden_state='all'` to return the last layer's hidden
+states for both the prefill prompt tokens and generated tokens.
+
+```python
+from lmdeploy import pipeline, GenerationConfig
+
+pipe = pipeline('internlm/internlm2_5-7b-chat')
+
+gen_config=GenerationConfig(output_last_hidden_state='all',
+                            max_new_tokens=10)
+response = pipe(['Hi, pls intro yourself', 'Shanghai is'],
+                gen_config=gen_config)
+hidden_states = [x.last_hidden_state for x in response]
+```
+
+```{note}
+`output_last_hidden_state` is supported by the TurboMind engine. Use
+`'generation'` when you only need generated-token hidden states, and use
+`'all'` when you also need the prompt/prefill hidden states. Prefix caching
+cannot be enabled together with `output_last_hidden_state='all'`.
+```
+
 ### Calculate ppl
 
 ```python

--- a/docs/zh_cn/llm/pipeline.md
+++ b/docs/zh_cn/llm/pipeline.md
@@ -144,6 +144,30 @@ response = pipe(['Hi, pls intro yourself', 'Shanghai is'],
 hidden_states = [x.last_hidden_state for x in response]
 ```
 
+### 获取 prompt 和生成 token 最后一层的 hidden_states
+
+设置 `output_last_hidden_state='all'` 可以同时返回 prefill 阶段的 prompt
+token 和生成 token 的最后一层 hidden states。
+
+```python
+from lmdeploy import pipeline, GenerationConfig
+
+pipe = pipeline('internlm/internlm2_5-7b-chat')
+
+gen_config=GenerationConfig(output_last_hidden_state='all',
+                            max_new_tokens=10)
+response = pipe(['Hi, pls intro yourself', 'Shanghai is'],
+                gen_config=gen_config)
+hidden_states = [x.last_hidden_state for x in response]
+```
+
+```{note}
+`output_last_hidden_state` 由 TurboMind 引擎支持。如果只需要生成 token
+的 hidden states，使用 `'generation'`；如果还需要 prompt/prefill 的 hidden
+states，使用 `'all'`。`output_last_hidden_state='all'` 不能和 prefix caching
+同时开启。
+```
+
 ### 计算 ppl
 
 ```python


### PR DESCRIPTION
## Motivation

The pipeline docs only showed how to fetch last-layer hidden states for generated tokens with `output_last_hidden_state='generation'`. Issue #3456 asks how to obtain the prompt/prefill hidden states.

Refs #3456

## Modification

- Add English and Chinese pipeline examples for `GenerationConfig(output_last_hidden_state='all')`.
- Clarify that `generation` returns generated-token hidden states, while `all` also includes prompt/prefill hidden states.
- Note the current constraints: this is supported by TurboMind, and prefix caching cannot be enabled with `output_last_hidden_state='all'`.

## BC-breaking (Optional)

No. Documentation only.

## Use cases (Optional)

Users who need prompt/prefill hidden states can use:

```python
gen_config = GenerationConfig(output_last_hidden_state='all', max_new_tokens=10)
response = pipe(['Hi, pls intro yourself'], gen_config=gen_config)
hidden_states = [x.last_hidden_state for x in response]
```

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
   - `PYTHONPATH= python -m pre_commit run --files docs/en/llm/pipeline.md docs/zh_cn/llm/pipeline.md`
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
   - Documentation-only change; verified by grep for the new `output_last_hidden_state='all'` examples.
3. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
   - N/A
4. The documentation has been modified accordingly, like docstring or example tutorials.
   - Updated `docs/en/llm/pipeline.md` and `docs/zh_cn/llm/pipeline.md`.
