### PR TITLE
docs: update recent model support

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,8 @@ LMDeploy is a toolkit for compressing, deploying, and serving LLM, developed by 
   <li>DeepSeek-V2.5 (236B)</li>
   <li>DeepSeek-V3 (685B)</li>
   <li>DeepSeek-V3.2 (685B)</li>
+  <li>DeepSeek-V4 (284B, 1.6T)</li>
+  <li>Hy3 (295B-A21B)</li>
   <li>Mixtral (8x7B, 8x22B)</li>
   <li>Gemma (2B - 7B)</li>
   <li>Phi-3-mini (3.8B)</li>
@@ -161,6 +163,7 @@ LMDeploy is a toolkit for compressing, deploying, and serving LLM, developed by 
   <li>gpt-oss (20B, 120B)</li>
   <li>GLM-4.7-Flash (30B)</li>
   <li>GLM-5 (754B)</li>
+  <li>GLM-5.2 (754B)</li>
 </ul>
 </td>
 <td>
@@ -181,7 +184,8 @@ LMDeploy is a toolkit for compressing, deploying, and serving LLM, developed by 
   <li>Intern-S1 (241B)</li>
   <li>Intern-S1-mini (8.3B)</li>
   <li>Intern-S1-Pro (1TB)</li>
-  <li>Intern-S2-Preview (35B-A3B)</li>
+  <li>Intern-S2-Preview (35B-A3B, 397B)</li>
+  <li>Intern-S2-Mobius (35B)</li>
   <li>ChemVLM (8B-26B)</li>
   <li>CogVLM-Chat (17B)</li>
   <li>CogVLM2-Chat (19B)</li>

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -152,6 +152,8 @@ LMDeploy TurboMind 引擎拥有卓越的推理能力，在各种规模的模型�
   <li>DeepSeek-V2.5 (236B)</li>
   <li>DeepSeek-V3 (685B)</li>
   <li>DeepSeek-V3.2 (685B)</li>
+  <li>DeepSeek-V4 (284B, 1.6T)</li>
+  <li>Hy3 (295B-A21B)</li>
   <li>Mixtral (8x7B, 8x22B)</li>
   <li>Gemma (2B - 7B)</li>
   <li>Phi-3-mini (3.8B)</li>
@@ -163,6 +165,7 @@ LMDeploy TurboMind 引擎拥有卓越的推理能力，在各种规模的模型�
   <li>gpt-oss (20B, 120B)</li>
   <li>GLM-4.7-Flash (30B)</li>
   <li>GLM-5 (754B)</li>
+  <li>GLM-5.2 (754B)</li>
 </ul>
 </td>
 <td>
@@ -183,7 +186,8 @@ LMDeploy TurboMind 引擎拥有卓越的推理能力，在各种规模的模型�
   <li>Intern-S1 (241B)</li>
   <li>Intern-S1-mini (8.3B)</li>
   <li>Intern-S1-Pro (1TB)</li>
-  <li>Intern-S2-Preview (35B-A3B)</li>
+  <li>Intern-S2-Preview (35B-A3B, 397B)</li>
+  <li>Intern-S2-Mobius (35B)</li>
   <li>ChemVLM (8B-26B)</li>
   <li>CogVLM-Chat (17B)</li>
   <li>CogVLM2-Chat (19B)</li>

--- a/docs/en/supported_models/supported_models.md
+++ b/docs/en/supported_models/supported_models.md
@@ -68,7 +68,8 @@ The following tables detail the models supported by LMDeploy's TurboMind engine 
 |           Intern-S1            |      241B       | MLLM |    Yes    |   Yes   |   Yes   | Yes  |   -   |
 |         Intern-S1-mini         |      8.3B       | MLLM |    Yes    |   Yes   |   Yes   | Yes  |   -   |
 |         Intern-S1-Pro          |       1TB       | MLLM |    Yes    |    -    |    -    |  -   |  No   |
-|       Intern-S2-Preview        |     35B-A3B     | MLLM |    Yes    |   No    |   No    |  No  |  No   |
+|       Intern-S2-Preview        |  35B-A3B, 397B  | MLLM |    Yes    |   No    |   No    |  No  |  No   |
+|        Intern-S2-Mobius        |       35B       | MLLM |    Yes    |   No    |   No    |  No  |  No   |
 |            ChatGLM2            |       6B        | LLM  |    Yes    |   Yes   |   Yes   |  No  |  No   |
 |               YI               |    6B - 34B     | LLM  |    Yes    |   Yes   |   Yes   | Yes  |  Yes  |
 |            Mistral             |       7B        | LLM  |    Yes    |   Yes   |   Yes   | Yes  |  Yes  |
@@ -89,6 +90,8 @@ The following tables detail the models supported by LMDeploy's TurboMind engine 
 |         DeepSeek-V2.5          |      236B       | LLM  |    Yes    |   No    |   No    |  No  |  No   |
 |          DeepSeek-V3           |      685B       | LLM  |    Yes    |   No    |   No    |  No  |  No   |
 |         DeepSeek-V3.2          |      685B       | LLM  |    Yes    |   No    |   No    |  No  |  No   |
+|          DeepSeek-V4           |   284B, 1.6T    | LLM  |    Yes    |   No    |   No    |  No  |  No   |
+|              Hy3               |    295B-A21B    | LLM  |    Yes    |   No    |   No    | Yes  |  No   |
 |          DeepSeek-VL2          |    3B - 27B     | MLLM |    Yes    |   No    |   No    |  No  |  No   |
 |            MiniCPM3            |       4B        | LLM  |    Yes    |   Yes   |   Yes   |  No  |  No   |
 |         MiniCPM-V-2_6          |       8B        | LLM  |    Yes    |   No    |   No    |  No  |  Yes  |
@@ -120,6 +123,7 @@ The following tables detail the models supported by LMDeploy's TurboMind engine 
 |              SDAR              |    1.7B-30B     | LLM  |    Yes    |   Yes   |   No    |  -   |   -   |
 |         GLM-4.7-Flash          |       30B       | LLM  |    Yes    |   No    |   No    |  No  |  No   |
 |             GLM-5              |      754B       | LLM  |    Yes    |   No    |   No    |  No  |  No   |
+|            GLM-5.2             |      754B       | LLM  |    Yes    |   No    |   No    |  No  |  No   |
 
 ```{note}
 * [1] PyTorch engine removes the support of original llava models after v0.6.4. Please use their corresponding transformers models instead, which can be found in https://huggingface.co/llava-hf

--- a/docs/zh_cn/supported_models/supported_models.md
+++ b/docs/zh_cn/supported_models/supported_models.md
@@ -69,7 +69,8 @@
 |           Intern-S1            |      241B       | MLLM |    Yes    |   Yes   |   Yes   | Yes  |   -   |
 |         Intern-S1-mini         |      8.3B       | MLLM |    Yes    |   Yes   |   Yes   | Yes  |   -   |
 |         Intern-S1-Pro          |       1TB       | MLLM |    Yes    |    -    |    -    |  -   |  No   |
-|       Intern-S2-Preview        |     35B-A3B     | MLLM |    Yes    |   No    |   No    |  No  |  No   |
+|       Intern-S2-Preview        |  35B-A3B, 397B  | MLLM |    Yes    |   No    |   No    |  No  |  No   |
+|        Intern-S2-Mobius        |       35B       | MLLM |    Yes    |   No    |   No    |  No  |  No   |
 |            ChatGLM2            |       6B        | LLM  |    Yes    |   Yes   |   Yes   |  No  |  No   |
 |               YI               |    6B - 34B     | LLM  |    Yes    |   Yes   |   Yes   | Yes  |  Yes  |
 |            Mistral             |       7B        | LLM  |    Yes    |   Yes   |   Yes   | Yes  |  Yes  |
@@ -90,6 +91,8 @@
 |         DeepSeek-V2.5          |      236B       | LLM  |    Yes    |   No    |   No    |  No  |  No   |
 |          DeepSeek-V3           |      685B       | LLM  |    Yes    |   No    |   No    |  No  |  No   |
 |         DeepSeek-V3.2          |      685B       | LLM  |    Yes    |   No    |   No    |  No  |  No   |
+|          DeepSeek-V4           |   284B, 1.6T    | LLM  |    Yes    |   No    |   No    |  No  |  No   |
+|              Hy3               |    295B-A21B    | LLM  |    Yes    |   No    |   No    | Yes  |  No   |
 |          DeepSeek-VL2          |    3B - 27B     | MLLM |    Yes    |   No    |   No    |  No  |  No   |
 |            MiniCPM3            |       4B        | LLM  |    Yes    |   Yes   |   Yes   |  No  |  No   |
 |         MiniCPM-V-2_6          |       8B        | LLM  |    Yes    |   No    |   No    |  No  |  Yes  |
@@ -116,6 +119,7 @@
 |          GLM-4.5-Air           |      106B       | LLM  |    Yes    |   Yes   |   Yes   |  -   |   -   |
 |         GLM-4.7-Flash          |       30B       | LLM  |    Yes    |   No    |   No    |  No  |  No   |
 |             GLM-5              |      754B       | LLM  |    Yes    |   No    |   No    |  No  |  No   |
+|            GLM-5.2             |      754B       | LLM  |    Yes    |   No    |   No    |  No  |  No   |
 |           CodeGeeX4            |       9B        | LLM  |    Yes    |   Yes   |   Yes   |  -   |   -   |
 |          Phi-3.5-mini          |      3.8B       | LLM  |    Yes    |   Yes   |   No    |  -   |   -   |
 |          Phi-3.5-MoE           |     16x3.8B     | LLM  |    Yes    |   Yes   |   No    |  -   |   -   |

--- a/lmdeploy/pytorch/models/hy3.py
+++ b/lmdeploy/pytorch/models/hy3.py
@@ -318,7 +318,7 @@ class Hy3DecoderLayer(nn.Module):
             prefix=add_prefix('self_attn', prefix),
         )
 
-        # Hy3 的第 0 层是 Dense，后续层是 MoE。
+        # The first Hy3 layer is dense; subsequent layers are MoE.
         if layer_idx < config.first_k_dense_replace:
             self.mlp = Hy3MLP(
                 config,
@@ -481,7 +481,6 @@ class Hy3Model(nn.Module):
             position_ids,
         )
 
-        # LMDeploy RoPE 的第 0 维是 batch 维。
         cos, sin = cos[0], sin[0]
         rotary_pos_emb = (cos, sin)
 


### PR DESCRIPTION
## Summary

- document GLM-5.2 and Hy3 support in the English and Chinese model tables and README overviews
- add recent DeepSeek-V4, Intern-S2-Mobius, and Intern-S2-Preview-397B coverage
- replace Chinese wording in the Hy3 modeling implementation

## Validation

- all configured pre-commit hooks pass on the changed files
- the pull request delta contains only the five intended files

## Assistance

Assisted with Codex + GPT-5.6-Sol xHigh, reviewed manually
