### PR TITLE
fix(serve): emit signatures for Anthropic thinking blocks

### DIFF
--- a/lmdeploy/serve/anthropic/protocol.py
+++ b/lmdeploy/serve/anthropic/protocol.py
@@ -11,6 +11,7 @@ from pydantic import BaseModel, ConfigDict, Field
 
 RoutedExperts = list[list[list[int]]] | str | None
 MessageStopReason = Literal['end_turn', 'max_tokens', 'stop_sequence', 'tool_use', 'parse_error']
+LOCAL_THINKING_SIGNATURE = 'lmdeploy-local'
 
 
 class AnthropicError(BaseModel):
@@ -156,6 +157,7 @@ class MessageThinkingBlock(BaseModel):
 
     type: Literal['thinking'] = 'thinking'
     thinking: str
+    signature: str = LOCAL_THINKING_SIGNATURE
 
 
 class MessageToolUseBlock(BaseModel):

--- a/lmdeploy/serve/anthropic/streaming.py
+++ b/lmdeploy/serve/anthropic/streaming.py
@@ -12,6 +12,7 @@ from lmdeploy.serve.openai.protocol import DeltaMessage
 
 from .adapter import map_finish_reason
 from .protocol import (
+    LOCAL_THINKING_SIGNATURE,
     AnthropicStreamEvent,
     ContentBlockDeltaEvent,
     ContentBlockStartEvent,
@@ -24,6 +25,7 @@ from .protocol import (
     MessageStartMessage,
     MessageStopEvent,
     MessageUsage,
+    SignatureDelta,
     StreamTextBlock,
     StreamThinkingBlock,
     StreamToolUseBlock,
@@ -49,21 +51,30 @@ class _StreamBlockState:
     tool_blocks: dict[int, dict[str, Any]] = field(default_factory=dict)
 
 
-def _close_current_block(state: _StreamBlockState) -> str | None:
-    if state.current_block is None:
-        return None
-    payload = _format_sse(ContentBlockStopEvent(index=state.current_block['block_index']))
+def _close_current_block(state: _StreamBlockState) -> list[str]:
+    block = state.current_block
+    if block is None:
+        return []
+
+    block_index = block['block_index']
+    events: list[str] = []
+    if block['kind'] == 'thinking':
+        events.append(
+            _format_sse(
+                ContentBlockDeltaEvent(
+                    index=block_index,
+                    delta=SignatureDelta(signature=LOCAL_THINKING_SIGNATURE),
+                )))
+    events.append(_format_sse(ContentBlockStopEvent(index=block_index)))
     state.current_block = None
-    return payload
+    return events
 
 
 def _start_text_or_thinking(state: _StreamBlockState, kind: str) -> list[str]:
     events: list[str] = []
     if state.current_block is not None and state.current_block['kind'] == kind:
         return events
-    closing = _close_current_block(state)
-    if closing:
-        events.append(closing)
+    events.extend(_close_current_block(state))
     block_index = state.next_block_index
     state.next_block_index += 1
     if kind == 'text':
@@ -90,9 +101,7 @@ def _start_tool_block(state: _StreamBlockState, tool_delta) -> list[str]:
         and block is not None
         and current_block['block_index'] == block['block_index'])
     if not same_block:
-        closing = _close_current_block(state)
-        if closing:
-            events.append(closing)
+        events.extend(_close_current_block(state))
     if block is None:
         function_delta = tool_delta.function
         tool_name = '' if function_delta is None else function_delta.name or ''
@@ -308,9 +317,8 @@ async def stream_messages_response(result_generator,
         if res.finish_reason == 'stop' and streaming_tools:
             res.finish_reason = 'tool_calls'
 
-    closing = _close_current_block(block_state)
-    if closing:
-        yield closing
+    for event in _close_current_block(block_state):
+        yield event
 
     output_tokens = 0 if final_res is None else final_res.generate_token_len
     stop_reason = map_finish_reason(None if final_res is None else final_res.finish_reason)

--- a/tests/test_lmdeploy/serve/anthropic/test_adapter_conversion.py
+++ b/tests/test_lmdeploy/serve/anthropic/test_adapter_conversion.py
@@ -294,13 +294,14 @@ def test_to_openai_messages_puts_assistant_tool_result_into_content():
     }]
 
 
-def test_to_openai_messages_maps_thinking_block_to_reasoning_content():
+def test_to_openai_messages_maps_signed_thinking_block_to_reasoning_content():
     request = _make_request(
         messages=[{
             'role': 'assistant',
             'content': [{
                 'type': 'thinking',
                 'thinking': 'internal chain',
+                'signature': 'lmdeploy-local',
             }],
         }])
     messages = to_openai_messages(request)

--- a/tests/test_lmdeploy/serve/anthropic/test_endpoints.py
+++ b/tests/test_lmdeploy/serve/anthropic/test_endpoints.py
@@ -430,7 +430,11 @@ def test_messages_non_stream_with_reasoning_and_tool_use_blocks():
     assert response.status_code == 200
     data = response.json()
     assert data['stop_reason'] == 'tool_use'
-    assert data['content'][0] == {'type': 'thinking', 'thinking': 'internal reasoning'}
+    assert data['content'][0] == {
+        'type': 'thinking',
+        'thinking': 'internal reasoning',
+        'signature': 'lmdeploy-local',
+    }
     assert data['content'][1] == {'type': 'text', 'text': 'visible text'}
     assert data['content'][2]['type'] == 'tool_use'
     assert data['content'][2]['name'] == 'search'
@@ -468,9 +472,40 @@ def test_messages_streaming_usage_matches_anthropic_event_spec():
 def test_messages_streaming_with_reasoning_and_tool_use_events():
     client = _make_client(response_parser_cls=_ToolAndReasoningParser)
     status_code, body = _stream_messages_body(client, tools=[SEARCH_TOOL], return_token_ids=True)
+    payloads = _sse_payloads(body)
+    thinking_events = [payload for payload in payloads if payload.get('index') == 0]
 
     assert status_code == 200
-    assert '"type": "thinking_delta"' in body
+    assert thinking_events == [
+        {
+            'type': 'content_block_start',
+            'index': 0,
+            'content_block': {
+                'type': 'thinking',
+                'thinking': '',
+            },
+        },
+        {
+            'type': 'content_block_delta',
+            'index': 0,
+            'delta': {
+                'type': 'thinking_delta',
+                'thinking': 'internal reasoning',
+            },
+        },
+        {
+            'type': 'content_block_delta',
+            'index': 0,
+            'delta': {
+                'type': 'signature_delta',
+                'signature': 'lmdeploy-local',
+            },
+        },
+        {
+            'type': 'content_block_stop',
+            'index': 0,
+        },
+    ]
     assert '"type": "input_json_delta"' in body
     assert '"type": "tool_use"' in body
     assert '"output_ids": [102]' in body


### PR DESCRIPTION
## Motivation

Anthropic-compatible responses currently omit the `signature` field from thinking blocks.

Clients may replay assistant thinking blocks in subsequent requests and expect each block to contain a signature. For streaming responses, the Anthropic protocol delivers the signature through a `signature_delta` event immediately before `content_block_stop`.

This PR adds a local opaque signature marker so that LMDeploy-generated thinking blocks can be replayed by Anthropic-compatible clients.

## Modification

- Add `signature` to non-streaming thinking blocks.
- Emit one `signature_delta` before closing each streaming thinking block.
- Keep `content_block_start` unchanged and only emit signatures for thinking blocks.
- Use the existing block-closing path so the event ordering is consistent when thinking is followed by text, tool use, or the end of generation.
- Add unit tests covering:
  - non-streaming thinking signatures;
  - streaming event ordering;
  - signed thinking block conversion in subsequent requests.

The streaming sequence is:

```text
content_block_start
thinking_delta
signature_delta
content_block_stop