### PR TITLE
[Docs] Explain sm_120 Triton check failure

### DIFF
--- a/docs/en/faq.md
+++ b/docs/en/faq.md
@@ -59,6 +59,12 @@ export LD_LIBRARY_PATH={Location}/nvidia/nccl/lib:$LD_LIBRARY_PATH
 
 It's probably due to a low-version cuda toolkit. LMDeploy runtime requires a minimum CUDA version of 11.2
 
+### `ptxas fatal: Value 'sm_120' is not defined for option 'gpu-name'`
+
+This usually means that the Triton/CUDA toolchain in the current Python environment does not recognize the GPU compute capability, for example RTX 50 series / Blackwell (`sm_120`). LMDeploy runs a small Triton vector-add kernel during environment checks before starting the PyTorch engine, so an incompatible Triton or CUDA package can fail before model loading starts.
+
+Please install a PyTorch, Triton, and CUDA runtime combination that supports your GPU architecture, then run `lmdeploy check_env` again. If the error still comes from Triton's code generation, report it to the Triton project or use an LMDeploy image/package built with a compatible Triton stack.
+
 ## Inference
 
 ### RuntimeError: \[TM\]\[ERROR\] CUDA runtime error: out of memory /workspace/lmdeploy/src/turbomind/utils/allocator.h

--- a/docs/zh_cn/faq.md
+++ b/docs/zh_cn/faq.md
@@ -59,6 +59,12 @@ export LD_LIBRARY_PATH={Location}/nvidia/nccl/lib:$LD_LIBRARY_PATH
 
 很可能是机器上的 cuda 版本太低导致的。LMDeploy运行时要求 cuda 不低于 11.2
 
+### `ptxas fatal: Value 'sm_120' is not defined for option 'gpu-name'`
+
+这通常表示当前 Python 环境里的 Triton/CUDA 工具链无法识别 GPU 的计算能力，例如 RTX 50 系列 / Blackwell（`sm_120`）。LMDeploy 在启动 PyTorch 引擎前会运行一个很小的 Triton vector-add kernel 做环境检查，因此 Triton 或 CUDA 包不兼容时，可能在模型加载前就失败。
+
+请安装支持当前 GPU 架构的 PyTorch、Triton 和 CUDA runtime 组合，然后重新运行 `lmdeploy check_env`。如果错误仍然来自 Triton code generation，请向 Triton 项目反馈，或使用带兼容 Triton 栈的 LMDeploy 镜像/安装包。
+
 ## 推理
 
 ### RuntimeError: \[TM\]\[ERROR\] CUDA runtime error: out of memory /workspace/lmdeploy/src/turbomind/utils/allocator.h


### PR DESCRIPTION
## Motivation

Issue #3410 reports an RTX 50 series / Blackwell startup failure where LMDeploy's PyTorch engine environment check fails in Triton with:

```text
ptxas fatal: Value 'sm_120' is not defined for option 'gpu-name'
```

The maintainer response explains that LMDeploy runs a small Triton vector-add kernel during environment checks, and that this kind of failure should be addressed by using a Triton/CUDA stack that supports the GPU architecture.

Refs #3410

## Modification

- Add English and Chinese FAQ entries for the `sm_120` / `ptxas fatal` Triton check failure.
- Explain that the failure usually comes from an incompatible Triton/CUDA/PyTorch runtime stack, not from model loading itself.
- Point users to rerun `lmdeploy check_env` after installing compatible packages, or use a compatible LMDeploy image/package.

## BC-breaking (Optional)

No. Documentation only.

## Use cases (Optional)

N/A

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
   - `PYTHONPATH= python -m pre_commit run --files docs/en/faq.md docs/zh_cn/faq.md`
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
   - Documentation-only change; verified by grep for `sm_120` / `ptxas fatal` in both FAQ files.
3. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
   - N/A
4. The documentation has been modified accordingly, like docstring or example tutorials.
   - Updated `docs/en/faq.md` and `docs/zh_cn/faq.md`.
