### PR TITLE
[Docs] Document GLM-4.7 tool parser

### DIFF
--- a/docs/en/llm/api_server_tools.md
+++ b/docs/en/llm/api_server_tools.md
@@ -1,11 +1,18 @@
 # Tools Calling
 
-LMDeploy supports tools for InternLM2, InternLM2.5, llama3.1 and Qwen2.5 models. Please use `--tool-call-parser` to specify
+LMDeploy supports tools for InternLM2, InternLM2.5, Llama3.1, Qwen2.5, and GLM-4.7 models. Please use `--tool-call-parser` to specify
 which parser to use when launching the api_server. Supported names are:
 
 1. internlm
 2. qwen
 3. llama3
+4. glm47
+
+For example, start a GLM-4.7 service with:
+
+```shell
+lmdeploy serve api_server /path/to/GLM-4.7-Flash --tool-call-parser glm47
+```
 
 ## Single Round Invocation
 

--- a/docs/zh_cn/llm/api_server_tools.md
+++ b/docs/zh_cn/llm/api_server_tools.md
@@ -1,11 +1,18 @@
 # Tools
 
-LMDeploy 支持 InternLM2, InternLM2.5, Llama3.1 和 Qwen2.5模型的工具调用。请在启动 api_server 的时候使用 `--tool-call-parser` 指定
+LMDeploy 支持 InternLM2, InternLM2.5, Llama3.1, Qwen2.5 和 GLM-4.7 模型的工具调用。请在启动 api_server 的时候使用 `--tool-call-parser` 指定
 parser 名字。以下是支持的名字:
 
 1. internlm
 2. qwen
 3. llama3
+4. glm47
+
+例如，启动 GLM-4.7 服务时可以使用：
+
+```shell
+lmdeploy serve api_server /path/to/GLM-4.7-Flash --tool-call-parser glm47
+```
 
 ## 单轮调用
 


### PR DESCRIPTION
## Motivation

Issues #4400 and #4329 ask how to configure GLM-4.7 tool-calling options in LMDeploy. Current `main` includes the `glm47` tool parser, but the tool-calling docs only list `internlm`, `qwen`, and `llama3` parser names.

Refs #4400
Refs #4329

## Modification

- Add GLM-4.7 to the English and Chinese tool-calling docs.
- List `glm47` as a supported `--tool-call-parser` name.
- Add a minimal GLM-4.7 launch example using `--tool-call-parser glm47`.

## BC-breaking (Optional)

No. Documentation only.

## Use cases (Optional)

```shell
lmdeploy serve api_server /path/to/GLM-4.7-Flash --tool-call-parser glm47
```

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
   - `PYTHONPATH= python -m pre_commit run --files docs/en/llm/api_server_tools.md docs/zh_cn/llm/api_server_tools.md`
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
   - Documentation-only change; verified by grep for `glm47` in both docs.
3. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
   - N/A
4. The documentation has been modified accordingly, like docstring or example tutorials.
   - Updated `docs/en/llm/api_server_tools.md` and `docs/zh_cn/llm/api_server_tools.md`.
