### PR TITLE
fix: fix allgather/allgather2d for cuda-ipc when byte_width is not multiple of uint

### DIFF
--- a/lmdeploy/turbomind/builders/text_model.py
+++ b/lmdeploy/turbomind/builders/text_model.py
@@ -1,7 +1,7 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 
 from ..linear import round_up_output_groups
-from ._base import Builder, BuiltModule, ParallelGroup, SplitSide
+from ._base import _CPP_TO_TORCH, Builder, BuiltModule, ParallelGroup, SplitSide
 
 
 class TextModelBuilder(Builder):
@@ -47,8 +47,9 @@ class TextModelBuilder(Builder):
                             split_side=SplitSide.OUTPUT)
 
     def add_lm_head(self, linear):
-        """Pad output dim to ``round_up(vocab_size, tp)`` and commit to the
-        ``output`` LinearWeight root child."""
-        linear = round_up_output_groups(linear, self._vocab_size,
-                                        self.tp.size)
+        """Pad lm-head vocab so each TP-local logits row is uint4-aligned."""
+        _VECTOR_BYTES = 16
+        itemsize = _CPP_TO_TORCH[self.config.data_type].itemsize
+        div = (_VECTOR_BYTES // itemsize) * self.tp.size if self.tp.size > 1 else 1
+        linear = round_up_output_groups(linear, self._vocab_size, div)
         self._add_linear('output', linear, split_side=SplitSide.OUTPUT)

--- a/src/turbomind/comm/cuda_ipc/allgather.cu
+++ b/src/turbomind/comm/cuda_ipc/allgather.cu
@@ -132,10 +132,7 @@ void CudaIpcCommImpl::AllGather(
             invoke(uint{});
         }
         else {
-            // multimem.st only supports dtype-width of 32/64/128 bits.
-            // Fall back to the copy engine for smaller alignments (for example,
-            // an odd number of bf16 elements) instead of aborting.
-            invoke_copy_engine();
+            TM_LOG_FATAL("not implemented");
         }
     }
     else {
@@ -342,10 +339,7 @@ void CudaIpcCommImpl::AllGather2D(const void*  sendbuff,
             invoke(uint{});
         }
         else {
-            // multimem.st only supports dtype-width of 32/64/128 bits.
-            // Fall back to the copy engine for smaller alignments (for example,
-            // an odd number of bf16 elements) instead of aborting.
-            invoke_copy_engine();
+            TM_LOG_FATAL("not implemented");
         }
     }
     else {

--- a/src/turbomind/comm/cuda_ipc/allgather.cu
+++ b/src/turbomind/comm/cuda_ipc/allgather.cu
@@ -342,8 +342,9 @@ void CudaIpcCommImpl::AllGather2D(const void*  sendbuff,
             invoke(uint{});
         }
         else {
-            // cudaMemcpy2DAsync supports row widths that are not aligned to
-            // the vector types used by the P2P kernels.
+            // multimem.st only supports dtype-width of 32/64/128 bits.
+            // Fall back to the copy engine for smaller alignments (for example,
+            // an odd number of bf16 elements) instead of aborting.
             invoke_copy_engine();
         }
     }

--- a/src/turbomind/comm/cuda_ipc/allgather.cu
+++ b/src/turbomind/comm/cuda_ipc/allgather.cu
@@ -132,7 +132,10 @@ void CudaIpcCommImpl::AllGather(
             invoke(uint{});
         }
         else {
-            TM_LOG_FATAL("not implemented");
+            // multimem.st only supports dtype-width of 32/64/128 bits.
+            // Fall back to the copy engine for smaller alignments (for example,
+            // an odd number of bf16 elements) instead of aborting.
+            invoke_copy_engine();
         }
     }
     else {
@@ -339,7 +342,9 @@ void CudaIpcCommImpl::AllGather2D(const void*  sendbuff,
             invoke(uint{});
         }
         else {
-            TM_LOG_FATAL("not implemented");
+            // cudaMemcpy2DAsync supports row widths that are not aligned to
+            // the vector types used by the P2P kernels.
+            invoke_copy_engine();
         }
     }
     else {

--- a/src/turbomind/comm/cuda_ipc/multimem.cuh
+++ b/src/turbomind/comm/cuda_ipc/multimem.cuh
@@ -78,8 +78,15 @@ inline __device__ void multimem_st(uint4* mc_ptr, const uint4& u)
         "multimem.st.weak.global.v4.f16x2 [%0], {%1,%2,%3,%4};" ::"l"(mc_ptr), "r"(u.x), "r"(u.y), "r"(u.z), "r"(u.w));
 }
 
-inline __device__ void multimem_st(uint2* mc_ptr, const uint2& u) {}
+inline __device__ void multimem_st(uint2* mc_ptr, const uint2& u)
+{
+    const uint64_t value = static_cast<uint64_t>(u.x) | (static_cast<uint64_t>(u.y) << 32);
+    asm volatile("multimem.st.weak.global.b64 [%0], %1;" : : "l"(mc_ptr), "l"(value) : "memory");
+}
 
-inline __device__ void multimem_st(uint* mc_ptr, const uint& u) {}
+inline __device__ void multimem_st(uint* mc_ptr, const uint& u)
+{
+    asm volatile("multimem.st.weak.global.b32 [%0], %1;" : : "l"(mc_ptr), "r"(u) : "memory");
+}
 
 }  // namespace turbomind


### PR DESCRIPTION
## Summary

- add 32-bit and 64-bit multimem store support for CUDA IPC allgather
- fall back to the copy engine when the allgather byte width is smaller than `uint` alignment

## Testing

- `cmake --build build --target cuda_ipc_comm -j2`
- focused `test_comm` run on 8 x NVIDIA H200 GPUs covering 2-, 4-, 8-, and 16-byte widths for AllGather and AllGather2D