### PR TITLE
[Docs] Explain Ray object spilling warning

### DIFF
--- a/docs/en/faq.md
+++ b/docs/en/faq.md
@@ -89,6 +89,20 @@ lmdeploy chat internlm/internlm2_5-7b-chat --cache-max-entry-count 0.2
 lmdeploy serve api_server internlm/internlm2_5-7b-chat --cache-max-entry-count 0.2
 ```
 
+### Ray reports `/tmp/ray/... is over 95% full` and `Object creation will fail if spilling is required`
+
+This warning comes from Ray, which LMDeploy may use for multi-GPU or distributed PyTorch execution. Ray stores logs and temporary session data under `/tmp/ray` by default, and object spilling also writes to the local filesystem when the Ray object store is full.
+
+If the server is otherwise healthy and no object spilling happens, this warning can be ignored temporarily. If it appears repeatedly or the disk is almost full, stop the related LMDeploy/Ray processes first and then free space from stale Ray session directories. Do not remove the active Ray session while LMDeploy is still running.
+
+For long-running services, consider starting Ray with an object spilling directory on a disk with enough free space:
+
+```shell
+ray start --head --object-spilling-directory=/path/to/spill/dir
+```
+
+See Ray's [object spilling](https://docs.ray.io/en/latest/ray-core/objects/object-spilling.html) documentation for more details.
+
 ## Serve
 
 ### Api Server Fetch Timeout

--- a/docs/zh_cn/faq.md
+++ b/docs/zh_cn/faq.md
@@ -88,6 +88,20 @@ lmdeploy chat internlm/internlm2_5-7b-chat --cache-max-entry-count 0.2
 lmdeploy serve api_server internlm/internlm2_5-7b-chat --cache-max-entry-count 0.2
 ```
 
+### Ray 输出 `/tmp/ray/... is over 95% full` 和 `Object creation will fail if spilling is required`
+
+这是 Ray 的告警。LMDeploy 在多卡或分布式 PyTorch 执行时可能会使用 Ray。Ray 默认会把日志和临时 session 数据放在 `/tmp/ray` 下；当 Ray object store 空间不足并触发 object spilling 时，也会把对象溢写到本地文件系统。
+
+如果服务本身正常，而且没有发生 object spilling，可以暂时忽略该告警。如果告警频繁出现或磁盘确实接近写满，请先停止相关 LMDeploy/Ray 进程，再清理已经失效的 Ray session 目录。不要在 LMDeploy 仍在运行时删除当前活跃的 Ray session。
+
+对于长期运行的服务，可以把 Ray 的 object spilling 目录放到空间充足的磁盘上：
+
+```shell
+ray start --head --object-spilling-directory=/path/to/spill/dir
+```
+
+更多细节请参考 Ray 的 [object spilling](https://docs.ray.io/en/latest/ray-core/objects/object-spilling.html) 文档。
+
 ## 服务
 
 ### Api 服务器获取超时


### PR DESCRIPTION
## Motivation

Issue #3457 reports repeated Ray filesystem warnings like `/tmp/ray/... is over 95% full` and `Object creation will fail if spilling is required` while serving with the PyTorch backend. Maintainer feedback explains this is a Ray filesystem/log warning rather than an LMDeploy model failure, but the FAQ did not document what users should do safely.

Refs #3457

## Modification

- Add English and Chinese FAQ entries for Ray object-spilling / `/tmp/ray` disk-space warnings.
- Explain when the warning can be ignored temporarily.
- Advise users to stop related LMDeploy/Ray processes before cleaning stale Ray session directories.
- Mention configuring Ray's object spilling directory for long-running services.

## BC-breaking (Optional)

No. Documentation only.

## Use cases (Optional)

N/A

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
   - `PYTHONPATH= python -m pre_commit run --files docs/en/faq.md docs/zh_cn/faq.md`
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
   - Documentation-only change; verified by grep for the new FAQ heading.
3. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
   - N/A
4. The documentation has been modified accordingly, like docstring or example tutorials.
   - Updated `docs/en/faq.md` and `docs/zh_cn/faq.md`.
