### PR TITLE
Fix int4 KV cache quantization range when the packed head width is not a power of two

### DIFF
--- a/lmdeploy/pytorch/kernels/cuda/fill_kv_cache.py
+++ b/lmdeploy/pytorch/kernels/cuda/fill_kv_cache.py
@@ -303,6 +303,7 @@ def _fill_page_quant_int4(
     """Fill page int4."""
     d_off = tl.arange(0, BLOCK_D)
     mask_kc = kv_mask[:, None] & (d_off[None, :] < head_dim)
+    d_off = d_off % head_dim
     state_ptr = state_ptr + head_id * stride_sh
     state0_ptrs = state_ptr + q_offs[:, None] * stride_ss + d_off[None, :] * stride_sd
     state1_ptrs = state0_ptrs + head_dim * stride_sd
@@ -312,8 +313,8 @@ def _fill_page_quant_int4(
     scales_ptrs = scales_zeros_ptr + page_offs[:, None] * stride_szb
     zeros_ptrs = scales_ptrs + stride_szd
 
-    state0 = tl.load(state0_ptrs, mask=mask_kc)
-    state1 = tl.load(state1_ptrs, mask=mask_kc)
+    state0 = tl.load(state0_ptrs, mask=kv_mask[:, None])
+    state1 = tl.load(state1_ptrs, mask=kv_mask[:, None])
     state, scales, zeros = _quant_int4(state0, state1)
 
     tl.store(cache_ptrs, state, mask=mask_kc)

--- a/tests/pytorch/kernel/test_fill_kv_cache.py
+++ b/tests/pytorch/kernel/test_fill_kv_cache.py
@@ -293,6 +293,33 @@ class TestFillKVCacheInt4(TestFillKVCacheInt8):
         torch.testing.assert_close(v_caches, gt[1])
 
 
+class TestFillKVCacheInt4NonPow2(TestFillKVCacheInt4):
+    """Int4 with a packed head width that is not a power of two.
+
+    BLOCK_D then covers lanes past the end of the head. The states are kept away from zero so that those lanes would
+    widen the quantization range if they took part in it.
+    """
+
+    @pytest.fixture
+    def k_states(self, num_tokens, num_heads, head_dim):
+        yield torch.rand(num_tokens, num_heads, head_dim).cuda() * 2 + 1
+
+    @pytest.fixture
+    def v_states(self, k_states):
+        yield torch.rand_like(k_states) * 2 + 1
+
+    @pytest.mark.parametrize('head_dim', [96, 128], indirect=True)
+    @pytest.mark.parametrize(['seq_lens', 'history_lens'], [
+        ((1, 1, 1, 1), (1, 16, 31, 24)),
+        ((1, 8, 16, 24), (1, 16, 31, 24)),
+    ],
+                             indirect=True)
+    def test_fill_kv_cache(self, k_states, v_states, k_caches, v_caches, k_scales_zeros, v_scales_zeros, block_offsets,
+                           q_start_loc, q_seq_length, kv_seq_length, max_q_seq_length, gt, nbits):
+        super().test_fill_kv_cache(k_states, v_states, k_caches, v_caches, k_scales_zeros, v_scales_zeros,
+                                   block_offsets, q_start_loc, q_seq_length, kv_seq_length, max_q_seq_length, gt, nbits)
+
+
 class TestFillKVCacheInt42(TestFillKVCacheInt4):
     """quant_policy == QuantPolicy.TURBO_QUANT:
 


### PR DESCRIPTION
## Motivation

Fixes #4849.

## Modification

- `_fill_page_quant_int4`: add `d_off = d_off % head_dim` so the lanes past the head wrap onto real channels, and load `state0`/`state1` with `kv_mask[:, None]` instead of `mask_kc` so those lanes carry data rather than `0.0`. This is exactly the shape `_fill_page_quant_int8` has. The store keeps `mask_kc`, so nothing extra is written, and every address stays inside the head.
- `TestFillKVCacheInt4NonPow2`: a subclass of the existing int4 test at `head_dim` 96 and 128, with states drawn away from zero. Both are needed — 128 packs to a power of two, and states that straddle zero make `[min(0, lo), max(0, hi)]` coincide with `[lo, hi]`, which is why the current int4 test (`head_dim` 128 only, `randn` states) cannot see this. Reverting the kernel change alone fails the two `head_dim=96` cases and leaves everything else green.

Addressing-only change, so it is perf neutral; `fill_kv_cache` int4 prefill, three interleaved before/after runs on a B200:

| shape | before | after |
|---|---|---|
| head_dim 96, 8 heads, 4096 tokens | 12.30-12.31 us | 12.31-12.33 us |
| head_dim 128, 8 heads, 4096 tokens | 12.55-12.62 us | 12.56-12.57 us |
| head_dim 96, 32 heads, 8192 tokens | 38.86-38.90 us | 38.91-38.92 us |
| head_dim 128, 32 heads, 8192 tokens | 39.02-39.05 us | 39.02-39.04 us |

## Environment

```
lmdeploy: main @ 98058c354a83f25f52b5d5ea80bfb4686996451e, installed with DISABLE_TURBOMIND=1 pip install -e .
GPU: NVIDIA B200, driver 595.71.05 (CUDA 13.2)
torch 2.12.1+cu130, triton 3.7.1, Python 3.11
```
