### PR TITLE
fix: support inline system messages in Anthropic API

### DIFF
--- a/lmdeploy/serve/anthropic/adapter.py
+++ b/lmdeploy/serve/anthropic/adapter.py
@@ -218,7 +218,10 @@ def _convert_image_source_to_url(source: Any) -> str:
 
 
 def _convert_system_message(content: str | list[ContentBlockParam]) -> list[dict[str, str]]:
-    """Convert Anthropic system content into zero or one chat message."""
+    """Convert Anthropic system content into zero or one chat message.
+
+    Only text blocks are retained when ``content`` is a block list.
+    """
 
     if isinstance(content, str):
         system_text = content

--- a/lmdeploy/serve/anthropic/adapter.py
+++ b/lmdeploy/serve/anthropic/adapter.py
@@ -34,6 +34,25 @@ def get_model_list(server_context) -> list[str]:
     return model_names
 
 
+def detect_inline_system_support(chat_template) -> bool:
+    """Return whether a chat template renders system messages in-place."""
+
+    if chat_template is None:
+        return False
+
+    sentinel = '__lmdeploy_inline_system_sentinel__'
+    try:
+        prompt = chat_template.messages2prompt([
+            dict(role='system', content='system'),
+            dict(role='user', content='user'),
+            dict(role='system', content=sentinel),
+            dict(role='user', content='user'),
+        ])
+    except Exception:
+        return False
+    return isinstance(prompt, str) and sentinel in prompt
+
+
 def ensure_tools_not_requested(request: MessagesRequest | CountTokensRequest) -> None:
     """Reject tool-related fields while parser refactor is in progress."""
 
@@ -196,16 +215,41 @@ def _convert_image_source_to_url(source: Any) -> str:
     return ''
 
 
-def _convert_system_blocks_to_text(system: list[ContentBlockParam]) -> str:
-    system_prompt = ''
-    for block in system:
-        if _block_get(block, 'type') != 'text':
-            continue
-        text = _block_get(block, 'text')
-        if not text or text.startswith('x-anthropic-billing-header'):
-            continue
-        system_prompt += text
-    return system_prompt
+def _convert_system_message(content: str | list[ContentBlockParam]) -> list[dict[str, str]]:
+    """Convert Anthropic system content into zero or one chat message."""
+
+    if isinstance(content, str):
+        system_text = content
+    else:
+        system_parts: list[str] = []
+        for block in content:
+            if _block_get(block, 'type') != 'text':
+                continue
+            text = _block_get(block, 'text')
+            if not text or text.startswith('x-anthropic-billing-header'):
+                continue
+            system_parts.append(text)
+        system_text = ''.join(system_parts)
+
+    if not system_text:
+        return []
+    return [dict(role='system', content=system_text)]
+
+
+def _merge_system_messages(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Move system messages to the front and concatenate their content."""
+
+    system_parts: list[str] = []
+    non_system_messages: list[dict[str, Any]] = []
+    for message in messages:
+        if message['role'] == 'system':
+            system_parts.append(message['content'])
+        else:
+            non_system_messages.append(message)
+
+    if not system_parts:
+        return non_system_messages
+    return [dict(role='system', content=''.join(system_parts)), *non_system_messages]
 
 
 def _convert_user_tool_result(block: ContentBlockParam | dict[str, Any]) -> list[dict[str, Any]]:
@@ -242,18 +286,23 @@ def _convert_user_tool_result(block: ContentBlockParam | dict[str, Any]) -> list
     return messages
 
 
-def to_openai_messages(request: MessagesRequest | CountTokensRequest) -> list[dict[str, Any]]:
+def to_openai_messages(
+    request: MessagesRequest | CountTokensRequest,
+    *,
+    merge_inline_system: bool = False,
+) -> list[dict[str, Any]]:
     """Convert Anthropic request messages into OpenAI-compatible message
     dicts."""
 
     openai_messages: list[dict[str, Any]] = []
     if request.system is not None:
-        if isinstance(request.system, str):
-            openai_messages.append(dict(role='system', content=request.system))
-        else:
-            openai_messages.append(dict(role='system', content=_convert_system_blocks_to_text(request.system)))
+        openai_messages.extend(_convert_system_message(request.system))
 
     for idx, message in enumerate(request.messages):
+        if message.role == 'system':
+            openai_messages.extend(_convert_system_message(message.content))
+            continue
+
         if isinstance(message.content, str):
             openai_messages.append(dict(role=message.role, content=message.content))
             continue
@@ -326,19 +375,29 @@ def to_openai_messages(request: MessagesRequest | CountTokensRequest) -> list[di
         if ('content' in openai_message or 'tool_calls' in openai_message
                 or 'reasoning_content' in openai_message):
             openai_messages.append(openai_message)
+    if merge_inline_system:
+        return _merge_system_messages(openai_messages)
     return openai_messages
 
 
-def to_lmdeploy_messages(request: MessagesRequest | CountTokensRequest) -> list[dict[str, str]]:
+def to_lmdeploy_messages(
+    request: MessagesRequest | CountTokensRequest,
+    *,
+    merge_inline_system: bool = False,
+) -> list[dict[str, str]]:
     """Convert Anthropic request messages into LMDeploy chat messages."""
 
-    lm_messages: list[dict[str, str]] = []
+    lm_messages: list[dict[str, Any]] = []
     if request.system is not None:
-        lm_messages.append(
-            dict(role='system', content=text_from_content(request.system, field_name='system')))
+        lm_messages.extend(_convert_system_message(request.system))
     for idx, message in enumerate(request.messages):
+        if message.role == 'system':
+            lm_messages.extend(_convert_system_message(message.content))
+            continue
         content = text_from_content(message.content, field_name=f'messages[{idx}].content')
         lm_messages.append(dict(role=message.role, content=content))
+    if merge_inline_system:
+        return _merge_system_messages(lm_messages)
     return lm_messages
 
 

--- a/lmdeploy/serve/anthropic/adapter.py
+++ b/lmdeploy/serve/anthropic/adapter.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 import json
-from typing import Any
+from typing import Any, TypeVar
 
 import shortuuid
 
@@ -23,6 +23,8 @@ from .protocol import (
     ToolChoiceToolParam,
     ToolParam,
 )
+
+_MessageT = TypeVar('_MessageT', bound=dict[str, Any])
 
 
 def get_model_list(server_context) -> list[str]:
@@ -236,20 +238,24 @@ def _convert_system_message(content: str | list[ContentBlockParam]) -> list[dict
     return [dict(role='system', content=system_text)]
 
 
-def _merge_system_messages(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    """Move system messages to the front and concatenate their content."""
+def _merge_system_messages(messages: list[_MessageT]) -> list[_MessageT]:
+    """Move system messages to the front while preserving the message type."""
 
     system_parts: list[str] = []
-    non_system_messages: list[dict[str, Any]] = []
+    system_message: _MessageT | None = None
+    non_system_messages: list[_MessageT] = []
     for message in messages:
         if message['role'] == 'system':
+            if system_message is None:
+                system_message = message
             system_parts.append(message['content'])
         else:
             non_system_messages.append(message)
 
-    if not system_parts:
+    if system_message is None:
         return non_system_messages
-    return [dict(role='system', content=''.join(system_parts)), *non_system_messages]
+    system_message['content'] = ''.join(system_parts)
+    return [system_message, *non_system_messages]
 
 
 def _convert_user_tool_result(block: ContentBlockParam | dict[str, Any]) -> list[dict[str, Any]]:
@@ -387,7 +393,7 @@ def to_lmdeploy_messages(
 ) -> list[dict[str, str]]:
     """Convert Anthropic request messages into LMDeploy chat messages."""
 
-    lm_messages: list[dict[str, Any]] = []
+    lm_messages: list[dict[str, str]] = []
     if request.system is not None:
         lm_messages.extend(_convert_system_message(request.system))
     for idx, message in enumerate(request.messages):

--- a/lmdeploy/serve/anthropic/endpoints/messages.py
+++ b/lmdeploy/serve/anthropic/endpoints/messages.py
@@ -63,7 +63,7 @@ def _validate_extended_outputs(request: MessagesRequest, server_context):
     return None
 
 
-def register(router: APIRouter, server_context) -> None:
+def register(router: APIRouter, server_context, *, merge_inline_system: bool = False) -> None:
     """Register endpoint onto router."""
 
     @router.post('/v1/messages', dependencies=[Depends(validate_json_request)])
@@ -143,7 +143,7 @@ def register(router: APIRouter, server_context) -> None:
                 resolved_input_ids = None
         else:
             try:
-                parser_messages = to_openai_messages(request)
+                parser_messages = to_openai_messages(request, merge_inline_system=merge_inline_system)
             except ValueError as err:
                 return create_error_response(HTTPStatus.BAD_REQUEST, str(err))
 

--- a/lmdeploy/serve/anthropic/endpoints/messages_count_tokens.py
+++ b/lmdeploy/serve/anthropic/endpoints/messages_count_tokens.py
@@ -21,7 +21,7 @@ def _validate_headers(raw_request: Request):
     return None
 
 
-def register(router: APIRouter, server_context) -> None:
+def register(router: APIRouter, server_context, *, merge_inline_system: bool = False) -> None:
     """Register endpoint onto router."""
 
     @router.post('/v1/messages/count_tokens', dependencies=[Depends(validate_json_request)])
@@ -38,7 +38,7 @@ def register(router: APIRouter, server_context) -> None:
             )
 
         try:
-            messages = to_lmdeploy_messages(request)
+            messages = to_lmdeploy_messages(request, merge_inline_system=merge_inline_system)
             input_tokens = count_input_tokens(server_context.async_engine, messages)
         except ValueError as err:
             return create_error_response(HTTPStatus.BAD_REQUEST, str(err))

--- a/lmdeploy/serve/anthropic/router.py
+++ b/lmdeploy/serve/anthropic/router.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 from fastapi import APIRouter
 
+from .adapter import detect_inline_system_support
 from .endpoints import messages, messages_count_tokens, models
 
 
@@ -12,7 +13,8 @@ def create_anthropic_router(server_context) -> APIRouter:
     """Create router with all Anthropic endpoints."""
 
     router = APIRouter(tags=['anthropic'])
-    messages.register(router, server_context)
-    messages_count_tokens.register(router, server_context)
+    merge_inline_system = not detect_inline_system_support(server_context.async_engine.chat_template)
+    messages.register(router, server_context, merge_inline_system=merge_inline_system)
+    messages_count_tokens.register(router, server_context, merge_inline_system=merge_inline_system)
     models.register(router, server_context)
     return router

--- a/tests/test_lmdeploy/serve/anthropic/test_adapter_conversion.py
+++ b/tests/test_lmdeploy/serve/anthropic/test_adapter_conversion.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
-from lmdeploy.serve.anthropic.adapter import to_generation_config, to_openai_messages
+from lmdeploy.serve.anthropic.adapter import (
+    to_generation_config,
+    to_lmdeploy_messages,
+    to_openai_messages,
+)
 from lmdeploy.serve.anthropic.protocol import MessagesRequest
 
 
@@ -62,6 +66,46 @@ def test_to_openai_messages_preserves_system_role_message_order():
             'content': 'second',
         },
     ]
+
+
+def test_to_openai_messages_merges_inline_system_messages_at_the_front():
+    request = _make_request(
+        system='Top-level.',
+        messages=[
+            {
+                'role': 'user',
+                'content': 'first',
+            },
+            {
+                'role': 'system',
+                'content': 'Inline one.',
+            },
+            {
+                'role': 'assistant',
+                'content': 'ack',
+            },
+            {
+                'role': 'system',
+                'content': 'Inline two.',
+            },
+        ])
+
+    expected = [
+        {
+            'role': 'system',
+            'content': 'Top-level.Inline one.Inline two.',
+        },
+        {
+            'role': 'user',
+            'content': 'first',
+        },
+        {
+            'role': 'assistant',
+            'content': 'ack',
+        },
+    ]
+    assert to_openai_messages(request, merge_inline_system=True) == expected
+    assert to_lmdeploy_messages(request, merge_inline_system=True) == expected
 
 
 def test_to_openai_messages_converts_system_text_blocks():

--- a/tests/test_lmdeploy/serve/anthropic/test_endpoints.py
+++ b/tests/test_lmdeploy/serve/anthropic/test_endpoints.py
@@ -74,6 +74,16 @@ class _FakeChatTemplate:
         return '\n'.join(parts)
 
 
+class _SystemFirstChatTemplate(_FakeChatTemplate):
+
+    def messages2prompt(self, messages, **kwargs):
+        for index, message in enumerate(messages):
+            if message['role'] == 'system' and index != 0:
+                raise ValueError('System message must be at the beginning.')
+        parts = [f"{item['role']}:{item['content']}" for item in messages]
+        return '\n'.join(parts)
+
+
 class _FakeEngine:
 
     def __init__(
@@ -81,13 +91,14 @@ class _FakeEngine:
             *,
             logprobs_mode='raw_logprobs',
             enable_return_routed_experts: bool = True,
+            chat_template=None,
     ):
         self.model_name = 'fake-model'
         self.backend_config = SimpleNamespace(adapters=['adapter-model'],
                                              logprobs_mode=logprobs_mode,
                                              enable_return_routed_experts=enable_return_routed_experts)
         self.tokenizer = _FakeTokenizer()
-        self.chat_template = _FakeChatTemplate()
+        self.chat_template = chat_template or _FakeChatTemplate()
         self.preprocess_calls = []
         self.generate_calls = []
 
@@ -144,11 +155,13 @@ class _FakeServerContext:
             response_parser_cls=_BasicParser,
             logprobs_mode='raw_logprobs',
             enable_return_routed_experts: bool = True,
+            chat_template=None,
     ):
         self.session_mgr = _FakeSessionManager()
         self.async_engine = _FakeEngine(
             logprobs_mode=logprobs_mode,
             enable_return_routed_experts=enable_return_routed_experts,
+            chat_template=chat_template,
         )
         self.async_engine.session_mgr = self.session_mgr
         self.default_gen_config = {}
@@ -485,6 +498,68 @@ def test_messages_beta_accepts_system_role_message():
             'content': 'hi',
         },
     ]
+
+
+def test_messages_merges_inline_system_for_system_first_template():
+    context = _FakeServerContext(chat_template=_SystemFirstChatTemplate())
+    response = _post_messages(
+        _make_client(server_context=context),
+        system='Top-level.',
+        messages=[
+            {
+                'role': 'user',
+                'content': 'first',
+            },
+            {
+                'role': 'system',
+                'content': 'Inline.',
+            },
+            {
+                'role': 'user',
+                'content': 'second',
+            },
+        ],
+    )
+
+    assert response.status_code == 200
+    args, _kwargs = context.async_engine.preprocess_calls[-1]
+    assert args[0] == [
+        {
+            'role': 'system',
+            'content': 'Top-level.Inline.',
+        },
+        {
+            'role': 'user',
+            'content': 'first',
+        },
+        {
+            'role': 'user',
+            'content': 'second',
+        },
+    ]
+
+
+def test_messages_count_tokens_merges_inline_system_for_system_first_template():
+    context = _FakeServerContext(chat_template=_SystemFirstChatTemplate())
+    response = _post_count_tokens(
+        _make_client(server_context=context),
+        messages=[
+            {
+                'role': 'user',
+                'content': 'first',
+            },
+            {
+                'role': 'system',
+                'content': 'Inline.',
+            },
+            {
+                'role': 'user',
+                'content': 'second',
+            },
+        ],
+    )
+
+    assert response.status_code == 200
 
 
 def test_messages_non_stream_with_reasoning_and_tool_use_blocks():


### PR DESCRIPTION
## Motivation

Anthropic Messages requests can contain system-role messages after conversation turns. Chat templates that require system messages to appear first, such as Qwen3.5, reject these histories during prompt rendering. The same compatibility issue affects token counting.

## Modification

- Detect whether the active chat template renders inline system messages.
- For incompatible templates, concatenate top-level and inline system content without separators and move it into one leading system message.
- Apply the normalization to both /v1/messages and /v1/messages/count_tokens.
- Keep inline system messages in place for templates that support them.
- Preserve the existing structured conversion of tool calls, tool results, images, and reasoning content.

This change is limited to the Anthropic-compatible API and does not alter /v1/chat/completions.

## BC-breaking

No backward-incompatible changes.

## Use cases

Anthropic-compatible clients can submit interleaved system updates to models using system-first chat templates, including Qwen3.5.

## Checklist

- [x] Pre-commit checks pass.
- [x] The modification is covered by unit and endpoint tests.
- [x] No new downstream dependency is introduced.
- [x] New helper functions include docstrings.

## Test plan

- pre-commit on all modified files
- python -m pytest tests/test_lmdeploy/serve/anthropic/test_adapter_conversion.py tests/test_lmdeploy/serve/anthropic/test_endpoints.py tests/test_lmdeploy/test_content_merge.py -q
- Result: 70 passed