### PR TITLE
feat(pytorch): add optimized Gluon blocked FP8 GEMM for Hopper

### DIFF
--- a/lmdeploy/pytorch/backends/blockedf8_modules.py
+++ b/lmdeploy/pytorch/backends/blockedf8_modules.py
@@ -38,6 +38,11 @@ class LinearBlockedF8Builder(ABC):
 
     @staticmethod
     @abstractmethod
-    def build(in_features: int, out_features: int, bias: bool = True, dtype: torch.dtype = None):
+    def build(in_features: int,
+              out_features: int,
+              block_size: int = 128,
+              bias: bool = True,
+              dtype: torch.dtype = None,
+              fp8_dtype: torch.dtype = torch.float8_e4m3fn):
         """build."""
         raise NotImplementedError

--- a/lmdeploy/pytorch/backends/cuda/blockedf8_modules.py
+++ b/lmdeploy/pytorch/backends/cuda/blockedf8_modules.py
@@ -1,6 +1,7 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 
 import functools
+from abc import abstractmethod
 
 import torch
 from packaging import version
@@ -16,16 +17,16 @@ from .warmup_manager import WarmupMeta, get_warmup_manager
 logger = get_logger('lmdeploy')
 
 _GLUON_TRITON_MIN_VERSION = version.parse('3.6.0')
-_GLUON_TRITON_MAX_VERSION = version.parse('3.7.0')
+_GLUON_TRITON_MAX_EXCLUSIVE = version.parse('3.8.0')
 
 
 def _is_supported_gluon_triton_version(triton_version: str) -> bool:
     """Whether the installed Triton has the validated experimental API."""
     try:
-        triton_version = version.parse(triton_version)
+        parsed_version = version.parse(triton_version)
     except version.InvalidVersion:
         return False
-    return _GLUON_TRITON_MIN_VERSION <= triton_version < _GLUON_TRITON_MAX_VERSION
+    return _GLUON_TRITON_MIN_VERSION <= parsed_version < _GLUON_TRITON_MAX_EXCLUSIVE
 
 
 class CudaLinearBlockedF8Impl(LinearBlockedF8Impl):
@@ -44,6 +45,7 @@ class CudaLinearBlockedF8Impl(LinearBlockedF8Impl):
         self.fp8_dtype = fp8_dtype
         self.block_size = block_size
 
+    @abstractmethod
     def _gemm(self, x: torch.Tensor, weight: torch.Tensor, scale: torch.Tensor):
         raise NotImplementedError
 
@@ -255,7 +257,8 @@ class CudaLinearBlockedF8Builder(LinearBlockedF8Builder):
                 except ImportError:
                     triton_version = 'not installed'
                 raise RuntimeError('Gluon blocked-FP8 linear requires Hopper, BF16 output, FP8 E4M3, block size 128, '
-                                   'K divisible by 128, N divisible by 8, and Triton >=3.6.0,<3.7.0 '
+                                   'K divisible by 128, N divisible by 8, and Triton '
+                                   f'>={_GLUON_TRITON_MIN_VERSION},<{_GLUON_TRITON_MAX_EXCLUSIVE} '
                                    f'(found {triton_version}).')
             impl_cls = GluonLinearBlockedF8Impl
         else:

--- a/lmdeploy/pytorch/backends/cuda/blockedf8_modules.py
+++ b/lmdeploy/pytorch/backends/cuda/blockedf8_modules.py
@@ -1,8 +1,12 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 
+import functools
+
 import torch
+from packaging import version
 
 import lmdeploy.pytorch.distributed as dist
+from lmdeploy.pytorch.envs import blocked_fp8_gemm_backend
 from lmdeploy.pytorch.kernels.cuda.blocked_gemm_fp8 import blocked_gemm_fp8, deep_gemm_fp8, quant_fp8, quant_fp8_tma
 from lmdeploy.utils import get_logger
 
@@ -11,16 +15,37 @@ from .warmup_manager import WarmupMeta, get_warmup_manager
 
 logger = get_logger('lmdeploy')
 
+_GLUON_TRITON_MIN_VERSION = version.parse('3.6.0')
+_GLUON_TRITON_MAX_VERSION = version.parse('3.7.0')
 
-class TritonLinearBlockedF8Impl(LinearBlockedF8Impl):
-    """Triton linear blocked f8 implementation."""
 
-    def __init__(self, in_features: int, out_features: int, block_size: int, out_dtype: torch.dtype = torch.float16):
+def _is_supported_gluon_triton_version(triton_version: str) -> bool:
+    """Whether the installed Triton has the validated experimental API."""
+    try:
+        triton_version = version.parse(triton_version)
+    except version.InvalidVersion:
+        return False
+    return _GLUON_TRITON_MIN_VERSION <= triton_version < _GLUON_TRITON_MAX_VERSION
+
+
+class CudaLinearBlockedF8Impl(LinearBlockedF8Impl):
+    """Common CUDA blocked-FP8 linear lifecycle around a provider GEMM."""
+
+    def __init__(self,
+                 in_features: int,
+                 out_features: int,
+                 block_size: int,
+                 out_dtype: torch.dtype = torch.float16,
+                 fp8_dtype: torch.dtype = torch.float8_e4m3fn):
         super().__init__()
         self.in_features = in_features
         self.out_features = out_features
         self.out_dtype = out_dtype
+        self.fp8_dtype = fp8_dtype
         self.block_size = block_size
+
+    def _gemm(self, x: torch.Tensor, weight: torch.Tensor, scale: torch.Tensor):
+        raise NotImplementedError
 
     def forward(self,
                 x,
@@ -31,19 +56,13 @@ class TritonLinearBlockedF8Impl(LinearBlockedF8Impl):
                 group: dist.ProcessGroup | None = None,
                 rank: int = 0,
                 scatter_size: list[int] = None):
-        """forward."""
+        """Quantize, run the selected GEMM, and apply linear postprocessing."""
         x_shape = x.shape
         x = x.flatten(0, -2)
-        input_quant, input_scale = quant_fp8(x,
-                                             self.block_size,
-                                             dtype=weight.dtype,
-                                             trans_scale=True,
-                                             scale_fmt=self.scale_fmt)
+        out = self._gemm(x, weight, scale)
 
-        out = blocked_gemm_fp8(input_quant, input_scale, weight.t(), scale.t(), out_dtype=x.dtype)
         if bias is not None:
             out += bias
-
         out = out.unflatten(0, x_shape[:-1])
 
         if all_reduce:
@@ -54,83 +73,193 @@ class TritonLinearBlockedF8Impl(LinearBlockedF8Impl):
         return out
 
 
-class TritonLinearBlockedF8Builder(LinearBlockedF8Builder):
-    """Triton linear blocked f8 implementation builder."""
+class TritonLinearBlockedF8Impl(CudaLinearBlockedF8Impl):
+    """Portable Triton blocked-FP8 linear implementation."""
 
-    @staticmethod
-    def build(in_features: int, out_features: int, block_size: int = 128, bias: bool = True, dtype: torch.dtype = None):
-        """build."""
-        try:
-            import deep_gemm  # noqa
-            logger.debug('build with DeepGemmLinearBlockedF8Impl')
-            return DeepGemmLinearBlockedF8Impl(in_features, out_features, block_size, dtype)
-        except:  # noqa
-            logger.warning('Failed to import deep_gemm, LinearBlockedF8 fallback to triton implementation.')
-            return TritonLinearBlockedF8Impl(in_features, out_features, block_size, dtype)
+    def _gemm(self, x: torch.Tensor, weight: torch.Tensor, scale: torch.Tensor):
+        input_quant, input_scale = quant_fp8(x,
+                                             self.block_size,
+                                             dtype=weight.dtype,
+                                             trans_scale=True,
+                                             scale_fmt=self.scale_fmt)
+        return blocked_gemm_fp8(input_quant, input_scale, weight.t(), scale.t(), out_dtype=x.dtype)
 
 
-class DeepGemmLinearBlockedF8Impl(LinearBlockedF8Impl):
-    """Deep gemm blocked f8 implementation."""
+class GluonLinearBlockedF8Impl(CudaLinearBlockedF8Impl):
+    """Hopper Gluon blocked-FP8 linear implementation."""
 
-    def __init__(self, in_features: int, out_features: int, block_size: int, out_dtype: torch.dtype = torch.float16):
-        super().__init__()
-        self.in_features = in_features
-        self.out_features = out_features
-        self.out_dtype = out_dtype
-        self.block_size = block_size
+    def __init__(self,
+                 in_features: int,
+                 out_features: int,
+                 block_size: int,
+                 out_dtype: torch.dtype = torch.bfloat16,
+                 fp8_dtype: torch.dtype = torch.float8_e4m3fn):
+        super().__init__(in_features, out_features, block_size, out_dtype, fp8_dtype)
+        from lmdeploy.pytorch.kernels.cuda.blocked_fp8_gemm_gluon import fp8_gemm_nt
+
+        self._fp8_gemm_nt = fp8_gemm_nt
 
         warmup_mgr = get_warmup_manager()
-        key = ('deepgemm_blockedfp8_gemm_'
-               f'{in_features}_{out_features}_{block_size}_{out_dtype}')
+        key = f'gluon_blockedfp8_gemm_{in_features}_{out_features}_{block_size}_{out_dtype}_{fp8_dtype}'
+        if key not in warmup_mgr:
+            warmup_mgr[key] = self.warmup
+
+    def _gemm(self, x: torch.Tensor, weight: torch.Tensor, scale: torch.Tensor):
+        input_quant, input_scale = quant_fp8(x,
+                                             self.block_size,
+                                             dtype=weight.dtype,
+                                             trans_scale=True,
+                                             scale_fmt=self.scale_fmt)
+        out = x.new_empty((x.size(0), weight.size(0)))
+        self._fp8_gemm_nt((input_quant, input_scale), (weight, scale), out, None)
+        return out
+
+    def warmup(self, warmup_meta: WarmupMeta):
+        """Compile one representative from every reachable M schedule."""
+        max_num_tokens = warmup_meta.max_num_tokens
+        if max_num_tokens <= 0:
+            return
+
+        device = 'cuda'
+        k, n = self.in_features, self.out_features
+        block_size = self.block_size
+        weight = torch.empty(n, k, dtype=self.fp8_dtype, device=device)
+        scale = torch.empty(
+            ((n + block_size - 1) // block_size, (k + block_size - 1) // block_size),
+            dtype=torch.float32,
+            device=device,
+        )
+
+        # M is dynamic inside each schedule. These values compile only the
+        # Python-selected tiny, small, mid, and persistent configurations.
+        candidates = (1, 16, 128, 256, 257, max_num_tokens)
+        for m in sorted({m for m in candidates if m <= max_num_tokens}):
+            inputs = torch.empty(m, k, dtype=self.out_dtype, device=device)
+            self._gemm(inputs, weight, scale)
+
+
+class DeepGemmLinearBlockedF8Impl(CudaLinearBlockedF8Impl):
+    """DeepGEMM blocked-FP8 linear implementation."""
+
+    def __init__(self,
+                 in_features: int,
+                 out_features: int,
+                 block_size: int,
+                 out_dtype: torch.dtype = torch.bfloat16,
+                 fp8_dtype: torch.dtype = torch.float8_e4m3fn):
+        super().__init__(in_features, out_features, block_size, out_dtype, fp8_dtype)
+
+        warmup_mgr = get_warmup_manager()
+        key = f'deepgemm_blockedfp8_gemm_{in_features}_{out_features}_{block_size}_{out_dtype}_{fp8_dtype}'
         if key not in warmup_mgr:
             warmup_mgr[key] = self.warmup
 
     def warmup(self, warmup_meta: WarmupMeta):
-        """warmup."""
+        """Warm up DeepGEMM specializations up to the configured token cap."""
         import random
 
         from lmdeploy.pytorch.third_party.deep_gemm import get_m_alignment_for_contiguous_layout
+
         device = 'cuda'
         max_num_tokens = warmup_meta.max_num_tokens
         alignment = get_m_alignment_for_contiguous_layout()
         range_end = max_num_tokens + alignment - 1
         k, n = self.in_features, self.out_features
         block_size = self.block_size
-        weight = torch.empty(n, k, dtype=torch.float8_e4m3fn, device=device)
-        scale = torch.empty(((n + block_size - 1) // block_size, (k + block_size - 1) // block_size),
-                            dtype=torch.float32,
-                            device=device)
-        # shuffle ranges so ranks might compile different kernels concurrently.
+        weight = torch.empty(n, k, dtype=self.fp8_dtype, device=device)
+        scale = torch.empty(
+            ((n + block_size - 1) // block_size, (k + block_size - 1) // block_size),
+            dtype=torch.float32,
+            device=device,
+        )
+        # Shuffle ranges so ranks might compile different kernels concurrently.
         ranges = list(range(alignment, range_end, alignment))
         random.shuffle(ranges)
         for m in ranges:
             inputs = torch.empty(m, k, dtype=self.out_dtype, device=device)
-            input_quant, input_scale = quant_fp8_tma(inputs, self.block_size, dtype=weight.dtype)
-            deep_gemm_fp8(input_quant, input_scale, weight, scale, out_dtype=inputs.dtype)
+            self._gemm(inputs, weight, scale)
 
-    def forward(self,
-                x,
-                weight: torch.Tensor,
-                scale: torch.Tensor,
-                bias: torch.Tensor | None = None,
-                all_reduce: bool = False,
-                group: dist.ProcessGroup | None = None,
-                rank: int = 0,
-                scatter_size: list[int] = None):
-        """forward."""
-        x_shape = x.shape
-        x = x.flatten(0, -2)
-        input_quant, input_scale = quant_fp8_tma(x, self.block_size, dtype=weight.dtype, scale_fmt=self.scale_fmt)
-
+    def _gemm(self, x: torch.Tensor, weight: torch.Tensor, scale: torch.Tensor):
+        input_quant, input_scale = quant_fp8_tma(x,
+                                                 self.block_size,
+                                                 dtype=weight.dtype,
+                                                 scale_fmt=self.scale_fmt)
         out = deep_gemm_fp8(input_quant, input_scale, weight, scale, out_dtype=x.dtype)
-        out = out[:x.size(0)]
-        if bias is not None:
-            out += bias
-        out = out.unflatten(0, x_shape[:-1])
+        return out[:x.size(0)]
 
-        if all_reduce:
-            if scatter_size is not None:
-                out = dist.reduce_scatter_by_tp_sizes(out, rank, scatter_size, group=group)
+
+@functools.lru_cache
+def _has_deep_gemm() -> bool:
+    try:
+        import deep_gemm  # noqa: F401
+    except ImportError:
+        return False
+    return torch.cuda.is_available() and torch.cuda.get_device_capability()[0] >= 9
+
+
+@functools.lru_cache
+def _has_gluon() -> bool:
+    if not torch.cuda.is_available() or torch.cuda.get_device_capability()[0] != 9:
+        return False
+    try:
+        import triton
+
+        if not _is_supported_gluon_triton_version(triton.__version__):
+            return False
+        from lmdeploy.pytorch.kernels.cuda.blocked_fp8_gemm_gluon import fp8_gemm_nt  # noqa: F401
+    except (AttributeError, ImportError):
+        return False
+    return True
+
+
+def _supports_deep_gemm(block_size: int, dtype: torch.dtype, fp8_dtype: torch.dtype) -> bool:
+    return (_has_deep_gemm() and block_size == 128 and dtype == torch.bfloat16
+            and fp8_dtype == torch.float8_e4m3fn)
+
+
+def _supports_gluon(in_features: int, out_features: int, block_size: int, dtype: torch.dtype,
+                    fp8_dtype: torch.dtype) -> bool:
+    return (_has_gluon() and block_size == 128 and dtype == torch.bfloat16
+            and fp8_dtype == torch.float8_e4m3fn and in_features % block_size == 0 and out_features % 8 == 0)
+
+
+class CudaLinearBlockedF8Builder(LinearBlockedF8Builder):
+    """Select one blocked-FP8 GEMM provider when constructing the layer."""
+
+    @staticmethod
+    def build(in_features: int,
+              out_features: int,
+              block_size: int = 128,
+              bias: bool = True,
+              dtype: torch.dtype = None,
+              fp8_dtype: torch.dtype = torch.float8_e4m3fn):
+        """Build the requested provider or the best compatible provider."""
+        provider = blocked_fp8_gemm_backend
+
+        if provider == 'auto':
+            if _supports_deep_gemm(block_size, dtype, fp8_dtype):
+                impl_cls = DeepGemmLinearBlockedF8Impl
+            elif _supports_gluon(in_features, out_features, block_size, dtype, fp8_dtype):
+                impl_cls = GluonLinearBlockedF8Impl
             else:
-                dist.all_reduce(out, group=group)
-        return out
+                impl_cls = TritonLinearBlockedF8Impl
+        elif provider == 'deepgemm':
+            if not _supports_deep_gemm(block_size, dtype, fp8_dtype):
+                raise RuntimeError('DeepGEMM blocked-FP8 linear was requested but is unavailable or incompatible.')
+            impl_cls = DeepGemmLinearBlockedF8Impl
+        elif provider == 'gluon':
+            if not _supports_gluon(in_features, out_features, block_size, dtype, fp8_dtype):
+                try:
+                    import triton
+                    triton_version = triton.__version__
+                except ImportError:
+                    triton_version = 'not installed'
+                raise RuntimeError('Gluon blocked-FP8 linear requires Hopper, BF16 output, FP8 E4M3, block size 128, '
+                                   'K divisible by 128, N divisible by 8, and Triton >=3.6.0,<3.7.0 '
+                                   f'(found {triton_version}).')
+            impl_cls = GluonLinearBlockedF8Impl
+        else:
+            impl_cls = TritonLinearBlockedF8Impl
+
+        logger.debug(f'Build LinearBlockedF8 with {impl_cls.__name__}.')
+        return impl_cls(in_features, out_features, block_size, dtype, fp8_dtype)

--- a/lmdeploy/pytorch/backends/cuda/op_backend.py
+++ b/lmdeploy/pytorch/backends/cuda/op_backend.py
@@ -65,8 +65,8 @@ class CudaOpsBackend(DefaultOpsBackend):
             from .moe import TritonFusedMoEV4FP4Builder
             return TritonFusedMoEV4FP4Builder
         elif layer_type == OpType.LinearBlockedF8:
-            from .blockedf8_modules import TritonLinearBlockedF8Builder
-            return TritonLinearBlockedF8Builder
+            from .blockedf8_modules import CudaLinearBlockedF8Builder
+            return CudaLinearBlockedF8Builder
         elif layer_type == OpType.NSAIndexFP8:
             from .nsa import TritonNSAIndexFP8Builder
             return TritonNSAIndexFP8Builder

--- a/lmdeploy/pytorch/check_env/transformers.py
+++ b/lmdeploy/pytorch/check_env/transformers.py
@@ -1,10 +1,9 @@
 # Copyright (c) OpenMMLab. All rights reserved.
-from packaging import version
+from packaging.specifiers import SpecifierSet
 
 from .base import BaseChecker
 
-MIN_TRANSFORMERS_VERSION = '4.33.0'
-MAX_TRANSFORMERS_VERSION = '5.3.0'
+TRANSFORMERS_VERSION_SPEC = ('>=4.56.0,!=5.0.*,!=5.1.*,!=5.2.*,!=5.3.*,!=5.4.*,!=5.5.0,!=5.7.*,!=5.8.*,!=5.9.*')
 
 
 class TransformersChecker(BaseChecker):
@@ -15,14 +14,8 @@ class TransformersChecker(BaseChecker):
         import transformers
         logger = self.get_logger()
         try:
-            trans_version = version.parse(transformers.__version__)
-            min_version = version.parse(MIN_TRANSFORMERS_VERSION)
-            max_version = version.parse(MAX_TRANSFORMERS_VERSION)
-            if trans_version < min_version or trans_version > max_version:
-                logger.warning('LMDeploy requires transformers version: '
-                               f'[{MIN_TRANSFORMERS_VERSION} ~ '
-                               f'{MAX_TRANSFORMERS_VERSION}], '
-                               'but found version: '
-                               f'{transformers.__version__}')
+            if not SpecifierSet(TRANSFORMERS_VERSION_SPEC).contains(transformers.__version__):
+                logger.warning(f'LMDeploy requires transformers{TRANSFORMERS_VERSION_SPEC}, '
+                               f'but found transformers=={transformers.__version__}.')
         except Exception as e:
             self.log_and_exit(e, 'transformers', 'transformers is not available.')

--- a/lmdeploy/pytorch/envs.py
+++ b/lmdeploy/pytorch/envs.py
@@ -175,6 +175,8 @@ with set_envs():
     # deepgemm
     os.getenv('DG_JIT_DEBUG', '0')
     os.getenv('DG_JIT_PRINT_COMPILER_COMMAND', '0')
+    blocked_fp8_gemm_backend = env_to_choice('LMDEPLOY_BLOCKED_FP8_GEMM_BACKEND', 'auto',
+                                             {'auto', 'deepgemm', 'gluon', 'triton'})
 
     # model agent
     skip_warmup = env_to_bool('LMDEPLOY_SKIP_WARMUP', False)

--- a/lmdeploy/pytorch/envs.py
+++ b/lmdeploy/pytorch/envs.py
@@ -175,6 +175,8 @@ with set_envs():
     # deepgemm
     os.getenv('DG_JIT_DEBUG', '0')
     os.getenv('DG_JIT_PRINT_COMPILER_COMMAND', '0')
+
+    # blocked FP8 GEMM
     blocked_fp8_gemm_backend = env_to_choice('LMDEPLOY_BLOCKED_FP8_GEMM_BACKEND', 'auto',
                                              {'auto', 'deepgemm', 'gluon', 'triton'})
 

--- a/lmdeploy/pytorch/kernels/cuda/blocked_fp8_gemm_gluon.py
+++ b/lmdeploy/pytorch/kernels/cuda/blocked_fp8_gemm_gluon.py
@@ -1,6 +1,8 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 """Shape-specialized blocked-FP8 GEMM for NVIDIA Hopper GPUs."""
 
+import functools
+
 import torch
 import triton
 from triton.experimental import gluon
@@ -14,6 +16,8 @@ from triton.experimental.gluon.language.nvidia.hopper import (
     warpgroup_mma_wait,
 )
 from triton.experimental.gluon.nvidia.hopper import TensorDescriptor
+
+from .utils import get_device_props
 
 try:
     from gluon import aggregate
@@ -33,8 +37,9 @@ MID_M_THRESHOLD = 256
 
 # The three schedules keep the same blocked-scaling math but optimize different
 # bottlenecks. Small M keeps loading and compute in one partition to minimize
-# overhead; middle M separates a TMA producer from the compute warpgroup; large
-# M additionally persists CTAs and splits its 256-row accumulator into waves.
+# overhead; the middle schedule separates a TMA producer from the compute
+# warpgroup while its grid fits two CTAs per SM; larger grids additionally
+# persist CTAs and split each 256-row accumulator into waves.
 
 
 @gluon.constexpr_function
@@ -1141,7 +1146,7 @@ def _launch_large_m_kernel(a_quant, a_scale, b_quant, b_scale, output):
     a_scale_desc = TensorDescriptor.from_tensor(a_scale_transposed, a_scale_block_shape, a_scale_layout)
 
     num_tiles = triton.cdiv(m, block_m) * triton.cdiv(n, block_n)
-    num_sms = torch.cuda.get_device_properties(a_quant.device).multi_processor_count
+    num_sms = get_device_props(a_quant.device.index)['multi_processor_count']
     # Cap the persistent grid at the SM count; each program obtains further
     # logical output tiles from PersistentTileScheduler.
     grid = (min(num_sms, num_tiles), )
@@ -1162,6 +1167,21 @@ def _launch_large_m_kernel(a_quant, a_scale, b_quant, b_scale, output):
     )
 
 
+@functools.lru_cache
+def _use_mid_m_kernel(m, n, device_index):
+    """Use the mid schedule while its grid fits one resident CTA wave."""
+    if m <= MID_M_THRESHOLD:
+        return True
+
+    # The mid kernel can keep two CTAs resident per Hopper SM, whereas the
+    # register-heavy persistent kernel is limited to one. Prefer mid when all
+    # of its 64x128 tiles fit in that resident capacity; this avoids launching
+    # an underfilled persistent grid, notably at M=512, N=4096 on H200.
+    mid_tiles = triton.cdiv(m, 64) * triton.cdiv(n, 128)
+    num_sms = get_device_props(device_index)['multi_processor_count']
+    return mid_tiles <= 2 * num_sms
+
+
 def fp8_gemm_nt(a, b, d, c):
     """Compute a blocked-scaled FP8 GEMM with an NT operand convention.
 
@@ -1175,17 +1195,17 @@ def fp8_gemm_nt(a, b, d, c):
 
     M up to 128 uses a single-partition multistage schedule. Within that body,
     M up to 8 with K at least 4096 computes the equivalent transposed GEMM to
-    avoid padding the tensor-core result to 64 rows. M from 129 through 256
-    uses a primed warp-specialized schedule. Larger M uses a persistent
-    two-wave schedule that reuses B data and scales while controlling
-    accumulator register pressure.
+    avoid padding the tensor-core result to 64 rows. M above 128 uses a primed
+    warp-specialized schedule while its 64x128 tile grid fits the two-CTA-per-SM
+    resident capacity. Larger grids use a persistent two-wave schedule that
+    reuses B data and scales while controlling accumulator register pressure.
     """
     a_quant, a_scale = a
     b_quant, b_scale = b
 
     if d.size(0) <= SMALL_M_THRESHOLD:
         _launch_small_m_kernel(a_quant, a_scale, b_quant, b_scale, d)
-    elif d.size(0) <= MID_M_THRESHOLD:
+    elif _use_mid_m_kernel(d.size(0), d.size(1), d.device.index):
         _launch_mid_m_kernel(a_quant, a_scale, b_quant, b_scale, d)
     else:
         _launch_large_m_kernel(a_quant, a_scale, b_quant, b_scale, d)

--- a/lmdeploy/pytorch/kernels/cuda/blocked_fp8_gemm_gluon.py
+++ b/lmdeploy/pytorch/kernels/cuda/blocked_fp8_gemm_gluon.py
@@ -1139,7 +1139,7 @@ def _launch_warp_specialized(a_quant, a_scale, b_quant, b_scale, output):
     )
 
 
-def _launch_persistent(a_quant, a_scale, b_quant, b_scale, output):
+def _launch_persistent(a_quant, a_scale, b_quant, b_scale, output, num_sms):
     m, n = output.shape
     k = a_quant.size(-1)
     block_m = 256
@@ -1158,9 +1158,8 @@ def _launch_persistent(a_quant, a_scale, b_quant, b_scale, output):
     a_scale_desc = TensorDescriptor.from_tensor(a_scale_transposed, a_scale_block_shape, a_scale_layout)
 
     num_tiles = triton.cdiv(m, block_m) * triton.cdiv(n, block_n)
-    num_sms = get_device_props(a_quant.device.index)['multi_processor_count']
-    # Cap the persistent grid at the SM count; each program obtains further
-    # logical output tiles from PersistentTileScheduler.
+    # Cap the persistent grid at the per-call SM budget; each program obtains
+    # further logical output tiles from PersistentTileScheduler.
     grid = (min(num_sms, num_tiles), )
     _fp8_gemm_nt_persistent_kernel[grid](
         a_desc,
@@ -1221,7 +1220,7 @@ def _use_warp_specialized(m, n, device_index):
     return warp_specialized_tiles <= 2 * num_sms
 
 
-def fp8_gemm_nt(a, b, d, c):
+def fp8_gemm_nt(a, b, d, c, *, num_sms=None):
     """Compute a blocked-scaled FP8 GEMM with an NT operand convention.
 
     ``a`` contains contiguous FP8 values shaped ``[M, K]`` and per-row scales
@@ -1240,14 +1239,25 @@ def fp8_gemm_nt(a, b, d, c):
     single-partition body to avoid warp-specialization barriers. Other middle
     shapes use a primed warp-specialized 64x128 schedule. Larger grids use a
     persistent two-wave schedule that reuses B data and scales while
-    controlling accumulator register pressure.
+    controlling accumulator register pressure. ``num_sms`` optionally limits
+    the persistent launch to that many programs, leaving the remaining SMs
+    available for overlapping work. It is a scheduling hint for the persistent
+    path; the finite small and middle grids are unchanged.
     """
     a_quant, a_scale = a
     b_quant, b_scale = b
+
+    device_num_sms = get_device_props(d.device.index)['multi_processor_count']
+    if num_sms is None:
+        num_sms = device_num_sms
+    elif not isinstance(num_sms, int) or isinstance(num_sms, bool):
+        raise TypeError(f'num_sms must be an integer or None, got {type(num_sms).__name__}')
+    elif not 1 <= num_sms <= device_num_sms:
+        raise ValueError(f'num_sms must be between 1 and {device_num_sms}, got {num_sms}')
 
     if _use_single_partition(d.size(0), d.size(1), d.device.index):
         _launch_single_partition(a_quant, a_scale, b_quant, b_scale, d)
     elif _use_warp_specialized(d.size(0), d.size(1), d.device.index):
         _launch_warp_specialized(a_quant, a_scale, b_quant, b_scale, d)
     else:
-        _launch_persistent(a_quant, a_scale, b_quant, b_scale, d)
+        _launch_persistent(a_quant, a_scale, b_quant, b_scale, d, num_sms)

--- a/lmdeploy/pytorch/kernels/cuda/blocked_fp8_gemm_gluon.py
+++ b/lmdeploy/pytorch/kernels/cuda/blocked_fp8_gemm_gluon.py
@@ -1,0 +1,1100 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+"""Shape-specialized blocked-FP8 GEMM for NVIDIA Hopper GPUs."""
+
+import torch
+import triton
+from triton.experimental import gluon
+from triton.experimental.gluon import language as gl
+from triton.experimental.gluon.language.nvidia.hopper import (
+    fence_async_shared,
+    mbarrier,
+    tma,
+    warpgroup_mma,
+    warpgroup_mma_init,
+    warpgroup_mma_wait,
+)
+from triton.experimental.gluon.nvidia.hopper import TensorDescriptor
+
+try:
+    from gluon import aggregate
+except ImportError:
+    from triton.language.core import _aggregate as aggregate
+
+
+BLOCK_K = 128
+SMALL_M_THRESHOLD = 128
+MID_M_THRESHOLD = 256
+
+
+@gluon.constexpr_function
+def get_warps_per_cta(block_m, block_n, num_warps):
+    warps_per_cta = [4, 1]
+    instr_m = 16
+    # Tile the atom until we have enough warps.
+    while warps_per_cta[0] * warps_per_cta[1] != num_warps:
+        # Tile along M only if it would not cause broadcasting.
+        if block_m > instr_m * warps_per_cta[0]:
+            warps_per_cta[0] *= 2
+        else:
+            warps_per_cta[1] *= 2
+    return warps_per_cta
+
+
+@gluon.constexpr_function
+def get_instr_shape_n(block_m, block_n, num_warps):
+    instr_m = 16
+    m_repetitions = triton.cdiv(block_m, instr_m)
+    n_repetitions = triton.cdiv(num_warps, m_repetitions)
+    max_instr_n = max(block_n // n_repetitions, 8)
+    instr_n = 256
+    while instr_n > max_instr_n or block_n % instr_n != 0:
+        instr_n -= 8
+    assert instr_n >= 8, 'expected to find a valid N instruction shape'
+    return instr_n
+
+
+@gluon.constexpr_function
+def pick_wgmma_layout(dtype, block_m, block_n, num_warps):
+    instr_m = 16
+    instr_k = 256 // dtype.primitive_bitwidth
+    instr_n = get_instr_shape_n(block_m, block_n, num_warps)
+    warps_per_cta = get_warps_per_cta(block_m, block_n, num_warps)
+    return gl.NVMMADistributedLayout(
+        version=[3, 0],
+        warps_per_cta=warps_per_cta,
+        instr_shape=[instr_m, instr_n, instr_k],
+    )
+
+
+@gluon.jit
+def _fp8_gemm_nt_small_kernel(
+    a_desc,
+    a_scale_ptr,
+    b_desc,
+    b_scale_ptr,
+    d_desc,
+    M,
+    N: gl.constexpr,
+    K: gl.constexpr,
+    stride_asm: gl.constexpr,
+    stride_ask: gl.constexpr,
+    stride_bsn: gl.constexpr,
+    stride_bsk: gl.constexpr,
+    transpose_output: gl.constexpr,
+    lhs_in_reg: gl.constexpr,
+    num_buffers: gl.constexpr,
+    num_warps: gl.constexpr,
+):
+    block_m: gl.constexpr = a_desc.block_type.shape[0]
+    block_n: gl.constexpr = b_desc.block_type.shape[0]
+    block_k: gl.constexpr = a_desc.block_type.shape[1]
+
+    if transpose_output:
+        # Compute C^T = B @ A^T so WGMMA's flexible N dimension represents
+        # the tiny logical M dimension of the original output.
+        off_m = gl.program_id(axis=1) * block_m
+        off_n = gl.program_id(axis=0) * block_n
+    else:
+        off_m = gl.program_id(axis=0) * block_m
+        off_n = gl.program_id(axis=1) * block_n
+
+    gl.static_assert(num_buffers >= 2)
+    a_smem = gl.allocate_shared_memory(
+        a_desc.dtype,
+        [num_buffers] + a_desc.block_type.shape,
+        a_desc.layout,
+    )
+    b_smem = gl.allocate_shared_memory(
+        b_desc.dtype,
+        [num_buffers] + b_desc.block_type.shape,
+        b_desc.layout,
+    )
+    gl.static_assert(isinstance(a_smem.type.layout, gl.NVMMASharedLayout))
+    gl.static_assert(isinstance(b_smem.type.layout, gl.NVMMASharedLayout))
+
+    acc_layout: gl.constexpr = pick_wgmma_layout(a_desc.dtype, block_m, block_n, num_warps)
+    if transpose_output:
+        scale_layout: gl.constexpr = gl.SliceLayout(0, acc_layout)
+        scale_offsets = off_n + gl.arange(0, block_n, layout=scale_layout)
+        scale_mask = scale_offsets < M
+        a_scale_ptrs = a_scale_ptr + scale_offsets * stride_asm
+        b_scale_ptrs = b_scale_ptr + (off_m // 128) * stride_bsn
+    else:
+        scale_layout: gl.constexpr = gl.SliceLayout(1, acc_layout)
+        scale_offsets = off_m + gl.arange(0, block_m, layout=scale_layout)
+        scale_mask = scale_offsets < M
+        a_scale_ptrs = a_scale_ptr + scale_offsets * stride_asm
+        b_scale_ptrs = b_scale_ptr + (off_n // 128) * stride_bsn
+
+    lhs_layout: gl.constexpr = gl.DotOperandLayout(
+        operand_index=0,
+        parent=acc_layout,
+        k_width=32 // a_desc.dtype.primitive_bitwidth,
+    )
+
+    ready_bars = gl.allocate_shared_memory(gl.int64, [num_buffers, 1], mbarrier.MBarrierLayout())
+    for stage_idx in gl.static_range(0, num_buffers):
+        mbarrier.init(ready_bars.index(stage_idx), count=1)
+
+    final_acc = gl.zeros((block_m, block_n), dtype=gl.float32, layout=acc_layout)
+    raw_acc = warpgroup_mma_init(gl.zeros_like(final_acc))
+    if transpose_output:
+        a_scale = gl.zeros((block_n, ), dtype=gl.float32, layout=scale_layout) + 1.0
+    else:
+        a_scale = gl.zeros((block_m, ), dtype=gl.float32, layout=scale_layout) + 1.0
+    b_scale = 1.0
+    # Queue raw scale values one block beyond the scale paired with raw_acc.
+    # Do not multiply here: that would immediately serialize on these LDGs.
+    next_a_scale = gl.load(a_scale_ptrs, mask=scale_mask, other=1.0)
+    next_b_scale = gl.load(b_scale_ptrs)
+    a_scale_ptrs += stride_ask
+    b_scale_ptrs += stride_bsk
+
+    num_k_blocks: gl.constexpr = K // block_k
+    num_preloads: gl.constexpr = min(num_buffers - 2, num_k_blocks)
+    for k_block_idx in gl.static_range(0, num_preloads):
+        stage_idx = k_block_idx % num_buffers
+        ready_barrier = ready_bars.index(stage_idx)
+        mbarrier.expect(ready_barrier, a_desc.block_type.nbytes + b_desc.block_type.nbytes)
+        tma.async_copy_global_to_shared(
+            a_desc,
+            [off_m, k_block_idx * block_k],
+            ready_barrier,
+            a_smem.index(stage_idx),
+        )
+        tma.async_copy_global_to_shared(
+            b_desc,
+            [off_n, k_block_idx * block_k],
+            ready_barrier,
+            b_smem.index(stage_idx),
+        )
+
+    preferred_unroll: gl.constexpr = 8 if transpose_output or block_n == 32 else 4
+    num_steady: gl.constexpr = num_k_blocks - num_preloads
+    num_prefix: gl.constexpr = num_steady % preferred_unroll
+
+    # Consume a short prefix first so the remaining runtime loop is cleanly
+    # partially unrolled by the shape-specific factor.
+    for producer_idx in gl.static_range(num_preloads, num_preloads + num_prefix):
+        producer_stage = producer_idx % num_buffers
+        producer_barrier = ready_bars.index(producer_stage)
+        mbarrier.expect(producer_barrier, a_desc.block_type.nbytes + b_desc.block_type.nbytes)
+        tma.async_copy_global_to_shared(
+            a_desc,
+            [off_m, producer_idx * block_k],
+            producer_barrier,
+            a_smem.index(producer_stage),
+        )
+        tma.async_copy_global_to_shared(
+            b_desc,
+            [off_n, producer_idx * block_k],
+            producer_barrier,
+            b_smem.index(producer_stage),
+        )
+
+        consumer_idx = producer_idx - num_preloads
+        consumer_stage = consumer_idx % num_buffers
+        consumer_phase = (consumer_idx // num_buffers) & 1
+        a_tile = a_smem.index(consumer_stage)
+        b_tile = b_smem.index(consumer_stage).permute((1, 0))
+        mbarrier.wait(ready_bars.index(consumer_stage), phase=consumer_phase)
+
+        if lhs_in_reg:
+            a_tile = a_tile.load(lhs_layout)
+        raw_acc = warpgroup_mma_wait(num_outstanding=0, deps=(raw_acc, ))
+        if transpose_output:
+            final_acc += raw_acc * (a_scale * b_scale)[None, :]
+        else:
+            final_acc += raw_acc * (a_scale * b_scale)[:, None]
+        raw_acc = gl.zeros_like(final_acc)
+        raw_acc = warpgroup_mma(a_tile, b_tile, raw_acc, is_async=True, use_acc=False)
+        a_scale = next_a_scale
+        b_scale = next_b_scale
+        next_a_scale = gl.load(
+            a_scale_ptrs,
+            mask=scale_mask & (consumer_idx + 1 < num_k_blocks),
+            other=1.0,
+        )
+        next_b_scale = gl.load(
+            b_scale_ptrs,
+            mask=consumer_idx + 1 < num_k_blocks,
+            other=1.0,
+        )
+        a_scale_ptrs += stride_ask
+        b_scale_ptrs += stride_bsk
+
+    for producer_group in range(num_preloads + num_prefix, num_k_blocks, preferred_unroll):
+        for producer_offset in gl.static_range(0, preferred_unroll):
+            group_producer_idx = producer_group + producer_offset
+            group_producer_stage = group_producer_idx % num_buffers
+            group_producer_barrier = ready_bars.index(group_producer_stage)
+            mbarrier.expect(group_producer_barrier, a_desc.block_type.nbytes + b_desc.block_type.nbytes)
+            tma.async_copy_global_to_shared(
+                a_desc,
+                [off_m, group_producer_idx * block_k],
+                group_producer_barrier,
+                a_smem.index(group_producer_stage),
+            )
+            tma.async_copy_global_to_shared(
+                b_desc,
+                [off_n, group_producer_idx * block_k],
+                group_producer_barrier,
+                b_smem.index(group_producer_stage),
+            )
+
+            group_consumer_idx = group_producer_idx - num_preloads
+            group_consumer_stage = group_consumer_idx % num_buffers
+            group_consumer_phase = (group_consumer_idx // num_buffers) & 1
+            group_a_tile = a_smem.index(group_consumer_stage)
+            group_b_tile = b_smem.index(group_consumer_stage).permute((1, 0))
+            mbarrier.wait(ready_bars.index(group_consumer_stage), phase=group_consumer_phase)
+
+            if lhs_in_reg:
+                group_a_tile = group_a_tile.load(lhs_layout)
+            raw_acc = warpgroup_mma_wait(num_outstanding=0, deps=(raw_acc, ))
+            if transpose_output:
+                final_acc += raw_acc * (a_scale * b_scale)[None, :]
+            else:
+                final_acc += raw_acc * (a_scale * b_scale)[:, None]
+            raw_acc = gl.zeros_like(final_acc)
+            raw_acc = warpgroup_mma(group_a_tile, group_b_tile, raw_acc, is_async=True, use_acc=False)
+            a_scale = next_a_scale
+            b_scale = next_b_scale
+            next_a_scale = gl.load(
+                a_scale_ptrs,
+                mask=scale_mask & (group_consumer_idx + 1 < num_k_blocks),
+                other=1.0,
+            )
+            next_b_scale = gl.load(
+                b_scale_ptrs,
+                mask=group_consumer_idx + 1 < num_k_blocks,
+                other=1.0,
+            )
+            a_scale_ptrs += stride_ask
+            b_scale_ptrs += stride_bsk
+
+    for drain_offset in gl.static_range(0, num_preloads):
+        consumer_idx = num_steady + drain_offset
+        consumer_stage = consumer_idx % num_buffers
+        consumer_phase = (consumer_idx // num_buffers) & 1
+        a_tile = a_smem.index(consumer_stage)
+        b_tile = b_smem.index(consumer_stage).permute((1, 0))
+        mbarrier.wait(ready_bars.index(consumer_stage), phase=consumer_phase)
+
+        if lhs_in_reg:
+            a_tile = a_tile.load(lhs_layout)
+        raw_acc = warpgroup_mma_wait(num_outstanding=0, deps=(raw_acc, ))
+        if transpose_output:
+            final_acc += raw_acc * (a_scale * b_scale)[None, :]
+        else:
+            final_acc += raw_acc * (a_scale * b_scale)[:, None]
+        raw_acc = gl.zeros_like(final_acc)
+        raw_acc = warpgroup_mma(a_tile, b_tile, raw_acc, is_async=True, use_acc=False)
+        a_scale = next_a_scale
+        b_scale = next_b_scale
+        next_a_scale = gl.load(
+            a_scale_ptrs,
+            mask=scale_mask & (consumer_idx + 1 < num_k_blocks),
+            other=1.0,
+        )
+        next_b_scale = gl.load(
+            b_scale_ptrs,
+            mask=consumer_idx + 1 < num_k_blocks,
+            other=1.0,
+        )
+        a_scale_ptrs += stride_ask
+        b_scale_ptrs += stride_bsk
+
+    raw_acc = warpgroup_mma_wait(num_outstanding=0, deps=(raw_acc, ))
+    if transpose_output:
+        final_acc += raw_acc * (a_scale * b_scale)[None, :]
+    else:
+        final_acc += raw_acc * (a_scale * b_scale)[:, None]
+
+    for stage_idx in gl.static_range(0, num_buffers):
+        mbarrier.invalidate(ready_bars.index(stage_idx))
+    d_smem = gl.allocate_shared_memory(d_desc.dtype, d_desc.block_type.shape, d_desc.layout)
+    if transpose_output:
+        d_smem.store(final_acc.permute(1, 0).to(d_desc.dtype))
+    else:
+        d_smem.store(final_acc.to(d_desc.dtype))
+    fence_async_shared()
+    if transpose_output:
+        tma.async_copy_shared_to_global(d_desc, [off_n, off_m], d_smem)
+    else:
+        tma.async_copy_shared_to_global(d_desc, [off_m, off_n], d_smem)
+    tma.store_wait(pendings=0)
+
+
+@gluon.jit
+def _load_mid_m_tile(
+    descs,
+    bars,
+    buffers,
+    offsets,
+    block_k: gl.constexpr,
+    num_buffers: gl.constexpr,
+    num_k_blocks: gl.constexpr,
+):
+    a_desc, b_desc = descs
+    ready_bars, empty_bars = bars
+    a_smem, b_smem = buffers
+    off_m, off_n = offsets
+
+    unroll: gl.constexpr = 2
+    prefix: gl.constexpr = num_k_blocks % unroll
+    for prefix_k_block_idx in gl.static_range(0, prefix):
+        prefix_stage_idx = prefix_k_block_idx % num_buffers
+        prefix_stage_phase = (prefix_k_block_idx // num_buffers) & 1
+        ready_barrier = ready_bars.index(prefix_stage_idx)
+        empty_barrier = empty_bars.index(prefix_stage_idx)
+
+        mbarrier.wait(empty_barrier, phase=prefix_stage_phase ^ 1)
+        mbarrier.expect(ready_barrier, a_desc.block_type.nbytes + b_desc.block_type.nbytes)
+        tma.async_copy_global_to_shared(
+            a_desc,
+            [off_m, prefix_k_block_idx * block_k],
+            ready_barrier,
+            a_smem.index(prefix_stage_idx),
+        )
+        tma.async_copy_global_to_shared(
+            b_desc,
+            [off_n, prefix_k_block_idx * block_k],
+            ready_barrier,
+            b_smem.index(prefix_stage_idx),
+        )
+
+    for k_block_group in range(prefix, num_k_blocks, unroll):
+        for k_block_offset in gl.static_range(0, unroll):
+            group_k_block_idx = k_block_group + k_block_offset
+            group_stage_idx = group_k_block_idx % num_buffers
+            group_stage_phase = (group_k_block_idx // num_buffers) & 1
+            ready_barrier = ready_bars.index(group_stage_idx)
+            empty_barrier = empty_bars.index(group_stage_idx)
+
+            mbarrier.wait(empty_barrier, phase=group_stage_phase ^ 1)
+            mbarrier.expect(ready_barrier, a_desc.block_type.nbytes + b_desc.block_type.nbytes)
+            tma.async_copy_global_to_shared(
+                a_desc,
+                [off_m, group_k_block_idx * block_k],
+                ready_barrier,
+                a_smem.index(group_stage_idx),
+            )
+            tma.async_copy_global_to_shared(
+                b_desc,
+                [off_n, group_k_block_idx * block_k],
+                ready_barrier,
+                b_smem.index(group_stage_idx),
+            )
+
+
+@gluon.jit
+def _compute_mid_m_tile(
+    bars,
+    buffers,
+    scale_ptrs,
+    acc_layout,
+    offsets,
+    M,
+    stride_asm: gl.constexpr,
+    stride_ask: gl.constexpr,
+    stride_bsn: gl.constexpr,
+    stride_bsk: gl.constexpr,
+    block_m: gl.constexpr,
+    block_n: gl.constexpr,
+    num_buffers: gl.constexpr,
+    num_k_blocks: gl.constexpr,
+):
+    ready_bars, empty_bars = bars
+    a_smem, b_smem = buffers
+    a_scale_ptr, b_scale_ptr = scale_ptrs
+    off_m, off_n = offsets
+
+    scale_layout: gl.constexpr = gl.SliceLayout(1, acc_layout)
+    row_offsets = off_m + gl.arange(0, block_m, layout=scale_layout)
+    a_scale_ptrs = a_scale_ptr + row_offsets * stride_asm
+    b_scale_ptrs = b_scale_ptr + (off_n // 128) * stride_bsn
+
+    final_acc = gl.zeros((block_m, block_n), dtype=gl.float32, layout=acc_layout)
+    raw_acc = gl.zeros_like(final_acc)
+
+    # Keep the next block's raw scale values live without consuming them yet.
+    # Their loads can overlap two WGMMA intervals; multiplying immediately
+    # would instead stall this warpgroup on the scale loads at the load site.
+    a_scale = gl.load(a_scale_ptrs, mask=row_offsets < M, other=1.0)
+    b_scale = gl.load(b_scale_ptrs)
+    a_scale_ptrs += stride_ask
+    b_scale_ptrs += stride_bsk
+
+    next_a_scale = gl.zeros((block_m, ), dtype=gl.float32, layout=scale_layout) + 1.0
+    next_b_scale = 1.0
+    if num_k_blocks > 1:
+        next_a_scale = gl.load(a_scale_ptrs, mask=row_offsets < M, other=1.0)
+        next_b_scale = gl.load(b_scale_ptrs)
+        a_scale_ptrs += stride_ask
+        b_scale_ptrs += stride_bsk
+
+    # Prime K block zero without waiting on or promoting a sentinel.
+    prime_stage: gl.constexpr = 0
+    mbarrier.wait(ready_bars.index(prime_stage), phase=0)
+    a_tile = a_smem.index(prime_stage)
+    b_tile = b_smem.index(prime_stage).permute((1, 0))
+    raw_acc = warpgroup_mma(a_tile, b_tile, raw_acc, is_async=True, use_acc=False)
+
+    unroll: gl.constexpr = 2
+    prefix: gl.constexpr = (num_k_blocks - 1) % unroll
+    for prefix_k_block_idx in gl.static_range(1, 1 + prefix):
+        prefix_stage_idx = prefix_k_block_idx % num_buffers
+        prefix_stage_phase = (prefix_k_block_idx // num_buffers) & 1
+        mbarrier.wait(ready_bars.index(prefix_stage_idx), phase=prefix_stage_phase)
+
+        prefix_a_tile = a_smem.index(prefix_stage_idx)
+        prefix_b_tile = b_smem.index(prefix_stage_idx).permute((1, 0))
+
+        raw_acc = warpgroup_mma_wait(num_outstanding=0, deps=(raw_acc, ))
+        previous_stage_idx = (prefix_k_block_idx - 1) % num_buffers
+        fence_async_shared()
+        mbarrier.arrive(empty_bars.index(previous_stage_idx), count=1)
+        final_acc += raw_acc * (a_scale * b_scale)[:, None]
+
+        raw_acc = gl.zeros_like(final_acc)
+        raw_acc = warpgroup_mma(prefix_a_tile, prefix_b_tile, raw_acc, is_async=True, use_acc=False)
+
+        a_scale = next_a_scale
+        b_scale = next_b_scale
+        prefix_has_future_scale: gl.constexpr = prefix_k_block_idx + 1 < num_k_blocks
+        next_a_scale = gl.load(
+            a_scale_ptrs,
+            mask=(row_offsets < M) & prefix_has_future_scale,
+            other=1.0,
+        )
+        next_b_scale = gl.load(b_scale_ptrs, mask=prefix_has_future_scale, other=1.0)
+        a_scale_ptrs += stride_ask
+        b_scale_ptrs += stride_bsk
+
+    for k_block_group in range(1 + prefix, num_k_blocks, unroll):
+        for k_block_offset in gl.static_range(0, unroll):
+            group_k_block_idx = k_block_group + k_block_offset
+            group_stage_idx = group_k_block_idx % num_buffers
+            group_stage_phase = (group_k_block_idx // num_buffers) & 1
+            mbarrier.wait(ready_bars.index(group_stage_idx), phase=group_stage_phase)
+
+            group_a_tile = a_smem.index(group_stage_idx)
+            group_b_tile = b_smem.index(group_stage_idx).permute((1, 0))
+
+            raw_acc = warpgroup_mma_wait(num_outstanding=0, deps=(raw_acc, ))
+            group_previous_stage_idx = (group_k_block_idx - 1) % num_buffers
+            fence_async_shared()
+            mbarrier.arrive(empty_bars.index(group_previous_stage_idx), count=1)
+            final_acc += raw_acc * (a_scale * b_scale)[:, None]
+
+            raw_acc = gl.zeros_like(final_acc)
+            raw_acc = warpgroup_mma(group_a_tile, group_b_tile, raw_acc, is_async=True, use_acc=False)
+            a_scale = next_a_scale
+            b_scale = next_b_scale
+            group_has_future_scale = group_k_block_idx + 1 < num_k_blocks
+            next_a_scale = gl.load(
+                a_scale_ptrs,
+                mask=(row_offsets < M) & group_has_future_scale,
+                other=1.0,
+            )
+            next_b_scale = gl.load(b_scale_ptrs, mask=group_has_future_scale, other=1.0)
+            a_scale_ptrs += stride_ask
+            b_scale_ptrs += stride_bsk
+
+    raw_acc = warpgroup_mma_wait(num_outstanding=0, deps=(raw_acc, ))
+    fence_async_shared()
+    mbarrier.arrive(empty_bars.index((num_k_blocks - 1) % num_buffers), count=1)
+    final_acc += raw_acc * (a_scale * b_scale)[:, None]
+    return (final_acc, )
+
+
+@gluon.jit
+def _fp8_gemm_nt_mid_m_kernel(
+    a_desc,
+    a_scale_ptr,
+    b_desc,
+    b_scale_ptr,
+    d_desc,
+    M,
+    N: gl.constexpr,
+    K: gl.constexpr,
+    stride_asm: gl.constexpr,
+    stride_ask: gl.constexpr,
+    stride_bsn: gl.constexpr,
+    stride_bsk: gl.constexpr,
+    num_buffers: gl.constexpr,
+    num_warps: gl.constexpr,
+):
+    block_m: gl.constexpr = d_desc.block_type.shape[0]
+    block_n: gl.constexpr = d_desc.block_type.shape[1]
+    block_k: gl.constexpr = a_desc.block_type.shape[1]
+    num_k_blocks: gl.constexpr = K // block_k
+
+    off_m = gl.program_id(axis=0) * block_m
+    off_n = gl.program_id(axis=1) * block_n
+
+    a_smem = gl.allocate_shared_memory(a_desc.dtype, [num_buffers] + a_desc.block_type.shape, a_desc.layout)
+    b_smem = gl.allocate_shared_memory(b_desc.dtype, [num_buffers] + b_desc.block_type.shape, b_desc.layout)
+    gl.static_assert(isinstance(a_smem.type.layout, gl.NVMMASharedLayout))
+    gl.static_assert(isinstance(b_smem.type.layout, gl.NVMMASharedLayout))
+
+    acc_layout: gl.constexpr = pick_wgmma_layout(a_desc.dtype, block_m, block_n, num_warps)
+
+    ready_bars = gl.allocate_shared_memory(gl.int64, [num_buffers, 1], mbarrier.MBarrierLayout())
+    empty_bars = gl.allocate_shared_memory(gl.int64, [num_buffers, 1], mbarrier.MBarrierLayout())
+    for stage_idx in gl.static_range(0, num_buffers):
+        mbarrier.init(ready_bars.index(stage_idx), count=1)
+        mbarrier.init(empty_bars.index(stage_idx), count=1)
+
+    bars = (ready_bars, empty_bars)
+    buffers = (a_smem, b_smem)
+    offsets = (off_m, off_n)
+    final_acc, = gl.warp_specialize(
+        [
+            (
+                _compute_mid_m_tile,
+                (
+                    bars,
+                    buffers,
+                    (a_scale_ptr, b_scale_ptr),
+                    acc_layout,
+                    offsets,
+                    M,
+                    stride_asm,
+                    stride_ask,
+                    stride_bsn,
+                    stride_bsk,
+                    block_m,
+                    block_n,
+                    num_buffers,
+                    num_k_blocks,
+                ),
+            ),
+            (
+                _load_mid_m_tile,
+                (
+                    (a_desc, b_desc),
+                    bars,
+                    buffers,
+                    offsets,
+                    block_k,
+                    num_buffers,
+                    num_k_blocks,
+                ),
+            ),
+        ],
+        worker_num_warps=[1],
+        worker_num_regs=[40],
+    )
+
+    for stage_idx in gl.static_range(0, num_buffers):
+        mbarrier.invalidate(ready_bars.index(stage_idx))
+        mbarrier.invalidate(empty_bars.index(stage_idx))
+    d_smem = gl.allocate_shared_memory(d_desc.dtype, d_desc.block_type.shape, d_desc.layout)
+    d_smem.store(final_acc.to(d_desc.dtype))
+    fence_async_shared()
+    tma.async_copy_shared_to_global(d_desc, [off_m, off_n], d_smem)
+    tma.store_wait(pendings=0)
+
+
+@aggregate
+class PersistentTileScheduler:
+    first_tile: gl.tensor
+    total_tiles: gl.tensor
+    num_tiles_m: gl.tensor
+    num_tiles_n: gl.tensor
+    num_programs: gl.tensor
+
+    @gluon.constexpr_function
+    def __init__(self, first_tile, total_tiles, num_tiles_m, num_tiles_n, num_programs):
+        self.first_tile = first_tile
+        self.total_tiles = total_tiles
+        self.num_tiles_m = num_tiles_m
+        self.num_tiles_n = num_tiles_n
+        self.num_programs = num_programs
+
+    @gluon.jit
+    def initialize(M, N: gl.constexpr, BLOCK_M: gl.constexpr, BLOCK_N: gl.constexpr):
+        first_tile = gl.program_id(axis=0)
+        num_programs = gl.num_programs(axis=0)
+        num_tiles_m = gl.cdiv(M, BLOCK_M)
+        num_tiles_n = gl.cdiv(N, BLOCK_N)
+        total_tiles = num_tiles_m * num_tiles_n
+        return PersistentTileScheduler(first_tile, total_tiles, num_tiles_m, num_tiles_n, num_programs)
+
+    @gluon.jit
+    def get_num_tiles(self):
+        return gl.cdiv(self.total_tiles - self.first_tile, self.num_programs)
+
+    @gluon.jit
+    def get_tile(self, idx):
+        tile_idx = self.first_tile + idx * self.num_programs
+
+        # DeepGEMM-style grouping on M for L2 locality.
+        group_size_m = 16
+        tiles_per_group = self.num_tiles_n * group_size_m
+        group_idx = tile_idx // tiles_per_group
+        first_tile_m = group_idx * group_size_m
+        tile_idx_in_group = tile_idx % tiles_per_group
+        tiles_m_in_group = min(group_size_m, self.num_tiles_m - first_tile_m)
+
+        tile_m = first_tile_m + tile_idx_in_group % tiles_m_in_group
+        tile_n = tile_idx_in_group // tiles_m_in_group
+        return tile_m, tile_n
+
+
+@gluon.jit
+def _load_persistent_tiles(
+    descs,
+    bars,
+    buffers,
+    M, N: gl.constexpr,
+    BLOCK_M: gl.constexpr,
+    BLOCK_N: gl.constexpr,
+    BLOCK_K: gl.constexpr,
+    NUM_BUFFERS: gl.constexpr,
+    NUM_K_BLOCKS: gl.constexpr,
+):
+    a_desc, b_desc, a_scale_desc = descs
+    ready_bars, empty_bars = bars
+    a_smem, b_smem, a_scale_smem = buffers
+
+    scheduler = PersistentTileScheduler.initialize(M, N, BLOCK_M, BLOCK_N)
+
+    for tile_iter in range(scheduler.get_num_tiles()):
+        tile_m, tile_n = scheduler.get_tile(tile_iter)
+        off_m = tile_m * BLOCK_M
+        off_n = tile_n * BLOCK_N
+
+        for k_block_idx in range(0, NUM_K_BLOCKS):
+            off_k = k_block_idx * BLOCK_K
+            pipeline_iter = tile_iter * NUM_K_BLOCKS + k_block_idx
+            stage_idx = pipeline_iter % NUM_BUFFERS
+            stage_phase = (pipeline_iter // NUM_BUFFERS) & 1
+
+            a_stage = a_smem.index(stage_idx)
+            b_stage = b_smem.index(stage_idx)
+            a_scale_stage = a_scale_smem.index(stage_idx)
+            ready_barrier = ready_bars.index(stage_idx)
+            empty_barrier = empty_bars.index(stage_idx)
+
+            mbarrier.wait(empty_barrier, phase=stage_phase ^ 1)
+
+            mbarrier.expect(
+                ready_barrier,
+                a_desc.block_type.nbytes + b_desc.block_type.nbytes + a_scale_desc.block_type.nbytes,
+            )
+            tma.async_copy_global_to_shared(a_desc, [off_m, off_k], ready_barrier, a_stage)
+            tma.async_copy_global_to_shared(b_desc, [off_n, off_k], ready_barrier, b_stage)
+            tma.async_copy_global_to_shared(a_scale_desc, [k_block_idx, off_m], ready_barrier, a_scale_stage)
+
+
+@gluon.jit
+def _compute_persistent_tiles(
+    dtype,
+    d_desc,
+    bars,
+    buffers,
+    b_scale_ptr,
+    M,
+    N: gl.constexpr,
+    stride_bsn: gl.constexpr,
+    stride_bsk: gl.constexpr,
+    BLOCK_M: gl.constexpr,
+    BLOCK_N: gl.constexpr,
+    LHS_IN_REG: gl.constexpr,
+    NUM_BUFFERS: gl.constexpr,
+    NUM_K_BLOCKS: gl.constexpr,
+    num_warps: gl.constexpr,
+):
+    ready_bars, empty_bars = bars
+    a_smem, b_smem, a_scale_smem = buffers
+
+    # BLOCK_M=256 is computed as two 128-row waves to keep the temporary
+    # WGMMA accumulator small enough to avoid register spills.
+    WAVE_M: gl.constexpr = min(BLOCK_M, 128)
+    NUM_M_WAVES: gl.constexpr = BLOCK_M // WAVE_M
+    wave_acc_layout: gl.constexpr = pick_wgmma_layout(dtype, WAVE_M, BLOCK_N, num_warps)
+    scale_layout: gl.constexpr = gl.SliceLayout(1, wave_acc_layout)
+
+    lhs_layout: gl.constexpr = gl.DotOperandLayout(
+        operand_index=0,
+        parent=wave_acc_layout,
+        k_width=32 // dtype.primitive_bitwidth,
+    )
+
+    scheduler = PersistentTileScheduler.initialize(M, N, BLOCK_M, BLOCK_N)
+    d_smem = gl.allocate_shared_memory(d_desc.dtype, d_desc.block_type.shape, d_desc.layout)
+
+    NUM_COMPUTE_WARPS: gl.constexpr = gl.num_warps()
+    NUM_B_SCALE_SLOTS: gl.constexpr = triton.next_power_of_2(max(NUM_K_BLOCKS, NUM_COMPUTE_WARPS * 32))
+
+    b_scale_load_layout: gl.constexpr = gl.BlockedLayout(
+        [1],
+        [32],
+        [NUM_COMPUTE_WARPS],
+        [0],
+    )
+    b_scale_smem_layout: gl.constexpr = gl.SwizzledSharedLayout(
+        vec=1,
+        per_phase=1,
+        max_phase=1,
+        order=[0],
+    )
+    b_scale_smem = gl.allocate_shared_memory(gl.float32, (NUM_B_SCALE_SLOTS, 1), b_scale_smem_layout)
+    b_scale_smem_flat = b_scale_smem._reinterpret(gl.float32, (NUM_B_SCALE_SLOTS, ), b_scale_smem_layout)
+
+    for tile_iter in range(scheduler.get_num_tiles()):
+        tile_m, tile_n = scheduler.get_tile(tile_iter)
+        off_m = tile_m * BLOCK_M
+        off_n = tile_n * BLOCK_N
+
+        # Cooperatively cache all B scales for this output-column tile. Every
+        # M wave reuses this cache throughout the K loop.
+        n_scale_group = off_n // 128
+        b_scale_tile_ptr = b_scale_ptr + n_scale_group * stride_bsn
+        gl.thread_barrier()
+        b_scale_offs = gl.arange(0, NUM_B_SCALE_SLOTS, layout=b_scale_load_layout)
+        b_scale_mask = b_scale_offs < NUM_K_BLOCKS
+        b_scales = gl.load(b_scale_tile_ptr + b_scale_offs * stride_bsk, mask=b_scale_mask, other=0.0)
+        b_scale_smem_flat.store(b_scales)
+        gl.thread_barrier()
+
+        wave_0_acc = gl.zeros(
+            (WAVE_M, BLOCK_N),
+            gl.float32,
+            wave_acc_layout,
+        )
+        if NUM_M_WAVES == 2:
+            wave_1_acc = gl.zeros_like(wave_0_acc)
+
+        for k_block_idx in range(0, NUM_K_BLOCKS):
+            pipeline_iter = tile_iter * NUM_K_BLOCKS + k_block_idx
+            stage_idx = pipeline_iter % NUM_BUFFERS
+            stage_phase = (pipeline_iter // NUM_BUFFERS) & 1
+            ready_barrier = ready_bars.index(stage_idx)
+            mbarrier.wait(ready_barrier, phase=stage_phase)
+
+            a_stage = a_smem.index(stage_idx)
+            b_stage = b_smem.index(stage_idx).permute((1, 0))
+            a_scale_stage = a_scale_smem.index(stage_idx)
+            b_scale = b_scale_smem.index(k_block_idx).load(scale_layout)
+
+            a_scale_wave_0 = a_scale_stage.slice(0, WAVE_M, dim=1).load(gl.AutoLayout())
+            a_scale_wave_0 = a_scale_wave_0.reshape((WAVE_M,))
+            a_scale_wave_0 = gl.set_auto_layout(a_scale_wave_0, scale_layout)
+            if NUM_M_WAVES == 2:
+                a_scale_wave_1 = a_scale_stage.slice(WAVE_M, WAVE_M, dim=1).load(gl.AutoLayout())
+                a_scale_wave_1 = a_scale_wave_1.reshape((WAVE_M,))
+                a_scale_wave_1 = gl.set_auto_layout(a_scale_wave_1, scale_layout)
+
+            a_wave_0 = a_stage.slice(0, WAVE_M, dim=0)
+            if NUM_M_WAVES == 2:
+                a_wave_1 = a_stage.slice(WAVE_M, WAVE_M, dim=0)
+
+            if LHS_IN_REG:
+                a_wave_0 = a_wave_0.load(lhs_layout)
+            partial_acc = gl.zeros_like(wave_0_acc)
+            partial_acc = warpgroup_mma(a_wave_0, b_stage, partial_acc, is_async=True, use_acc=False)
+            partial_acc = warpgroup_mma_wait(num_outstanding=0, deps=(partial_acc, ))
+            block_scale = a_scale_wave_0 * b_scale
+            wave_0_acc += partial_acc * block_scale[:, None]
+
+            if NUM_M_WAVES == 2:
+                if LHS_IN_REG:
+                    a_wave_1 = a_wave_1.load(lhs_layout)
+                partial_acc = warpgroup_mma(a_wave_1, b_stage, partial_acc, is_async=True, use_acc=False)
+                partial_acc = warpgroup_mma_wait(num_outstanding=0, deps=(partial_acc, ))
+                block_scale = a_scale_wave_1 * b_scale
+                wave_1_acc += partial_acc * block_scale[:, None]
+
+            # WGMMA has finished reading this stage. Publish that it is safe
+            # for the loader warp to overwrite on the next phase.
+            fence_async_shared()
+            empty_barrier = empty_bars.index(stage_idx)
+            mbarrier.arrive(empty_barrier, count=1)
+
+        # The output shared-memory buffer is reused across persistent tiles.
+        tma.store_wait(pendings=0)
+
+        d_smem.slice(0, WAVE_M, dim=0).store(wave_0_acc.to(d_desc.dtype))
+        if NUM_M_WAVES == 2:
+            d_smem.slice(WAVE_M, WAVE_M, dim=0).store(wave_1_acc.to(d_desc.dtype))
+        fence_async_shared()
+
+        tma.async_copy_shared_to_global(d_desc, [off_m, off_n], d_smem)
+
+    tma.store_wait(pendings=0)
+
+
+@gluon.jit
+def _fp8_gemm_nt_large_kernel(
+    a_desc,
+    a_scale_desc,
+    b_desc,
+    b_scale_ptr,
+    d_desc,
+    M,
+    N: gl.constexpr,
+    K: gl.constexpr,
+    stride_bsn: gl.constexpr,
+    stride_bsk: gl.constexpr,
+    LHS_IN_REG: gl.constexpr,
+    NUM_BUFFERS: gl.constexpr,
+    num_warps: gl.constexpr,
+):
+    BLOCK_M: gl.constexpr = d_desc.block_type.shape[0]
+    BLOCK_N: gl.constexpr = d_desc.block_type.shape[1]
+    BLOCK_K: gl.constexpr = a_desc.block_type.shape[1]
+    NUM_K_BLOCKS: gl.constexpr = K // BLOCK_K
+
+    a_smem = gl.allocate_shared_memory(
+        a_desc.dtype,
+        [NUM_BUFFERS] + a_desc.block_type.shape,
+        a_desc.layout,
+    )
+    b_smem = gl.allocate_shared_memory(
+        b_desc.dtype,
+        [NUM_BUFFERS] + b_desc.block_type.shape,
+        b_desc.layout,
+    )
+    a_scale_smem = gl.allocate_shared_memory(
+        a_scale_desc.dtype,
+        [NUM_BUFFERS] + a_scale_desc.block_type.shape,
+        a_scale_desc.layout,
+    )
+    gl.static_assert(isinstance(a_smem.type.layout, gl.NVMMASharedLayout))
+    gl.static_assert(isinstance(b_smem.type.layout, gl.NVMMASharedLayout))
+
+    dtype = a_desc.dtype
+
+    ready_bars = gl.allocate_shared_memory(gl.int64, [NUM_BUFFERS, 1], mbarrier.MBarrierLayout())
+    empty_bars = gl.allocate_shared_memory(gl.int64, [NUM_BUFFERS, 1], mbarrier.MBarrierLayout())
+    for stage_idx in gl.static_range(0, NUM_BUFFERS):
+        ready_barrier = ready_bars.index(stage_idx)
+        empty_barrier = empty_bars.index(stage_idx)
+        mbarrier.init(ready_barrier, count=1)
+        mbarrier.init(empty_barrier, count=1)
+
+    descs = (a_desc, b_desc, a_scale_desc)
+    bars = (ready_bars, empty_bars)
+    buffers = (a_smem, b_smem, a_scale_smem)
+
+    # The default partition uses the launcher's compute warps. One additional
+    # low-register worker warp owns the TMA producer pipeline.
+    gl.warp_specialize(
+        [
+            (
+                _compute_persistent_tiles,
+                (
+                    dtype,
+                    d_desc,
+                    bars,
+                    buffers,
+                    b_scale_ptr,
+                    M,
+                    N,
+                    stride_bsn,
+                    stride_bsk,
+                    BLOCK_M,
+                    BLOCK_N,
+                    LHS_IN_REG,
+                    NUM_BUFFERS,
+                    NUM_K_BLOCKS,
+                    num_warps,
+                ),
+            ),
+            (
+                _load_persistent_tiles,
+                (
+                    descs,
+                    bars,
+                    buffers,
+                    M,
+                    N,
+                    BLOCK_M,
+                    BLOCK_N,
+                    BLOCK_K,
+                    NUM_BUFFERS,
+                    NUM_K_BLOCKS,
+                ),
+            ),
+        ],
+        worker_num_warps=[1],
+        worker_num_regs=[40],
+    )
+
+    for stage_idx in gl.static_range(0, NUM_BUFFERS):
+        ready_barrier = ready_bars.index(stage_idx)
+        empty_barrier = empty_bars.index(stage_idx)
+        mbarrier.invalidate(ready_barrier)
+        mbarrier.invalidate(empty_barrier)
+
+
+def _make_matrix_descriptors(a_quant, b_quant, output, block_m, block_n):
+    """Build the A/B/output descriptors shared by all schedule families."""
+    a_block_shape = [block_m, BLOCK_K]
+    b_block_shape = [block_n, BLOCK_K]
+    d_block_shape = [block_m, block_n]
+    a_layout = gl.NVMMASharedLayout.get_default_for(a_block_shape, gl.float8e4nv)
+    b_layout = gl.NVMMASharedLayout.get_default_for(b_block_shape, gl.float8e4nv)
+    d_layout = gl.NVMMASharedLayout.get_default_for(d_block_shape, gl.bfloat16)
+
+    a_desc = TensorDescriptor.from_tensor(a_quant, a_block_shape, a_layout)
+    b_desc = TensorDescriptor.from_tensor(b_quant, b_block_shape, b_layout)
+    d_desc = TensorDescriptor.from_tensor(output, d_block_shape, d_layout)
+    return a_desc, b_desc, d_desc
+
+
+def _make_transposed_small_descriptors(a_quant, b_quant, output, block_m, block_n):
+    """Build descriptors for C^T = B @ A^T while storing C in-place."""
+    lhs_block_shape = [block_m, BLOCK_K]
+    rhs_block_shape = [block_n, BLOCK_K]
+    d_block_shape = [block_n, block_m]
+    lhs_layout = gl.NVMMASharedLayout.get_default_for(lhs_block_shape, gl.float8e4nv)
+    rhs_layout = gl.NVMMASharedLayout.get_default_for(rhs_block_shape, gl.float8e4nv)
+    d_layout = gl.NVMMASharedLayout.get_default_for(d_block_shape, gl.bfloat16)
+
+    lhs_desc = TensorDescriptor.from_tensor(b_quant, lhs_block_shape, lhs_layout)
+    rhs_desc = TensorDescriptor.from_tensor(a_quant, rhs_block_shape, rhs_layout)
+    d_desc = TensorDescriptor.from_tensor(output, d_block_shape, d_layout)
+    return lhs_desc, rhs_desc, d_desc
+
+
+def _launch_small_m_kernel(a_quant, a_scale, b_quant, b_scale, output):
+    m, n = output.shape
+    k = a_quant.size(-1)
+    transpose_output = m <= 8 and k >= 4096
+    block_m = 64
+    # Transposing the GEMM makes WGMMA's flexible N dimension represent the
+    # tiny logical M dimension, avoiding 56-63 rows of padded tensor-core and
+    # FP32 promotion work. Short K does not amortize the smaller 64-CTA grid.
+    if transpose_output:
+        block_n = 8
+        num_buffers = 16 if k >= 8192 else 8
+    elif m <= 64:
+        block_n = 32
+        num_buffers = 8
+    else:
+        block_n = 64
+        num_buffers = 6
+    num_warps = 4
+
+    if transpose_output:
+        a_desc, b_desc, d_desc = _make_transposed_small_descriptors(
+            a_quant,
+            b_quant,
+            output,
+            block_m,
+            block_n,
+        )
+    else:
+        a_desc, b_desc, d_desc = _make_matrix_descriptors(a_quant, b_quant, output, block_m, block_n)
+    grid = (triton.cdiv(m, block_m), triton.cdiv(n, block_n))
+    if transpose_output:
+        grid = (triton.cdiv(m, block_n), triton.cdiv(n, block_m))
+    _fp8_gemm_nt_small_kernel[grid](
+        a_desc,
+        a_scale,
+        b_desc,
+        b_scale,
+        d_desc,
+        m,
+        n,
+        k,
+        *a_scale.stride(),
+        *b_scale.stride(),
+        transpose_output=transpose_output,
+        lhs_in_reg=False,
+        num_buffers=num_buffers,
+        num_warps=num_warps,
+    )
+
+
+def _launch_mid_m_kernel(a_quant, a_scale, b_quant, b_scale, output):
+    m, n = output.shape
+    k = a_quant.size(-1)
+    block_m = 64
+    block_n = 128
+    num_buffers = 4
+    num_warps = 4
+
+    a_desc, b_desc, d_desc = _make_matrix_descriptors(a_quant, b_quant, output, block_m, block_n)
+    grid = (triton.cdiv(m, block_m), triton.cdiv(n, block_n))
+    _fp8_gemm_nt_mid_m_kernel[grid](
+        a_desc,
+        a_scale,
+        b_desc,
+        b_scale,
+        d_desc,
+        m,
+        n,
+        k,
+        *a_scale.stride(),
+        *b_scale.stride(),
+        num_buffers=num_buffers,
+        num_warps=num_warps,
+        maxnreg=128,
+    )
+
+
+def _launch_large_m_kernel(a_quant, a_scale, b_quant, b_scale, output):
+    m, n = output.shape
+    k = a_quant.size(-1)
+    block_m = 256
+    block_n = 128
+    num_buffers = 3
+    num_warps = 8
+
+    a_desc, b_desc, d_desc = _make_matrix_descriptors(a_quant, b_quant, output, block_m, block_n)
+
+    a_scale_transposed = a_scale.T
+    a_scale_block_shape = [1, block_m]
+    a_scale_layout = gl.NVMMASharedLayout.get_default_for(a_scale_block_shape, gl.float32)
+    a_scale_desc = TensorDescriptor.from_tensor(a_scale_transposed, a_scale_block_shape, a_scale_layout)
+
+    num_tiles = triton.cdiv(m, block_m) * triton.cdiv(n, block_n)
+    num_sms = torch.cuda.get_device_properties(a_quant.device).multi_processor_count
+    grid = (min(num_sms, num_tiles), )
+    _fp8_gemm_nt_large_kernel[grid](
+        a_desc,
+        a_scale_desc,
+        b_desc,
+        b_scale,
+        d_desc,
+        m,
+        n,
+        k,
+        *b_scale.stride(),
+        LHS_IN_REG=False,
+        NUM_BUFFERS=num_buffers,
+        num_warps=num_warps,
+        maxnreg=168,
+    )
+
+
+def fp8_gemm_nt(a, b, d, c):
+    """Compute a blocked-scaled FP8 GEMM with an NT operand convention.
+
+    ``a`` contains FP8 values shaped ``[M, K]`` and per-row scales shaped
+    ``[M, K / 128]``. ``b`` contains FP8 values shaped ``[N, K]`` and scales
+    shaped ``[N / 128, K / 128]``. The result is written to ``d``; ``c`` is
+    accepted for compatibility with the DeepGEMM-style launcher interface.
+
+    M up to 128 uses a single-partition multistage schedule. Within that body,
+    M up to 8 with K at least 4096 computes the equivalent transposed GEMM to
+    avoid padding the tensor-core result to 64 rows. M from 129 through 256
+    uses a primed warp-specialized schedule. Larger M uses a persistent
+    two-wave schedule that reuses B data and scales while controlling
+    accumulator register pressure.
+    """
+    a_quant, a_scale = a
+    b_quant, b_scale = b
+
+    if d.size(0) <= SMALL_M_THRESHOLD:
+        _launch_small_m_kernel(a_quant, a_scale, b_quant, b_scale, d)
+    elif d.size(0) <= MID_M_THRESHOLD:
+        _launch_mid_m_kernel(a_quant, a_scale, b_quant, b_scale, d)
+    else:
+        _launch_large_m_kernel(a_quant, a_scale, b_quant, b_scale, d)

--- a/lmdeploy/pytorch/kernels/cuda/blocked_fp8_gemm_gluon.py
+++ b/lmdeploy/pytorch/kernels/cuda/blocked_fp8_gemm_gluon.py
@@ -3,7 +3,6 @@
 
 import functools
 
-import torch
 import triton
 from triton.experimental import gluon
 from triton.experimental.gluon import language as gl
@@ -36,10 +35,10 @@ SMALL_M_THRESHOLD = 128
 MID_M_THRESHOLD = 256
 
 # The three schedules keep the same blocked-scaling math but optimize different
-# bottlenecks. Small M keeps loading and compute in one partition to minimize
-# overhead; the middle schedule separates a TMA producer from the compute
-# warpgroup while its grid fits two CTAs per SM; larger grids additionally
-# persist CTAs and split each 256-row accumulator into waves.
+# bottlenecks. The single-partition schedule keeps loading and compute together
+# to minimize overhead. Middle M otherwise separates a TMA producer from the
+# compute warpgroup, while larger grids additionally persist CTAs and split
+# each 256-row accumulator into waves.
 
 
 @gluon.constexpr_function
@@ -98,7 +97,7 @@ def _load_block_scales(
 
 
 @gluon.jit
-def _fp8_gemm_nt_small_kernel(
+def _fp8_gemm_nt_single_partition_kernel(
     a_desc,
     a_scale_ptr,
     b_desc,
@@ -566,7 +565,7 @@ def _compute_mid_m_tile(
 
 
 @gluon.jit
-def _fp8_gemm_nt_mid_m_kernel(
+def _fp8_gemm_nt_warp_specialized_kernel(
     a_desc,
     a_scale_ptr,
     b_desc,
@@ -900,7 +899,7 @@ def _compute_persistent_tiles(
 
 
 @gluon.jit
-def _fp8_gemm_nt_large_kernel(
+def _fp8_gemm_nt_persistent_kernel(
     a_desc,
     a_scale_desc,
     b_desc,
@@ -1051,7 +1050,7 @@ def _make_transposed_small_descriptors(a_quant, b_quant, output, block_m, block_
     return lhs_desc, rhs_desc, d_desc
 
 
-def _launch_small_m_kernel(a_quant, a_scale, b_quant, b_scale, output):
+def _launch_single_partition(a_quant, a_scale, b_quant, b_scale, output):
     m, n = output.shape
     k = a_quant.size(-1)
     transpose_output = m <= 8 and k >= 4096
@@ -1083,7 +1082,7 @@ def _launch_small_m_kernel(a_quant, a_scale, b_quant, b_scale, output):
     grid = (triton.cdiv(m, block_m), triton.cdiv(n, block_n))
     if transpose_output:
         grid = (triton.cdiv(m, block_n), triton.cdiv(n, block_m))
-    _fp8_gemm_nt_small_kernel[grid](
+    _fp8_gemm_nt_single_partition_kernel[grid](
         a_desc,
         a_scale,
         b_desc,
@@ -1100,7 +1099,7 @@ def _launch_small_m_kernel(a_quant, a_scale, b_quant, b_scale, output):
     )
 
 
-def _launch_mid_m_kernel(a_quant, a_scale, b_quant, b_scale, output):
+def _launch_warp_specialized(a_quant, a_scale, b_quant, b_scale, output):
     m, n = output.shape
     k = a_quant.size(-1)
     block_m = 64
@@ -1110,7 +1109,7 @@ def _launch_mid_m_kernel(a_quant, a_scale, b_quant, b_scale, output):
 
     a_desc, b_desc, d_desc = _make_matrix_descriptors(a_quant, b_quant, output, block_m, block_n)
     grid = (triton.cdiv(m, block_m), triton.cdiv(n, block_n))
-    _fp8_gemm_nt_mid_m_kernel[grid](
+    _fp8_gemm_nt_warp_specialized_kernel[grid](
         a_desc,
         a_scale,
         b_desc,
@@ -1127,7 +1126,7 @@ def _launch_mid_m_kernel(a_quant, a_scale, b_quant, b_scale, output):
     )
 
 
-def _launch_large_m_kernel(a_quant, a_scale, b_quant, b_scale, output):
+def _launch_persistent(a_quant, a_scale, b_quant, b_scale, output):
     m, n = output.shape
     k = a_quant.size(-1)
     block_m = 256
@@ -1150,7 +1149,7 @@ def _launch_large_m_kernel(a_quant, a_scale, b_quant, b_scale, output):
     # Cap the persistent grid at the SM count; each program obtains further
     # logical output tiles from PersistentTileScheduler.
     grid = (min(num_sms, num_tiles), )
-    _fp8_gemm_nt_large_kernel[grid](
+    _fp8_gemm_nt_persistent_kernel[grid](
         a_desc,
         a_scale_desc,
         b_desc,
@@ -1167,19 +1166,46 @@ def _launch_large_m_kernel(a_quant, a_scale, b_quant, b_scale, output):
     )
 
 
+def _prefer_single_partition(m, n, num_sms):
+    """Select the single-partition schedule for small or compact grids."""
+    if m <= SMALL_M_THRESHOLD:
+        return True
+    if m > MID_M_THRESHOLD:
+        return False
+
+    num_tiles_m = triton.cdiv(m, 64)
+    single_partition_tiles = num_tiles_m * triton.cdiv(n, 64)
+    if single_partition_tiles <= num_sms:
+        return True
+
+    # BN64 removes the producer/consumer barrier but doubles the grid relative
+    # to the warp-specialized BN128 schedule. It remains profitable for up to
+    # two dense CTA waves. Sparse final M tiles lose that tradeoff, so require
+    # at least 48 of their 64 rows to be useful in the second case.
+    warp_specialized_tiles = num_tiles_m * triton.cdiv(n, 128)
+    final_tile_rows = m - (num_tiles_m - 1) * 64
+    return warp_specialized_tiles <= num_sms and final_tile_rows >= 48
+
+
 @functools.lru_cache
-def _use_mid_m_kernel(m, n, device_index):
-    """Use the mid schedule while its grid fits one resident CTA wave."""
+def _use_single_partition(m, n, device_index):
+    num_sms = get_device_props(device_index)['multi_processor_count']
+    return _prefer_single_partition(m, n, num_sms)
+
+
+@functools.lru_cache
+def _use_warp_specialized(m, n, device_index):
+    """Use warp specialization while its grid fits one resident CTA wave."""
     if m <= MID_M_THRESHOLD:
         return True
 
-    # The mid kernel can keep two CTAs resident per Hopper SM, whereas the
-    # register-heavy persistent kernel is limited to one. Prefer mid when all
-    # of its 64x128 tiles fit in that resident capacity; this avoids launching
-    # an underfilled persistent grid, notably at M=512, N=4096 on H200.
-    mid_tiles = triton.cdiv(m, 64) * triton.cdiv(n, 128)
+    # The warp-specialized kernel can keep two CTAs resident per Hopper SM,
+    # whereas the register-heavy persistent kernel is limited to one. Prefer
+    # warp specialization when all 64x128 tiles fit in that resident capacity;
+    # this avoids an underfilled persistent grid, notably at M=512, N=4096.
+    warp_specialized_tiles = triton.cdiv(m, 64) * triton.cdiv(n, 128)
     num_sms = get_device_props(device_index)['multi_processor_count']
-    return mid_tiles <= 2 * num_sms
+    return warp_specialized_tiles <= 2 * num_sms
 
 
 def fp8_gemm_nt(a, b, d, c):
@@ -1187,7 +1213,7 @@ def fp8_gemm_nt(a, b, d, c):
 
     ``a`` contains contiguous FP8 values shaped ``[M, K]`` and per-row scales
     shaped ``[M, K / 128]``. The A scales must have stride 1 along M; their
-    physical K-block stride must be 16-byte aligned for the large-M TMA path.
+    physical K-block stride must be 16-byte aligned for the persistent path.
     ``b`` contains contiguous FP8 values shaped ``[N, K]`` and contiguous
     scales shaped ``[ceil(N / 128), K / 128]``. Both K and N scale groups are
     128 elements. The result is written to contiguous BF16 ``d``; ``c`` is
@@ -1195,17 +1221,19 @@ def fp8_gemm_nt(a, b, d, c):
 
     M up to 128 uses a single-partition multistage schedule. Within that body,
     M up to 8 with K at least 4096 computes the equivalent transposed GEMM to
-    avoid padding the tensor-core result to 64 rows. M above 128 uses a primed
-    warp-specialized schedule while its 64x128 tile grid fits the two-CTA-per-SM
-    resident capacity. Larger grids use a persistent two-wave schedule that
-    reuses B data and scales while controlling accumulator register pressure.
+    avoid padding the tensor-core result to 64 rows. For M up to 256, dense
+    64x64 grids that fit at most two CTA waves reuse the single-partition body
+    to avoid warp-specialization barriers. Other middle shapes use a primed
+    warp-specialized 64x128 schedule. Larger grids use a persistent two-wave
+    schedule that reuses B data and scales while controlling accumulator
+    register pressure.
     """
     a_quant, a_scale = a
     b_quant, b_scale = b
 
-    if d.size(0) <= SMALL_M_THRESHOLD:
-        _launch_small_m_kernel(a_quant, a_scale, b_quant, b_scale, d)
-    elif _use_mid_m_kernel(d.size(0), d.size(1), d.device.index):
-        _launch_mid_m_kernel(a_quant, a_scale, b_quant, b_scale, d)
+    if _use_single_partition(d.size(0), d.size(1), d.device.index):
+        _launch_single_partition(a_quant, a_scale, b_quant, b_scale, d)
+    elif _use_warp_specialized(d.size(0), d.size(1), d.device.index):
+        _launch_warp_specialized(a_quant, a_scale, b_quant, b_scale, d)
     else:
-        _launch_large_m_kernel(a_quant, a_scale, b_quant, b_scale, d)
+        _launch_persistent(a_quant, a_scale, b_quant, b_scale, d)

--- a/lmdeploy/pytorch/kernels/cuda/blocked_fp8_gemm_gluon.py
+++ b/lmdeploy/pytorch/kernels/cuda/blocked_fp8_gemm_gluon.py
@@ -21,9 +21,17 @@ except ImportError:
     from triton.language.core import _aggregate as aggregate
 
 
-BLOCK_K = 128
+# One WGMMA K tile covers exactly one quantization block, so every raw
+# accumulator can be promoted before the next K tile is accumulated.
+SCALE_BLOCK_K = 128
+SCALE_BLOCK_N = 128
 SMALL_M_THRESHOLD = 128
 MID_M_THRESHOLD = 256
+
+# The three schedules keep the same blocked-scaling math but optimize different
+# bottlenecks. Small M keeps loading and compute in one partition to minimize
+# overhead; middle M separates a TMA producer from the compute warpgroup; large
+# M additionally persists CTAs and splits its 256-row accumulator into waves.
 
 
 @gluon.constexpr_function
@@ -67,6 +75,21 @@ def pick_wgmma_layout(dtype, block_m, block_n, num_warps):
 
 
 @gluon.jit
+def _load_block_scales(
+    a_scale_ptrs,
+    b_scale_ptrs,
+    a_scale_mask,
+    block_valid,
+    stride_ask: gl.constexpr,
+    stride_bsk: gl.constexpr,
+):
+    """Fetch one scale slot, using identity past K, and advance the streams."""
+    a_scale = gl.load(a_scale_ptrs, mask=a_scale_mask & block_valid, other=1.0)
+    b_scale = gl.load(b_scale_ptrs, mask=block_valid, other=1.0)
+    return a_scale, b_scale, a_scale_ptrs + stride_ask, b_scale_ptrs + stride_bsk
+
+
+@gluon.jit
 def _fp8_gemm_nt_small_kernel(
     a_desc,
     a_scale_ptr,
@@ -74,20 +97,33 @@ def _fp8_gemm_nt_small_kernel(
     b_scale_ptr,
     d_desc,
     M,
-    N: gl.constexpr,
     K: gl.constexpr,
     stride_asm: gl.constexpr,
     stride_ask: gl.constexpr,
     stride_bsn: gl.constexpr,
     stride_bsk: gl.constexpr,
     transpose_output: gl.constexpr,
-    lhs_in_reg: gl.constexpr,
+    scale_block_n: gl.constexpr,
     num_buffers: gl.constexpr,
     num_warps: gl.constexpr,
 ):
+    # These are compile-time contract checks: they improve compiler failures
+    # without adding instructions or latency to the generated kernel.
+    gl.static_assert(a_desc.dtype == gl.float8e4nv, 'A must use FP8 E4M3')
+    gl.static_assert(b_desc.dtype == gl.float8e4nv, 'B must use FP8 E4M3')
+    gl.static_assert(d_desc.dtype == gl.bfloat16, 'output must use BF16')
+    gl.static_assert(a_scale_ptr.dtype.element_ty == gl.float32, 'A scales must use FP32')
+    gl.static_assert(b_scale_ptr.dtype.element_ty == gl.float32, 'B scales must use FP32')
+    gl.static_assert(isinstance(a_desc.layout, gl.NVMMASharedLayout), 'A descriptor must use an NVMMA layout')
+    gl.static_assert(isinstance(b_desc.layout, gl.NVMMASharedLayout), 'B descriptor must use an NVMMA layout')
+    gl.static_assert(isinstance(d_desc.layout, gl.NVMMASharedLayout), 'output descriptor must use an NVMMA layout')
+
     block_m: gl.constexpr = a_desc.block_type.shape[0]
     block_n: gl.constexpr = b_desc.block_type.shape[0]
     block_k: gl.constexpr = a_desc.block_type.shape[1]
+    gl.static_assert(b_desc.block_type.shape[1] == block_k, 'A and B tile K must match')
+    gl.static_assert(K % block_k == 0, 'K must contain whole scale blocks')
+    gl.static_assert(stride_asm == 1, 'A scales must be column-major')
 
     if transpose_output:
         # Compute C^T = B @ A^T so WGMMA's flexible N dimension represents
@@ -113,29 +149,32 @@ def _fp8_gemm_nt_small_kernel(
     gl.static_assert(isinstance(b_smem.type.layout, gl.NVMMASharedLayout))
 
     acc_layout: gl.constexpr = pick_wgmma_layout(a_desc.dtype, block_m, block_n, num_warps)
+    # Normally A scales index WGMMA M and broadcast across WGMMA N, so dim 1
+    # is dropped. After transposition they index WGMMA N and broadcast across
+    # WGMMA M, so dim 0 is dropped instead.
     if transpose_output:
         scale_layout: gl.constexpr = gl.SliceLayout(0, acc_layout)
         scale_offsets = off_n + gl.arange(0, block_n, layout=scale_layout)
         scale_mask = scale_offsets < M
         a_scale_ptrs = a_scale_ptr + scale_offsets * stride_asm
-        b_scale_ptrs = b_scale_ptr + (off_m // 128) * stride_bsn
+        b_scale_ptrs = b_scale_ptr + (off_m // scale_block_n) * stride_bsn
     else:
         scale_layout: gl.constexpr = gl.SliceLayout(1, acc_layout)
         scale_offsets = off_m + gl.arange(0, block_m, layout=scale_layout)
         scale_mask = scale_offsets < M
         a_scale_ptrs = a_scale_ptr + scale_offsets * stride_asm
-        b_scale_ptrs = b_scale_ptr + (off_n // 128) * stride_bsn
+        b_scale_ptrs = b_scale_ptr + (off_n // scale_block_n) * stride_bsn
 
-    lhs_layout: gl.constexpr = gl.DotOperandLayout(
-        operand_index=0,
-        parent=acc_layout,
-        k_width=32 // a_desc.dtype.primitive_bitwidth,
-    )
-
+    # This schedule has no producer worker: the same warpgroup issues TMA and
+    # WGMMA in a fixed order. A stage is not wrapped until an intervening
+    # warpgroup_mma_wait has retired its consumer, so ready barriers suffice;
+    # the warp-specialized schedules below also need explicit empty barriers.
     ready_bars = gl.allocate_shared_memory(gl.int64, [num_buffers, 1], mbarrier.MBarrierLayout())
     for stage_idx in gl.static_range(0, num_buffers):
         mbarrier.init(ready_bars.index(stage_idx), count=1)
 
+    # final_acc is the long-lived, scaled FP32 result. raw_acc contains only one
+    # unscaled K-block partial so it can be promoted before entering final_acc.
     final_acc = gl.zeros((block_m, block_n), dtype=gl.float32, layout=acc_layout)
     raw_acc = warpgroup_mma_init(gl.zeros_like(final_acc))
     if transpose_output:
@@ -145,10 +184,14 @@ def _fp8_gemm_nt_small_kernel(
     b_scale = 1.0
     # Queue raw scale values one block beyond the scale paired with raw_acc.
     # Do not multiply here: that would immediately serialize on these LDGs.
-    next_a_scale = gl.load(a_scale_ptrs, mask=scale_mask, other=1.0)
-    next_b_scale = gl.load(b_scale_ptrs)
-    a_scale_ptrs += stride_ask
-    b_scale_ptrs += stride_bsk
+    next_a_scale, next_b_scale, a_scale_ptrs, b_scale_ptrs = _load_block_scales(
+        a_scale_ptrs,
+        b_scale_ptrs,
+        scale_mask,
+        True,
+        stride_ask,
+        stride_bsk,
+    )
 
     num_k_blocks: gl.constexpr = K // block_k
     num_preloads: gl.constexpr = min(num_buffers - 2, num_k_blocks)
@@ -173,6 +216,10 @@ def _fp8_gemm_nt_small_kernel(
     num_steady: gl.constexpr = num_k_blocks - num_preloads
     num_prefix: gl.constexpr = num_steady % preferred_unroll
 
+    # Prefix, steady state, and drain preserve the same one-block lag:
+    # raw_acc/current scales describe the previous block, while next_*_scale
+    # describes the block about to be issued. The final promotion closes the
+    # lag after the last WGMMA.
     # Consume a short prefix first so the remaining runtime loop is cleanly
     # partially unrolled by the shape-specific factor.
     for producer_idx in gl.static_range(num_preloads, num_preloads + num_prefix):
@@ -199,8 +246,6 @@ def _fp8_gemm_nt_small_kernel(
         b_tile = b_smem.index(consumer_stage).permute((1, 0))
         mbarrier.wait(ready_bars.index(consumer_stage), phase=consumer_phase)
 
-        if lhs_in_reg:
-            a_tile = a_tile.load(lhs_layout)
         raw_acc = warpgroup_mma_wait(num_outstanding=0, deps=(raw_acc, ))
         if transpose_output:
             final_acc += raw_acc * (a_scale * b_scale)[None, :]
@@ -210,18 +255,14 @@ def _fp8_gemm_nt_small_kernel(
         raw_acc = warpgroup_mma(a_tile, b_tile, raw_acc, is_async=True, use_acc=False)
         a_scale = next_a_scale
         b_scale = next_b_scale
-        next_a_scale = gl.load(
+        next_a_scale, next_b_scale, a_scale_ptrs, b_scale_ptrs = _load_block_scales(
             a_scale_ptrs,
-            mask=scale_mask & (consumer_idx + 1 < num_k_blocks),
-            other=1.0,
-        )
-        next_b_scale = gl.load(
             b_scale_ptrs,
-            mask=consumer_idx + 1 < num_k_blocks,
-            other=1.0,
+            scale_mask,
+            consumer_idx + 1 < num_k_blocks,
+            stride_ask,
+            stride_bsk,
         )
-        a_scale_ptrs += stride_ask
-        b_scale_ptrs += stride_bsk
 
     for producer_group in range(num_preloads + num_prefix, num_k_blocks, preferred_unroll):
         for producer_offset in gl.static_range(0, preferred_unroll):
@@ -249,8 +290,6 @@ def _fp8_gemm_nt_small_kernel(
             group_b_tile = b_smem.index(group_consumer_stage).permute((1, 0))
             mbarrier.wait(ready_bars.index(group_consumer_stage), phase=group_consumer_phase)
 
-            if lhs_in_reg:
-                group_a_tile = group_a_tile.load(lhs_layout)
             raw_acc = warpgroup_mma_wait(num_outstanding=0, deps=(raw_acc, ))
             if transpose_output:
                 final_acc += raw_acc * (a_scale * b_scale)[None, :]
@@ -260,18 +299,14 @@ def _fp8_gemm_nt_small_kernel(
             raw_acc = warpgroup_mma(group_a_tile, group_b_tile, raw_acc, is_async=True, use_acc=False)
             a_scale = next_a_scale
             b_scale = next_b_scale
-            next_a_scale = gl.load(
+            next_a_scale, next_b_scale, a_scale_ptrs, b_scale_ptrs = _load_block_scales(
                 a_scale_ptrs,
-                mask=scale_mask & (group_consumer_idx + 1 < num_k_blocks),
-                other=1.0,
-            )
-            next_b_scale = gl.load(
                 b_scale_ptrs,
-                mask=group_consumer_idx + 1 < num_k_blocks,
-                other=1.0,
+                scale_mask,
+                group_consumer_idx + 1 < num_k_blocks,
+                stride_ask,
+                stride_bsk,
             )
-            a_scale_ptrs += stride_ask
-            b_scale_ptrs += stride_bsk
 
     for drain_offset in gl.static_range(0, num_preloads):
         consumer_idx = num_steady + drain_offset
@@ -281,8 +316,6 @@ def _fp8_gemm_nt_small_kernel(
         b_tile = b_smem.index(consumer_stage).permute((1, 0))
         mbarrier.wait(ready_bars.index(consumer_stage), phase=consumer_phase)
 
-        if lhs_in_reg:
-            a_tile = a_tile.load(lhs_layout)
         raw_acc = warpgroup_mma_wait(num_outstanding=0, deps=(raw_acc, ))
         if transpose_output:
             final_acc += raw_acc * (a_scale * b_scale)[None, :]
@@ -292,18 +325,14 @@ def _fp8_gemm_nt_small_kernel(
         raw_acc = warpgroup_mma(a_tile, b_tile, raw_acc, is_async=True, use_acc=False)
         a_scale = next_a_scale
         b_scale = next_b_scale
-        next_a_scale = gl.load(
+        next_a_scale, next_b_scale, a_scale_ptrs, b_scale_ptrs = _load_block_scales(
             a_scale_ptrs,
-            mask=scale_mask & (consumer_idx + 1 < num_k_blocks),
-            other=1.0,
-        )
-        next_b_scale = gl.load(
             b_scale_ptrs,
-            mask=consumer_idx + 1 < num_k_blocks,
-            other=1.0,
+            scale_mask,
+            consumer_idx + 1 < num_k_blocks,
+            stride_ask,
+            stride_bsk,
         )
-        a_scale_ptrs += stride_ask
-        b_scale_ptrs += stride_bsk
 
     raw_acc = warpgroup_mma_wait(num_outstanding=0, deps=(raw_acc, ))
     if transpose_output:
@@ -341,6 +370,9 @@ def _load_mid_m_tile(
     a_smem, b_smem = buffers
     off_m, off_n = offsets
 
+    # The low-register producer worker owns empty -> ready for every stage.
+    # Splitting out the short prefix leaves the runtime loop two-way unrolled
+    # without changing the stage/phase sequence.
     unroll: gl.constexpr = 2
     prefix: gl.constexpr = num_k_blocks % unroll
     for prefix_k_block_idx in gl.static_range(0, prefix):
@@ -402,6 +434,7 @@ def _compute_mid_m_tile(
     stride_bsk: gl.constexpr,
     block_m: gl.constexpr,
     block_n: gl.constexpr,
+    scale_block_n: gl.constexpr,
     num_buffers: gl.constexpr,
     num_k_blocks: gl.constexpr,
 ):
@@ -410,10 +443,12 @@ def _compute_mid_m_tile(
     a_scale_ptr, b_scale_ptr = scale_ptrs
     off_m, off_n = offsets
 
+    # Drop accumulator N: one A scale is distributed per output row and then
+    # broadcast across all BLOCK_N accumulator columns.
     scale_layout: gl.constexpr = gl.SliceLayout(1, acc_layout)
     row_offsets = off_m + gl.arange(0, block_m, layout=scale_layout)
     a_scale_ptrs = a_scale_ptr + row_offsets * stride_asm
-    b_scale_ptrs = b_scale_ptr + (off_n // 128) * stride_bsn
+    b_scale_ptrs = b_scale_ptr + (off_n // scale_block_n) * stride_bsn
 
     final_acc = gl.zeros((block_m, block_n), dtype=gl.float32, layout=acc_layout)
     raw_acc = gl.zeros_like(final_acc)
@@ -421,18 +456,27 @@ def _compute_mid_m_tile(
     # Keep the next block's raw scale values live without consuming them yet.
     # Their loads can overlap two WGMMA intervals; multiplying immediately
     # would instead stall this warpgroup on the scale loads at the load site.
-    a_scale = gl.load(a_scale_ptrs, mask=row_offsets < M, other=1.0)
-    b_scale = gl.load(b_scale_ptrs)
-    a_scale_ptrs += stride_ask
-    b_scale_ptrs += stride_bsk
+    row_mask = row_offsets < M
+    a_scale, b_scale, a_scale_ptrs, b_scale_ptrs = _load_block_scales(
+        a_scale_ptrs,
+        b_scale_ptrs,
+        row_mask,
+        True,
+        stride_ask,
+        stride_bsk,
+    )
 
     next_a_scale = gl.zeros((block_m, ), dtype=gl.float32, layout=scale_layout) + 1.0
     next_b_scale = 1.0
     if num_k_blocks > 1:
-        next_a_scale = gl.load(a_scale_ptrs, mask=row_offsets < M, other=1.0)
-        next_b_scale = gl.load(b_scale_ptrs)
-        a_scale_ptrs += stride_ask
-        b_scale_ptrs += stride_bsk
+        next_a_scale, next_b_scale, a_scale_ptrs, b_scale_ptrs = _load_block_scales(
+            a_scale_ptrs,
+            b_scale_ptrs,
+            row_mask,
+            True,
+            stride_ask,
+            stride_bsk,
+        )
 
     # Prime K block zero without waiting on or promoting a sentinel.
     prime_stage: gl.constexpr = 0
@@ -441,6 +485,10 @@ def _compute_mid_m_tile(
     b_tile = b_smem.index(prime_stage).permute((1, 0))
     raw_acc = warpgroup_mma(a_tile, b_tile, raw_acc, is_async=True, use_acc=False)
 
+    # After priming block zero, each iteration waits for the next ready stage,
+    # retires the previous WGMMA, releases that previous stage, promotes its
+    # partial with register-resident scales, and issues the next WGMMA. The
+    # WGMMA wait—not the following proxy fence—is what makes release safe.
     unroll: gl.constexpr = 2
     prefix: gl.constexpr = (num_k_blocks - 1) % unroll
     for prefix_k_block_idx in gl.static_range(1, 1 + prefix):
@@ -463,14 +511,14 @@ def _compute_mid_m_tile(
         a_scale = next_a_scale
         b_scale = next_b_scale
         prefix_has_future_scale: gl.constexpr = prefix_k_block_idx + 1 < num_k_blocks
-        next_a_scale = gl.load(
+        next_a_scale, next_b_scale, a_scale_ptrs, b_scale_ptrs = _load_block_scales(
             a_scale_ptrs,
-            mask=(row_offsets < M) & prefix_has_future_scale,
-            other=1.0,
+            b_scale_ptrs,
+            row_mask,
+            prefix_has_future_scale,
+            stride_ask,
+            stride_bsk,
         )
-        next_b_scale = gl.load(b_scale_ptrs, mask=prefix_has_future_scale, other=1.0)
-        a_scale_ptrs += stride_ask
-        b_scale_ptrs += stride_bsk
 
     for k_block_group in range(1 + prefix, num_k_blocks, unroll):
         for k_block_offset in gl.static_range(0, unroll):
@@ -493,14 +541,14 @@ def _compute_mid_m_tile(
             a_scale = next_a_scale
             b_scale = next_b_scale
             group_has_future_scale = group_k_block_idx + 1 < num_k_blocks
-            next_a_scale = gl.load(
+            next_a_scale, next_b_scale, a_scale_ptrs, b_scale_ptrs = _load_block_scales(
                 a_scale_ptrs,
-                mask=(row_offsets < M) & group_has_future_scale,
-                other=1.0,
+                b_scale_ptrs,
+                row_mask,
+                group_has_future_scale,
+                stride_ask,
+                stride_bsk,
             )
-            next_b_scale = gl.load(b_scale_ptrs, mask=group_has_future_scale, other=1.0)
-            a_scale_ptrs += stride_ask
-            b_scale_ptrs += stride_bsk
 
     raw_acc = warpgroup_mma_wait(num_outstanding=0, deps=(raw_acc, ))
     fence_async_shared()
@@ -517,18 +565,32 @@ def _fp8_gemm_nt_mid_m_kernel(
     b_scale_ptr,
     d_desc,
     M,
-    N: gl.constexpr,
     K: gl.constexpr,
     stride_asm: gl.constexpr,
     stride_ask: gl.constexpr,
     stride_bsn: gl.constexpr,
     stride_bsk: gl.constexpr,
+    scale_block_n: gl.constexpr,
     num_buffers: gl.constexpr,
     num_warps: gl.constexpr,
 ):
+    # Compile-time only: descriptor/pointer types and layouts are specialization
+    # properties, so these assertions do not execute on the GPU hot path.
+    gl.static_assert(a_desc.dtype == gl.float8e4nv, 'A must use FP8 E4M3')
+    gl.static_assert(b_desc.dtype == gl.float8e4nv, 'B must use FP8 E4M3')
+    gl.static_assert(d_desc.dtype == gl.bfloat16, 'output must use BF16')
+    gl.static_assert(a_scale_ptr.dtype.element_ty == gl.float32, 'A scales must use FP32')
+    gl.static_assert(b_scale_ptr.dtype.element_ty == gl.float32, 'B scales must use FP32')
+    gl.static_assert(isinstance(a_desc.layout, gl.NVMMASharedLayout), 'A descriptor must use an NVMMA layout')
+    gl.static_assert(isinstance(b_desc.layout, gl.NVMMASharedLayout), 'B descriptor must use an NVMMA layout')
+    gl.static_assert(isinstance(d_desc.layout, gl.NVMMASharedLayout), 'output descriptor must use an NVMMA layout')
+
     block_m: gl.constexpr = d_desc.block_type.shape[0]
     block_n: gl.constexpr = d_desc.block_type.shape[1]
     block_k: gl.constexpr = a_desc.block_type.shape[1]
+    gl.static_assert(b_desc.block_type.shape[1] == block_k, 'A and B tile K must match')
+    gl.static_assert(K % block_k == 0, 'K must contain whole scale blocks')
+    gl.static_assert(stride_asm == 1, 'A scales must be column-major')
     num_k_blocks: gl.constexpr = K // block_k
 
     off_m = gl.program_id(axis=0) * block_m
@@ -550,6 +612,8 @@ def _fp8_gemm_nt_mid_m_kernel(
     bars = (ready_bars, empty_bars)
     buffers = (a_smem, b_smem)
     offsets = (off_m, off_n)
+    # The default partition owns WGMMA, scale promotion, and the result. One
+    # additional worker warp owns the TMA producer side of the stage ring.
     final_acc, = gl.warp_specialize(
         [
             (
@@ -567,6 +631,7 @@ def _fp8_gemm_nt_mid_m_kernel(
                     stride_bsk,
                     block_m,
                     block_n,
+                    scale_block_n,
                     num_buffers,
                     num_k_blocks,
                 ),
@@ -629,9 +694,10 @@ class PersistentTileScheduler:
 
     @gluon.jit
     def get_tile(self, idx):
+        # Each persistent program advances by the resident grid size. Grouping
+        # nearby M tiles under the same N range improves B-tile L2 locality.
         tile_idx = self.first_tile + idx * self.num_programs
 
-        # DeepGEMM-style grouping on M for L2 locality.
         group_size_m = 16
         tiles_per_group = self.num_tiles_n * group_size_m
         group_idx = tile_idx // tiles_per_group
@@ -662,6 +728,9 @@ def _load_persistent_tiles(
 
     scheduler = PersistentTileScheduler.initialize(M, N, BLOCK_M, BLOCK_N)
 
+    # This worker owns empty -> ready across every persistent output tile. The
+    # flattened iteration keeps stage phase continuous at tile boundaries;
+    # resetting phase for each tile would eventually consume stale stages.
     for tile_iter in range(scheduler.get_num_tiles()):
         tile_m, tile_n = scheduler.get_tile(tile_iter)
         off_m = tile_m * BLOCK_M
@@ -703,7 +772,7 @@ def _compute_persistent_tiles(
     stride_bsk: gl.constexpr,
     BLOCK_M: gl.constexpr,
     BLOCK_N: gl.constexpr,
-    LHS_IN_REG: gl.constexpr,
+    SCALE_BLOCK_N: gl.constexpr,
     NUM_BUFFERS: gl.constexpr,
     NUM_K_BLOCKS: gl.constexpr,
     num_warps: gl.constexpr,
@@ -716,13 +785,8 @@ def _compute_persistent_tiles(
     WAVE_M: gl.constexpr = min(BLOCK_M, 128)
     NUM_M_WAVES: gl.constexpr = BLOCK_M // WAVE_M
     wave_acc_layout: gl.constexpr = pick_wgmma_layout(dtype, WAVE_M, BLOCK_N, num_warps)
+    # Each M wave has one A scale per accumulator row, broadcast across N.
     scale_layout: gl.constexpr = gl.SliceLayout(1, wave_acc_layout)
-
-    lhs_layout: gl.constexpr = gl.DotOperandLayout(
-        operand_index=0,
-        parent=wave_acc_layout,
-        k_width=32 // dtype.primitive_bitwidth,
-    )
 
     scheduler = PersistentTileScheduler.initialize(M, N, BLOCK_M, BLOCK_N)
     d_smem = gl.allocate_shared_memory(d_desc.dtype, d_desc.block_type.shape, d_desc.layout)
@@ -752,7 +816,7 @@ def _compute_persistent_tiles(
 
         # Cooperatively cache all B scales for this output-column tile. Every
         # M wave reuses this cache throughout the K loop.
-        n_scale_group = off_n // 128
+        n_scale_group = off_n // SCALE_BLOCK_N
         b_scale_tile_ptr = b_scale_ptr + n_scale_group * stride_bsn
         gl.thread_barrier()
         b_scale_offs = gl.arange(0, NUM_B_SCALE_SLOTS, layout=b_scale_load_layout)
@@ -769,6 +833,9 @@ def _compute_persistent_tiles(
         if NUM_M_WAVES == 2:
             wave_1_acc = gl.zeros_like(wave_0_acc)
 
+        # The consumer reconstructs the same flattened stage/phase sequence as
+        # the producer. A and its scales arrive together through TMA; B scales
+        # come from the per-output-tile shared cache above.
         for k_block_idx in range(0, NUM_K_BLOCKS):
             pipeline_iter = tile_iter * NUM_K_BLOCKS + k_block_idx
             stage_idx = pipeline_iter % NUM_BUFFERS
@@ -793,8 +860,6 @@ def _compute_persistent_tiles(
             if NUM_M_WAVES == 2:
                 a_wave_1 = a_stage.slice(WAVE_M, WAVE_M, dim=0)
 
-            if LHS_IN_REG:
-                a_wave_0 = a_wave_0.load(lhs_layout)
             partial_acc = gl.zeros_like(wave_0_acc)
             partial_acc = warpgroup_mma(a_wave_0, b_stage, partial_acc, is_async=True, use_acc=False)
             partial_acc = warpgroup_mma_wait(num_outstanding=0, deps=(partial_acc, ))
@@ -802,15 +867,13 @@ def _compute_persistent_tiles(
             wave_0_acc += partial_acc * block_scale[:, None]
 
             if NUM_M_WAVES == 2:
-                if LHS_IN_REG:
-                    a_wave_1 = a_wave_1.load(lhs_layout)
                 partial_acc = warpgroup_mma(a_wave_1, b_stage, partial_acc, is_async=True, use_acc=False)
                 partial_acc = warpgroup_mma_wait(num_outstanding=0, deps=(partial_acc, ))
                 block_scale = a_scale_wave_1 * b_scale
                 wave_1_acc += partial_acc * block_scale[:, None]
 
-            # WGMMA has finished reading this stage. Publish that it is safe
-            # for the loader warp to overwrite on the next phase.
+            # Both M waves have finished reading this stage. Publish that it is
+            # safe for the loader warp to overwrite on the next phase.
             fence_async_shared()
             empty_barrier = empty_bars.index(stage_idx)
             mbarrier.arrive(empty_barrier, count=1)
@@ -840,13 +903,31 @@ def _fp8_gemm_nt_large_kernel(
     K: gl.constexpr,
     stride_bsn: gl.constexpr,
     stride_bsk: gl.constexpr,
-    LHS_IN_REG: gl.constexpr,
+    SCALE_BLOCK_N: gl.constexpr,
     NUM_BUFFERS: gl.constexpr,
     num_warps: gl.constexpr,
 ):
+    # Compile-time only: the persistent path additionally requires its staged
+    # A-scale descriptor to carry FP32 elements in an NVMMA shared layout.
+    gl.static_assert(a_desc.dtype == gl.float8e4nv, 'A must use FP8 E4M3')
+    gl.static_assert(b_desc.dtype == gl.float8e4nv, 'B must use FP8 E4M3')
+    gl.static_assert(d_desc.dtype == gl.bfloat16, 'output must use BF16')
+    gl.static_assert(a_scale_desc.dtype == gl.float32, 'A scales must use FP32')
+    gl.static_assert(b_scale_ptr.dtype.element_ty == gl.float32, 'B scales must use FP32')
+    gl.static_assert(isinstance(a_desc.layout, gl.NVMMASharedLayout), 'A descriptor must use an NVMMA layout')
+    gl.static_assert(isinstance(b_desc.layout, gl.NVMMASharedLayout), 'B descriptor must use an NVMMA layout')
+    gl.static_assert(
+        isinstance(a_scale_desc.layout, gl.NVMMASharedLayout),
+        'A-scale descriptor must use an NVMMA layout',
+    )
+    gl.static_assert(isinstance(d_desc.layout, gl.NVMMASharedLayout), 'output descriptor must use an NVMMA layout')
+
     BLOCK_M: gl.constexpr = d_desc.block_type.shape[0]
     BLOCK_N: gl.constexpr = d_desc.block_type.shape[1]
     BLOCK_K: gl.constexpr = a_desc.block_type.shape[1]
+    gl.static_assert(b_desc.block_type.shape[1] == BLOCK_K, 'A and B tile K must match')
+    gl.static_assert(K % BLOCK_K == 0, 'K must contain whole scale blocks')
+    gl.static_assert(a_scale_desc.block_type.shape == [1, BLOCK_M], 'A-scale TMA tile must cover one M tile')
     NUM_K_BLOCKS: gl.constexpr = K // BLOCK_K
 
     a_smem = gl.allocate_shared_memory(
@@ -899,7 +980,7 @@ def _fp8_gemm_nt_large_kernel(
                     stride_bsk,
                     BLOCK_M,
                     BLOCK_N,
-                    LHS_IN_REG,
+                    SCALE_BLOCK_N,
                     NUM_BUFFERS,
                     NUM_K_BLOCKS,
                     num_warps,
@@ -934,8 +1015,8 @@ def _fp8_gemm_nt_large_kernel(
 
 def _make_matrix_descriptors(a_quant, b_quant, output, block_m, block_n):
     """Build the A/B/output descriptors shared by all schedule families."""
-    a_block_shape = [block_m, BLOCK_K]
-    b_block_shape = [block_n, BLOCK_K]
+    a_block_shape = [block_m, SCALE_BLOCK_K]
+    b_block_shape = [block_n, SCALE_BLOCK_K]
     d_block_shape = [block_m, block_n]
     a_layout = gl.NVMMASharedLayout.get_default_for(a_block_shape, gl.float8e4nv)
     b_layout = gl.NVMMASharedLayout.get_default_for(b_block_shape, gl.float8e4nv)
@@ -949,8 +1030,8 @@ def _make_matrix_descriptors(a_quant, b_quant, output, block_m, block_n):
 
 def _make_transposed_small_descriptors(a_quant, b_quant, output, block_m, block_n):
     """Build descriptors for C^T = B @ A^T while storing C in-place."""
-    lhs_block_shape = [block_m, BLOCK_K]
-    rhs_block_shape = [block_n, BLOCK_K]
+    lhs_block_shape = [block_m, SCALE_BLOCK_K]
+    rhs_block_shape = [block_n, SCALE_BLOCK_K]
     d_block_shape = [block_n, block_m]
     lhs_layout = gl.NVMMASharedLayout.get_default_for(lhs_block_shape, gl.float8e4nv)
     rhs_layout = gl.NVMMASharedLayout.get_default_for(rhs_block_shape, gl.float8e4nv)
@@ -1001,12 +1082,11 @@ def _launch_small_m_kernel(a_quant, a_scale, b_quant, b_scale, output):
         b_scale,
         d_desc,
         m,
-        n,
         k,
         *a_scale.stride(),
         *b_scale.stride(),
         transpose_output=transpose_output,
-        lhs_in_reg=False,
+        scale_block_n=SCALE_BLOCK_N,
         num_buffers=num_buffers,
         num_warps=num_warps,
     )
@@ -1029,10 +1109,10 @@ def _launch_mid_m_kernel(a_quant, a_scale, b_quant, b_scale, output):
         b_scale,
         d_desc,
         m,
-        n,
         k,
         *a_scale.stride(),
         *b_scale.stride(),
+        scale_block_n=SCALE_BLOCK_N,
         num_buffers=num_buffers,
         num_warps=num_warps,
         maxnreg=128,
@@ -1049,6 +1129,9 @@ def _launch_large_m_kernel(a_quant, a_scale, b_quant, b_scale, output):
 
     a_desc, b_desc, d_desc = _make_matrix_descriptors(a_quant, b_quant, output, block_m, block_n)
 
+    # A scales are physically contiguous along M. The transposed descriptor
+    # exposes [K blocks, M], letting one TMA transaction stage all row scales
+    # needed by a 256-row output tile and one K block.
     a_scale_transposed = a_scale.T
     a_scale_block_shape = [1, block_m]
     a_scale_layout = gl.NVMMASharedLayout.get_default_for(a_scale_block_shape, gl.float32)
@@ -1056,6 +1139,8 @@ def _launch_large_m_kernel(a_quant, a_scale, b_quant, b_scale, output):
 
     num_tiles = triton.cdiv(m, block_m) * triton.cdiv(n, block_n)
     num_sms = torch.cuda.get_device_properties(a_quant.device).multi_processor_count
+    # Cap the persistent grid at the SM count; each program obtains further
+    # logical output tiles from PersistentTileScheduler.
     grid = (min(num_sms, num_tiles), )
     _fp8_gemm_nt_large_kernel[grid](
         a_desc,
@@ -1067,7 +1152,7 @@ def _launch_large_m_kernel(a_quant, a_scale, b_quant, b_scale, output):
         n,
         k,
         *b_scale.stride(),
-        LHS_IN_REG=False,
+        SCALE_BLOCK_N=SCALE_BLOCK_N,
         NUM_BUFFERS=num_buffers,
         num_warps=num_warps,
         maxnreg=168,
@@ -1077,10 +1162,13 @@ def _launch_large_m_kernel(a_quant, a_scale, b_quant, b_scale, output):
 def fp8_gemm_nt(a, b, d, c):
     """Compute a blocked-scaled FP8 GEMM with an NT operand convention.
 
-    ``a`` contains FP8 values shaped ``[M, K]`` and per-row scales shaped
-    ``[M, K / 128]``. ``b`` contains FP8 values shaped ``[N, K]`` and scales
-    shaped ``[N / 128, K / 128]``. The result is written to ``d``; ``c`` is
-    accepted for compatibility with the DeepGEMM-style launcher interface.
+    ``a`` contains contiguous FP8 values shaped ``[M, K]`` and per-row scales
+    shaped ``[M, K / 128]``. The A scales must have stride 1 along M; their
+    physical K-block stride must be 16-byte aligned for the large-M TMA path.
+    ``b`` contains contiguous FP8 values shaped ``[N, K]`` and contiguous
+    scales shaped ``[ceil(N / 128), K / 128]``. Both K and N scale groups are
+    128 elements. The result is written to contiguous BF16 ``d``; ``c`` is
+    accepted for DeepGEMM-style signature compatibility and is not used.
 
     M up to 128 uses a single-partition multistage schedule. Within that body,
     M up to 8 with K at least 4096 computes the equivalent transposed GEMM to

--- a/lmdeploy/pytorch/kernels/cuda/blocked_fp8_gemm_gluon.py
+++ b/lmdeploy/pytorch/kernels/cuda/blocked_fp8_gemm_gluon.py
@@ -1050,16 +1050,29 @@ def _make_transposed_small_descriptors(a_quant, b_quant, output, block_m, block_
     return lhs_desc, rhs_desc, d_desc
 
 
+def _get_transpose_m_limit(k):
+    """Choose where avoiding padded WGMMA rows outweighs reloading B."""
+    if k <= 5120:
+        return 32
+    if k < 8192:
+        return 24
+    if k < 16384:
+        return 16
+    return 8
+
+
 def _launch_single_partition(a_quant, a_scale, b_quant, b_scale, output):
     m, n = output.shape
     k = a_quant.size(-1)
-    transpose_output = m <= 8 and k >= 4096
+    transpose_output = m <= _get_transpose_m_limit(k) and k >= 4096
     block_m = 64
     # Transposing the GEMM makes WGMMA's flexible N dimension represent the
-    # tiny logical M dimension, avoiding 56-63 rows of padded tensor-core and
-    # FP32 promotion work. Short K does not amortize the smaller 64-CTA grid.
+    # small logical M dimension. Use BN8 for slices and BN16 at exactly M=32;
+    # the K-dependent limit balances avoided padded promotion against reloading
+    # each B tile for another M slice. Short K does not amortize the smaller
+    # 64-CTA grid used by M <= 8.
     if transpose_output:
-        block_n = 8
+        block_n = 16 if m == 32 else 8
         num_buffers = 16 if k >= 8192 else 8
     elif m <= 64:
         block_n = 32
@@ -1220,13 +1233,14 @@ def fp8_gemm_nt(a, b, d, c):
     accepted for DeepGEMM-style signature compatibility and is not used.
 
     M up to 128 uses a single-partition multistage schedule. Within that body,
-    M up to 8 with K at least 4096 computes the equivalent transposed GEMM to
-    avoid padding the tensor-core result to 64 rows. For M up to 256, dense
-    64x64 grids that fit at most two CTA waves reuse the single-partition body
-    to avoid warp-specialization barriers. Other middle shapes use a primed
-    warp-specialized 64x128 schedule. Larger grids use a persistent two-wave
-    schedule that reuses B data and scales while controlling accumulator
-    register pressure.
+    small M with K at least 4096 computes the equivalent transposed GEMM to
+    avoid padding the tensor-core result to 64 rows. Its tuned M limit shrinks
+    from 32 to 8 as K grows because each additional M slice reloads B. For M up
+    to 256, dense 64x64 grids that fit at most two CTA waves reuse the
+    single-partition body to avoid warp-specialization barriers. Other middle
+    shapes use a primed warp-specialized 64x128 schedule. Larger grids use a
+    persistent two-wave schedule that reuses B data and scales while
+    controlling accumulator register pressure.
     """
     a_quant, a_scale = a
     b_quant, b_scale = b

--- a/lmdeploy/pytorch/kernels/cuda/blocked_fp8_gemm_gluon.py
+++ b/lmdeploy/pytorch/kernels/cuda/blocked_fp8_gemm_gluon.py
@@ -20,6 +20,9 @@ try:
 except ImportError:
     from triton.language.core import _aggregate as aggregate
 
+# Triton 3.7 renamed the CTA-wide thread_barrier builtin to barrier.
+_cta_barrier = getattr(gl, 'barrier', None) or gl.thread_barrier
+
 
 # One WGMMA K tile covers exactly one quantization block, so every raw
 # accumulator can be promoted before the next K tile is accumulated.
@@ -818,12 +821,12 @@ def _compute_persistent_tiles(
         # M wave reuses this cache throughout the K loop.
         n_scale_group = off_n // SCALE_BLOCK_N
         b_scale_tile_ptr = b_scale_ptr + n_scale_group * stride_bsn
-        gl.thread_barrier()
+        _cta_barrier()
         b_scale_offs = gl.arange(0, NUM_B_SCALE_SLOTS, layout=b_scale_load_layout)
         b_scale_mask = b_scale_offs < NUM_K_BLOCKS
         b_scales = gl.load(b_scale_tile_ptr + b_scale_offs * stride_bsk, mask=b_scale_mask, other=0.0)
         b_scale_smem_flat.store(b_scales)
-        gl.thread_barrier()
+        _cta_barrier()
 
         wave_0_acc = gl.zeros(
             (WAVE_M, BLOCK_N),

--- a/lmdeploy/pytorch/kernels/cuda/blocked_gemm_fp8.py
+++ b/lmdeploy/pytorch/kernels/cuda/blocked_gemm_fp8.py
@@ -167,7 +167,11 @@ def quant_fp8(A: Tensor,
     num_groups = K // group_size
     out = torch.empty_like(A, dtype=dtype)
     if trans_scale:
-        scales = A.new_empty(num_groups, M, dtype=torch.float32).T
+        # Keep M logically contiguous while padding the physical K-block pitch
+        # to the 16-byte alignment required by Hopper TMA descriptors.
+        scale_alignment = 16 // torch.float32.itemsize
+        aligned_m = triton.cdiv(M, scale_alignment) * scale_alignment
+        scales = torch.empty_strided((M, num_groups), (1, aligned_m), dtype=torch.float32, device=A.device)
     else:
         scales = A.new_empty(M, num_groups, dtype=torch.float32)
     return _quant_fp8_launcher(A, group_size, out, scales, scale_fmt=scale_fmt)

--- a/lmdeploy/pytorch/nn/linear/blocked_fp8.py
+++ b/lmdeploy/pytorch/nn/linear/blocked_fp8.py
@@ -48,7 +48,8 @@ class BlockedF8Linear(LinearBase):
                                        out_features,
                                        block_size=128,
                                        bias=bias is not None,
-                                       dtype=self.dtype)
+                                       dtype=self.dtype,
+                                       fp8_dtype=self.fp8_dtype)
         self.impl.set_scale_fmt(scale_fmt)
         weight, weight_scale_inv, bias = self.create_weights(in_features, out_features, bias, self.dtype, self.device)
         self.register_all_parameters(weight, weight_scale_inv, bias)

--- a/lmdeploy/pytorch/nn/linear/blocked_fp8.py
+++ b/lmdeploy/pytorch/nn/linear/blocked_fp8.py
@@ -46,8 +46,8 @@ class BlockedF8Linear(LinearBase):
         impl_builder = get_backend().get_layer_impl_builder(OpType.LinearBlockedF8)
         self.impl = impl_builder.build(in_features,
                                        out_features,
-                                       block_size=128,
-                                       bias=bias is not None,
+                                       block_size=self.block_size,
+                                       bias=bias,
                                        dtype=self.dtype,
                                        fp8_dtype=self.fp8_dtype)
         self.impl.set_scale_fmt(scale_fmt)

--- a/lmdeploy/pytorch/tools/audit_dependency_versions.py
+++ b/lmdeploy/pytorch/tools/audit_dependency_versions.py
@@ -1,0 +1,360 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+"""Inventory dependency constraints and source-level version checks.
+
+This is a read-only maintenance tool. It does not decide whether a dependency
+is compatible; it points maintainers to the requirement, environment, feature,
+model, and API-policy locations that should be reviewed together.
+
+Examples:
+
+    python lmdeploy/pytorch/tools/audit_dependency_versions.py
+    python lmdeploy/pytorch/tools/audit_dependency_versions.py triton
+    python lmdeploy/pytorch/tools/audit_dependency_versions.py transformers
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import importlib.metadata
+import re
+import sys
+from collections.abc import Iterable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TextIO
+
+from packaging.requirements import InvalidRequirement, Requirement
+from packaging.utils import canonicalize_name
+
+_VERSION_LITERAL = re.compile(r'^v?\d+(?:\.\d+)+(?:[-+._a-zA-Z0-9]*)?$')
+_VERSION_SPEC = re.compile(r'(?:===|==|~=|!=|<=|>=|<|>)\s*v?\d+(?:\.\d+)+(?:\.\*)?')
+_VERSION_PARSERS = frozenset({'parse', 'parse_version', 'Version', 'SpecifierSet'})
+
+
+@dataclass(frozen=True)
+class RequirementReference:
+    """One install constraint declared by a requirements file."""
+
+    package: str
+    requirement: str
+    path: Path
+    line: int
+    marker_applies: bool
+
+
+@dataclass(frozen=True)
+class SourceReference:
+    """One source-level version policy or API threshold."""
+
+    package: str
+    value: str
+    symbol: str | None
+    role: str
+    path: Path
+    line: int
+
+
+@dataclass(frozen=True)
+class _VersionCandidate:
+    value: str
+    symbol: str | None
+    line: int
+
+
+def _repository_root() -> Path:
+    return Path(__file__).resolve().parents[3]
+
+
+def _relative(path: Path, root: Path) -> str:
+    try:
+        return str(path.relative_to(root))
+    except ValueError:
+        return str(path)
+
+
+def _iter_requirement_lines(path: Path, visited: set[Path] | None = None):
+    if visited is None:
+        visited = set()
+    path = path.resolve()
+    if path in visited:
+        return
+    visited.add(path)
+
+    for line_number, raw_line in enumerate(path.read_text(encoding='utf-8').splitlines(), 1):
+        line = raw_line.split('#', 1)[0].strip()
+        if not line:
+            continue
+        if line.startswith(('-r ', '--requirement ')):
+            include = line.split(maxsplit=1)[1]
+            yield from _iter_requirement_lines(path.parent / include, visited)
+            continue
+        if line.startswith('-e '):
+            continue
+        yield path, line_number, line
+
+
+def collect_requirement_references(root: Path) -> list[RequirementReference]:
+    """Collect the CUDA runtime requirements without importing setup.py."""
+    references = []
+    requirements_path = root / 'requirements/runtime_cuda.txt'
+    for path, line_number, line in _iter_requirement_lines(requirements_path):
+        try:
+            requirement = Requirement(line)
+        except InvalidRequirement:
+            continue
+        references.append(
+            RequirementReference(
+                package=canonicalize_name(requirement.name),
+                requirement=str(requirement),
+                path=path,
+                line=line_number,
+                marker_applies=requirement.marker is None or requirement.marker.evaluate(),
+            ))
+    return references
+
+
+def _call_name(node: ast.expr) -> str | None:
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        return node.attr
+    return None
+
+
+def _target_name(node: ast.expr) -> str | None:
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, (ast.Tuple, ast.List)):
+        names = [name for item in node.elts if (name := _target_name(item))]
+        return ','.join(names) or None
+    return None
+
+
+def _looks_like_version(value: str) -> bool:
+    return bool(_VERSION_LITERAL.fullmatch(value.strip()) or _VERSION_SPEC.search(value))
+
+
+def _string_values(node: ast.AST) -> Iterable[ast.Constant]:
+    for child in ast.walk(node):
+        if isinstance(child, ast.Constant) and isinstance(child.value, str) and _looks_like_version(child.value):
+            yield child
+
+
+def _import_aliases(tree: ast.AST) -> dict[str, str]:
+    aliases = {}
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Import):
+            continue
+        for imported in node.names:
+            aliases[imported.asname or imported.name.split('.')[0]] = canonicalize_name(imported.name.split('.')[0])
+    return aliases
+
+
+def _versioned_packages(tree: ast.AST, aliases: dict[str, str]) -> set[str]:
+    packages = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Attribute) or node.attr != '__version__':
+            continue
+        if isinstance(node.value, ast.Name):
+            packages.add(aliases.get(node.value.id, canonicalize_name(node.value.id)))
+    return packages
+
+
+def _collect_candidates(tree: ast.AST) -> list[_VersionCandidate]:
+    candidates = []
+    assigned_values = set()
+    for node in ast.walk(tree):
+        symbol = None
+        value_node = None
+        if isinstance(node, ast.Assign):
+            symbol = ','.join(filter(None, (_target_name(target) for target in node.targets))) or None
+            is_parser_call = isinstance(node.value, ast.Call) and _call_name(node.value.func) in _VERSION_PARSERS
+            if symbol and ('version' in symbol.lower() or is_parser_call):
+                value_node = node.value
+        elif isinstance(node, ast.AnnAssign):
+            symbol = _target_name(node.target)
+            is_parser_call = isinstance(node.value, ast.Call) and _call_name(node.value.func) in _VERSION_PARSERS
+            if symbol and ('version' in symbol.lower() or is_parser_call):
+                value_node = node.value
+
+        if value_node is None:
+            continue
+        for value in _string_values(value_node):
+            candidates.append(_VersionCandidate(value=value.value, symbol=symbol, line=value.lineno))
+            assigned_values.add(id(value))
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call) or _call_name(node.func) not in _VERSION_PARSERS:
+            continue
+        for value in _string_values(node):
+            if id(value) not in assigned_values:
+                candidates.append(_VersionCandidate(value=value.value, symbol=None, line=value.lineno))
+
+    return list(dict.fromkeys(candidates))
+
+
+def _candidate_packages(candidate: _VersionCandidate, source: str, versioned_packages: set[str]) -> set[str]:
+    if len(versioned_packages) == 1:
+        return versioned_packages
+
+    context = source.splitlines()[candidate.line - 1].lower()
+    if candidate.symbol:
+        context += ' ' + candidate.symbol.lower()
+    return {package for package in versioned_packages if package.replace('-', '_') in context}
+
+
+def _classify_source(path: Path, symbol: str | None) -> str:
+    path_text = path.as_posix()
+    symbol_text = (symbol or '').lower()
+    if '/check_env/' in path_text:
+        return 'environment warning'
+    if '/models/' in path_text:
+        return 'model compatibility'
+    if '/backends/' in path_text and any(token in symbol_text for token in ('min', 'max', 'spec', 'required')):
+        return 'feature compatibility'
+    if '/kernels/' in path_text:
+        return 'API threshold'
+    return 'version branch'
+
+
+def collect_source_references(root: Path) -> list[SourceReference]:
+    """Find explicit version policies and branches in PyTorch source."""
+    references = []
+    source_root = root / 'lmdeploy/pytorch'
+    for path in sorted(source_root.rglob('*.py')):
+        if path == Path(__file__).resolve():
+            continue
+        source = path.read_text(encoding='utf-8')
+        try:
+            tree = ast.parse(source, filename=str(path))
+        except SyntaxError:
+            continue
+        versioned_packages = _versioned_packages(tree, _import_aliases(tree))
+        if not versioned_packages:
+            continue
+        for candidate in _collect_candidates(tree):
+            for package in _candidate_packages(candidate, source, versioned_packages):
+                references.append(
+                    SourceReference(
+                        package=package,
+                        value=candidate.value,
+                        symbol=candidate.symbol,
+                        role=_classify_source(path, candidate.symbol),
+                        path=path,
+                        line=candidate.line,
+                    ))
+    return references
+
+
+def _installed_version(package: str) -> str | None:
+    try:
+        return importlib.metadata.version(package)
+    except importlib.metadata.PackageNotFoundError:
+        return None
+
+
+def _requirement_status(reference: RequirementReference, installed_version: str | None) -> str:
+    if not reference.marker_applies:
+        return 'marker does not apply on this platform'
+    if installed_version is None:
+        return 'package not installed'
+    requirement = Requirement(reference.requirement)
+    if requirement.specifier.contains(installed_version, prereleases=True):
+        return 'installed version matches'
+    return 'REVIEW: CUDA runtime requirement excludes the installed version'
+
+
+def _review_action(role: str) -> str:
+    actions = {
+        'environment warning': 'update after engine-wide compatibility review',
+        'feature compatibility': 'update after this feature passes correctness and performance validation',
+        'model compatibility': 'review only for the affected model family',
+        'API threshold': 'usually retain; inspect only if the dependency API branch changed',
+        'version branch': 'inspect the owning call path before changing',
+    }
+    return actions[role]
+
+
+def print_package_report(package: str,
+                         requirements: list[RequirementReference],
+                         source_references: list[SourceReference],
+                         root: Path,
+                         output: TextIO = sys.stdout):
+    """Print an actionable review checklist for one dependency."""
+    package = canonicalize_name(package)
+    installed_version = _installed_version(package)
+    package_requirements = [item for item in requirements if item.package == package]
+    package_sources = [item for item in source_references if item.package == package]
+
+    print(f'\n{package}', file=output)
+    print(f'  installed: {installed_version or "not installed"}', file=output)
+
+    print('  install constraints:', file=output)
+    if not package_requirements:
+        print('    (none found)', file=output)
+    for item in package_requirements:
+        location = f'{_relative(item.path, root)}:{item.line}'
+        status = _requirement_status(item, installed_version)
+        print(f'    - {item.requirement} [{status}]', file=output)
+        print(f'      {location}', file=output)
+
+    print('  source version references:', file=output)
+    if not package_sources:
+        print('    (none found)', file=output)
+    grouped_sources = {}
+    for item in package_sources:
+        grouped_sources.setdefault((item.path, item.role), []).append(item)
+    for (path, role), items in sorted(grouped_sources.items(), key=lambda pair: (str(pair[0][0]), pair[0][1])):
+        sorted_items = sorted(items, key=lambda item: item.line)
+        values = ', '.join(f'{item.symbol}={item.value}' if item.symbol else item.value for item in sorted_items)
+        lines = ','.join(str(item.line) for item in sorted_items)
+        print(f'    - {role}: {values}', file=output)
+        print(f'      {_relative(path, root)}:{lines}', file=output)
+        print(f'      action: {_review_action(role)}', file=output)
+
+    locations = sorted({f'{_relative(item.path, root)}:{item.line}' for item in package_requirements}
+                       | {f'{_relative(item.path, root)}:{item.line}' for item in package_sources})
+    print('  review checklist:', file=output)
+    if not locations:
+        print('    - No requirement or explicit source version reference was found.', file=output)
+    else:
+        print(f'    - Review all {len(locations)} locations listed above when changing {package}.', file=output)
+        print('    - Do not update API thresholds merely to match the installation version.', file=output)
+        print('    - Run the owner-specific correctness and performance tests before widening a tested range.',
+              file=output)
+
+
+def _parse_args(argv: list[str] | None = None):
+    parser = argparse.ArgumentParser(
+        description='Inventory dependency constraints and source-level version checks.',
+        epilog=(
+            'examples:\n'
+            '  python lmdeploy/pytorch/tools/audit_dependency_versions.py\n'
+            '  python lmdeploy/pytorch/tools/audit_dependency_versions.py triton\n'
+            '  python lmdeploy/pytorch/tools/audit_dependency_versions.py transformers'),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        'packages',
+        nargs='*',
+        help='dependencies to audit (default: CUDA dependencies with PyTorch source version references)',
+    )
+    parser.add_argument('--root', type=Path, default=_repository_root(), help=argparse.SUPPRESS)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None):
+    args = _parse_args(argv)
+    root = args.root.resolve()
+    requirements = collect_requirement_references(root)
+    source_references = collect_source_references(root)
+    requirement_packages = {item.package for item in requirements}
+    source_packages = {item.package for item in source_references}
+    packages = args.packages or sorted(requirement_packages & source_packages)
+    for package in dict.fromkeys(canonicalize_name(package) for package in packages):
+        print_package_report(package, requirements, source_references, root)
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/pytorch/kernel/test_blocked_fp8_gemm_gluon.py
+++ b/tests/pytorch/kernel/test_blocked_fp8_gemm_gluon.py
@@ -1,5 +1,6 @@
 import pytest
 import torch
+from triton.compiler.errors import CompileTimeAssertionFailure
 
 GROUP_SIZE = 128
 FP8_DTYPE = torch.float8_e4m3fn
@@ -95,22 +96,21 @@ def _run_case(m: int, n: int, k: int, repeats: int = 1):
     a, b = _make_inputs(m, n, k)
     expected = _dequantized_reference(a, b)
     output = torch.full((m, n), torch.nan, device='cuda', dtype=torch.bfloat16)
-    first_output = None
 
-    for repeat in range(repeats):
+    fp8_gemm_nt(a, b, output, None)
+    if repeats > 1:
+        first_output = output.clone()
+    for repeat in range(1, repeats):
         fp8_gemm_nt(a, b, output, None)
-        if first_output is None:
-            first_output = output.clone()
-        else:
-            assert torch.equal(output, first_output), f'output changed on repeat {repeat + 1}'
+        assert torch.equal(output, first_output), f'output changed on repeat {repeat + 1}'
 
     assert torch.isfinite(output).all()
     assert _calc_diff(output, expected) < 1e-3
 
 
 def test_fp8_gemm_nt_one_tile_one_k_block():
-    """Milestone 1: get one synchronous TMA/WGMMA tile correct."""
-    _run_case(m=64, n=128, k=128)
+    """Milestone 1: cover exactly one output tile and one scale block."""
+    _run_case(m=64, n=32, k=128)
 
 
 def test_fp8_gemm_nt_multiple_k_scale_blocks():
@@ -120,7 +120,7 @@ def test_fp8_gemm_nt_multiple_k_scale_blocks():
 
 def test_fp8_gemm_nt_ragged_output_tiles():
     """Milestone 3: zero-pad loads and bound the M/N output edges."""
-    _run_case(m=37, n=192, k=256)
+    _run_case(m=37, n=200, k=256)
 
 
 def test_fp8_gemm_nt_multiple_mn_tiles():
@@ -137,13 +137,10 @@ def test_fp8_gemm_nt_dispatch_boundaries(m):
 @pytest.mark.parametrize(
     ('m', 'k'),
     [
-        (37, 640),
         (37, 1152),
         (128, 2176),
-        (256, 512),
         (256, 640),
         (256, 1152),
-        (256, 2176),
     ],
 )
 def test_fp8_gemm_nt_reuses_pipeline_stages_and_phases(m, k):
@@ -151,19 +148,20 @@ def test_fp8_gemm_nt_reuses_pipeline_stages_and_phases(m, k):
     _run_case(m=m, n=192, k=k, repeats=5)
 
 
-@torch.inference_mode()
-def test_fp8_gemm_nt_large_grid_is_deterministic():
-    """Catch CTA-concurrency bugs hidden by aggregate error tolerances."""
-    from lmdeploy.pytorch.kernels.cuda.blocked_fp8_gemm_gluon import fp8_gemm_nt
+def test_fp8_gemm_nt_mid_m_compiles_at_one_pipeline_turn():
+    """Guard the four-block scale queue that exposed a loop-carried type
+    error."""
+    _run_case(m=256, n=192, k=512, repeats=5)
 
-    a, b = _make_inputs(m=1024, n=4096, k=1152)
-    output = torch.empty((1024, 4096), device='cuda', dtype=torch.bfloat16)
-    fp8_gemm_nt(a, b, output, None)
-    expected = output.clone()
 
-    for repeat in range(10):
-        fp8_gemm_nt(a, b, output, None)
-        assert torch.equal(output, expected), f'output changed on repeat {repeat + 1}'
+def test_fp8_gemm_nt_persistent_grid_is_correct_and_deterministic():
+    """Exercise persistent tile reuse and detect CTA-concurrency races."""
+    num_sms = torch.cuda.get_device_properties('cuda').multi_processor_count
+    n = 4096
+    num_tiles_n = n // GROUP_SIZE
+    num_tiles_m = max(2, num_sms // num_tiles_n + 1)
+    m = num_tiles_m * 256
+    _run_case(m=m, n=n, k=1152, repeats=10)
 
 
 def test_fp8_gemm_nt_tiny_m_reuses_eight_pipeline_stages():
@@ -175,3 +173,25 @@ def test_fp8_gemm_nt_tiny_m_reuses_eight_pipeline_stages():
 def test_fp8_gemm_nt_transposed_tiny_m(m, k):
     """Cover both stage depths of the transposed M<=8 schedule."""
     _run_case(m=m, n=192, k=k, repeats=5)
+
+
+def test_fp8_gemm_nt_rejects_invalid_dtype_and_layout():
+    """Reject invalid contracts during specialization or descriptor setup."""
+    from lmdeploy.pytorch.kernels.cuda.blocked_fp8_gemm_gluon import fp8_gemm_nt
+
+    a, b = _make_inputs(m=64, n=128, k=256)
+    output = torch.empty((64, 128), device='cuda', dtype=torch.bfloat16)
+
+    with pytest.raises(CompileTimeAssertionFailure, match='A must use FP8 E4M3'):
+        fp8_gemm_nt((a[0].to(torch.float16), a[1]), b, output, None)
+    with pytest.raises(CompileTimeAssertionFailure, match='A scales must be column-major'):
+        fp8_gemm_nt((a[0], a[1].contiguous()), b, output, None)
+    with pytest.raises(CompileTimeAssertionFailure, match='B scales must use FP32'):
+        fp8_gemm_nt(a, (b[0], b[1].to(torch.float16)), output, None)
+    with pytest.raises(CompileTimeAssertionFailure, match='output must use BF16'):
+        fp8_gemm_nt(a, b, output.to(torch.float16), None)
+
+    ragged_a, ragged_b = _make_inputs(m=64, n=129, k=256)
+    misaligned_output = torch.empty((64, 129), device='cuda', dtype=torch.bfloat16)
+    with pytest.raises(AssertionError, match='strides must be 16-byte aligned'):
+        fp8_gemm_nt(ragged_a, ragged_b, misaligned_output, None)

--- a/tests/pytorch/kernel/test_blocked_fp8_gemm_gluon.py
+++ b/tests/pytorch/kernel/test_blocked_fp8_gemm_gluon.py
@@ -140,6 +140,27 @@ def test_fp8_gemm_nt_dispatch_boundaries(m):
 
 
 @pytest.mark.parametrize(
+    ('m', 'n', 'expected'),
+    [
+        (128, 2048, True),
+        (129, 2048, True),
+        (256, 2048, True),
+        (160, 4096, False),
+        (192, 4096, True),
+        (224, 4096, False),
+        (256, 4096, True),
+        (256, 8192, False),
+        (257, 2048, False),
+    ],
+)
+def test_fp8_gemm_nt_single_partition_policy(m, n, expected):
+    """Use the single-partition schedule within its measured wave budget."""
+    from lmdeploy.pytorch.kernels.cuda.blocked_fp8_gemm_gluon import _prefer_single_partition
+
+    assert _prefer_single_partition(m, n, num_sms=132) is expected
+
+
+@pytest.mark.parametrize(
     ('m', 'k'),
     [
         (37, 1152),

--- a/tests/pytorch/kernel/test_blocked_fp8_gemm_gluon.py
+++ b/tests/pytorch/kernel/test_blocked_fp8_gemm_gluon.py
@@ -95,18 +95,18 @@ def _calc_diff(actual: torch.Tensor, expected: torch.Tensor) -> torch.Tensor:
 
 
 @torch.inference_mode()
-def _run_case(m: int, n: int, k: int, repeats: int = 1):
+def _run_case(m: int, n: int, k: int, repeats: int = 1, num_sms: int | None = None):
     from lmdeploy.pytorch.kernels.cuda.blocked_fp8_gemm_gluon import fp8_gemm_nt
 
     a, b = _make_inputs(m, n, k)
     expected = _dequantized_reference(a, b)
     output = torch.full((m, n), torch.nan, device='cuda', dtype=torch.bfloat16)
 
-    fp8_gemm_nt(a, b, output, None)
+    fp8_gemm_nt(a, b, output, None, num_sms=num_sms)
     if repeats > 1:
         first_output = output.clone()
     for repeat in range(1, repeats):
-        fp8_gemm_nt(a, b, output, None)
+        fp8_gemm_nt(a, b, output, None, num_sms=num_sms)
         assert torch.equal(output, first_output), f'output changed on repeat {repeat + 1}'
 
     assert torch.isfinite(output).all()
@@ -190,6 +190,16 @@ def test_fp8_gemm_nt_persistent_grid_is_correct_and_deterministic():
     _run_case(m=m, n=n, k=1152, repeats=10)
 
 
+def test_fp8_gemm_nt_persistent_grid_honors_sm_budget():
+    """Redistribute every logical tile across a deliberately smaller grid."""
+    device_num_sms = torch.cuda.get_device_properties('cuda').multi_processor_count
+    n = 4096
+    num_tiles_n = n // GROUP_SIZE
+    num_tiles_m = max(2, device_num_sms // num_tiles_n + 1)
+    m = num_tiles_m * 256
+    _run_case(m=m, n=n, k=1152, repeats=3, num_sms=max(1, device_num_sms - 8))
+
+
 def test_fp8_gemm_nt_tiny_m_reuses_eight_pipeline_stages():
     """Exercise reuse and a full phase wrap in the tuned M<=64 path."""
     _run_case(m=4, n=192, k=2176, repeats=5)
@@ -234,3 +244,11 @@ def test_fp8_gemm_nt_rejects_invalid_dtype_and_layout():
     misaligned_output = torch.empty((64, 129), device='cuda', dtype=torch.bfloat16)
     with pytest.raises(AssertionError, match='strides must be 16-byte aligned'):
         fp8_gemm_nt(ragged_a, ragged_b, misaligned_output, None)
+
+    device_num_sms = torch.cuda.get_device_properties('cuda').multi_processor_count
+    with pytest.raises(TypeError, match='num_sms must be an integer or None'):
+        fp8_gemm_nt(a, b, output, None, num_sms=1.5)
+    with pytest.raises(ValueError, match='num_sms must be between 1 and'):
+        fp8_gemm_nt(a, b, output, None, num_sms=0)
+    with pytest.raises(ValueError, match='num_sms must be between 1 and'):
+        fp8_gemm_nt(a, b, output, None, num_sms=device_num_sms + 1)

--- a/tests/pytorch/kernel/test_blocked_fp8_gemm_gluon.py
+++ b/tests/pytorch/kernel/test_blocked_fp8_gemm_gluon.py
@@ -189,7 +189,9 @@ def test_fp8_gemm_nt_rejects_invalid_dtype_and_layout():
     a, b = _make_inputs(m=64, n=128, k=256)
     output = torch.empty((64, 128), device='cuda', dtype=torch.bfloat16)
 
-    with pytest.raises(CompileTimeAssertionFailure, match='A must use FP8 E4M3'):
+    # Triton 3.7 validates the descriptor element width before Gluon reaches
+    # the equivalent compile-time dtype assertion used by Triton 3.6.
+    with pytest.raises((CompileTimeAssertionFailure, AssertionError)):
         fp8_gemm_nt((a[0].to(torch.float16), a[1]), b, output, None)
     with pytest.raises(CompileTimeAssertionFailure, match='A scales must be column-major'):
         fp8_gemm_nt((a[0], a[1].contiguous()), b, output, None)

--- a/tests/pytorch/kernel/test_blocked_fp8_gemm_gluon.py
+++ b/tests/pytorch/kernel/test_blocked_fp8_gemm_gluon.py
@@ -1,16 +1,21 @@
 import pytest
 import torch
-from triton.compiler.errors import CompileTimeAssertionFailure
 
 GROUP_SIZE = 128
 FP8_DTYPE = torch.float8_e4m3fn
 
 
-def _has_hopper() -> bool:
-    return torch.cuda.is_available() and torch.cuda.get_device_capability()[0] == 9
+def _has_gluon() -> bool:
+    if not torch.cuda.is_available() or torch.cuda.get_device_capability()[0] != 9:
+        return False
+    try:
+        from lmdeploy.pytorch.backends.cuda.blockedf8_modules import _has_gluon as has_gluon
+    except (AttributeError, ImportError):
+        return False
+    return has_gluon()
 
 
-pytestmark = pytest.mark.skipif(not _has_hopper(), reason='Gluon WGMMA kernel requires Hopper')
+pytestmark = pytest.mark.skipif(not _has_gluon(), reason='Gluon WGMMA kernel requires supported Triton on Hopper')
 
 
 def _quantize_a(a: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
@@ -177,6 +182,8 @@ def test_fp8_gemm_nt_transposed_tiny_m(m, k):
 
 def test_fp8_gemm_nt_rejects_invalid_dtype_and_layout():
     """Reject invalid contracts during specialization or descriptor setup."""
+    from triton.compiler.errors import CompileTimeAssertionFailure
+
     from lmdeploy.pytorch.kernels.cuda.blocked_fp8_gemm_gluon import fp8_gemm_nt
 
     a, b = _make_inputs(m=64, n=128, k=256)

--- a/tests/pytorch/kernel/test_blocked_fp8_gemm_gluon.py
+++ b/tests/pytorch/kernel/test_blocked_fp8_gemm_gluon.py
@@ -195,10 +195,19 @@ def test_fp8_gemm_nt_tiny_m_reuses_eight_pipeline_stages():
     _run_case(m=4, n=192, k=2176, repeats=5)
 
 
-@pytest.mark.parametrize(('m', 'k'), [(1, 4096), (8, 8192)])
+@pytest.mark.parametrize(('m', 'k'), [(1, 4096), (32, 4096), (24, 6144), (8, 8192), (16, 8192)])
 def test_fp8_gemm_nt_transposed_tiny_m(m, k):
-    """Cover both stage depths of the transposed M<=8 schedule."""
+    """Cover the K-dependent transposed schedule and both stage depths."""
     _run_case(m=m, n=192, k=k, repeats=5)
+
+
+@pytest.mark.parametrize(('k', 'expected'), [(4096, 32), (5120, 32), (6144, 24), (8192, 16), (15360, 16),
+                                              (16384, 8), (17408, 8)])
+def test_fp8_gemm_nt_transpose_m_limit(k, expected):
+    """Keep long-K B-reload regressions outside the transposed schedule."""
+    from lmdeploy.pytorch.kernels.cuda.blocked_fp8_gemm_gluon import _get_transpose_m_limit
+
+    assert _get_transpose_m_limit(k) == expected
 
 
 def test_fp8_gemm_nt_rejects_invalid_dtype_and_layout():

--- a/tests/pytorch/kernel/test_blocked_fp8_gemm_gluon.py
+++ b/tests/pytorch/kernel/test_blocked_fp8_gemm_gluon.py
@@ -1,0 +1,177 @@
+import pytest
+import torch
+
+GROUP_SIZE = 128
+FP8_DTYPE = torch.float8_e4m3fn
+
+
+def _has_hopper() -> bool:
+    return torch.cuda.is_available() and torch.cuda.get_device_capability()[0] == 9
+
+
+pytestmark = pytest.mark.skipif(not _has_hopper(), reason='Gluon WGMMA kernel requires Hopper')
+
+
+def _quantize_a(a: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    """Quantize A with one scale per row and 128-wide K block."""
+    m, k = a.shape
+    assert k % GROUP_SIZE == 0
+
+    blocks = a.float().view(m, k // GROUP_SIZE, GROUP_SIZE)
+    fp8_info = torch.finfo(FP8_DTYPE)
+    scale = blocks.abs().amax(dim=-1).clamp_min(1e-6) / fp8_info.max
+    quant = (blocks / scale[..., None]).clamp(fp8_info.min, fp8_info.max).to(FP8_DTYPE)
+
+    # Exercise the column-major logical [M, K / 128] scale layout used by the
+    # DeepGEMM-facing LMDeploy quantization path. TMA requires the physical
+    # stride between K-block columns to be 16-byte aligned.
+    scale_alignment = 16 // scale.element_size()
+    aligned_m = (m + scale_alignment - 1) // scale_alignment * scale_alignment
+    aligned_scale = torch.empty_strided(scale.shape, (1, aligned_m), dtype=scale.dtype, device=scale.device)
+    aligned_scale.copy_(scale)
+    scale = aligned_scale
+    return quant.view(m, k), scale
+
+
+def _quantize_b_nt(b: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    """Quantize B[N, K] with one scale per 128x128 (N, K) block."""
+    n, k = b.shape
+    assert k % GROUP_SIZE == 0
+
+    padded_n = (n + GROUP_SIZE - 1) // GROUP_SIZE * GROUP_SIZE
+    padded = torch.zeros((padded_n, k), dtype=torch.float32, device=b.device)
+    padded[:n] = b
+
+    blocks = padded.view(padded_n // GROUP_SIZE, GROUP_SIZE, k // GROUP_SIZE, GROUP_SIZE)
+    fp8_info = torch.finfo(FP8_DTYPE)
+    scale = blocks.abs().amax(dim=(1, 3)).clamp_min(1e-6) / fp8_info.max
+    quant = (blocks / scale[:, None, :, None]).clamp(fp8_info.min, fp8_info.max).to(FP8_DTYPE)
+    return quant.view(padded_n, k)[:n].contiguous(), scale
+
+
+def _dequantized_reference(a: tuple[torch.Tensor, torch.Tensor],
+                           b: tuple[torch.Tensor, torch.Tensor]) -> torch.Tensor:
+    a_quant, a_scale = a
+    b_quant, b_scale = b
+    m, k = a_quant.shape
+    n = b_quant.size(0)
+    k_blocks = k // GROUP_SIZE
+
+    a_dequant = a_quant.float().view(m, k_blocks, GROUP_SIZE) * a_scale.float()[..., None]
+    b_scale_per_row = b_scale.float().repeat_interleave(GROUP_SIZE, dim=0)[:n]
+    b_dequant = b_quant.float().view(n, k_blocks, GROUP_SIZE) * b_scale_per_row[..., None]
+    return (a_dequant.view(m, k) @ b_dequant.view(n, k).T).to(torch.bfloat16)
+
+
+def _make_inputs(m: int, n: int, k: int):
+    torch.manual_seed(42)
+    a = torch.randn((m, k), device='cuda', dtype=torch.bfloat16)
+    b = torch.randn((n, k), device='cuda', dtype=torch.bfloat16)
+
+    # Make scale products clearly different across K and N blocks. This catches
+    # kernels that accumulate all raw WGMMA partials and apply only one scale.
+    num_k_blocks = k // GROUP_SIZE
+    num_n_blocks = (n + GROUP_SIZE - 1) // GROUP_SIZE
+    k_factors = torch.logspace(-1, 1, num_k_blocks, device='cuda')
+    n_factors = torch.logspace(-0.5, 0.5, num_n_blocks, device='cuda')
+    k_factors = k_factors.repeat_interleave(GROUP_SIZE)
+    n_factors = n_factors.repeat_interleave(GROUP_SIZE)[:n]
+    a = (a.float() * k_factors[None, :]).to(torch.bfloat16)
+    b = (b.float() * n_factors[:, None] * k_factors[None, :]).to(torch.bfloat16)
+
+    return _quantize_a(a), _quantize_b_nt(b)
+
+
+def _calc_diff(actual: torch.Tensor, expected: torch.Tensor) -> torch.Tensor:
+    actual = actual.double()
+    expected = expected.double()
+    return 1 - 2 * (actual * expected).sum() / (actual.square() + expected.square()).sum()
+
+
+@torch.inference_mode()
+def _run_case(m: int, n: int, k: int, repeats: int = 1):
+    from lmdeploy.pytorch.kernels.cuda.blocked_fp8_gemm_gluon import fp8_gemm_nt
+
+    a, b = _make_inputs(m, n, k)
+    expected = _dequantized_reference(a, b)
+    output = torch.full((m, n), torch.nan, device='cuda', dtype=torch.bfloat16)
+    first_output = None
+
+    for repeat in range(repeats):
+        fp8_gemm_nt(a, b, output, None)
+        if first_output is None:
+            first_output = output.clone()
+        else:
+            assert torch.equal(output, first_output), f'output changed on repeat {repeat + 1}'
+
+    assert torch.isfinite(output).all()
+    assert _calc_diff(output, expected) < 1e-3
+
+
+def test_fp8_gemm_nt_one_tile_one_k_block():
+    """Milestone 1: get one synchronous TMA/WGMMA tile correct."""
+    _run_case(m=64, n=128, k=128)
+
+
+def test_fp8_gemm_nt_multiple_k_scale_blocks():
+    """Milestone 2: promote every K partial with the correct A/B scales."""
+    _run_case(m=64, n=128, k=384)
+
+
+def test_fp8_gemm_nt_ragged_output_tiles():
+    """Milestone 3: zero-pad loads and bound the M/N output edges."""
+    _run_case(m=37, n=192, k=256)
+
+
+def test_fp8_gemm_nt_multiple_mn_tiles():
+    """Milestone 4: cover nonzero M/N program ids and ragged final tiles."""
+    _run_case(m=137, n=320, k=384)
+
+
+@pytest.mark.parametrize('m', [128, 129, 256, 257])
+def test_fp8_gemm_nt_dispatch_boundaries(m):
+    """Keep all three schedule families correct at their boundaries."""
+    _run_case(m=m, n=192, k=384, repeats=3)
+
+
+@pytest.mark.parametrize(
+    ('m', 'k'),
+    [
+        (37, 640),
+        (37, 1152),
+        (128, 2176),
+        (256, 512),
+        (256, 640),
+        (256, 1152),
+        (256, 2176),
+    ],
+)
+def test_fp8_gemm_nt_reuses_pipeline_stages_and_phases(m, k):
+    """Exercise stage reuse and phase changes in the small and mid paths."""
+    _run_case(m=m, n=192, k=k, repeats=5)
+
+
+@torch.inference_mode()
+def test_fp8_gemm_nt_large_grid_is_deterministic():
+    """Catch CTA-concurrency bugs hidden by aggregate error tolerances."""
+    from lmdeploy.pytorch.kernels.cuda.blocked_fp8_gemm_gluon import fp8_gemm_nt
+
+    a, b = _make_inputs(m=1024, n=4096, k=1152)
+    output = torch.empty((1024, 4096), device='cuda', dtype=torch.bfloat16)
+    fp8_gemm_nt(a, b, output, None)
+    expected = output.clone()
+
+    for repeat in range(10):
+        fp8_gemm_nt(a, b, output, None)
+        assert torch.equal(output, expected), f'output changed on repeat {repeat + 1}'
+
+
+def test_fp8_gemm_nt_tiny_m_reuses_eight_pipeline_stages():
+    """Exercise reuse and a full phase wrap in the tuned M<=64 path."""
+    _run_case(m=4, n=192, k=2176, repeats=5)
+
+
+@pytest.mark.parametrize(('m', 'k'), [(1, 4096), (8, 8192)])
+def test_fp8_gemm_nt_transposed_tiny_m(m, k):
+    """Cover both stage depths of the transposed M<=8 schedule."""
+    _run_case(m=m, n=192, k=k, repeats=5)


### PR DESCRIPTION
## Kernel design

The kernel uses three shape-specific schedules:

- `M <= 128`: single-partition multistage kernel, with a transposed GEMM schedule for `M <= 8` and large K;
- `129 <= M <= 256`: non-persistent, warp-specialized pipeline;
- `M > 256`: persistent, warp-specialized kernel using two M waves and scale caching.

## Dispatch

The automatic provider order is:

1. DeepGEMM
2. Gluon
3. Triton fallback

The provider can be overridden with:

```bash
LMDEPLOY_BLOCKED_FP8_GEMM_BACKEND={auto,deepgemm,gluon,triton}
```

## Performance

Measured on an NVIDIA H200 with `N=K=4096`, identical preallocated inputs, 50 ms warmup, 250 ms measurement, and five alternating trials. Values are median p50 latency.

| M | Triton µs | Gluon µs | DeepGEMM µs | Gluon TFLOP/s | Gluon/Triton | Gluon/DeepGEMM |
|---:|---:|---:|---:|---:|---:|---:|
| 1 | 24.30 | 13.42 | 14.94 | 2.50 | 0.55x | **0.90x** |
| 8 | 24.83 | 14.21 | 12.58 | 18.89 | 0.57x | 1.13x |
| 9 | 25.12 | 14.24 | 12.58 | 21.21 | 0.57x | 1.13x |
| 16 | 26.27 | 14.69 | 12.64 | 36.55 | 0.56x | 1.16x |
| 24 | 26.26 | 14.08 | 12.64 | 57.20 | 0.54x | 1.11x |
| 32 | 26.50 | 15.09 | 12.83 | 71.17 | 0.57x | 1.18x |
| 64 | 26.94 | 14.58 | 12.56 | 147.33 | 0.54x | 1.16x |
| 128 | 28.00 | 16.10 | 13.15 | 266.83 | 0.57x | 1.22x |
| 160 | 28.51 | 19.12 | 14.14 | 280.79 | 0.67x | 1.35x |
| 192 | 28.21 | 16.72 | 14.19 | 385.31 | 0.59x | 1.18x |
| 224 | 28.93 | 19.22 | 15.30 | 391.14 | 0.66x | 1.26x |
| 256 | 28.98 | 17.52 | 15.36 | 490.29 | 0.60x | 1.14x |
| 512 | 31.28 | 21.23 | 21.18 | 809.15 | 0.68x | **1.00x** |
| 1024 | 56.45 | 34.30 | 32.48 | 1001.62 | 0.61x | 1.06x |
| 2048 | 90.30 | 60.98 | 61.87 | 1126.99 | 0.68x | **0.99x** |
| 4096 | 181.04 | 125.68 | 127.12 | 1093.56 | 0.69x | **0.99x** |
| 8192 | 355.09 | 255.46 | 253.40 | 1076.03 | 0.72x | **1.01x** |

> [!WARNING]
> The kernel for large M follow the same design of deepgemm, but kernel for middle/small M failed to get the same prerformance.

