### PR TITLE
fix(turbomind): reject fp8 model_format early on sm<9.0

### DIFF
--- a/lmdeploy/turbomind/converter.py
+++ b/lmdeploy/turbomind/converter.py
@@ -33,11 +33,15 @@ def _check_fp8_capability():
     Turbomind's fp8 path has no such gate, so an unsupported GPU falls through to a native 'No feasible kernel found'
     abort deep inside gemm.cu instead of a clear Python-level error.
     """
+    if not torch.cuda.is_available():
+        raise RuntimeError('model_format="fp8" requires a CUDA GPU with compute capability >= 9.0 '
+                           '(e.g. H100/H800), but no CUDA device is available. '
+                           'See https://github.com/InternLM/lmdeploy/issues/4863.')
     device = torch.cuda.current_device()
-    major = torch.cuda.get_device_properties(device).major
+    major, minor = torch.cuda.get_device_capability(device)
     if major < 9:
         raise RuntimeError(f'model_format="fp8" requires a GPU with compute capability >= 9.0 '
-                           f'(e.g. H100/H800), but the current GPU (device {device}) is sm{major}.x. '
+                           f'(e.g. H100/H800), but the current GPU (device {device}) is sm{major}.{minor}. '
                            'See https://github.com/InternLM/lmdeploy/issues/4863.')
 
 

--- a/lmdeploy/turbomind/converter.py
+++ b/lmdeploy/turbomind/converter.py
@@ -26,6 +26,21 @@ from .weight_format import (
 logger = get_logger('lmdeploy')
 
 
+def _check_fp8_capability():
+    """Reject model_format='fp8' early on GPUs without native fp8 tensor cores.
+
+    Mirrors lmdeploy/pytorch/check_env/cuda.py's CudaChecker, which runs the same sm>=9.0 check for the pytorch backend.
+    Turbomind's fp8 path has no such gate, so an unsupported GPU falls through to a native 'No feasible kernel found'
+    abort deep inside gemm.cu instead of a clear Python-level error.
+    """
+    device = torch.cuda.current_device()
+    major = torch.cuda.get_device_properties(device).major
+    if major < 9:
+        raise RuntimeError(f'model_format="fp8" requires a GPU with compute capability >= 9.0 '
+                           f'(e.g. H100/H800), but the current GPU (device {device}) is sm{major}.x. '
+                           'See https://github.com/InternLM/lmdeploy/issues/4863.')
+
+
 def _build_resolver(model_format: str | None,
                     group_size: int | None,
                     dtype: torch.dtype) -> (WeightFormatResolver, torch.dtype):
@@ -219,6 +234,8 @@ def get_tm_config(model_path,
 
     # Build resolver after dtype is finalized but before the CT→AWQ rename,
     # so compressed-tensors models instantiate CompressedTensorFormat.
+    if engine_config.model_format == 'fp8':
+        _check_fp8_capability()
     resolver, dtype = _build_resolver(engine_config.model_format,
                                       group_size, dtype)
 

--- a/tests/test_lmdeploy/turbomind/test_converter.py
+++ b/tests/test_lmdeploy/turbomind/test_converter.py
@@ -9,23 +9,30 @@ from lmdeploy.messages import TurbomindEngineConfig
 from lmdeploy.turbomind.converter import _check_fp8_capability, get_tm_config
 
 
-def _fake_device_properties(major):
-    return SimpleNamespace(major=major)
-
-
 @pytest.mark.parametrize('major', [7, 8])
 def test_check_fp8_capability_rejects_pre_hopper(major):
-    with patch('torch.cuda.current_device', return_value=0), \
-            patch('torch.cuda.get_device_properties', return_value=_fake_device_properties(major)):
+    with patch('torch.cuda.is_available', return_value=True), \
+            patch('torch.cuda.current_device', return_value=0), \
+            patch('torch.cuda.get_device_capability', return_value=(major, 0)):
         with pytest.raises(RuntimeError, match='requires a GPU with compute capability >= 9.0'):
             _check_fp8_capability()
 
 
 @pytest.mark.parametrize('major', [9, 10])
 def test_check_fp8_capability_accepts_hopper_and_newer(major):
-    with patch('torch.cuda.current_device', return_value=0), \
-            patch('torch.cuda.get_device_properties', return_value=_fake_device_properties(major)):
+    with patch('torch.cuda.is_available', return_value=True), \
+            patch('torch.cuda.current_device', return_value=0), \
+            patch('torch.cuda.get_device_capability', return_value=(major, 0)):
         _check_fp8_capability()
+
+
+def test_check_fp8_capability_rejects_without_cuda():
+    """No CUDA device visible: fail with the same clear RuntimeError rather
+    than a raw torch.cuda init error (2026-08-17 Copilot review on PR #4875:
+    the original guard called torch.cuda.current_device() unconditionally)."""
+    with patch('torch.cuda.is_available', return_value=False):
+        with pytest.raises(RuntimeError, match='no CUDA device is available'):
+            _check_fp8_capability()
 
 
 def test_get_tm_config_rejects_fp8_on_sm75_before_building_resolver():
@@ -42,8 +49,9 @@ def test_get_tm_config_rejects_fp8_on_sm75_before_building_resolver():
 
     with patch('lmdeploy.turbomind.converter.get_model_arch', return_value=('LlamaForCausalLM', hf_cfg)), \
             patch('lmdeploy.turbomind.converter.search_nested_config', return_value=None), \
+            patch('torch.cuda.is_available', return_value=True), \
             patch('torch.cuda.current_device', return_value=0), \
-            patch('torch.cuda.get_device_properties', return_value=_fake_device_properties(7)):
+            patch('torch.cuda.get_device_capability', return_value=(7, 5)):
         with pytest.raises(RuntimeError, match='requires a GPU with compute capability >= 9.0'):
             get_tm_config('fake/model/path', engine_config)
 
@@ -61,8 +69,9 @@ def test_get_tm_config_does_not_reject_non_fp8_format_on_sm75():
 
     with patch('lmdeploy.turbomind.converter.get_model_arch', return_value=('LlamaForCausalLM', hf_cfg)), \
             patch('lmdeploy.turbomind.converter.search_nested_config', return_value=None), \
+            patch('torch.cuda.is_available', return_value=True), \
             patch('torch.cuda.current_device', return_value=0), \
-            patch('torch.cuda.get_device_properties', return_value=_fake_device_properties(7)), \
+            patch('torch.cuda.get_device_capability', return_value=(7, 5)), \
             patch('lmdeploy.turbomind.converter.get_registered_name', return_value='fake'), \
             patch('lmdeploy.turbomind.converter.INPUT_MODELS') as mock_models, \
             patch('lmdeploy.turbomind.converter._get_and_verify_max_len', return_value=2048), \
@@ -73,3 +82,28 @@ def test_get_tm_config_does_not_reject_non_fp8_format_on_sm75():
         get_tm_config('fake/model/path', engine_config)
 
         mock_model_cls.assert_called_once()
+
+
+def test_get_tm_config_rejects_fp8_from_checkpoint_quant_config_on_sm75():
+    """Reproduces the other #4863 entry point (2026-08-17 Copilot review on
+    PR #4875): a checkpoint whose own quantization_config declares
+    quant_method='fp8' must trip the same guard as the user-forced CLI flag,
+    even though engine_config.model_format starts out None here and is only
+    set to 'fp8' by search_nested_config's result inside get_tm_config."""
+    hf_cfg = SimpleNamespace(to_dict=lambda: {'architectures': ['LlamaForCausalLM']},
+                              text_config=None,
+                              llm_config=None,
+                              dtype=torch.float16,
+                              torch_dtype=None)
+    engine_config = TurbomindEngineConfig(model_format=None)
+    quant_config = {'quant_method': 'fp8'}
+
+    with patch('lmdeploy.turbomind.converter.get_model_arch', return_value=('LlamaForCausalLM', hf_cfg)), \
+            patch('lmdeploy.turbomind.converter.search_nested_config', return_value=quant_config), \
+            patch('torch.cuda.is_available', return_value=True), \
+            patch('torch.cuda.current_device', return_value=0), \
+            patch('torch.cuda.get_device_capability', return_value=(7, 5)):
+        with pytest.raises(RuntimeError, match='requires a GPU with compute capability >= 9.0'):
+            get_tm_config('fake/model/path', engine_config)
+
+        assert engine_config.model_format == 'fp8'

--- a/tests/test_lmdeploy/turbomind/test_converter.py
+++ b/tests/test_lmdeploy/turbomind/test_converter.py
@@ -1,0 +1,75 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+import torch
+
+from lmdeploy.messages import TurbomindEngineConfig
+from lmdeploy.turbomind.converter import _check_fp8_capability, get_tm_config
+
+
+def _fake_device_properties(major):
+    return SimpleNamespace(major=major)
+
+
+@pytest.mark.parametrize('major', [7, 8])
+def test_check_fp8_capability_rejects_pre_hopper(major):
+    with patch('torch.cuda.current_device', return_value=0), \
+            patch('torch.cuda.get_device_properties', return_value=_fake_device_properties(major)):
+        with pytest.raises(RuntimeError, match='requires a GPU with compute capability >= 9.0'):
+            _check_fp8_capability()
+
+
+@pytest.mark.parametrize('major', [9, 10])
+def test_check_fp8_capability_accepts_hopper_and_newer(major):
+    with patch('torch.cuda.current_device', return_value=0), \
+            patch('torch.cuda.get_device_properties', return_value=_fake_device_properties(major)):
+        _check_fp8_capability()
+
+
+def test_get_tm_config_rejects_fp8_on_sm75_before_building_resolver():
+    """Reproduces #4863: a user forcing model_format='fp8' (the CLI's `--model-
+    format fp8`) on an sm75 GPU must fail fast with a clear RuntimeError
+    instead of proceeding into weight-format resolution and crashing later
+    inside turbomind's C++ gemm dispatch."""
+    hf_cfg = SimpleNamespace(to_dict=lambda: {'architectures': ['LlamaForCausalLM']},
+                              text_config=None,
+                              llm_config=None,
+                              dtype=torch.float16,
+                              torch_dtype=None)
+    engine_config = TurbomindEngineConfig(model_format='fp8')
+
+    with patch('lmdeploy.turbomind.converter.get_model_arch', return_value=('LlamaForCausalLM', hf_cfg)), \
+            patch('lmdeploy.turbomind.converter.search_nested_config', return_value=None), \
+            patch('torch.cuda.current_device', return_value=0), \
+            patch('torch.cuda.get_device_properties', return_value=_fake_device_properties(7)):
+        with pytest.raises(RuntimeError, match='requires a GPU with compute capability >= 9.0'):
+            get_tm_config('fake/model/path', engine_config)
+
+
+def test_get_tm_config_does_not_reject_non_fp8_format_on_sm75():
+    """The new guard must not touch unrelated formats (regression: it lives
+    right before `_build_resolver`, so a broad placement mistake would reject
+    every model_format on old hardware, not only fp8)."""
+    hf_cfg = SimpleNamespace(to_dict=lambda: {'architectures': ['LlamaForCausalLM']},
+                              text_config=None,
+                              llm_config=None,
+                              dtype=torch.float16,
+                              torch_dtype=None)
+    engine_config = TurbomindEngineConfig(model_format=None)
+
+    with patch('lmdeploy.turbomind.converter.get_model_arch', return_value=('LlamaForCausalLM', hf_cfg)), \
+            patch('lmdeploy.turbomind.converter.search_nested_config', return_value=None), \
+            patch('torch.cuda.current_device', return_value=0), \
+            patch('torch.cuda.get_device_properties', return_value=_fake_device_properties(7)), \
+            patch('lmdeploy.turbomind.converter.get_registered_name', return_value='fake'), \
+            patch('lmdeploy.turbomind.converter.INPUT_MODELS') as mock_models, \
+            patch('lmdeploy.turbomind.converter._get_and_verify_max_len', return_value=2048), \
+            patch('lmdeploy.turbomind.converter.source_model_config', return_value={}):
+        mock_model_cls = mock_models.get.return_value
+        mock_model_cls._vision = False
+
+        get_tm_config('fake/model/path', engine_config)
+
+        mock_model_cls.assert_called_once()


### PR DESCRIPTION
Turbomind's fp8 conversion path has no hardware-capability check. `get_tm_config` (converter.py) builds an `FP8Format` resolver for `model_format="fp8"` regardless of GPU, whether that came from the checkpoint's own `quantization_config` or was forced via `--model-format fp8`. On a GPU without native fp8 tensor cores (sm<9.0), conversion proceeds and the failure only surfaces deep inside kernel dispatch as an unreadable C++ abort (`No feasible kernel found for the problem`, `gemm.cu:341`), as in #4863.

The pytorch backend already has this exact gate: `lmdeploy/pytorch/check_env/cuda.py`'s `CudaChecker` rejects `model_format=fp8` on `sm<9.0` with a clear message before touching CUDA. This PR adds the equivalent check to turbomind's converter, `_check_fp8_capability()`, called once right before `_build_resolver` (the single place `FP8Format` gets instantiated), so both the checkpoint-detected and user-forced paths get the same early `RuntimeError` instead of the native crash.

This does not add fp8 support for sm<9.0 (that's the separate ask in #4865, and there's an ongoing discussion on #4863 about whether it's feasible the way AWQ-style quantization is). It only turns a cryptic native abort into a clear, early Python error for the hardware that genuinely cannot run the current fp8 kernels today, without foreclosing that discussion. Left as `Refs #4863` rather than `Fixes` for that reason.

**Verification**
- New `tests/test_lmdeploy/turbomind/test_converter.py`: `_check_fp8_capability` rejects sm7.x/sm8.x and accepts sm9.x/sm10.x; `get_tm_config` raises before `_build_resolver` for `model_format="fp8"` on a mocked sm75 device, and leaves `model_format=None` untouched on the same hardware. Confirmed the new test fails on unmodified `main` (imports `_check_fp8_capability`, which doesn't exist there) and, with that import removed, that `get_tm_config` silently proceeds on sm75 fp8 today, i.e. the bug reproduces.
- Ran the new tests plus `tests/test_lmdeploy/test_fp8_kv_cache_policy.py` (existing fp8-adjacent suite) green on Python 3.11, CPU-only PyTorch.
- Not verified: no CUDA toolkit or GPU on this machine, so `_turbomind`/`_xgrammar` aren't built here; the above ran against a mock stand-in for those compiled extensions, and I could not execute against a real sm<9.0 GPU or reproduce the original C++ abort live.
