### PR TITLE
[Docs] Clarify VLM LoRA serving scope

### DIFF
--- a/docs/en/llm/api_server_lora.md
+++ b/docs/en/llm/api_server_lora.md
@@ -4,6 +4,8 @@
 
 LoRA is currently only supported by the PyTorch backend. Its deployment process is similar to that of other models, and you can view the commands using lmdeploy `serve api_server -h`. Among the parameters supported by the PyTorch backend, there are configuration options for LoRA.
 
+For multimodal models, such as InternVL-style VLMs, the current LoRA serving path is intended for language-model adapters. If a VLM wrapper exposes a language-model LoRA loader, LMDeploy delegates adapter loading to that language model. Vision-encoder LoRA adapters are not covered by this generic serving path; merge them into the checkpoint or validate them with a model-specific path before serving.
+
 ```
 PyTorch engine arguments:
   --adapters [ADAPTERS [ADAPTERS ...]]

--- a/docs/zh_cn/llm/api_server_lora.md
+++ b/docs/zh_cn/llm/api_server_lora.md
@@ -4,6 +4,8 @@
 
 LoRA 目前只有 pytorch 后端支持。它的服务化，和其他模型服务化一样，命令都可以用 `lmdeploy serve api_server -h` 查看。其中 pytorch 后端支持的参数就有 LoRA 的配置内容。
 
+对于 InternVL 这类多模态模型，当前 LoRA 服务化路径主要用于语言模型侧 adapter。如果 VLM wrapper 暴露了语言模型的 LoRA 加载接口，LMDeploy 会把 adapter 加载委托给内部语言模型。视觉编码器 LoRA adapter 不属于该通用服务化路径覆盖范围；如果需要使用视觉侧 LoRA，请先将其合并进 checkpoint，或通过模型专用路径验证后再服务化。
+
 ```
 PyTorch engine arguments:
   --adapters [ADAPTERS [ADAPTERS ...]]


### PR DESCRIPTION
## Motivation

Issue #3981 asks whether LMDeploy supports serving multiple LoRA adapters for multimodal models and notes that vision-side LoRA did not work in their test.

Current InternVL model wrappers route LoRA loading through the language model when that loader is available, so the existing generic LoRA serving docs should clarify the VLM scope instead of implying that arbitrary visual-encoder adapters are covered.

Refs #3981

## Modification

- Clarify in English and Chinese LoRA serving docs that the generic serving path is intended for language-model adapters on multimodal models.
- Mention that vision-encoder LoRA adapters are not covered by the generic serving path and should be merged or validated through a model-specific path before serving.

## BC-breaking (Optional)

No. Documentation only.

## Use cases (Optional)

N/A

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
   - `PYTHONPATH= python -m pre_commit run --files docs/en/llm/api_server_lora.md docs/zh_cn/llm/api_server_lora.md`
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
   - Documentation-only change; verified by grep for the new VLM LoRA scope text.
3. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
   - N/A
4. The documentation has been modified accordingly, like docstring or example tutorials.
   - Updated `docs/en/llm/api_server_lora.md` and `docs/zh_cn/llm/api_server_lora.md`.
