### PR TITLE
[Fix] Allow InternVL to skip dynamic preprocessing

### DIFF
--- a/docs/en/multi_modal/internvl.md
+++ b/docs/en/multi_modal/internvl.md
@@ -51,6 +51,26 @@ response = pipe((f'describe this image', image))
 print(response)
 ```
 
+### Control dynamic image preprocessing
+
+InternVL models use dynamic image preprocessing by default: an input image may be resized and split into multiple visual patches before inference. You can pass image-level parameters through `image_url` to control this behavior. For example, `max_dynamic_patch` limits the maximum number of dynamic patches, and `skip_preprocess=True` skips the dynamic splitting step when your application has already prepared the image and needs a stable mapping back to that image.
+
+```python
+from lmdeploy import pipeline
+
+pipe = pipeline('OpenGVLab/InternVL2-8B')
+messages = [dict(role='user', content=[
+    dict(type='text', text='Describe this image.'),
+    dict(type='image_url', image_url=dict(
+        url='https://raw.githubusercontent.com/open-mmlab/mmdeploy/main/tests/data/tiger.jpeg',
+        max_dynamic_patch=1,
+        skip_preprocess=True))
+])]
+response = pipe(messages)
+```
+
+`skip_preprocess=True` only skips InternVL's dynamic preprocessing. The image still goes through the model transform required by the vision encoder.
+
 More examples are listed below:
 
 <details>

--- a/docs/zh_cn/multi_modal/internvl.md
+++ b/docs/zh_cn/multi_modal/internvl.md
@@ -51,6 +51,26 @@ response = pipe((f'describe this image', image))
 print(response)
 ```
 
+### 控制动态图片预处理
+
+InternVL 模型默认会使用动态图片预处理：输入图片在推理前可能会被 resize，并被切分成多个视觉 patch。你可以通过 `image_url` 传入图片级参数来控制该行为。例如，`max_dynamic_patch` 可以限制动态 patch 数量上限；当业务已经提前处理好图片，并且需要稳定映射回该图片时，可以设置 `skip_preprocess=True` 跳过动态切分步骤。
+
+```python
+from lmdeploy import pipeline
+
+pipe = pipeline('OpenGVLab/InternVL2-8B')
+messages = [dict(role='user', content=[
+    dict(type='text', text='Describe this image.'),
+    dict(type='image_url', image_url=dict(
+        url='https://raw.githubusercontent.com/open-mmlab/mmdeploy/main/tests/data/tiger.jpeg',
+        max_dynamic_patch=1,
+        skip_preprocess=True))
+])]
+response = pipe(messages)
+```
+
+`skip_preprocess=True` 只会跳过 InternVL 的动态预处理。图片仍会经过视觉编码器所需的模型 transform。
+
 更多例子如下：
 
 <details>

--- a/lmdeploy/vl/model/internvl.py
+++ b/lmdeploy/vl/model/internvl.py
@@ -153,16 +153,20 @@ class InternVLVisionModel(VisionModel):
         self.model = model.eval()
 
     def _preprocess_v1_5(self, image, params=None):
+        params = params or {}
         image_res = {'low': 6, 'medium': 12, 'high': 24}
-        max_num = params.get('max_dynamic_patch')
-        if max_num is None or not isinstance(max_num, int):
-            res_key = params.get('detail', 'default')
-            max_num = image_res.get(res_key, self.config.max_dynamic_patch)
-        out = dynamic_preprocess(image,
-                                 min_num=self.config.min_dynamic_patch,
-                                 max_num=max_num,
-                                 image_size=self.vision_config.image_size,
-                                 use_thumbnail=self.config.use_thumbnail)
+        if params.get('skip_preprocess', False):
+            out = [image]
+        else:
+            max_num = params.get('max_dynamic_patch')
+            if max_num is None or not isinstance(max_num, int):
+                res_key = params.get('detail', 'default')
+                max_num = image_res.get(res_key, self.config.max_dynamic_patch)
+            out = dynamic_preprocess(image,
+                                     min_num=self.config.min_dynamic_patch,
+                                     max_num=max_num,
+                                     image_size=self.vision_config.image_size,
+                                     use_thumbnail=self.config.use_thumbnail)
         pixel_values = [self.transform(x) for x in out]
         # (patch) x c x h x w
         pixel_values = torch.stack(pixel_values)

--- a/tests/test_lmdeploy/test_vl/test_internvl_preprocess.py
+++ b/tests/test_lmdeploy/test_vl/test_internvl_preprocess.py
@@ -1,0 +1,25 @@
+from types import SimpleNamespace
+
+import torch
+from PIL import Image
+
+from lmdeploy.vl.model import internvl as internvl_module
+from lmdeploy.vl.model.internvl import InternVLVisionModel
+
+
+def test_internvl_skip_preprocess_bypasses_dynamic_preprocess(monkeypatch):
+    def fail_dynamic_preprocess(*args, **kwargs):
+        raise AssertionError('dynamic_preprocess should be skipped')
+
+    monkeypatch.setattr(internvl_module, 'dynamic_preprocess', fail_dynamic_preprocess)
+
+    model = InternVLVisionModel.__new__(InternVLVisionModel)
+    model.config = SimpleNamespace(min_dynamic_patch=1, max_dynamic_patch=6, use_thumbnail=False)
+    model.vision_config = SimpleNamespace(image_size=448)
+    model.transform = lambda image: torch.tensor(image.size, dtype=torch.float32)
+
+    image = Image.new('RGB', (320, 240))
+    pixel_values = model._preprocess_v1_5(image, params={'skip_preprocess': True})
+
+    assert pixel_values.shape == (1, 2)
+    torch.testing.assert_close(pixel_values[0], torch.tensor([320.0, 240.0]))


### PR DESCRIPTION
## Motivation

Issue #3778 asks how to avoid InternVL's internal dynamic resize/splitting when the application needs a stable mapping back to a prepared image, e.g. grounding coordinates.

Refs #3778

## Modification

- Add `skip_preprocess=True` support for the legacy InternVL dynamic image preprocessing path.
- When enabled, LMDeploy skips `dynamic_preprocess(...)` and applies the existing model transform to the original image as a single patch.
- Document `max_dynamic_patch` and `skip_preprocess` in the English and Chinese InternVL docs.
- Add a regression test that fails if `skip_preprocess=True` still calls `dynamic_preprocess`.

## BC-breaking (Optional)

No. The default preprocessing path is unchanged.

## Use cases (Optional)

```python
messages = [dict(role='user', content=[
    dict(type='text', text='Describe this image.'),
    dict(type='image_url', image_url=dict(
        url='https://example.com/image.jpg',
        max_dynamic_patch=1,
        skip_preprocess=True))
])]
```

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
   - `PYTHONPATH= python -m pre_commit run --files lmdeploy/vl/model/internvl.py tests/test_lmdeploy/test_vl/test_internvl_preprocess.py docs/en/multi_modal/internvl.md docs/zh_cn/multi_modal/internvl.md`
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
   - `python -m pytest tests/test_lmdeploy/test_vl/test_internvl_preprocess.py -q`
3. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
   - N/A
4. The documentation has been modified accordingly, like docstring or example tutorials.
   - Updated `docs/en/multi_modal/internvl.md` and `docs/zh_cn/multi_modal/internvl.md`.
