### PR TITLE
 perf(cuda): use PDL for paged attention and V4 prefill

### DIFF
--- a/lmdeploy/pytorch/backends/cuda/v4_compressor.py
+++ b/lmdeploy/pytorch/backends/cuda/v4_compressor.py
@@ -3,10 +3,9 @@ import torch
 
 from lmdeploy.pytorch.consts import V4_INDEX_SCALE_BYTES
 from lmdeploy.pytorch.kernels.cuda.v4_compressor import (
-    fill_compress_state,
     fill_compressed_kv,
     score_and_fill_state_decode,
-    score_kv,
+    score_and_fill_state_prefill,
 )
 
 from ..compressor import BaseV4Compressor, BaseV4CompressorBuilder, V4CompressorMetadata
@@ -61,11 +60,10 @@ class TritonV4CompressorImpl(BaseV4Compressor):
                 meta.cu_q_seqlens, meta.kv_seqlens, compressed_kv,
                 self.overlap)
         else:
-            score_kv(kv, score, ape, kv_state, score_state, state_ids,
-                     meta.cu_q_seqlens, meta.kv_seqlens, compressed_kv,
-                     self.overlap, meta.max_q_seqlen)
-            fill_compress_state(kv, score, ape, kv_state, score_state, state_ids,
-                                meta.cu_q_seqlens, meta.kv_seqlens)
+            score_and_fill_state_prefill(
+                kv, score, ape, kv_state, score_state, state_ids,
+                meta.cu_q_seqlens, meta.kv_seqlens, compressed_kv,
+                self.overlap, meta.max_q_seqlen)
         return compressed_kv
 
     def write_compressed_kv(

--- a/lmdeploy/pytorch/check_env/triton.py
+++ b/lmdeploy/pytorch/check_env/triton.py
@@ -4,7 +4,7 @@ from packaging import version
 from .base import BaseChecker
 
 MAX_TRITON_VERSION = '3.7.1'
-MIN_TRITON_VERSION = '3.0.0'
+MIN_TRITON_VERSION = '3.4.0'
 
 
 class TritonChecker(BaseChecker):

--- a/lmdeploy/pytorch/kernels/cuda/activation.py
+++ b/lmdeploy/pytorch/kernels/cuda/activation.py
@@ -2,16 +2,10 @@
 import torch
 import triton
 import triton.language as tl
-from packaging import version
 
 from .utils import get_device_props
 
-TRITON_VERSION = version.parse(triton.__version__)
-
-if TRITON_VERSION >= version.parse('3.0.0'):
-    fast_expf = tl.math.exp
-else:
-    fast_expf = tl.math.fast_expf
+fast_expf = tl.math.exp
 
 
 @triton.jit

--- a/lmdeploy/pytorch/kernels/cuda/bitonic_topk.py
+++ b/lmdeploy/pytorch/kernels/cuda/bitonic_topk.py
@@ -5,15 +5,12 @@ import triton.language as tl
 from triton.language import core
 from triton.language.standard import _log2
 
-try:
-    # For Triton >= 3.6.0, core.get_int_dtype must be wrapped with
-    # triton.runtime.jit.constexpr_function to be usable as a constexpr helper
-    # inside @triton.jit kernels. This try/except keeps compatibility with
-    # older Triton versions where constexpr_function is not available.
-    get_int_dtype = triton.runtime.jit.constexpr_function(core.get_int_dtype)
-except Exception:
-    # fallback to original function if constexpr_function is not available (Triton < 3.6.0)
+constexpr_function = getattr(triton.runtime.jit, 'constexpr_function', None)
+if constexpr_function is None:
     get_int_dtype = core.get_int_dtype
+else:
+    # Required by Triton >= 3.6 for constexpr helpers called from JIT kernels.
+    get_int_dtype = constexpr_function(core.get_int_dtype)
 
 
 @triton.jit
@@ -177,12 +174,11 @@ def _bitonic_topk_kernel0(score_ptr,
 
 
 @triton.jit
-def _concate(a, b):
-    """concate."""
+def _concat(a, b):
+    """Concatenate two vectors."""
     c = tl.join(a, b)  # [k, 2]
     c = c.trans()  # [2, k]
-    # there are bugs in `tr.ravel` when triton<=3.2.0
-    c = tl.reshape(c, (a.numel + b.numel, ))
+    c = tl.ravel(c)
     return c
 
 
@@ -228,8 +224,8 @@ def _bitonic_topk_kernel1(score_ptr,
         new_scores = tl.load(score_ptrs, mask=mask, other=threshold)
         new_ids = tl.load(ids_ptrs, mask=mask, other=fill)
 
-        merged_scores = _concate(scores, new_scores)
-        merged_ids = _concate(ids, new_ids)
+        merged_scores = _concat(scores, new_scores)
+        merged_ids = _concat(ids, new_ids)
 
         merged_scores, merged_ids = _bitonic_merge(merged_scores, merged_ids, stage, descending, stage)
 

--- a/lmdeploy/pytorch/kernels/cuda/blocked_gemm_fp8.py
+++ b/lmdeploy/pytorch/kernels/cuda/blocked_gemm_fp8.py
@@ -428,12 +428,12 @@ def blocked_gemm_fp8(A: Tensor,
 
     from .utils import supports_tma
 
-    run_tma = supports_tma()
+    run_tma = supports_tma(A.device.index)
     run_tma = run_tma and A.is_contiguous() and B.T.is_contiguous()
 
     # run_tma = False
     if run_tma:
-        from .utils import TensorDescriptor
+        from triton.tools.tensor_descriptor import TensorDescriptor
 
         dummy_block = (1, 1)
         desc_a = TensorDescriptor.from_tensor(A, block_shape=dummy_block)

--- a/lmdeploy/pytorch/kernels/cuda/flashattention.py
+++ b/lmdeploy/pytorch/kernels/cuda/flashattention.py
@@ -5,17 +5,13 @@ from collections.abc import Sequence
 import torch
 import triton
 import triton.language as tl
-from packaging import version
 from torch import Tensor
 
 from lmdeploy.utils import get_logger
 
-logger = get_logger('lmdeploy')
+from .utils import get_device_props
 
-TRITON_VERSION = version.parse(triton.__version__)
-VERSION_300 = version.parse('3.0.0')
-VERSION_320 = version.parse('3.2.0')
-assert TRITON_VERSION >= VERSION_300
+logger = get_logger('lmdeploy')
 
 # TODO: fast op might not work on non-nv device
 tanh = tl.extra.cuda.libdevice.tanh
@@ -379,9 +375,6 @@ def _flash_prefill_fwd_kernel(
     tl.store(out_ptrs, acc, mask=(offs_m[:, None] < q_seqlen) & mask_dv[None, :])
 
 
-_nv_cap = None
-
-
 def _kernel_meta_sm7x(BLOCK_DK):
     num_warps = 4
     num_stages = min(4, max(2, 768 // BLOCK_DK))
@@ -426,11 +419,6 @@ def _kernel_meta_sm9x(BLOCK_DK: int, shared_kv: bool):
     BLOCK_M = 128 if BLOCK_DK <= 256 else 64
     if not shared_kv and BLOCK_DK >= 512:
         BLOCK_M = 32
-
-    # fix crash on triton<3.2.0
-    if BLOCK_DK >= 512 and TRITON_VERSION < VERSION_320:
-        BLOCK_M = 32
-        num_warps = 4
 
     BLOCK_N = 128 if BLOCK_DK <= 128 else 64
 
@@ -500,10 +488,6 @@ def flash_attn_varlen_func(
     Support sliding window, softcapping.
     """
 
-    global _nv_cap
-    if _nv_cap is None:
-        _nv_cap = torch.cuda.get_device_capability()
-
     def grid(args):
         return (triton.cdiv(max_seqlen_q, args['BLOCK_M']), num_heads, batch)
 
@@ -559,14 +543,15 @@ def flash_attn_varlen_func(
     if hip_mode:
         BLOCK_M, BLOCK_N, num_warps, num_stages = _kernel_meta_rocm(BLOCK_DK, shared_kv)
     else:
-        if _nv_cap[0] < 8:
+        nv_cap = get_device_props(q.device.index)['compute_capability']
+        if nv_cap[0] < 8:
             BLOCK_M, BLOCK_N, num_warps, num_stages = _kernel_meta_sm7x(BLOCK_DK)
-        elif _nv_cap[0] < 9:
-            if _nv_cap[1] in [6, 9]:
+        elif nv_cap[0] < 9:
+            if nv_cap[1] in [6, 9]:
                 BLOCK_M, BLOCK_N, num_warps, num_stages = _kernel_meta_sm86(BLOCK_DK, shared_kv)
             else:
                 BLOCK_M, BLOCK_N, num_warps, num_stages = _kernel_meta_sm8x(BLOCK_DK, shared_kv)
-        elif _nv_cap[0] < 10:
+        elif nv_cap[0] < 10:
             BLOCK_M, BLOCK_N, num_warps, num_stages = _kernel_meta_sm9x(BLOCK_DK, shared_kv)
         else:
             BLOCK_M, BLOCK_N, num_warps, num_stages = _kernel_meta_sm12x(BLOCK_DK, shared_kv)

--- a/lmdeploy/pytorch/kernels/cuda/pagedattention.py
+++ b/lmdeploy/pytorch/kernels/cuda/pagedattention.py
@@ -6,14 +6,13 @@ from collections.abc import Sequence
 import torch
 import triton
 import triton.language as tl
-from packaging import version
 from torch import Tensor
 
 from lmdeploy.messages import QuantPolicy
 from lmdeploy.utils import get_logger
 
 from .turbo_quant import hadamard_rotate
-from .utils import get_device_props
+from .utils import get_device_props, is_cuda
 
 logger = get_logger('lmdeploy')
 
@@ -26,22 +25,11 @@ Q_POLICY_INT8 = tl.constexpr(8)
 Q_POLICY_FP8 = tl.constexpr(16)
 Q_POLICY_TURBO = tl.constexpr(42)
 
-TRITON_VERSION = version.parse(triton.__version__)
-VERSION_300 = version.parse('3.0.0')
-
-assert TRITON_VERSION >= version.parse('2.2.0')
-
 # TODO: fast op might not work on non-nv device
-if TRITON_VERSION >= VERSION_300:
-    tanh = tl.extra.cuda.libdevice.tanh
-    fast_dividef = tl.extra.cuda.libdevice.fast_dividef
-    tl_log2 = tl.log2
-    tl_exp2 = tl.exp2
-else:
-    tanh = tl.math.tanh
-    fast_dividef = tl.math.fast_dividef
-    tl_log2 = tl.math.log2
-    tl_exp2 = tl.math.exp2
+tanh = tl.extra.cuda.libdevice.tanh
+fast_dividef = tl.extra.cuda.libdevice.fast_dividef
+tl_log2 = tl.log2
+tl_exp2 = tl.exp2
 
 
 @triton.jit
@@ -84,6 +72,7 @@ def _fwd_grouped_split_kernel(
     BLOCK_N: tl.constexpr,
     BLOCK_H: tl.constexpr,
     BLOCK_DMODEL1: tl.constexpr,
+    USE_PDL: tl.constexpr,
 ):
     """First step kernel of split k attention."""
     cur_batch = tl.program_id(2)
@@ -218,6 +207,11 @@ def _fwd_grouped_split_kernel(
         l_i = l_i_new
         m_i = m_i_new
 
+    # Let the reducer launch while this kernel retires its scratch stores. The
+    # reducer waits for the whole producer grid before reading the scratch.
+    if USE_PDL:
+        tl.extra.cuda.gdc_launch_dependents()
+
     # initialize pointers to output
     if loop_end > loop_start:
         off_acc = (cur_token[:, None] * stride_obs + split_k_id * stride_ok + cur_head[:, None] * stride_oh +
@@ -318,6 +312,7 @@ def _fwd_grouped_split_quant_kernel(
     BLOCK_N: tl.constexpr,
     BLOCK_H: tl.constexpr,
     BLOCK_DMODEL1: tl.constexpr,
+    USE_PDL: tl.constexpr,
 ):
     """First step kernel of split k attention.
 
@@ -555,6 +550,11 @@ def _fwd_grouped_split_quant_kernel(
         l_i = l_i_new
         m_i = m_i_new
 
+    # Let the reducer launch while this kernel retires its scratch stores. The
+    # reducer waits for the whole producer grid before reading the scratch.
+    if USE_PDL:
+        tl.extra.cuda.gdc_launch_dependents()
+
     # initialize pointers to output
     if loop_end > loop_start:
         off_acc = (cur_batch * stride_obs + split_k_id * stride_ok + cur_head[:, None] * stride_oh +
@@ -586,6 +586,7 @@ def _reduce_split_kernel(
     head_size_v: tl.constexpr,
     SPLIT_K: tl.constexpr,
     BLOCK_DV: tl.constexpr,
+    USE_PDL: tl.constexpr,
 ):
     """Second step kernel of split k attention."""
     cur_batch = tl.program_id(1)
@@ -599,6 +600,9 @@ def _reduce_split_kernel(
     offs_acc = (cur_batch * stride_abs + cur_head * stride_ah + offs_k[:, None] * stride_ak +
                 offs_dv[None, :] * stride_ad)
     offs_mi = (cur_batch * stride_abs + cur_head * stride_ah + stride_ak * offs_k + head_size_v)
+
+    if USE_PDL:
+        tl.extra.cuda.gdc_wait()
 
     m_k = tl.load(acc_ptr + offs_mi)
     l_k = tl.load(acc_ptr + offs_mi + 1)
@@ -629,16 +633,13 @@ def _convert_pv(p, v):
     return p, v
 
 
-_nv_cap = None
-
-
 def _kernel_meta_default(BLOCK_DMODEL: int, BLOCK_H: int):
     """Kernel meta default."""
     return 4, 2
 
 
 def _kernel_meta_sm8x(BLOCK_DMODEL: int, BLOCK_H: int):
-    """Kernel meta default."""
+    """Kernel meta for Ampere and Ada."""
     num_stages = 2
     if BLOCK_DMODEL * BLOCK_H > 8192:
         num_warps = 8
@@ -648,7 +649,7 @@ def _kernel_meta_sm8x(BLOCK_DMODEL: int, BLOCK_H: int):
 
 
 def _kernel_meta_sm9x(BLOCK_DMODEL: int, BLOCK_H: int):
-    """Kernel meta default."""
+    """Kernel meta for Hopper and newer architectures."""
     num_warps = 4
     if BLOCK_DMODEL * BLOCK_H > 4096:
         num_stages = 2
@@ -671,6 +672,17 @@ def _get_split_k(device_idx: int, head_grid: int, batch_size: int, num_warps: in
     max_split = 1 << (num_sm.bit_length() - 1)
     SPLIT_K = max(min(SPLIT_K, max_split), 4)
     return SPLIT_K
+
+
+def _get_block_d(head_dim_k: int, head_dim_v: int):
+    """Get the padded K and V block dimensions."""
+    block_dk = triton.next_power_of_2(head_dim_k)
+    block_dk1 = 0
+    if block_dk != head_dim_k:
+        block_dk //= 2
+        block_dk1 = max(16, triton.next_power_of_2(head_dim_k - block_dk))
+    block_dv = triton.next_power_of_2(head_dim_v)
+    return block_dk, block_dk1, block_dv
 
 
 @triton.jit
@@ -697,6 +709,7 @@ def _fused_reduce_hadamard_kernel(
     SPLIT_K: tl.constexpr,
     BLOCK_DV: tl.constexpr,
     LOG2_DV: tl.constexpr,
+    USE_PDL: tl.constexpr,
 ):
     """Fused split-K reduce + inverse Hadamard transform for TURBO_QUANT.
 
@@ -712,6 +725,9 @@ def _fused_reduce_hadamard_kernel(
                 + offs_k[:, None] * stride_ak + offs_dv[None, :] * stride_ad)
     offs_mi = (cur_batch * stride_abs + cur_head * stride_ah
                + stride_ak * offs_k + head_size_v)
+
+    if USE_PDL:
+        tl.extra.cuda.gdc_wait()
 
     m_k = tl.load(acc_ptr + offs_mi)
     l_k = tl.load(acc_ptr + offs_mi + 1)
@@ -785,10 +801,6 @@ def flash_attn_with_kvcache(
             per-tensor value scale for per-tensor FP8 KV cache.
     """
 
-    global _nv_cap
-    if _nv_cap is None:
-        _nv_cap = torch.cuda.get_device_capability()
-
     if kv_layout == 'bshd':
         b_dim, s_dim, h_dim, d_dim = (0, 1, 2, 3)
     elif kv_layout == 'bhsd':
@@ -809,17 +821,6 @@ def flash_attn_with_kvcache(
     # quant42 K/V have different semantics and meta shape, should not share buffer
     if quant_policy == QuantPolicy.TURBO_QUANT:
         assert not shared_kv, 'quant_policy==42 does not support shared_kv'
-
-    def _get_block_d(Lk):
-        """Get block d."""
-        BLOCK_DMODEL = triton.next_power_of_2(Lk)
-        BLOCK_DMODEL1 = 0
-        if BLOCK_DMODEL != Lk:
-            BLOCK_DMODEL = BLOCK_DMODEL // 2
-            BLOCK_DMODEL1 = max(16, triton.next_power_of_2(Lk - BLOCK_DMODEL))
-        BLOCK_DV = triton.next_power_of_2(Lv)
-        return BLOCK_DMODEL, BLOCK_DMODEL1, BLOCK_DV
-
 
     # shape constraints
     Lq, Lk, Lv = q.shape[-1], k_cache.shape[d_dim], v_cache.shape[d_dim]
@@ -878,21 +879,25 @@ def flash_attn_with_kvcache(
     if max_seqlen_q is not None:
         assert max_seqlen_q == seq_len, 'we only support decoding paged attention.'
 
-    BLOCK_DMODEL, BLOCK_DMODEL1, BLOCK_DV = _get_block_d(Lq)
+    BLOCK_DMODEL, BLOCK_DMODEL1, BLOCK_DV = _get_block_d(Lq, Lv)
     HEADS_PER_REQ = kv_group_num * seq_len
     BLOCK_H = max(16, min(BLOCK, triton.next_power_of_2(HEADS_PER_REQ)))
     TILES_PER_GROUP = triton.cdiv(HEADS_PER_REQ, BLOCK_H)
     grid_1 = TILES_PER_GROUP * num_kv_heads
 
-    if _nv_cap[0] < 8:
+    device_props = get_device_props(q.device.index)
+    nv_cap = device_props['compute_capability']
+    if nv_cap[0] < 8:
         num_warps, num_stages = _kernel_meta_default(BLOCK_DMODEL, BLOCK_H)
-    elif _nv_cap[0] < 9:
+    elif nv_cap[0] < 9:
         num_warps, num_stages = _kernel_meta_sm8x(BLOCK_DMODEL, BLOCK_H)
     else:
         num_warps, num_stages = _kernel_meta_sm9x(BLOCK_DMODEL, BLOCK_H)
 
     is_fp8_scalar = quant_policy in (QuantPolicy.FP8, QuantPolicy.FP8_E5M2)
     SPLIT_K = _get_split_k(q.device.index, grid_1, batch, num_warps)
+    use_pdl = is_cuda() and nv_cap[0] >= 9
+    pdl_launch = {'launch_pdl': True} if use_pdl else {}
 
     if quant_policy == QuantPolicy.INT4 or quant_policy == QuantPolicy.TURBO_QUANT:
         acc = q.new_empty(num_tokens, head, SPLIT_K, o.shape[-1] + 2, dtype=torch.float32)
@@ -973,6 +978,7 @@ def flash_attn_with_kvcache(
                                               BLOCK_N=BLOCK,
                                               BLOCK_H=BLOCK_H,
                                               BLOCK_DMODEL1=BLOCK_DMODEL1,
+                                              USE_PDL=use_pdl,
                                               num_warps=num_warps,
                                               num_stages=num_stages)
 
@@ -1015,6 +1021,7 @@ def flash_attn_with_kvcache(
                                         BLOCK_N=BLOCK,
                                         BLOCK_H=BLOCK_H,
                                         BLOCK_DMODEL1=BLOCK_DMODEL1,
+                                        USE_PDL=use_pdl,
                                         num_warps=num_warps,
                                         num_stages=num_stages)
 
@@ -1043,8 +1050,10 @@ def flash_attn_with_kvcache(
                                             head_size_v=Lv,
                                             BLOCK_DV=BLOCK_DV,
                                             LOG2_DV=LOG2_DV,
+                                            USE_PDL=use_pdl,
                                             num_warps=num_warps,
-                                            num_stages=1)
+                                            num_stages=1,
+                                            **pdl_launch)
     else:
         _reduce_split_kernel[grid](acc,
                                    o,
@@ -1059,6 +1068,8 @@ def flash_attn_with_kvcache(
                                    SPLIT_K=SPLIT_K,
                                    head_size_v=Lv,
                                    BLOCK_DV=BLOCK_DV,
+                                   USE_PDL=use_pdl,
                                    num_warps=num_warps,
-                                   num_stages=1)
+                                   num_stages=1,
+                                   **pdl_launch)
     return o

--- a/lmdeploy/pytorch/kernels/cuda/utils.py
+++ b/lmdeploy/pytorch/kernels/cuda/utils.py
@@ -3,7 +3,6 @@ import functools
 
 import torch
 import triton
-from packaging import version
 
 WARPS_PER_SM = {
     (8, 0): 64,
@@ -29,9 +28,6 @@ BLOCKS_PER_SM = {
     (12, 0): 24,
 }
 
-TRITON_VERSION = version.parse(triton.__version__)
-
-
 @functools.lru_cache
 def get_device_props(device=None):
     if device is None:
@@ -43,6 +39,7 @@ def get_device_props(device=None):
     blocks_per_sm = BLOCKS_PER_SM.get((props.major, props.minor), warps_per_sm // 2)
     out = dict(
         multi_processor_count=props.multi_processor_count,
+        compute_capability=(props.major, props.minor),
         warps_per_sm=warps_per_sm,
         blocks_per_sm=blocks_per_sm,
     )
@@ -54,14 +51,8 @@ def is_cuda():
 
 
 @functools.lru_cache
-def supports_tma():
-    ret = is_cuda() and torch.cuda.get_device_capability()[0] >= 9
-    if not ret:
+def supports_tma(device=None):
+    if not is_cuda():
         return False
 
-    VALID_VERSION = version.parse('3.4.0')
-    return TRITON_VERSION >= VALID_VERSION
-
-
-if supports_tma():
-    from triton.tools.tensor_descriptor import TensorDescriptor  # noqa: F401
+    return get_device_props(device)['compute_capability'][0] >= 9

--- a/lmdeploy/pytorch/kernels/cuda/v4_compressor.py
+++ b/lmdeploy/pytorch/kernels/cuda/v4_compressor.py
@@ -5,6 +5,10 @@ import torch
 import triton
 import triton.language as tl
 
+from .utils import get_device_props, is_cuda
+
+PDL_MIN_PREFILL_TOKENS = 4096
+
 
 @triton.jit
 def _fill_compress_state_kernel(
@@ -31,10 +35,11 @@ def _fill_compress_state_kernel(
     D: tl.constexpr,
     ratio: tl.constexpr,
     overlap: tl.constexpr,
+    USE_PDL: tl.constexpr,
 ):
     """Fill kv_state and score_state for the Compressor ring buffer.
 
-    Called BEFORE score_kv (score_kv reads state, this writes state).
+    Called AFTER score_kv (score_kv reads state, this writes state).
 
     Grid: (max_write, B) for prefill, (1, B) for decode.
     Each CTA handles one token position within a batch sequence.
@@ -97,6 +102,9 @@ def _fill_compress_state_kernel(
     score = tl.load(score_ptrs)
     ape = tl.load(ape_ptrs)
 
+    if USE_PDL:
+        tl.extra.cuda.gdc_wait()
+
     tl.store(kv_state_ptrs, kv)
     tl.store(score_state_ptrs, score + ape)
 
@@ -130,6 +138,7 @@ def _score_kv_kernel(
     ratio: tl.constexpr,
     overlap: tl.constexpr,
     is_decoding: tl.constexpr,
+    USE_PDL: tl.constexpr,
     BLOCK_D: tl.constexpr,
 ):
     """Compute compressed kv via softmax-weighted sum, write to compressed_kv.
@@ -338,6 +347,9 @@ def _score_kv_kernel(
                         offs_d[None, :] * ape_stride_d).to(tl.float32)
                     prev_score = _prev_score_raw + _prev_ape
 
+                if USE_PDL:
+                    tl.extra.cuda.gdc_launch_dependents()
+
                 _curr_kv_pos = seq_start + (curr_abs_base - start_pos)
                 _curr_abs_pos = curr_abs_base + row_ids
                 curr_kv = tl.load(
@@ -357,6 +369,9 @@ def _score_kv_kernel(
                 sum_exp = tl.sum(exp_prev, 0) + tl.sum(exp_curr, 0)
                 compressed = (tl.sum(prev_kv * exp_prev, 0) + tl.sum(curr_kv * exp_curr, 0)) / sum_exp
             else:
+                if USE_PDL:
+                    tl.extra.cuda.gdc_launch_dependents()
+
                 _abs_pos_base = compress_abs - ratio + 1
                 _kv_pos_base = seq_start + (_abs_pos_base - start_pos)
                 merged_kv = tl.load(
@@ -604,6 +619,7 @@ def _score_kv_tiled_prefill_kernel(
     head_dim: tl.constexpr,
     ratio: tl.constexpr,
     overlap: tl.constexpr,
+    USE_PDL: tl.constexpr,
     BLOCK_D: tl.constexpr,
 ):
     """Tiled score_kv for prefill. Grid: (num_groups * n_tiles, B).
@@ -684,6 +700,9 @@ def _score_kv_tiled_prefill_kernel(
                 offs_d[None, :] * ape_stride_d).to(tl.float32)
             prev_score = _prev_score_raw + _prev_ape
 
+        if USE_PDL:
+            tl.extra.cuda.gdc_launch_dependents()
+
         _curr_kv_pos = seq_start + (curr_abs_base - start_pos)
         _curr_abs_pos = curr_abs_base + row_ids
         curr_kv = tl.load(
@@ -707,6 +726,9 @@ def _score_kv_tiled_prefill_kernel(
         compressed = (weighted_prev + weighted_curr) / sum_exp
 
     else:
+        if USE_PDL:
+            tl.extra.cuda.gdc_launch_dependents()
+
         _abs_pos_base = compress_abs - ratio + 1
         _kv_pos_base = seq_start + (_abs_pos_base - start_pos)
         merged_kv = tl.load(
@@ -736,11 +758,13 @@ def fill_compress_state(
     state_ids: torch.Tensor,
     cu_q_seqlens: torch.Tensor,
     kv_seqlens: torch.Tensor,
+    use_pdl: bool = False,
     ):
     """Fill kv_state and score_state for the Compressor ring buffer.
 
-    Called AFTER score_kv in the execution order: score_kv reads prev state,
-    then this overwrites state with new values — no synchronization needed.
+    Called AFTER score_kv in the execution order: score_kv reads previous
+    state, then this overwrites it. With PDL enabled, input preparation can
+    overlap score_kv, but state stores wait for score_kv to finish.
 
     Ring buffer layout (overlap=True, ratio=4):
       State shape [N, 2*ratio, D] where D = 2*head_dim.
@@ -770,6 +794,7 @@ def fill_compress_state(
         state_ids: [B] state index per batch.
         cu_q_seqlens: [B + 1] cumulative query sequence lengths.
         kv_seqlens: [B] total kv sequence lengths (history + new).
+        use_pdl: whether this is the PDL consumer of the preceding score_kv.
     """
     assert state_ids.is_contiguous()
     assert cu_q_seqlens.is_contiguous()
@@ -785,6 +810,7 @@ def fill_compress_state(
     max_write = ratio * 2 if overlap else ratio
 
     grid = (1 if is_decoding else max_write, B, )
+    pdl_launch = {'launch_pdl': True} if use_pdl else {}
     _fill_compress_state_kernel[grid](
         kv, score, ape, kv_state, score_state, state_ids, cu_q_seqlens, kv_seqlens,
         *kv.stride(),
@@ -792,7 +818,7 @@ def fill_compress_state(
         *ape.stride(),
         *kv_state.stride(),
         *score_state.stride(),
-        D, ratio, overlap
+        D, ratio, overlap, USE_PDL=use_pdl, **pdl_launch
     )
 
 
@@ -808,6 +834,7 @@ def score_kv(
     compressed_kv: torch.Tensor,
     overlap: bool,
     max_seqlen_q: int = None,
+    use_pdl: bool = False,
     ):
     """Compute compressed kv via softmax-weighted sum, write to compressed_kv.
 
@@ -845,6 +872,7 @@ def score_kv(
             Written at compression point positions.
         overlap: whether overlap mode (True when ratio=4).
         max_seqlen_q: max query seq len (used for prefill grid size).
+        use_pdl: signal the immediately following fill_compress_state launch.
     """
     ratio = ape.size(0)
     D = ape.size(1)
@@ -890,7 +918,7 @@ def score_kv(
                 *score_state.stride(),
                 *compressed_kv.stride(),
                 head_dim=head_dim, ratio=ratio,
-                overlap=overlap, is_decoding=True,
+                overlap=overlap, is_decoding=True, USE_PDL=False,
                 BLOCK_D=BLOCK_D,
             )
     else:
@@ -912,7 +940,7 @@ def score_kv(
                 *score_state.stride(),
                 *compressed_kv.stride(),
                 head_dim=head_dim, ratio=ratio,
-                overlap=overlap, BLOCK_D=BLOCK_D,
+                overlap=overlap, USE_PDL=use_pdl, BLOCK_D=BLOCK_D,
                 num_warps=2,
             )
         else:
@@ -928,8 +956,43 @@ def score_kv(
                 *compressed_kv.stride(),
                 head_dim=head_dim, ratio=ratio,
                 overlap=overlap, is_decoding=False,
-                BLOCK_D=BLOCK_D,
+                USE_PDL=use_pdl, BLOCK_D=BLOCK_D,
             )
+
+
+def score_and_fill_state_prefill(
+    kv: torch.Tensor,
+    score: torch.Tensor,
+    ape: torch.Tensor,
+    kv_state: torch.Tensor,
+    score_state: torch.Tensor,
+    state_ids: torch.Tensor,
+    cu_q_seqlens: torch.Tensor,
+    kv_seqlens: torch.Tensor,
+    compressed_kv: torch.Tensor,
+    overlap: bool,
+    max_seqlen_q: int,
+    use_pdl: bool | None = None,
+):
+    """Prefill score and state fill with an optional PDL anti-dependency."""
+    assert kv.size(0) != state_ids.size(0)
+    if use_pdl is not False:
+        pdl_supported = is_cuda()
+        if pdl_supported:
+            nv_cap = get_device_props(kv.device.index)['compute_capability']
+            pdl_supported = nv_cap[0] >= 9
+        # H200 A/B shows a consistent ratio-4 crossover at roughly 4K
+        # prefill tokens. Ratio-128 and smaller eager launches do not recover
+        # the PDL scheduling overhead.
+        use_pdl = pdl_supported and (use_pdl is True or
+                                     (overlap and kv.size(0) >= PDL_MIN_PREFILL_TOKENS))
+
+    score_kv(
+        kv, score, ape, kv_state, score_state, state_ids, cu_q_seqlens,
+        kv_seqlens, compressed_kv, overlap, max_seqlen_q, use_pdl=use_pdl)
+    fill_compress_state(
+        kv, score, ape, kv_state, score_state, state_ids, cu_q_seqlens,
+        kv_seqlens, use_pdl=use_pdl)
 
 
 def score_and_fill_state_decode(

--- a/lmdeploy/pytorch/kernels/cuda/w8a8_triton_kernels.py
+++ b/lmdeploy/pytorch/kernels/cuda/w8a8_triton_kernels.py
@@ -3,15 +3,10 @@ import torch
 import torch.nn.functional as F
 import triton
 import triton.language as tl
-from packaging import version
 
 from ..default.w8a8_kernels import per_channel_quant
 
-TRITON_VERSION = version.parse(triton.__version__)
-if TRITON_VERSION >= version.parse('3.0.0'):
-    tl_round = tl.extra.cuda.libdevice.round
-else:
-    tl_round = tl.math.round
+tl_round = tl.extra.cuda.libdevice.round
 
 
 @triton.autotune(

--- a/requirements/runtime_cuda.txt
+++ b/requirements/runtime_cuda.txt
@@ -10,4 +10,4 @@ prometheus_client
 tilelang==0.1.11; sys_platform == "linux" and "aarch64" not in platform_machine and "arm" not in platform_machine
 torch<=2.12.1,>=2.0.0
 torchvision<=0.27.1,>=0.15.0
-triton<=3.7.1,>=3.0.0; sys_platform == "linux" and "aarch64" not in platform_machine and "arm" not in platform_machine
+triton<=3.7.1,>=3.4.0; sys_platform == "linux" and "aarch64" not in platform_machine and "arm" not in platform_machine

--- a/tests/pytorch/kernel/test_v4_compressor.py
+++ b/tests/pytorch/kernel/test_v4_compressor.py
@@ -682,6 +682,79 @@ class TestScoreAndFillStateDecode:
 
 
 @pytest.mark.skipif(torch.cuda.get_device_capability()[0] < 9, reason='require device with cc>=9.0')
+class TestScoreAndFillStatePrefill:
+
+    @pytest.mark.parametrize(
+        'ratio,overlap,head_dim,q_seqlens,kv_seqlens_list', [
+            (4, True, 512, [8, 16], [12, 24]),
+            (128, False, 128, [256, 128], [512, 1024]),
+        ])
+    def test_pdl_matches_sequential(self, ratio, overlap, head_dim, q_seqlens,
+                                    kv_seqlens_list):
+        device = 'cuda'
+        dtype = torch.bfloat16
+        D = (1 + overlap) * head_dim
+        B = len(q_seqlens)
+
+        cu_q_seqlens = torch.tensor([0] + q_seqlens, dtype=torch.int32,
+                                    device=device).cumsum(0)
+        kv_seqlens = torch.tensor(kv_seqlens_list, dtype=torch.int32,
+                                  device=device)
+        state_ids = torch.arange(B, dtype=torch.int32, device=device)
+        kv = torch.randn(sum(q_seqlens), D, dtype=dtype, device=device)
+        score = torch.randn_like(kv)
+        ape = torch.randn(ratio, D, dtype=torch.float32, device=device)
+        kv_state = torch.zeros(B, ratio * (1 + overlap), D,
+                               dtype=dtype, device=device)
+        score_state = torch.full_like(kv_state, float('-inf'), dtype=torch.float32)
+
+        from lmdeploy.pytorch.kernels.cuda.v4_compressor import fill_compress_state
+        for batch_id, (kvlen, q_seqlen) in enumerate(zip(kv_seqlens_list, q_seqlens)):
+            history_len = kvlen - q_seqlen
+            hist_kv = torch.randn(history_len, D, dtype=dtype, device=device)
+            hist_score = torch.randn_like(hist_kv)
+            hist_cu_q = torch.tensor([0, history_len], dtype=torch.int32,
+                                     device=device)
+            hist_kvlen = torch.tensor([history_len], dtype=torch.int32,
+                                      device=device)
+            hist_state_id = torch.tensor([batch_id], dtype=torch.int32,
+                                         device=device)
+            fill_compress_state(
+                hist_kv, hist_score, ape, kv_state, score_state,
+                hist_state_id, hist_cu_q, hist_kvlen)
+
+        ref_compressed = _reference_score_kv(
+            kv, score, ape, kv_state, score_state, state_ids,
+            cu_q_seqlens, kv_seqlens, overlap)
+        ref_kv_state, ref_score_state = _reference_fill_compress_state(
+            kv, score, ape, kv_state, score_state, state_ids,
+            cu_q_seqlens, kv_seqlens, overlap)
+
+        from lmdeploy.pytorch.kernels.cuda.v4_compressor import score_and_fill_state_prefill
+        results = []
+        for use_pdl in (False, True):
+            test_kv_state = kv_state.clone()
+            test_score_state = score_state.clone()
+            compressed = torch.zeros(sum(q_seqlens), head_dim,
+                                     dtype=dtype, device=device)
+            score_and_fill_state_prefill(
+                kv, score, ape, test_kv_state, test_score_state, state_ids,
+                cu_q_seqlens, kv_seqlens, compressed, overlap,
+                max(q_seqlens), use_pdl=use_pdl)
+            results.append((compressed, test_kv_state, test_score_state))
+
+            torch.testing.assert_close(
+                compressed.float(), ref_compressed.float(), atol=1e-2, rtol=1e-2)
+            torch.testing.assert_close(
+                test_kv_state.float(), ref_kv_state.float(), atol=1e-2, rtol=1e-2)
+            torch.testing.assert_close(
+                test_score_state, ref_score_state, atol=1e-2, rtol=1e-2)
+
+        for pdl_value, sequential_value in zip(results[1], results[0]):
+            torch.testing.assert_close(pdl_value, sequential_value)
+
+
+@pytest.mark.skipif(torch.cuda.get_device_capability()[0] < 9, reason='require device with cc>=9.0')
 class TestFillCompressedKVFP8:
     """Test FP8 direct write in fill_compressed_kv.
 


### PR DESCRIPTION
## Summary

Use CUDA Programmatic Dependent Launch (PDL) to reduce launch gaps in two adjacent Triton kernel pipelines:

- split-K paged-attention producer → reducer during decode;
- DeepSeek-V4 prefill `score_kv` → `fill_compress_state`.

This also raises the minimum supported Triton version from 3.0 to 3.4 and removes obsolete compatibility branches.

## Changes

### Split-K paged attention

- Signal dependents before the producer’s final scratch stores.
- Launch the reducer with `launch_pdl=True`.
- Wait immediately before the reducer reads producer scratch.
- Cover standard, quantized, and TurboQuant reducer paths.
- Enable on NVIDIA SM90+.

### DeepSeek-V4 prefill compressor

- Add a wrapper that owns the adjacent score and state-fill launches.
- Signal after the score kernel’s final read of the old ring-buffer state.
- Let the fill kernel preload independent inputs before waiting.
- Wait immediately before overwriting compressor state.
- Automatically enable PDL only for:
  - NVIDIA SM90+;
  - ratio-4 overlap prefill;
  - at least 4096 total prefill tokens.
- Keep ratio-128 on the sequential path.
- Leave decode unchanged because score and state fill are already fused there.

### Triton cleanup

- Require Triton `>=3.4.0`.
- Remove Triton 2.x/early-3.x compatibility branches.
- Use device-specific compute capability queries.
- Simplify TMA descriptor and Triton math helper selection.

## Performance

H200 split-K paged-attention CUDA graph latency:

| Shape | Before | PDL | Change |
|---|---:|---:|---:|
| Batch 1, context 1K | 12.096 µs | 11.520 µs | -4.8% |
| Batch 1, context 8K | 22.080 µs | 21.248 µs | -3.8% |
| Batch 8, context 1K | 21.376 µs | 20.704 µs | -3.1% |
| Batch 32, context 8K | 260.384 µs | 259.296 µs | -0.4% |

All nine measured CUDA graph cases improved. The eager batch-1/context-1K case regressed from 14.464 µs to 16.352 µs; paged attention is used for decode, which uses CUDA graphs by default. Eager mode remains opt-in.

For V4 ratio-4 prefill at 4K–8K tokens, eager p50 improved by approximately 1.3%–3.2%. CUDA graph results were neutral to slightly better. Smaller prefills and ratio-128 do not automatically enable PDL.
