### PR TITLE
[Docs] Clarify TurboMind engine acceleration

### DIFF
--- a/docs/en/inference/turbomind.md
+++ b/docs/en/inference/turbomind.md
@@ -63,6 +63,35 @@ Apart of the features described above, there are still many minor differences th
 
 ## FAQ
 
+### What does TurbomindEngineConfig speed up?
+
+`TurbomindEngineConfig` selects and configures the TurboMind backend. The
+speedup comes from TurboMind itself rather than from a single config option:
+
+- persistent batching keeps requests in a continuously running batch and
+  reuses freed batch slots for new requests;
+- the KV cache manager stores KV blocks in a reusable memory pool, supports
+  prefix/cache hits, and avoids repeated context decoding when history KV is
+  available;
+- FasterTransformer/CUTLASS kernels, paged attention, tensor parallelism, and
+  KV-cache quantization reduce compute or memory bandwidth bottlenecks.
+
+Speculative decoding is configured separately through `SpeculativeConfig`.
+The current speculative decoding guide uses the PyTorch backend, so switch to
+`PytorchEngineConfig` for those examples instead of expecting
+`TurbomindEngineConfig` to enable it.
+
+TurboMind can serve supported full-precision and quantized text models. For
+quantized checkpoints, see the AWQ/GPTQ and llm-compressor guides. Multimodal
+models are also supported when listed in the supported-model matrix, but
+quantized multimodal support depends on the specific model and quantization
+format rather than on `TurbomindEngineConfig` alone.
+
+- [Speculative decoding](../advance/spec_decoding.md)
+- [AWQ/GPTQ quantized models](../quantization/w4a16.md)
+- [llm-compressor quantized models](../quantization/llm_compressor.md)
+- [Supported models](../supported_models/supported_models.md)
+
 ### Supporting Huggingface models
 
 For historical reasons, TurboMind's weight layout is based on [the original LLaMa implementation](https://github.com/facebookresearch/llama) (differ only by a transpose). The implementation in huggingface transformers uses a [different layout](https://github.com/huggingface/transformers/blob/45025d92f815675e483f32812caa28cce3a960e7/src/transformers/models/llama/convert_llama_weights_to_hf.py#L123C76-L123C76) for `W_q` and `W_k` which is handled in [deploy.py](https://github.com/InternLM/lmdeploy/blob/ff4648a1d09e5aec74cf70efef35bfaeeac552e0/lmdeploy/serve/turbomind/deploy.py#L398).

--- a/docs/zh_cn/inference/turbomind.md
+++ b/docs/zh_cn/inference/turbomind.md
@@ -63,6 +63,32 @@ TurboMind 的 Python API 支持流式结果返回和张量并行模式。
 
 ## FAQ
 
+### TurbomindEngineConfig 加速了什么？
+
+`TurbomindEngineConfig` 用于选择并配置 TurboMind 后端。加速主要来自
+TurboMind 后端本身，而不是某一个单独的配置项：
+
+- persistent batch 会把请求放入持续运行的 batch，并在请求结束后复用
+  batch slot；
+- KV cache 管理器以 block 形式管理可复用的 KV 缓存，命中历史 KV 时可避免
+  重复 context decoding；
+- FasterTransformer/CUTLASS kernel、paged attention、张量并行以及 KV cache
+  量化可以降低计算或显存带宽瓶颈。
+
+推测解码通过 `SpeculativeConfig` 单独配置。当前推测解码文档使用的是
+PyTorch 后端，因此相关示例应切换到 `PytorchEngineConfig`，而不是期望
+`TurbomindEngineConfig` 直接开启推测解码。
+
+TurboMind 可以服务受支持的全精度和量化文本模型。量化 checkpoint 的使用
+方式请参考 AWQ/GPTQ 和 llm-compressor 文档。多模态模型在受支持模型列表中
+列出时也可以使用 TurboMind；但量化多模态模型是否可用取决于具体模型和量化
+格式，而不是只由 `TurbomindEngineConfig` 决定。
+
+- [推测解码](../advance/spec_decoding.md)
+- [AWQ/GPTQ 量化模型](../quantization/w4a16.md)
+- [llm-compressor 量化模型](../quantization/llm_compressor.md)
+- [支持的模型](../supported_models/supported_models.md)
+
 ### 对 Huggingface 模型的支持
 
 因为历史因素， TurboMind 的权重设计是基于 [LLaMa 的官方实现](https://github.com/facebookresearch/llama) 完成的，两者只相差一个转置操作。但是 Huggingface 版本的实现却是[另一种形式](https://github.com/huggingface/transformers/blob/45025d92f815675e483f32812caa28cce3a960e7/src/transformers/models/llama/convert_llama_weights_to_hf.py#L123C76-L123C76)，两种权重实现方式在 `W_q` 和 `W_k` 上的区别我们在 [deploy.py](https://github.com/InternLM/lmdeploy/blob/ff4648a1d09e5aec74cf70efef35bfaeeac552e0/lmdeploy/serve/turbomind/deploy.py#L398) 进行了适配处理，用户可前往查看。


### PR DESCRIPTION
## Motivation

Issue #3512 asks what `TurbomindEngineConfig` accelerates, whether it enables speculative decoding, and how it relates to quantized text / multimodal models. The current TurboMind architecture page explains persistent batch and KV cache internals, but it does not summarize these practical FAQ answers in one place.

Refs #3512

## Modification

- Add an English and Chinese FAQ entry to the TurboMind architecture docs.
- Explain that `TurbomindEngineConfig` selects/configures the TurboMind backend; the speedup comes from persistent batching, KV cache reuse, optimized kernels, paged attention, tensor parallelism, and KV-cache quantization.
- Clarify that speculative decoding is configured separately and the current guide uses the PyTorch backend.
- Link users to quantized model and supported-model documentation for text and multimodal deployment constraints.

## BC-breaking (Optional)

No. Documentation only.

## Use cases (Optional)

N/A

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
   - `PYTHONPATH= python -m pre_commit run --files docs/en/inference/turbomind.md docs/zh_cn/inference/turbomind.md`
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
   - Documentation-only change; verified by grep for the new FAQ headings.
3. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
   - N/A
4. The documentation has been modified accordingly, like docstring or example tutorials.
   - Updated `docs/en/inference/turbomind.md` and `docs/zh_cn/inference/turbomind.md`.
