### PR TITLE
feat(pytorch): support MiMo-V2-Flash inference

### DIFF
--- a/lmdeploy/pytorch/backends/cuda/attention/__init__.py
+++ b/lmdeploy/pytorch/backends/cuda/attention/__init__.py
@@ -33,8 +33,60 @@ def use_fa3_warning():
     return False
 
 
+def _fa3_build_supports_head_dims(head_size: int, v_head_size: int | None = None) -> bool:
+    """Return whether the installed FA3 wheel contains a required head shape.
+
+    FlashAttention-3 wheels may omit template instantiations to reduce build
+    time and binary size.  In particular, MiMo-V2-Flash needs the asymmetric
+    ``Q/K=192, V=128`` instantiation, which is controlled by both HDIM192 and
+    HDIMDIFF192 build flags.
+
+    A wheel without build metadata is accepted only for symmetric head shapes,
+    preserving compatibility with older FA3 packages while avoiding unsafe
+    asymmetric dispatch.
+    """
+    if v_head_size is None:
+        v_head_size = head_size
+
+    try:
+        from flash_attn_config import CONFIG
+        flags = CONFIG['build_flags']
+    except (ImportError, KeyError, TypeError):
+        return head_size == v_head_size
+
+    def _disabled(name: str) -> bool:
+        # Older generated configs used FLASH_ATTENTION for HDIMDIFF while the
+        # other flags use FLASHATTENTION.  Accept both spellings.
+        aliases = (name, name.replace('FLASHATTENTION_DISABLE_HDIMDIFF',
+                                      'FLASH_ATTENTION_DISABLE_HDIMDIFF'))
+        return any(bool(flags.get(alias, False)) for alias in aliases)
+
+    if head_size <= 64:
+        if _disabled('FLASHATTENTION_DISABLE_HDIM64'):
+            return False
+        return v_head_size <= 64 or (
+            v_head_size <= 512 and not _disabled('FLASHATTENTION_DISABLE_HDIMDIFF64'))
+    if head_size <= 96:
+        return v_head_size <= 96 and not _disabled('FLASHATTENTION_DISABLE_HDIM96')
+    if head_size <= 128:
+        return v_head_size <= 128 and not _disabled('FLASHATTENTION_DISABLE_HDIM128')
+    if head_size <= 192:
+        if _disabled('FLASHATTENTION_DISABLE_HDIM192'):
+            return False
+        if v_head_size <= 128:
+            return not _disabled('FLASHATTENTION_DISABLE_HDIMDIFF192')
+        return v_head_size <= 192
+    if head_size <= 256:
+        return v_head_size <= 256 and not _disabled('FLASHATTENTION_DISABLE_HDIM256')
+    return False
+
+
 @functools.lru_cache
-def _enable_fa3(alibi: bool, learnable_sink: bool, block_sparse_size: int, head_size: int) -> bool:
+def _enable_fa3(alibi: bool,
+                learnable_sink: bool,
+                block_sparse_size: int,
+                head_size: int,
+                v_head_size: int | None = None) -> bool:
     """Check if FA3 should be enabled.
 
     FA3 is enabled when:
@@ -46,7 +98,8 @@ def _enable_fa3(alibi: bool, learnable_sink: bool, block_sparse_size: int, head_
     Returns:
         True if FA3 should be enabled, False otherwise.
     """
-    enable = not alibi and not learnable_sink and block_sparse_size == 1 and head_size <= 256
+    enable = (not alibi and not learnable_sink and block_sparse_size == 1
+              and _fa3_build_supports_head_dims(head_size, v_head_size))
     if enable and not use_fa3_warning():
         enable = False
     return enable
@@ -91,6 +144,7 @@ class TritonAttentionBuilder(AttentionBuilder[TritonAttentionMetadata]):
         use_flash_mla: bool = False,
         learnable_sink: bool = False,
         block_sparse_size: int = 1,
+        enable_fa3: bool = True,
         **kwargs,
     ) -> TritonAttentionImpl:
         """Build appropriate attention implementation.
@@ -108,6 +162,7 @@ class TritonAttentionBuilder(AttentionBuilder[TritonAttentionMetadata]):
             use_flash_mla: Whether to use Flash MLA implementation.
             learnable_sink: Whether to use learnable sink tokens.
             block_sparse_size: Block sparse attention size.
+            enable_fa3: Whether this attention configuration may use FA3.
             **kwargs: Additional arguments.
 
         Returns:
@@ -129,7 +184,8 @@ class TritonAttentionBuilder(AttentionBuilder[TritonAttentionMetadata]):
             causal=causal,
             **kwargs,
         )
-        enable_fa3 = _enable_fa3(alibi, learnable_sink, block_sparse_size, head_size)
+        enable_fa3 = enable_fa3 and _enable_fa3(
+            alibi, learnable_sink, block_sparse_size, head_size, v_head_size)
 
         if use_flash_mla is True:
             logger.debug('Build FlashMLAImpl Attention')

--- a/lmdeploy/pytorch/backends/cuda/attention/fa3.py
+++ b/lmdeploy/pytorch/backends/cuda/attention/fa3.py
@@ -289,6 +289,9 @@ class FA3Impl(TritonAttentionImpl):
             causal=causal,
             **kwargs,
         )
+        # TritonAttentionImpl uses -1 as its disabled-softcap sentinel, while
+        # FlashAttention-3 requires exactly 0.0 to select non-softcap kernels.
+        self.logit_softcapping = max(float(logit_softcapping), 0.0)
         from lmdeploy.pytorch.third_party.flash_attn_interface import flash_attn_varlen_func, flash_attn_with_kvcache
         self.flash_attn_varlen_func_v3 = flash_attn_varlen_func
         self.flash_attn_with_kvcache_v3 = flash_attn_with_kvcache

--- a/lmdeploy/pytorch/backends/mimo_swa.py
+++ b/lmdeploy/pytorch/backends/mimo_swa.py
@@ -1,0 +1,178 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+"""MiMo-V2-Flash SWA backed by a sequence-scoped BF16 state ring."""
+
+from dataclasses import dataclass
+from typing import Any
+
+import torch
+
+
+@dataclass
+class MiMoSWAAttentionMetadata:
+    """Layer-invariant sequence layout for MiMo's SWA state ring."""
+
+    state_slots: torch.Tensor
+    start_positions: torch.Tensor
+    q_seqlens: torch.Tensor
+    cu_q_seqlens: torch.Tensor
+    history_lens: torch.Tensor
+    kv_seqlens: torch.Tensor
+    cu_kv_seqlens: torch.Tensor
+    max_q_seqlen: int
+    max_kv_seqlen: int
+    window_size: int
+
+    @classmethod
+    def from_step_context(
+        cls,
+        attn_metadata: Any,
+        step_context: Any,
+        state_slots: torch.Tensor,
+        num_state_slots: int,
+        window_size: int,
+    ) -> 'MiMoSWAAttentionMetadata':
+        """Build once per model step, then reuse for all SWA layers."""
+        if attn_metadata is None:
+            raise RuntimeError('MiMo SWA state attention requires attention metadata.')
+        if not isinstance(window_size, int) or window_size <= 1:
+            raise ValueError(f'MiMo SWA window_size must be greater than one, got {window_size!r}.')
+
+        q_seqlens = getattr(attn_metadata, 'q_seqlens', None)
+        kv_seqlens = getattr(attn_metadata, 'kv_seqlens', None)
+        if q_seqlens is None or kv_seqlens is None:
+            raise RuntimeError('MiMo SWA state attention requires q_seqlens and kv_seqlens.')
+        q_seqlens = q_seqlens.to(dtype=torch.int32)
+        kv_seqlens = kv_seqlens.to(device=q_seqlens.device, dtype=torch.int64)
+        state_slots = state_slots.to(device=q_seqlens.device, dtype=torch.int64)
+        if state_slots.dim() != 1 or state_slots.numel() != q_seqlens.numel():
+            raise ValueError(
+                f'MiMo state_slots must have shape [{q_seqlens.numel()}], got {tuple(state_slots.shape)}.'
+            )
+
+        start_positions = kv_seqlens - q_seqlens.to(torch.int64)
+        history_limit = window_size - 1
+        valid_slots = (state_slots >= 0) & (state_slots < num_state_slots) & (start_positions >= 0)
+        history_lens = start_positions.clamp(min=0, max=history_limit).to(torch.int32)
+        history_lens = torch.where(valid_slots, history_lens, 0)
+
+        cu_q_seqlens = torch.zeros(q_seqlens.numel() + 1, dtype=torch.int32, device=q_seqlens.device)
+        torch.cumsum(q_seqlens, dim=0, out=cu_q_seqlens[1:])
+        ring_kv_seqlens = history_lens + q_seqlens
+        cu_kv_seqlens = torch.zeros_like(cu_q_seqlens)
+        torch.cumsum(ring_kv_seqlens, dim=0, out=cu_kv_seqlens[1:])
+
+        max_q_seqlen = getattr(step_context, 'max_q_seqlen', None)
+        if max_q_seqlen is None:
+            max_q_seqlen = getattr(attn_metadata, 'max_q_seqlen', None)
+        if max_q_seqlen is None:
+            # A synchronization-free upper bound.  It is exact for batch=1
+            # and only affects launch metadata for ragged batches.
+            max_q_seqlen = int(step_context.input_ids.numel())
+        max_q_seqlen = int(max_q_seqlen)
+
+        return cls(
+            state_slots=state_slots,
+            start_positions=start_positions,
+            q_seqlens=q_seqlens,
+            cu_q_seqlens=cu_q_seqlens,
+            history_lens=history_lens,
+            kv_seqlens=ring_kv_seqlens,
+            cu_kv_seqlens=cu_kv_seqlens,
+            max_q_seqlen=max_q_seqlen,
+            max_kv_seqlen=max_q_seqlen + history_limit,
+            window_size=window_size,
+        )
+
+
+def mimo_swa_state_attention(
+    attention,
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    k_ring: torch.Tensor,
+    v_ring: torch.Tensor,
+    metadata: MiMoSWAAttentionMetadata,
+    sink: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Attend to chronological ring history plus current K/V, then update it."""
+    if k_ring.size(0) != v_ring.size(0) or k_ring.size(1) != v_ring.size(1):
+        raise ValueError('MiMo SWA K/V rings must have identical state-slot and window dimensions.')
+    if k_ring.size(1) != metadata.window_size:
+        raise ValueError(
+            f'MiMo SWA metadata window {metadata.window_size} does not match ring window {k_ring.size(1)}.'
+        )
+
+    impl = attention.impl
+    if not hasattr(impl, 'flash_attention_fwd'):
+        raise RuntimeError(f'MiMo SWA state ring requires Triton varlen attention, got {type(impl).__name__}.')
+    if getattr(impl, 'alibi', False):
+        raise RuntimeError('MiMo SWA state ring does not support ALiBi.')
+
+    # Delay CUDA/Triton kernel imports until a real SWA forward.  Model/config
+    # inspection on a CPU-only host must not initialize the Triton driver.
+    from lmdeploy.pytorch.kernels.cuda.mimo_swa_ring import (
+        flatten_mimo_swa_ring,
+        scatter_mimo_swa_ring,
+    )
+
+    flat_key = flatten_mimo_swa_ring(
+        k_ring,
+        key,
+        metadata.state_slots,
+        metadata.start_positions,
+        metadata.q_seqlens,
+        metadata.cu_q_seqlens,
+        metadata.history_lens,
+        metadata.cu_kv_seqlens,
+        metadata.max_q_seqlen,
+    )
+    flat_value = flatten_mimo_swa_ring(
+        v_ring,
+        value,
+        metadata.state_slots,
+        metadata.start_positions,
+        metadata.q_seqlens,
+        metadata.cu_q_seqlens,
+        metadata.history_lens,
+        metadata.cu_kv_seqlens,
+        metadata.max_q_seqlen,
+    )
+
+    attention._lazy_init(query.device)
+    output = impl.flash_attention_fwd(
+        query,
+        flat_key,
+        flat_value,
+        cu_seqlens_q=metadata.cu_q_seqlens,
+        cu_seqlens_k=metadata.cu_kv_seqlens,
+        max_seqlen_q=metadata.max_q_seqlen,
+        max_seqlen_k=metadata.max_kv_seqlen,
+        window_size=metadata.window_size - 1,
+        softmax_scale=impl.scale,
+        softcap=impl.logit_softcapping,
+        causal=True,
+        sinks=sink,
+        alibi_slopes=None,
+        block_sparse_size=impl.block_sparse_size,
+        kv_layout='shd',
+    )
+
+    # Preserve the old ring until the attention kernel has consumed it.  CUDA
+    # stream ordering then makes these writes visible to the next model step.
+    scatter_mimo_swa_ring(
+        key,
+        k_ring,
+        metadata.state_slots,
+        metadata.start_positions,
+        metadata.q_seqlens,
+        metadata.cu_q_seqlens,
+    )
+    scatter_mimo_swa_ring(
+        value,
+        v_ring,
+        metadata.state_slots,
+        metadata.start_positions,
+        metadata.q_seqlens,
+        metadata.cu_q_seqlens,
+    )
+    return output

--- a/lmdeploy/pytorch/configurations/mimo_v2_flash.py
+++ b/lmdeploy/pytorch/configurations/mimo_v2_flash.py
@@ -1,0 +1,166 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+from functools import partial
+
+from lmdeploy.pytorch.config import BlockCacheSpec, ModelConfig, StateCacheSpec
+
+from .builder import AutoModelConfigBuilder
+
+
+def _get_mimo_cache_layers(hf_config):
+    """Validate the hybrid pattern and return full/SWA layer partitions."""
+    num_layers = hf_config.num_hidden_layers
+    pattern = list(hf_config.hybrid_layer_pattern)
+    if len(pattern) != num_layers:
+        raise ValueError(
+            "MiMo-V2-Flash hybrid_layer_pattern must contain one entry per layer, "
+            f"but got {len(pattern)} entries for num_hidden_layers={num_layers}."
+        )
+
+    invalid = sorted(set(pattern) - {0, 1})
+    if invalid:
+        raise ValueError(
+            f"MiMo-V2-Flash hybrid_layer_pattern only supports 0 (full attention) and 1 (SWA), but got {invalid}."
+        )
+
+    full_layers = [i for i, layer_type in enumerate(pattern) if layer_type == 0]
+    swa_layers = [i for i, layer_type in enumerate(pattern) if layer_type == 1]
+    if not full_layers or not swa_layers:
+        raise ValueError("MiMo-V2-Flash requires both full-attention and SWA layers.")
+    return full_layers, swa_layers
+
+
+def _num_kv_heads_per_rank(num_heads: int, tp: int, attention_type: str) -> int:
+    """Return local KV heads, including replication when TP exceeds KV heads."""
+    if num_heads >= tp:
+        if num_heads % tp != 0:
+            raise ValueError(f"MiMo-V2-Flash {attention_type} KV heads ({num_heads}) must be divisible by TP ({tp}).")
+        return num_heads // tp
+    if tp % num_heads != 0:
+        raise ValueError(f"MiMo-V2-Flash TP ({tp}) must be divisible by {attention_type} KV heads ({num_heads}).")
+    return 1
+
+
+def _update_kv_heads_for_tp(hf_config, *, heads_attr: str, replicate_attr: str, tp: int, attention_type: str) -> int:
+    """Record independent Full/SWA KV replication metadata on HF config."""
+    original_heads_attr = f"mimo_original_{heads_attr}"
+    num_heads = getattr(hf_config, original_heads_attr, getattr(hf_config, heads_attr))
+    setattr(hf_config, original_heads_attr, num_heads)
+    _num_kv_heads_per_rank(num_heads, tp, attention_type)
+    if tp > num_heads:
+        setattr(hf_config, replicate_attr, tp // num_heads)
+        num_heads = tp
+        setattr(hf_config, heads_attr, num_heads)
+    else:
+        setattr(hf_config, replicate_attr, 1)
+    return num_heads
+
+
+def _finalize_mimo_cache_specs(model_config: ModelConfig, block_size: int, *, tp: int):
+    """Materialize P1 Full block caches and the fixed-size SWA state ring."""
+    hf_config = model_config.hf_config
+    full_layers, swa_layers = _get_mimo_cache_layers(hf_config)
+    full_heads = _num_kv_heads_per_rank(hf_config.num_key_value_heads, tp, "full-attention")
+    swa_heads = _num_kv_heads_per_rank(hf_config.swa_num_key_value_heads, tp, "SWA")
+    window_size = getattr(hf_config, "sliding_window_size", getattr(hf_config, "sliding_window", None))
+    if not isinstance(window_size, int) or window_size <= 0:
+        raise ValueError(f"MiMo-V2-Flash requires a positive integer SWA window size, but got {window_size!r}.")
+
+    model_config.block_cache_specs = [
+        BlockCacheSpec("mimo_full_k", full_layers, (block_size, full_heads, hf_config.head_dim), model_config.dtype),
+        BlockCacheSpec("mimo_full_v", full_layers, (block_size, full_heads, hf_config.v_head_dim), model_config.dtype),
+    ]
+    state_specs = [
+        StateCacheSpec(
+            "mimo_swa_ring_k",
+            (window_size, swa_heads, hf_config.swa_head_dim),
+            model_config.dtype,
+            layer_ids=swa_layers,
+        ),
+        StateCacheSpec(
+            "mimo_swa_ring_v",
+            (window_size, swa_heads, hf_config.swa_v_head_dim),
+            model_config.dtype,
+            layer_ids=swa_layers,
+        ),
+    ]
+    model_config.state_cache_specs = state_specs
+    # StateCacheSpec owns the named/layered physical allocation.  This legacy
+    # bridge only tells Scheduler/Executor that the model has sequence state;
+    # StateCacheEngine must not allocate a second anonymous copy.
+    model_config.states_shapes = [(tuple(spec.shape), spec.dtype) for spec in state_specs]
+
+
+def update_cache_config(cache_config):
+    """Keep all logical blocks and align named-cache allocation granularity."""
+    # The named cache shapes are finalized with ModelConfig.block_size. Keep
+    # CacheEngine's kernel-block granularity identical so each physical block
+    # has exactly the shape declared by the specs.
+    cache_config.kernel_block_size = cache_config.block_size
+    # SWA masking is handled by the model backend. Using DefaultBlockManager
+    # preserves the full-attention history and keeps BlockTrie available.
+    cache_config.window_size = -1
+
+
+class MiMoV2FlashModelConfigBuilder(AutoModelConfigBuilder):
+    """Build the Full-block + SWA-state configuration for MiMo-V2-Flash."""
+
+    @classmethod
+    def condition(cls, hf_config):
+        """Match MiMo-V2-Flash Hugging Face configurations."""
+        return hf_config.model_type == "mimo_v2_flash"
+
+    @classmethod
+    def build(
+        cls,
+        hf_config,
+        model_path: str | None = None,
+        tp: int = 1,
+        is_draft_model: bool = False,
+        spec_method: str | None = None,
+        **kwargs,
+    ):
+        """Build the target model configuration and its hybrid cache specs."""
+        _get_mimo_cache_layers(hf_config)
+        if is_draft_model:
+            raise ValueError("MiMo-V2-Flash draft-model support is not available yet.")
+        if spec_method is not None:
+            raise ValueError("MiMo-V2-Flash speculative decoding support is not available yet.")
+
+        if getattr(hf_config, "routed_scaling_factor", None) is None:
+            # The official eager implementation interprets null as 1.0;
+            # LMDeploy's fused noaux_tc router expects a numeric multiplier.
+            hf_config.routed_scaling_factor = 1.0
+        num_key_value_heads = _update_kv_heads_for_tp(
+            hf_config,
+            heads_attr="num_key_value_heads",
+            replicate_attr="num_replicate_key_value_heads",
+            tp=tp,
+            attention_type="full-attention",
+        )
+        _update_kv_heads_for_tp(
+            hf_config,
+            heads_attr="swa_num_key_value_heads",
+            replicate_attr="swa_num_replicate_key_value_heads",
+            tp=tp,
+            attention_type="SWA",
+        )
+
+        config = ModelConfig(
+            hidden_size=hf_config.hidden_size,
+            num_layers=hf_config.num_hidden_layers,
+            num_attention_heads=hf_config.num_attention_heads,
+            num_key_value_heads=num_key_value_heads,
+            bos_token_id=getattr(hf_config, "bos_token_id", None),
+            eos_token_id=getattr(hf_config, "eos_token_id", None),
+            head_dim=hf_config.head_dim,
+            k_head_dim=hf_config.head_dim,
+            v_head_dim=hf_config.v_head_dim,
+            sliding_window=-1,
+            vocab_size=hf_config.vocab_size,
+            model_paradigm="ar",
+            use_standard_kv_cache=False,
+        )
+        config.block_cache_specs = []
+        config.post_build_func = partial(_finalize_mimo_cache_specs, tp=tp)
+        config.update_cache_config_func = update_cache_config
+        return config

--- a/lmdeploy/pytorch/kernels/cuda/flashattention.py
+++ b/lmdeploy/pytorch/kernels/cuda/flashattention.py
@@ -551,25 +551,32 @@ def flash_attn_varlen_func(
         assert sinks.numel() == num_heads
 
     BLOCK_DK, BLOCK_DK1, BLOCK_DV = _get_block_d(head_dim_k, head_dim_v)
+    # Kernel resource tuning must account for both Q/K tiles. For a
+    # non-power-of-two head such as MiMo's 192, computation is split into
+    # BLOCK_DK=128 and BLOCK_DK1=64. Tuning from BLOCK_DK alone incorrectly
+    # selects the aggressive 128-dim SM90 config and exceeds H200 shared
+    # memory. Use the padded complete dimension for launch metadata while
+    # retaining the split tiles for the actual computation.
+    meta_block_dk = triton.next_power_of_2(head_dim_k)
 
     shared_kv = k.data_ptr() == v.data_ptr() and BLOCK_DK == BLOCK_DV
 
     num_warps = 4
     hip_mode = getattr(torch.version, 'hip', None) is not None
     if hip_mode:
-        BLOCK_M, BLOCK_N, num_warps, num_stages = _kernel_meta_rocm(BLOCK_DK, shared_kv)
+        BLOCK_M, BLOCK_N, num_warps, num_stages = _kernel_meta_rocm(meta_block_dk, shared_kv)
     else:
         if _nv_cap[0] < 8:
-            BLOCK_M, BLOCK_N, num_warps, num_stages = _kernel_meta_sm7x(BLOCK_DK)
+            BLOCK_M, BLOCK_N, num_warps, num_stages = _kernel_meta_sm7x(meta_block_dk)
         elif _nv_cap[0] < 9:
             if _nv_cap[1] in [6, 9]:
-                BLOCK_M, BLOCK_N, num_warps, num_stages = _kernel_meta_sm86(BLOCK_DK, shared_kv)
+                BLOCK_M, BLOCK_N, num_warps, num_stages = _kernel_meta_sm86(meta_block_dk, shared_kv)
             else:
-                BLOCK_M, BLOCK_N, num_warps, num_stages = _kernel_meta_sm8x(BLOCK_DK, shared_kv)
+                BLOCK_M, BLOCK_N, num_warps, num_stages = _kernel_meta_sm8x(meta_block_dk, shared_kv)
         elif _nv_cap[0] < 10:
-            BLOCK_M, BLOCK_N, num_warps, num_stages = _kernel_meta_sm9x(BLOCK_DK, shared_kv)
+            BLOCK_M, BLOCK_N, num_warps, num_stages = _kernel_meta_sm9x(meta_block_dk, shared_kv)
         else:
-            BLOCK_M, BLOCK_N, num_warps, num_stages = _kernel_meta_sm12x(BLOCK_DK, shared_kv)
+            BLOCK_M, BLOCK_N, num_warps, num_stages = _kernel_meta_sm12x(meta_block_dk, shared_kv)
 
     BLOCK_M = min(128, BLOCK_M)
     _flash_prefill_fwd_kernel[grid](

--- a/lmdeploy/pytorch/kernels/cuda/mimo_swa_ring.py
+++ b/lmdeploy/pytorch/kernels/cuda/mimo_swa_ring.py
@@ -1,0 +1,429 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+"""Triton gather/scatter kernels for MiMo-V2-Flash BF16 SWA state rings."""
+
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _gather_mimo_swa_ring_kernel(
+    ring_ptr,
+    output_ptr,
+    state_slots_ptr,
+    start_positions_ptr,
+    history_lens_ptr,
+    cu_history_lens_ptr,
+    stride_ring_slot,
+    stride_ring_pos,
+    stride_ring_head,
+    stride_ring_dim,
+    stride_output_token,
+    stride_output_head,
+    stride_output_dim,
+    NUM_STATE_SLOTS: tl.constexpr,
+    WINDOW_SIZE: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    BLOCK_DIM: tl.constexpr,
+):
+    batch_id = tl.program_id(0)
+    history_idx = tl.program_id(1)
+    head_idx = tl.program_id(2)
+
+    history_len = tl.load(history_lens_ptr + batch_id)
+    if history_idx >= history_len:
+        return
+
+    state_slot = tl.load(state_slots_ptr + batch_id)
+    if state_slot < 0 or state_slot >= NUM_STATE_SLOTS:
+        return
+
+    start_position = tl.load(start_positions_ptr + batch_id)
+    absolute_position = start_position - history_len + history_idx
+    ring_position = absolute_position % WINDOW_SIZE
+    output_token = tl.load(cu_history_lens_ptr + batch_id) + history_idx
+
+    dim_offsets = tl.arange(0, BLOCK_DIM)
+    dim_mask = dim_offsets < HEAD_DIM
+    source_offsets = (
+        state_slot.to(tl.int64) * stride_ring_slot
+        + ring_position.to(tl.int64) * stride_ring_pos
+        + head_idx * stride_ring_head
+        + dim_offsets * stride_ring_dim
+    )
+    output_offsets = (
+        output_token.to(tl.int64) * stride_output_token
+        + head_idx * stride_output_head
+        + dim_offsets * stride_output_dim
+    )
+    payload = tl.load(ring_ptr + source_offsets, mask=dim_mask)
+    tl.store(output_ptr + output_offsets, payload, mask=dim_mask)
+
+
+@triton.jit
+def _scatter_mimo_swa_ring_kernel(
+    tokens_ptr,
+    ring_ptr,
+    state_slots_ptr,
+    start_positions_ptr,
+    q_seqlens_ptr,
+    cu_q_seqlens_ptr,
+    stride_tokens_token,
+    stride_tokens_head,
+    stride_tokens_dim,
+    stride_ring_slot,
+    stride_ring_pos,
+    stride_ring_head,
+    stride_ring_dim,
+    NUM_STATE_SLOTS: tl.constexpr,
+    WINDOW_SIZE: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    BLOCK_DIM: tl.constexpr,
+):
+    batch_id = tl.program_id(0)
+    write_idx = tl.program_id(1)
+    head_idx = tl.program_id(2)
+
+    state_slot = tl.load(state_slots_ptr + batch_id)
+    if state_slot < 0 or state_slot >= NUM_STATE_SLOTS:
+        return
+
+    start_position = tl.load(start_positions_ptr + batch_id)
+    if start_position < 0:
+        return
+
+    q_seqlen = tl.load(q_seqlens_ptr + batch_id)
+    write_len = tl.minimum(q_seqlen, WINDOW_SIZE)
+    if write_idx >= write_len:
+        return
+
+    # If a chunk exceeds the ring capacity, its early tokens cannot be part of
+    # the final state.  Starting at q_seqlen - write_len also prevents two
+    # programs from racing to write the same modulo slot.
+    local_position = q_seqlen - write_len + write_idx
+    token_idx = tl.load(cu_q_seqlens_ptr + batch_id) + local_position
+    absolute_position = start_position + local_position
+    ring_position = absolute_position % WINDOW_SIZE
+
+    dim_offsets = tl.arange(0, BLOCK_DIM)
+    dim_mask = dim_offsets < HEAD_DIM
+    token_offsets = (
+        token_idx.to(tl.int64) * stride_tokens_token
+        + head_idx * stride_tokens_head
+        + dim_offsets * stride_tokens_dim
+    )
+    ring_offsets = (
+        state_slot.to(tl.int64) * stride_ring_slot
+        + ring_position.to(tl.int64) * stride_ring_pos
+        + head_idx * stride_ring_head
+        + dim_offsets * stride_ring_dim
+    )
+    payload = tl.load(tokens_ptr + token_offsets, mask=dim_mask)
+    tl.store(ring_ptr + ring_offsets, payload, mask=dim_mask)
+
+
+@triton.jit
+def _flatten_mimo_swa_ring_kernel(
+    ring_ptr,
+    current_ptr,
+    output_ptr,
+    state_slots_ptr,
+    start_positions_ptr,
+    q_seqlens_ptr,
+    cu_q_seqlens_ptr,
+    history_lens_ptr,
+    cu_kv_seqlens_ptr,
+    stride_ring_slot,
+    stride_ring_pos,
+    stride_ring_head,
+    stride_ring_dim,
+    stride_current_token,
+    stride_current_head,
+    stride_current_dim,
+    stride_output_token,
+    stride_output_head,
+    stride_output_dim,
+    NUM_STATE_SLOTS: tl.constexpr,
+    WINDOW_SIZE: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    BLOCK_DIM: tl.constexpr,
+):
+    """Pack each sequence as chronological history followed by current KV."""
+    batch_id = tl.program_id(0)
+    sequence_token = tl.program_id(1)
+    head_idx = tl.program_id(2)
+
+    history_len = tl.load(history_lens_ptr + batch_id)
+    q_seqlen = tl.load(q_seqlens_ptr + batch_id)
+    if sequence_token >= history_len + q_seqlen:
+        return
+
+    output_token = tl.load(cu_kv_seqlens_ptr + batch_id) + sequence_token
+    dim_offsets = tl.arange(0, BLOCK_DIM)
+    dim_mask = dim_offsets < HEAD_DIM
+    output_offsets = (
+        output_token.to(tl.int64) * stride_output_token
+        + head_idx * stride_output_head
+        + dim_offsets * stride_output_dim
+    )
+
+    if sequence_token < history_len:
+        state_slot = tl.load(state_slots_ptr + batch_id)
+        start_position = tl.load(start_positions_ptr + batch_id)
+        absolute_position = start_position - history_len + sequence_token
+        ring_position = absolute_position % WINDOW_SIZE
+        source_offsets = (
+            state_slot.to(tl.int64) * stride_ring_slot
+            + ring_position.to(tl.int64) * stride_ring_pos
+            + head_idx * stride_ring_head
+            + dim_offsets * stride_ring_dim
+        )
+        payload = tl.load(ring_ptr + source_offsets, mask=dim_mask)
+    else:
+        current_token = tl.load(cu_q_seqlens_ptr + batch_id) + sequence_token - history_len
+        source_offsets = (
+            current_token.to(tl.int64) * stride_current_token
+            + head_idx * stride_current_head
+            + dim_offsets * stride_current_dim
+        )
+        payload = tl.load(current_ptr + source_offsets, mask=dim_mask)
+    tl.store(output_ptr + output_offsets, payload, mask=dim_mask)
+
+
+def _validate_ring(ring: torch.Tensor) -> None:
+    if ring.dim() != 4:
+        raise ValueError(f'MiMo SWA ring must be [state_slots, window, heads, dim], got {tuple(ring.shape)}.')
+    if ring.dtype != torch.bfloat16:
+        raise TypeError(f'MiMo SWA ring must use torch.bfloat16, got {ring.dtype}.')
+    if not ring.is_cuda:
+        raise ValueError('MiMo SWA ring kernels require CUDA tensors.')
+    if ring.size(1) <= 1:
+        raise ValueError(f'MiMo SWA ring window must be greater than one, got {ring.size(1)}.')
+
+
+def _validate_batch_vector(name: str, tensor: torch.Tensor, batch_size: int, device: torch.device) -> None:
+    if tensor.dim() != 1 or tensor.numel() != batch_size:
+        raise ValueError(f'{name} must have shape [{batch_size}], got {tuple(tensor.shape)}.')
+    if tensor.device != device:
+        raise ValueError(f'{name} must be on {device}, got {tensor.device}.')
+    if tensor.dtype not in (torch.int32, torch.int64):
+        raise TypeError(f'{name} must use int32 or int64, got {tensor.dtype}.')
+
+
+def gather_mimo_swa_ring(
+    ring: torch.Tensor,
+    state_slots: torch.Tensor,
+    start_positions: torch.Tensor,
+    history_limit: int | None = None,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Gather previous MiMo SWA state in chronological order.
+
+    Args:
+        ring: One layer's state view with shape
+            ``[num_state_slots, window_size, local_kv_heads, head_dim]``.
+        state_slots: ``[batch]`` state row IDs.  A negative or out-of-range ID
+            is a dummy sequence and contributes zero history tokens.
+        start_positions: ``[batch]`` absolute positions of each current chunk.
+        history_limit: Maximum previous-token count.  MiMo uses
+            ``window_size - 1`` so the current query plus its history contains
+            at most ``window_size`` tokens.
+
+    Returns:
+        A capacity-sized packed payload buffer, actual per-sequence history
+        lengths, and their cumulative offsets.  Only rows before
+        ``cu_history_lens[-1]`` contain payload.
+    """
+    _validate_ring(ring)
+    batch_size = state_slots.numel()
+    _validate_batch_vector('state_slots', state_slots, batch_size, ring.device)
+    _validate_batch_vector('start_positions', start_positions, batch_size, ring.device)
+
+    window_size = ring.size(1)
+    if history_limit is None:
+        history_limit = window_size - 1
+    if history_limit < 0 or history_limit > window_size:
+        raise ValueError(f'history_limit must be in [0, {window_size}], got {history_limit}.')
+
+    valid_slots = (state_slots >= 0) & (state_slots < ring.size(0)) & (start_positions >= 0)
+    history_lens = start_positions.clamp(min=0, max=history_limit).to(torch.int32)
+    history_lens = torch.where(valid_slots, history_lens, 0)
+    cu_history_lens = torch.zeros(batch_size + 1, dtype=torch.int32, device=ring.device)
+    torch.cumsum(history_lens, dim=0, out=cu_history_lens[1:])
+
+    num_heads = ring.size(2)
+    head_dim = ring.size(3)
+    output_capacity = batch_size * history_limit
+    output = torch.empty(
+        (output_capacity, num_heads, head_dim), dtype=ring.dtype, device=ring.device
+    )
+    if batch_size == 0 or history_limit == 0:
+        return output, history_lens, cu_history_lens
+
+    block_dim = triton.next_power_of_2(head_dim)
+    grid = (batch_size, history_limit, num_heads)
+    _gather_mimo_swa_ring_kernel[grid](
+        ring,
+        output,
+        state_slots,
+        start_positions,
+        history_lens,
+        cu_history_lens,
+        ring.stride(0),
+        ring.stride(1),
+        ring.stride(2),
+        ring.stride(3),
+        output.stride(0),
+        output.stride(1),
+        output.stride(2),
+        NUM_STATE_SLOTS=ring.size(0),
+        WINDOW_SIZE=window_size,
+        HEAD_DIM=head_dim,
+        BLOCK_DIM=block_dim,
+    )
+    return output, history_lens, cu_history_lens
+
+
+def flatten_mimo_swa_ring(
+    ring: torch.Tensor,
+    current: torch.Tensor,
+    state_slots: torch.Tensor,
+    start_positions: torch.Tensor,
+    q_seqlens: torch.Tensor,
+    cu_q_seqlens: torch.Tensor,
+    history_lens: torch.Tensor,
+    cu_kv_seqlens: torch.Tensor,
+    max_q_seqlen: int,
+) -> torch.Tensor:
+    """Pack chronological ring history and current tokens for varlen attention.
+
+    The output order is ``history_i + current_i`` for every sequence ``i``.
+    Its allocation uses a synchronization-free upper bound; only entries
+    addressed by ``cu_kv_seqlens`` are consumed by varlen attention.
+    """
+    _validate_ring(ring)
+    if current.dim() != 3:
+        raise ValueError(f'current must be [total_q, heads, dim], got {tuple(current.shape)}.')
+    if current.dtype != ring.dtype or current.device != ring.device:
+        raise ValueError('current and ring must have the same BF16 dtype and CUDA device.')
+    if current.shape[1:] != ring.shape[2:]:
+        raise ValueError(
+            f'current head shape {tuple(current.shape[1:])} does not match ring {tuple(ring.shape[2:])}.'
+        )
+    if not isinstance(max_q_seqlen, int) or max_q_seqlen < 0:
+        raise ValueError(f'max_q_seqlen must be a non-negative int, got {max_q_seqlen!r}.')
+
+    batch_size = state_slots.numel()
+    _validate_batch_vector('state_slots', state_slots, batch_size, ring.device)
+    _validate_batch_vector('start_positions', start_positions, batch_size, ring.device)
+    _validate_batch_vector('q_seqlens', q_seqlens, batch_size, ring.device)
+    _validate_batch_vector('history_lens', history_lens, batch_size, ring.device)
+    if cu_q_seqlens.dim() != 1 or cu_q_seqlens.numel() != batch_size + 1:
+        raise ValueError(f'cu_q_seqlens must have shape [{batch_size + 1}], got {tuple(cu_q_seqlens.shape)}.')
+    if cu_kv_seqlens.dim() != 1 or cu_kv_seqlens.numel() != batch_size + 1:
+        raise ValueError(f'cu_kv_seqlens must have shape [{batch_size + 1}], got {tuple(cu_kv_seqlens.shape)}.')
+    for name, cumulative in (('cu_q_seqlens', cu_q_seqlens), ('cu_kv_seqlens', cu_kv_seqlens)):
+        if cumulative.device != ring.device or cumulative.dtype not in (torch.int32, torch.int64):
+            raise ValueError(f'{name} must be an int32/int64 tensor on the ring device.')
+
+    history_limit = ring.size(1) - 1
+    output_capacity = current.size(0) + batch_size * history_limit
+    output = torch.empty(
+        (output_capacity, ring.size(2), ring.size(3)),
+        dtype=ring.dtype,
+        device=ring.device,
+    )
+    if batch_size == 0 or output_capacity == 0:
+        return output
+
+    block_dim = triton.next_power_of_2(ring.size(3))
+    grid = (batch_size, history_limit + max_q_seqlen, ring.size(2))
+    _flatten_mimo_swa_ring_kernel[grid](
+        ring,
+        current,
+        output,
+        state_slots,
+        start_positions,
+        q_seqlens,
+        cu_q_seqlens,
+        history_lens,
+        cu_kv_seqlens,
+        ring.stride(0),
+        ring.stride(1),
+        ring.stride(2),
+        ring.stride(3),
+        current.stride(0),
+        current.stride(1),
+        current.stride(2),
+        output.stride(0),
+        output.stride(1),
+        output.stride(2),
+        NUM_STATE_SLOTS=ring.size(0),
+        WINDOW_SIZE=ring.size(1),
+        HEAD_DIM=ring.size(3),
+        BLOCK_DIM=block_dim,
+    )
+    return output
+
+
+def scatter_mimo_swa_ring(
+    tokens: torch.Tensor,
+    ring: torch.Tensor,
+    state_slots: torch.Tensor,
+    start_positions: torch.Tensor,
+    q_seqlens: torch.Tensor,
+    cu_q_seqlens: torch.Tensor,
+) -> None:
+    """Write each chunk's newest tokens into one layer's MiMo SWA ring.
+
+    ``tokens`` is packed by sequence.  Valid state slot IDs must be unique
+    within the batch.  At most the last ``window_size`` tokens of each chunk
+    are written; attention must gather the old state before this function is
+    called.
+    """
+    _validate_ring(ring)
+    if tokens.dim() != 3:
+        raise ValueError(f'tokens must be [total_q, heads, dim], got {tuple(tokens.shape)}.')
+    if tokens.dtype != ring.dtype or tokens.device != ring.device:
+        raise ValueError('tokens and ring must have the same BF16 dtype and CUDA device.')
+    if tokens.size(1) != ring.size(2) or tokens.size(2) != ring.size(3):
+        raise ValueError(
+            f'tokens head shape {tuple(tokens.shape[1:])} does not match ring {tuple(ring.shape[2:])}.'
+        )
+
+    batch_size = state_slots.numel()
+    _validate_batch_vector('state_slots', state_slots, batch_size, ring.device)
+    _validate_batch_vector('start_positions', start_positions, batch_size, ring.device)
+    _validate_batch_vector('q_seqlens', q_seqlens, batch_size, ring.device)
+    if cu_q_seqlens.dim() != 1 or cu_q_seqlens.numel() != batch_size + 1:
+        raise ValueError(
+            f'cu_q_seqlens must have shape [{batch_size + 1}], got {tuple(cu_q_seqlens.shape)}.'
+        )
+    if cu_q_seqlens.device != ring.device or cu_q_seqlens.dtype not in (torch.int32, torch.int64):
+        raise ValueError('cu_q_seqlens must be an int32/int64 tensor on the ring device.')
+    if batch_size == 0 or tokens.numel() == 0:
+        return
+
+    window_size = ring.size(1)
+    num_heads = ring.size(2)
+    head_dim = ring.size(3)
+    block_dim = triton.next_power_of_2(head_dim)
+    grid = (batch_size, window_size, num_heads)
+    _scatter_mimo_swa_ring_kernel[grid](
+        tokens,
+        ring,
+        state_slots,
+        start_positions,
+        q_seqlens,
+        cu_q_seqlens,
+        tokens.stride(0),
+        tokens.stride(1),
+        tokens.stride(2),
+        ring.stride(0),
+        ring.stride(1),
+        ring.stride(2),
+        ring.stride(3),
+        NUM_STATE_SLOTS=ring.size(0),
+        WINDOW_SIZE=window_size,
+        HEAD_DIM=head_dim,
+        BLOCK_DIM=block_dim,
+    )

--- a/lmdeploy/pytorch/models/mimo_v2_flash.py
+++ b/lmdeploy/pytorch/models/mimo_v2_flash.py
@@ -1,0 +1,792 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+import re
+from collections.abc import Iterable
+from dataclasses import dataclass
+from typing import Any
+
+import torch
+import torch.distributed as dist
+from torch import nn
+
+from lmdeploy.pytorch.backends.mimo_swa import (
+    MiMoSWAAttentionMetadata,
+    mimo_swa_state_attention,
+)
+from lmdeploy.pytorch.distributed import get_dist_manager, get_ep_world_rank, get_tp_world_rank
+from lmdeploy.pytorch.model_inputs import StepContext, StepContextManager
+from lmdeploy.pytorch.nn import ApplyRotaryEmb, Attention, RMSNorm, SiluAndMul, build_rotary_embedding
+from lmdeploy.pytorch.nn.eplb import EPLBManager
+from lmdeploy.pytorch.nn.linear import build_down_linear, build_gateup_linear, build_o_proj, build_qkv_proj
+from lmdeploy.pytorch.weight_loader.model_weight_loader import default_weight_loader, load_weight
+
+from .deepseek_v2 import DeepseekV2MoE
+from .patch import add_prefix, get_build_model_context
+from .utils.cudagraph import CudaGraphMixin
+from .utils.model import DeployModelMixinV1, build_embedding
+
+
+def _get_norm_eps(config: Any) -> float:
+    """Read the native or remote-code MiMo RMSNorm epsilon field."""
+    norm_eps = getattr(config, "rms_norm_eps", None)
+    if norm_eps is None:
+        norm_eps = config.layernorm_epsilon
+    return norm_eps
+
+
+def _all_reduce_mimo(output: torch.Tensor, group=None) -> torch.Tensor:
+    """Reduce a MiMo tensor over its tensor-parallel group."""
+    dist.all_reduce(output, group=group)
+    return output
+
+
+def _reduce_tp_output(linear: nn.Module, output: torch.Tensor) -> torch.Tensor:
+    """Reduce one MiMo row-parallel output."""
+    if linear.tp > 1:
+        output = _all_reduce_mimo(output, group=linear.tp_group)
+    return output
+
+
+def _dequantize_blocked_fp8(weight: torch.Tensor, scale: torch.Tensor, dtype: torch.dtype) -> torch.Tensor:
+    """Dequantize 2D FP8 using the checkpoint's serialized scale grid.
+
+    MiMo Full-K is (768, 4096) with an (8, 32) scale grid, so its effective
+    output tile is 96 rather than the config-level 128.  Deriving the tile from
+    both tensors matches Transformers' official FP8 dequantization reference.
+    """
+    rows, columns = weight.shape
+    scale_rows, scale_columns = scale.shape
+    if rows % scale_rows != 0 or columns % scale_columns != 0:
+        raise ValueError(
+            f"Invalid blocked-FP8 weight/scale shapes: weight={tuple(weight.shape)}, scale={tuple(scale.shape)}."
+        )
+    weight = weight.reshape(scale_rows, rows // scale_rows, scale_columns, columns // scale_columns)
+    weight = weight.float() * scale.reshape(scale_rows, 1, scale_columns, 1).float()
+    return weight.to(dtype).reshape(rows, columns)
+
+
+def _load_attention_sink(param: nn.Parameter, loaded_weight: torch.Tensor):
+    """Load this rank's Q-head slice of an attention sink vector."""
+    world_size, rank = get_tp_world_rank("attn")
+    if loaded_weight.size(0) % world_size != 0:
+        raise ValueError(f"Cannot shard {loaded_weight.size(0)} MiMo sink heads over TP={world_size}.")
+    loaded_weight = loaded_weight.chunk(world_size, dim=0)[rank]
+    default_weight_loader(param, loaded_weight)
+
+
+@dataclass
+class MiMoV2Caches:
+    """Named P1 Full block caches and SWA state rings."""
+
+    block_caches: Any
+    state_caches: Any
+
+    def block_cache(self, cache_name: str, layer_idx: int) -> torch.Tensor:
+        """Resolve a compact named-cache row by global layer index."""
+        if hasattr(self.block_caches, "layer"):
+            return self.block_caches.layer(cache_name, layer_idx)
+        return self.block_caches[cache_name][layer_idx]
+
+    def state_cache(self, cache_name: str, layer_idx: int) -> torch.Tensor:
+        """Resolve a compact named-state row by global layer index."""
+        if hasattr(self.state_caches, "layer"):
+            return self.state_caches.layer(cache_name, layer_idx)
+        return self.state_caches[cache_name][layer_idx]
+
+
+class MiMoV2Attention(nn.Module):
+    """Common MiMo-V2 QKV projection, partial RoPE and output projection."""
+
+    def __init__(
+        self,
+        config: Any,
+        is_swa: bool,
+        dtype: torch.dtype | None = None,
+        device: torch.device | None = None,
+        prefix: str = "",
+    ):
+        super().__init__()
+        quantization_config = getattr(config, "quantization_config", None)
+        if is_swa:
+            self.head_dim = config.swa_head_dim
+            self.v_head_dim = config.swa_v_head_dim
+            num_heads = config.swa_num_attention_heads
+            num_kv_heads = config.swa_num_key_value_heads
+            num_replicate_kv_heads = getattr(config, "swa_num_replicate_key_value_heads", 1)
+            sliding_window = getattr(config, "sliding_window_size", getattr(config, "sliding_window", -1))
+            has_sink = getattr(config, "add_swa_attention_sink_bias", False)
+        else:
+            self.head_dim = config.head_dim
+            self.v_head_dim = config.v_head_dim
+            num_heads = config.num_attention_heads
+            num_kv_heads = config.num_key_value_heads
+            num_replicate_kv_heads = getattr(config, "num_replicate_key_value_heads", 1)
+            sliding_window = None
+            has_sink = getattr(config, "add_full_attention_sink_bias", False)
+
+        self.v_scale = getattr(config, "attention_value_scale", None)
+        self.rotary_dim = int(self.head_dim * config.partial_rotary_factor)
+        if self.rotary_dim <= 0 or self.rotary_dim > self.head_dim or self.rotary_dim % 2 != 0:
+            raise ValueError(f"Invalid MiMo-V2 rotary dimension: {self.rotary_dim}.")
+
+        self.qkv_proj = build_qkv_proj(
+            config.hidden_size,
+            num_q_heads=num_heads,
+            num_kv_heads=num_kv_heads,
+            head_size=self.head_dim,
+            head_size_v=self.v_head_dim,
+            bias=config.attention_bias,
+            # P0 keeps QKV in BF16. A 192-wide local K head is not aligned to
+            # LMDeploy's 128-row packed-FP8 scale partitions at TP=4/8; the
+            # loader dequantizes the official FP8 Q/K/V tensors before the
+            # head-aware BF16 QKV loader shards or replicates them.
+            quant_config=None,
+            dtype=dtype,
+            device=device,
+            num_replicate_kv_heads=num_replicate_kv_heads,
+            prefix=add_prefix("qkv_proj", prefix),
+        )
+        self.apply_rotary_pos_emb = ApplyRotaryEmb()
+        self.attn_fwd = Attention(
+            num_heads,
+            self.head_dim,
+            num_kv_heads=num_kv_heads,
+            v_head_size=self.v_head_dim,
+            sliding_window=sliding_window,
+            learnable_sink=has_sink,
+            # Full Attention can use FA3 when its wheel contains the asymmetric
+            # Q/K=192, V=128 instantiation. SWA remains on the MiMo-specific
+            # Triton/ring path because it also implements attention sinks.
+            enable_fa3=not is_swa,
+        )
+        self.attention_sink_bias = None
+        if has_sink:
+            self.attention_sink_bias = nn.Parameter(
+                torch.empty(self.qkv_proj.num_q_heads, dtype=dtype, device=device),
+                requires_grad=False,
+            )
+            self.attention_sink_bias.weight_loader = _load_attention_sink
+        self.o_proj = build_o_proj(
+            num_heads * self.v_head_dim,
+            config.hidden_size,
+            bias=False,
+            quant_config=quantization_config,
+            dtype=dtype,
+            device=device,
+            is_tp=True,
+            # Keep reduction outside the linear so MiMo uses the same explicit
+            # tensor-parallel group for attention, dense FFN and MoE outputs.
+            all_reduce=False,
+            prefix=add_prefix("o_proj", prefix),
+        )
+
+    def _project_output(self, attn_output: torch.Tensor) -> torch.Tensor:
+        """Apply o_proj and the standard BF16 tensor-parallel reduction."""
+        output = self.o_proj(attn_output)
+        return _reduce_tp_output(self.o_proj, output)
+
+    def _project_qkv(
+        self,
+        hidden_states: torch.Tensor,
+        rotary_pos_emb: tuple[torch.Tensor, torch.Tensor],
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Project QKV, apply partial RoPE and scale V before caching."""
+        qkv_states = self.qkv_proj(hidden_states).flatten(0, -2)
+        query_states, key_states, value_states = self.qkv_proj.split_qkv(qkv_states)
+
+        # MiMo rotates only the leading rotary_dim features. Passing the views
+        # explicitly also keeps the default backend valid; broadcasting a
+        # rotary_dim-wide cos/sin table over the complete 192 features would
+        # be incorrect.
+        query_rope = query_states[..., : self.rotary_dim]
+        key_rope = key_states[..., : self.rotary_dim]
+        cos, sin = rotary_pos_emb
+        self.apply_rotary_pos_emb(query_rope, key_rope, cos, sin, inplace=True)
+        if self.v_scale is not None:
+            # Scale before either block/ring cache writes so current attention,
+            # decode and prefix restore share one V representation.
+            value_states = value_states * self.v_scale
+        return query_states, key_states, value_states
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        rotary_pos_emb: tuple[torch.Tensor, torch.Tensor],
+        past_key_value: tuple[torch.Tensor, torch.Tensor],
+        attn_metadata: Any,
+    ) -> torch.Tensor:
+        """Run the Full-Attention paged KV path."""
+        query_states, key_states, value_states = self._project_qkv(hidden_states, rotary_pos_emb)
+
+        attn_output = self.attn_fwd(
+            query_states,
+            key_states,
+            value_states,
+            past_key_value[0],
+            past_key_value[1],
+            attn_metadata,
+            s_aux=self.attention_sink_bias,
+            inplace=True,
+        )
+        attn_output = attn_output.reshape(*hidden_states.shape[:-1], -1)
+        return self._project_output(attn_output)
+
+
+class MiMoV2FullAttention(MiMoV2Attention):
+    """MiMo-V2 full attention backed by the named paged KV cache."""
+
+    def __init__(self, config: Any, **kwargs):
+        super().__init__(config, is_swa=False, **kwargs)
+
+
+class MiMoV2SWAAttention(MiMoV2Attention):
+    """P1 SWA attention backed by a sequence-scoped BF16 state ring."""
+
+    def __init__(self, config: Any, **kwargs):
+        super().__init__(config, is_swa=True, **kwargs)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        rotary_pos_emb: tuple[torch.Tensor, torch.Tensor],
+        state_cache: tuple[torch.Tensor, torch.Tensor],
+        swa_metadata: MiMoSWAAttentionMetadata,
+    ) -> torch.Tensor:
+        """Run varlen attention over chronological ring history + current KV."""
+        query_states, key_states, value_states = self._project_qkv(hidden_states, rotary_pos_emb)
+        attn_output = mimo_swa_state_attention(
+            self.attn_fwd,
+            query_states,
+            key_states,
+            value_states,
+            state_cache[0],
+            state_cache[1],
+            swa_metadata,
+            sink=self.attention_sink_bias,
+        )
+        attn_output = attn_output.reshape(*hidden_states.shape[:-1], -1)
+        return self._project_output(attn_output)
+
+
+class MiMoV2MLP(nn.Module):
+    """Dense SwiGLU block used by MiMo-V2-Flash."""
+
+    def __init__(
+        self,
+        config: Any,
+        intermediate_size: int | None = None,
+        dtype: torch.dtype | None = None,
+        device: torch.device | None = None,
+        prefix: str = "",
+    ):
+        super().__init__()
+        if intermediate_size is None:
+            intermediate_size = config.intermediate_size
+        quantization_config = getattr(config, "quantization_config", None)
+
+        # The official checkpoint stores gate_proj and up_proj separately.
+        # LMDeploy packs them into one column-parallel projection; SiluAndMul
+        # consumes the packed [gate, up] output without changing the math.
+        self.gate_up_proj = build_gateup_linear(
+            config.hidden_size,
+            [intermediate_size, intermediate_size],
+            bias=False,
+            dtype=dtype,
+            device=device,
+            quant_config=quantization_config,
+            is_tp=True,
+            prefix=add_prefix("gate_up_proj", prefix),
+        )
+        self.act_fn = SiluAndMul(inplace=True)
+        self.down_proj = build_down_linear(
+            intermediate_size,
+            config.hidden_size,
+            bias=False,
+            dtype=dtype,
+            device=device,
+            quant_config=quantization_config,
+            is_tp=True,
+            # Keep the framework reduction enabled.  In DP+TP mode this is a
+            # reduce-scatter that restores each DP rank's local token layout;
+            # replacing it with a plain all-reduce leaves gathered tokens in
+            # the output and breaks the residual shape in the next layer.
+            all_reduce=True,
+            prefix=add_prefix("down_proj", prefix),
+        )
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        """Apply down_proj(silu(gate_proj(x)) * up_proj(x))."""
+        gate_up = self.gate_up_proj(hidden_states)
+        return self.down_proj(self.act_fn(gate_up))
+
+
+class MiMoV2MoE(DeepseekV2MoE):
+    """MiMo-V2 MoE using LMDeploy's fused DeepSeek-style execution path."""
+
+    def forward(self, hidden_states: torch.Tensor, all_routed_experts: torch.Tensor = None):
+        """Run fused experts and reduce their BF16 output over MiMo TP."""
+        batch_size, sequence_length, hidden_dim = hidden_states.shape
+        hidden_states = hidden_states.view(-1, hidden_dim)
+        routed_experts = None
+        if all_routed_experts is not None:
+            routed_experts = all_routed_experts[:, self.layer_idx, :]
+        topk_weights, topk_ids = self.gate(hidden_states, routed_experts=routed_experts)
+
+        out_states = self.experts(hidden_states, topk_weights, topk_ids)
+        if self.shared_experts is not None:
+            out_states += self.shared_experts(hidden_states)
+        out_states = out_states.reshape(batch_size, sequence_length, -1)
+
+        if self._all_reduce:
+            out_states = _all_reduce_mimo(out_states, group=self.experts.tp_group)
+        return out_states
+
+
+class MiMoV2DecoderLayer(nn.Module):
+    """MiMo-V2 decoder layer with per-layer attention and FFN selection."""
+
+    def __init__(
+        self,
+        config: Any,
+        layer_idx: int,
+        dtype: torch.dtype | None = None,
+        device: torch.device | None = None,
+        prefix: str = "",
+    ):
+        super().__init__()
+        self.layer_idx = layer_idx
+        self.is_swa = config.hybrid_layer_pattern[layer_idx] == 1
+        self.is_moe = getattr(config, "n_routed_experts", None) is not None and bool(config.moe_layer_freq[layer_idx])
+        quantization_config = getattr(config, "quantization_config", None)
+
+        attention_cls = MiMoV2SWAAttention if self.is_swa else MiMoV2FullAttention
+        self.self_attn = attention_cls(
+            config,
+            dtype=dtype,
+            device=device,
+            prefix=add_prefix("self_attn", prefix),
+        )
+        if self.is_moe:
+            self.mlp = MiMoV2MoE(config, layer_idx, dtype=dtype, device=device)
+        else:
+            self.mlp = MiMoV2MLP(
+                config,
+                dtype=dtype,
+                device=device,
+                prefix=add_prefix("mlp", prefix),
+            )
+
+        norm_eps = _get_norm_eps(config)
+        self.input_layernorm = RMSNorm(
+            config.hidden_size,
+            norm_eps,
+            quant_config=quantization_config,
+            dtype=dtype,
+            device=device,
+            prefix=add_prefix("input_layernorm", prefix),
+        )
+        self.post_attention_layernorm = RMSNorm(
+            config.hidden_size,
+            norm_eps,
+            quant_config=quantization_config,
+            dtype=dtype,
+            device=device,
+            prefix=add_prefix("post_attention_layernorm", prefix),
+        )
+
+        cache_prefix = "mimo_swa_ring" if self.is_swa else "mimo_full"
+        self.k_cache_name = f"{cache_prefix}_k"
+        self.v_cache_name = f"{cache_prefix}_v"
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        rotary_pos_emb: tuple[torch.Tensor, torch.Tensor],
+        caches: MiMoV2Caches,
+        residual: torch.Tensor | None = None,
+        attn_metadata: Any = None,
+        swa_metadata: MiMoSWAAttentionMetadata | None = None,
+        all_routed_experts: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Run pre-norm attention and FFN while carrying fused residual."""
+        if residual is None:
+            residual = hidden_states
+            hidden_states = self.input_layernorm(hidden_states)
+        else:
+            hidden_states, residual = self.input_layernorm(hidden_states, residual)
+
+        if self.is_swa:
+            if swa_metadata is None:
+                raise RuntimeError("MiMo SWA layer requires state-ring attention metadata.")
+            state_cache = (
+                caches.state_cache(self.k_cache_name, self.layer_idx),
+                caches.state_cache(self.v_cache_name, self.layer_idx),
+            )
+            hidden_states = self.self_attn(
+                hidden_states=hidden_states,
+                rotary_pos_emb=rotary_pos_emb,
+                state_cache=state_cache,
+                swa_metadata=swa_metadata,
+            )
+        else:
+            past_key_value = (
+                caches.block_cache(self.k_cache_name, self.layer_idx),
+                caches.block_cache(self.v_cache_name, self.layer_idx),
+            )
+            hidden_states = self.self_attn(
+                hidden_states=hidden_states,
+                rotary_pos_emb=rotary_pos_emb,
+                past_key_value=past_key_value,
+                attn_metadata=attn_metadata,
+            )
+
+        hidden_states, residual = self.post_attention_layernorm(hidden_states, residual)
+        if self.is_moe:
+            hidden_states = self.mlp(hidden_states, all_routed_experts=all_routed_experts)
+        else:
+            hidden_states = self.mlp(hidden_states)
+        return hidden_states, residual
+
+
+class MiMoV2Model(nn.Module):
+    """MiMo-V2 transformer body using heterogeneous named block caches."""
+
+    def __init__(
+        self,
+        config: Any,
+        dtype: torch.dtype | None = None,
+        device: torch.device | None = None,
+        prefix: str = "",
+    ):
+        super().__init__()
+        self.config = config
+        self.padding_idx = getattr(config, "pad_token_id", None)
+        self.vocab_size = config.vocab_size
+
+        if len(config.hybrid_layer_pattern) != config.num_hidden_layers:
+            raise ValueError("MiMo-V2 hybrid_layer_pattern must contain one entry per decoder layer.")
+        if len(config.moe_layer_freq) != config.num_hidden_layers:
+            raise ValueError("MiMo-V2 moe_layer_freq must contain one entry per decoder layer.")
+
+        self.embed_tokens = build_embedding(
+            config.vocab_size,
+            config.hidden_size,
+            self.padding_idx,
+            dtype=dtype,
+            device=device,
+            is_tp=True,
+        )
+
+        if get_dist_manager().current_context().dist_config.enable_eplb:
+            ep_size, _ = get_ep_world_rank()
+            EPLBManager.init_global_eplb_metadata(
+                ep_size=ep_size,
+                num_routed_experts=config.n_routed_experts,
+                num_hidden_layers=config.num_hidden_layers,
+            )
+
+        self.layers = nn.ModuleList(
+            [
+                MiMoV2DecoderLayer(
+                    config,
+                    layer_idx,
+                    dtype=dtype,
+                    device=device,
+                    prefix=add_prefix(f"layers.{layer_idx}", prefix),
+                )
+                for layer_idx in range(config.num_hidden_layers)
+            ]
+        )
+        norm_eps = _get_norm_eps(config)
+        self.norm = RMSNorm(
+            config.hidden_size,
+            norm_eps,
+            dtype=dtype,
+            device=device,
+            prefix=add_prefix("norm", prefix),
+        )
+
+        rotary_kwargs = dict(
+            max_position_embeddings=config.max_position_embeddings,
+            partial_rotary_factor=config.partial_rotary_factor,
+            device=device,
+        )
+        self.rotary_emb = build_rotary_embedding(
+            dim=config.head_dim,
+            base=config.rope_theta,
+            **rotary_kwargs,
+        )
+        self.swa_rotary_emb = build_rotary_embedding(
+            dim=config.swa_head_dim,
+            base=config.swa_rope_theta,
+            **rotary_kwargs,
+        )
+
+    def forward(
+        self,
+        input_ids: torch.LongTensor | None,
+        position_ids: torch.LongTensor,
+        caches: MiMoV2Caches,
+        attn_metadata: Any = None,
+        swa_metadata: MiMoSWAAttentionMetadata | None = None,
+        inputs_embeds: torch.Tensor | None = None,
+        all_routed_experts: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        """Run all decoder layers with layer-appropriate RoPE and caches."""
+        if inputs_embeds is None:
+            inputs_embeds = self.embed_tokens(input_ids)
+        hidden_states = inputs_embeds
+
+        full_cos, full_sin = self.rotary_emb(hidden_states, position_ids)
+        swa_cos, swa_sin = self.swa_rotary_emb(hidden_states, position_ids)
+        full_rotary_pos_emb = (full_cos[0], full_sin[0])
+        swa_rotary_pos_emb = (swa_cos[0], swa_sin[0])
+
+        residual = None
+        for decoder_layer in self.layers:
+            rotary_pos_emb = swa_rotary_pos_emb if decoder_layer.is_swa else full_rotary_pos_emb
+            hidden_states, residual = decoder_layer(
+                hidden_states,
+                rotary_pos_emb=rotary_pos_emb,
+                caches=caches,
+                residual=residual,
+                attn_metadata=attn_metadata,
+                swa_metadata=swa_metadata,
+                all_routed_experts=all_routed_experts,
+            )
+        hidden_states, _ = self.norm(hidden_states, residual)
+        return hidden_states
+
+    def get_input_embeddings(self):
+        """Return the token embedding module."""
+        return self.embed_tokens
+
+
+class MiMoV2FlashForCausalLM(nn.Module, DeployModelMixinV1, CudaGraphMixin):
+    """MiMo-V2-Flash causal LM with named caches and FP8 checkpoint loading."""
+
+    packed_modules_mapping = {
+        "qkv_proj": ["q_proj", "k_proj", "v_proj"],
+        "gate_up_proj": ["gate_proj", "up_proj"],
+    }
+
+    def support_cuda_graph(
+        self,
+        input_ids: torch.Tensor,
+        position_ids: torch.Tensor,
+        past_key_values: list[list[torch.Tensor]],
+        attn_metadata: Any = None,
+        inputs_embeds: torch.Tensor | None = None,
+        **kwargs,
+    ) -> bool:
+        """Return whether the target-only invocation supports CUDA Graph."""
+        return super().support_cuda_graph(
+            input_ids,
+            position_ids,
+            past_key_values,
+            attn_metadata=attn_metadata,
+            inputs_embeds=inputs_embeds,
+            **kwargs,
+        )
+
+    def __init__(
+        self,
+        config: Any,
+        ctx_mgr: StepContextManager,
+        dtype: torch.dtype | None = None,
+        device: torch.device | None = None,
+        prefix: str = "",
+    ):
+        super().__init__()
+        self.config = config
+        self.ctx_mgr = ctx_mgr
+        self.model = MiMoV2Model(
+            config,
+            dtype=dtype,
+            device=device,
+            prefix=add_prefix("model", prefix),
+        )
+        self.lm_head = self.build_lm_head(
+            config.hidden_size,
+            config.vocab_size,
+            bias=False,
+            dtype=dtype,
+            device=device,
+        )
+        self.enable_return_routed_experts = get_build_model_context().enable_return_routed_experts
+        self._load_buffers: dict[str, dict[str, torch.Tensor]] = {}
+        self._first_swa_layer = next(
+            (layer_id for layer_id, layer_type in enumerate(config.hybrid_layer_pattern) if layer_type == 1),
+            None,
+        )
+        if self._first_swa_layer is None:
+            raise ValueError("MiMo-V2 requires at least one SWA layer.")
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        position_ids: torch.Tensor,
+        past_key_values: list[list[torch.Tensor]] | None = None,
+        attn_metadata: Any = None,
+        inputs_embeds: torch.Tensor | None = None,
+        state_ids: torch.Tensor | None = None,
+        **kwargs,
+    ):
+        """Resolve named caches once, then execute the transformer body."""
+        context = self.ctx_mgr.current_context()
+        if context.block_caches is None:
+            raise RuntimeError("MiMo-V2 requires named block caches in the current StepContext.")
+        if context.named_state_caches is None:
+            raise RuntimeError("MiMo-V2 requires named SWA state caches in the current StepContext.")
+        if state_ids is None:
+            raise RuntimeError("MiMo-V2 requires state_ids to provide stable SWA ring slots.")
+        caches = MiMoV2Caches(
+            block_caches=context.block_caches,
+            state_caches=context.named_state_caches,
+        )
+        swa_metadata = None
+        first_swa_ring = context.named_state_caches.layer("mimo_swa_ring_k", self._first_swa_layer)
+        swa_metadata = MiMoSWAAttentionMetadata.from_step_context(
+            attn_metadata,
+            context,
+            state_ids,
+            num_state_slots=first_swa_ring.size(0),
+            window_size=first_swa_ring.size(1),
+        )
+
+        all_routed_experts = None
+        if self.enable_return_routed_experts:
+            num_tokens = inputs_embeds.size(1) if inputs_embeds is not None else input_ids.size(1)
+            all_routed_experts = position_ids.new_full(
+                (num_tokens, self.config.num_hidden_layers, self.config.num_experts_per_tok),
+                torch.iinfo(torch.uint16).max,
+                dtype=torch.uint16,
+            )
+
+        hidden_states = self.model(
+            input_ids=input_ids,
+            position_ids=position_ids,
+            caches=caches,
+            attn_metadata=attn_metadata,
+            inputs_embeds=inputs_embeds,
+            swa_metadata=swa_metadata,
+            all_routed_experts=all_routed_experts,
+        )
+        if all_routed_experts is None:
+            return hidden_states
+        return dict(hidden_states=hidden_states, all_routed_experts=all_routed_experts)
+
+    def get_input_embeddings(self):
+        """Return the model token embedding module."""
+        return self.model.get_input_embeddings()
+
+    def prepare_inputs_for_generation(
+        self,
+        past_key_values: list[list[torch.Tensor]],
+        inputs_embeds: torch.Tensor | None = None,
+        context: StepContext | None = None,
+    ):
+        """Prepare the standard engine inputs; named caches live on context."""
+        return dict(
+            input_ids=context.input_ids,
+            position_ids=context.position_ids,
+            past_key_values=past_key_values,
+            attn_metadata=context.attn_metadata,
+            inputs_embeds=inputs_embeds,
+            state_ids=context.state_offsets,
+        )
+
+    def _load_qkv_weight(
+        self,
+        name: str,
+        loaded_weight: torch.Tensor,
+        params_dict: dict[str, nn.Parameter],
+        shard_id: str,
+    ):
+        """Pair FP8 Q/K/V weights with scales, dequantize, then TP-shard."""
+        if name.endswith(".weight_scale_inv"):
+            source_prefix = name.removesuffix(".weight_scale_inv")
+            tensor_kind = "scale"
+        elif name.endswith(".weight"):
+            source_prefix = name.removesuffix(".weight")
+            tensor_kind = "weight"
+        else:
+            raise KeyError(f"Unexpected MiMo QKV tensor name: {name}")
+
+        target_prefix = re.sub(r"\.(q|k|v)_proj$", ".qkv_proj", source_prefix)
+        target_param = params_dict[f"{target_prefix}.weight"]
+        if tensor_kind == "weight" and loaded_weight.dtype not in (torch.float8_e4m3fn, torch.float8_e5m2):
+            load_weight(target_param, loaded_weight, shard_id=shard_id)
+            return
+
+        buffer = self._load_buffers.setdefault(source_prefix, {})
+        buffer[tensor_kind] = loaded_weight
+        if "weight" not in buffer or "scale" not in buffer:
+            return
+
+        weight = _dequantize_blocked_fp8(buffer["weight"], buffer["scale"], target_param.dtype)
+        load_weight(target_param, weight, shard_id=shard_id)
+        self._load_buffers.pop(source_prefix)
+
+    @staticmethod
+    def _load_expert_weight(name: str, loaded_weight: torch.Tensor, params_dict: dict[str, nn.Parameter]):
+        """Map one checkpoint expert tensor to the fused MoE parameter."""
+        match = re.match(
+            r"^(.*\.experts)\.(\d+)\.(gate_proj|up_proj|down_proj)\.(weight|weight_scale_inv)$",
+            name,
+        )
+        if match is None:
+            raise KeyError(f"Unexpected MiMo expert tensor name: {name}")
+        experts_prefix, expert_id, projection, suffix = match.groups()
+        if projection == "gate_proj":
+            target_projection, shard_id = "gate_up", "gate"
+        elif projection == "up_proj":
+            target_projection, shard_id = "gate_up", "up"
+        else:
+            target_projection, shard_id = "down", "down"
+        param = params_dict[f"{experts_prefix}.{target_projection}.{suffix}"]
+        load_weight(param, loaded_weight, expert_id=int(expert_id), shard_id=shard_id)
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]):
+        """Load MiMo-V2-Flash target-model weights."""
+        stacked_params_mapping = [
+            (".qkv_proj", ".q_proj", "q"),
+            (".qkv_proj", ".k_proj", "k"),
+            (".qkv_proj", ".v_proj", "v"),
+            (".gate_up_proj", ".gate_proj", 0),
+            (".gate_up_proj", ".up_proj", 1),
+        ]
+        params_dict = dict(self.named_parameters())
+        for name, loaded_weight in weights:
+            if name.startswith("model.mtp."):
+                # The target model does not consume the optional draft block.
+                continue
+            if "rotary_emb.inv_freq" in name or "rotary_emb.cos_cached" in name or "rotary_emb.sin_cached" in name:
+                continue
+            if self.config.tie_word_embeddings and name == "lm_head.weight":
+                continue
+            if ".experts." in name:
+                self._load_expert_weight(name, loaded_weight, params_dict)
+                continue
+
+            for param_name, weight_name, shard_id in stacked_params_mapping:
+                if weight_name not in name:
+                    continue
+                if weight_name in (".q_proj", ".k_proj", ".v_proj"):
+                    self._load_qkv_weight(name, loaded_weight, params_dict, shard_id)
+                else:
+                    target_name = name.replace(weight_name, param_name)
+                    load_weight(params_dict[target_name], loaded_weight, shard_id=shard_id)
+                break
+            else:
+                try:
+                    param = params_dict[name]
+                except KeyError as error:
+                    raise KeyError(f"Unexpected MiMo-V2-Flash weight: {name}") from error
+                load_weight(param, loaded_weight)
+
+    def update_weights(self):
+        """Reject incomplete FP8 pairs before finalizing tied weights."""
+        if self._load_buffers:
+            pending = ", ".join(sorted(self._load_buffers))
+            raise RuntimeError(f"Incomplete MiMo FP8 QKV weight/scale pairs: {pending}")
+        super().update_weights()

--- a/lmdeploy/pytorch/models/module_map.py
+++ b/lmdeploy/pytorch/models/module_map.py
@@ -120,6 +120,11 @@ MODULE_MAP.update({'DeepseekV32ForCausalLM': f'{LMDEPLOY_PYTORCH_MODEL_PATH}.dee
 # deepseek-v4
 MODULE_MAP.update({'DeepseekV4ForCausalLM': f'{LMDEPLOY_PYTORCH_MODEL_PATH}.deepseek_v4.DeepseekV4ForCausalLM'})
 
+# mimo-v2-flash
+MODULE_MAP.update({
+    'MiMoV2FlashForCausalLM': f'{LMDEPLOY_PYTORCH_MODEL_PATH}.mimo_v2_flash.MiMoV2FlashForCausalLM',
+})
+
 # deepseek-vl2
 MODULE_MAP.update({'DeepseekVLV2ForCausalLM': f'{LMDEPLOY_PYTORCH_MODEL_PATH}.deepseek_vl2.DeepseekVLV2ForCausalLM'})
 

--- a/tests/pytorch/kernel/test_fa3_attention.py
+++ b/tests/pytorch/kernel/test_fa3_attention.py
@@ -2,11 +2,47 @@
 import torch
 
 from lmdeploy.messages import QuantPolicy
+from lmdeploy.pytorch.backends.cuda.attention import _fa3_build_supports_head_dims
 from lmdeploy.pytorch.backends.cuda.attention.default import TritonAttentionMetadata
 from lmdeploy.pytorch.backends.cuda.attention.fa3 import FA3Impl
 
 _BLOCK_SIZE = 16
 _PREFILL_SEQLENS = (29, 18)
+
+
+def test_fa3_build_capability_requires_mimo_asymmetric_instantiation(monkeypatch):
+    """MiMo Full FA3 requires both the 192 and 192/128 templates."""
+    import flash_attn_config
+
+    flags = {
+        'FLASHATTENTION_DISABLE_HDIM192': False,
+        'FLASH_ATTENTION_DISABLE_HDIMDIFF192': False,
+    }
+    monkeypatch.setattr(flash_attn_config, 'CONFIG', {'build_flags': flags})
+    assert _fa3_build_supports_head_dims(192, 128)
+
+    flags['FLASH_ATTENTION_DISABLE_HDIMDIFF192'] = True
+    assert not _fa3_build_supports_head_dims(192, 128)
+
+    flags['FLASH_ATTENTION_DISABLE_HDIMDIFF192'] = False
+    flags['FLASHATTENTION_DISABLE_HDIM192'] = True
+    assert not _fa3_build_supports_head_dims(192, 128)
+
+
+def test_fa3_uses_zero_as_disabled_softcap_sentinel(monkeypatch):
+    """FA3 must not inherit Triton's negative disabled-softcap sentinel."""
+    monkeypatch.setattr(
+        'lmdeploy.pytorch.third_party.flash_attn_interface.flash_attn_varlen_func',
+        lambda *args, **kwargs: None,
+    )
+    monkeypatch.setattr(
+        'lmdeploy.pytorch.third_party.flash_attn_interface.flash_attn_with_kvcache',
+        lambda *args, **kwargs: None,
+    )
+
+    impl = FA3Impl(8, 192, num_kv_heads=2, v_head_size=128, logit_softcapping=0.0)
+
+    assert impl.logit_softcapping == 0.0
 
 
 def _make_prefill_metadata(q_seqlens, block_offsets):

--- a/tests/pytorch/kernel/test_flash_attention.py
+++ b/tests/pytorch/kernel/test_flash_attention.py
@@ -146,6 +146,57 @@ def _naive_window_attention(q, k, v, seqlens_q, seqlens_k, window_size):
     return output
 
 
+@pytest.mark.parametrize(
+    ('head_dim_k', 'head_dim_v'),
+    [
+        (64, 64),
+        (80, 80),
+        (96, 96),
+        (128, 128),
+        (160, 160),
+        (192, 128),
+        (256, 256),
+    ],
+)
+def test_flash_attention_head_dimension_resource_metadata(head_dim_k, head_dim_v):
+    """Run standard and split-D heads against an independent reference."""
+    from lmdeploy.pytorch.kernels.cuda.flashattention import flash_attn_varlen_func
+
+    torch.manual_seed(123)
+    dtype = torch.float16
+    device = 'cuda'
+    num_heads_q = 4
+    num_heads_kv = 2
+    q_seqlens = torch.tensor([7, 11], dtype=torch.int32, device=device)
+    history_lens = torch.tensor([5, 3], dtype=torch.int32, device=device)
+    kv_seqlens = q_seqlens + history_lens
+
+    q = torch.rand(2, 11, num_heads_q, head_dim_k, dtype=dtype, device=device)
+    k = torch.rand(2, 14, num_heads_kv, head_dim_k, dtype=dtype, device=device)
+    v = torch.rand(2, 14, num_heads_kv, head_dim_v, dtype=dtype, device=device)
+    bias = _make_bias(q_seqlens, history_lens, -1e30, causal=True)
+    expected = _conti_input(_naive_attention(q, (k, v), bias), q_seqlens)
+
+    packed_q = _conti_input(q, q_seqlens)
+    packed_k = _conti_input(k, kv_seqlens).transpose(0, 1).contiguous()
+    packed_v = _conti_input(v, kv_seqlens).transpose(0, 1).contiguous()
+    cu_seqlens_q = torch.nn.functional.pad(q_seqlens.cumsum(0), (1, 0))
+    cu_seqlens_k = torch.nn.functional.pad(kv_seqlens.cumsum(0), (1, 0))
+
+    actual = flash_attn_varlen_func(
+        packed_q,
+        packed_k,
+        packed_v,
+        cu_seqlens_q=cu_seqlens_q,
+        cu_seqlens_k=cu_seqlens_k,
+        max_seqlen_q=int(q_seqlens.max().item()),
+        max_seqlen_k=int(kv_seqlens.max().item()),
+        causal=True,
+    )
+
+    torch.testing.assert_close(actual, expected, atol=2e-3, rtol=2e-3)
+
+
 class TestFlashAttention:
 
     @pytest.fixture

--- a/tests/pytorch/test_mimo_v2_flash.py
+++ b/tests/pytorch/test_mimo_v2_flash.py
@@ -1,0 +1,197 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+import torch
+from torch import nn
+
+from lmdeploy.pytorch.backends.mimo_swa import MiMoSWAAttentionMetadata
+from lmdeploy.pytorch.configurations.mimo_v2_flash import MiMoV2FlashModelConfigBuilder
+from lmdeploy.pytorch.models.mimo_v2_flash import (
+    MiMoV2Attention,
+    MiMoV2MLP,
+    _all_reduce_mimo,
+    _dequantize_blocked_fp8,
+    _reduce_tp_output,
+)
+
+
+def _make_mimo_hf_config():
+    """Build a minimal target-model config with the official layer pattern."""
+    full_layers = {0, 5, 11, 17, 23, 29, 35, 41, 47}
+    pattern = [0 if layer_id in full_layers else 1 for layer_id in range(48)]
+    return SimpleNamespace(
+        model_type='mimo_v2_flash',
+        architectures=['MiMoV2FlashForCausalLM'],
+        hidden_size=4096,
+        num_hidden_layers=48,
+        hybrid_layer_pattern=pattern,
+        num_attention_heads=64,
+        num_key_value_heads=8,
+        head_dim=192,
+        v_head_dim=128,
+        swa_num_attention_heads=64,
+        swa_num_key_value_heads=8,
+        swa_head_dim=192,
+        swa_v_head_dim=128,
+        sliding_window=128,
+        sliding_window_size=128,
+        vocab_size=152576,
+        bos_token_id=151643,
+        eos_token_id=151643,
+        routed_scaling_factor=None,
+    )
+
+
+@pytest.mark.parametrize(('is_swa', 'expected'), [(False, True), (True, False)])
+def test_mimo_enables_fa3_only_for_full_attention(is_swa, expected):
+    """Full Attention may select FA3 while SWA keeps its custom path."""
+    config = _make_mimo_hf_config()
+    config.partial_rotary_factor = 0.5
+    config.attention_bias = False
+    config.quantization_config = None
+    captured = {}
+
+    def fake_attention(*args, **kwargs):
+        captured.update(kwargs)
+        return nn.Identity()
+
+    with patch('lmdeploy.pytorch.models.mimo_v2_flash.build_qkv_proj',
+               return_value=nn.Identity()), patch(
+                   'lmdeploy.pytorch.models.mimo_v2_flash.build_o_proj',
+                   return_value=nn.Identity()), patch(
+                       'lmdeploy.pytorch.models.mimo_v2_flash.Attention',
+                       side_effect=fake_attention):
+        MiMoV2Attention(config, is_swa=is_swa)
+
+    assert captured['enable_fa3'] is expected
+
+
+def test_mimo_target_uses_full_blocks_and_sequence_state_ring():
+    """Target inference uses paged Full KV and fixed-size SWA state caches."""
+    hf_config = _make_mimo_hf_config()
+    config = MiMoV2FlashModelConfigBuilder.build(hf_config, tp=4)
+    config.hf_config = hf_config
+    config.post_build_func(config, 64)
+
+    assert config.model_paradigm == 'ar'
+    assert [spec.name for spec in config.block_cache_specs] == ['mimo_full_k', 'mimo_full_v']
+    assert [spec.name for spec in config.state_cache_specs] == ['mimo_swa_ring_k', 'mimo_swa_ring_v']
+    assert all(len(spec.layer_ids) == 39 for spec in config.state_cache_specs)
+    assert config.state_cache_specs[0].shape == (128, 2, 192)
+    assert config.state_cache_specs[1].shape == (128, 2, 128)
+
+
+@pytest.mark.parametrize(('is_draft_model', 'spec_method'), [(True, None), (False, 'mimo_mtp')])
+def test_mimo_target_pr_rejects_speculative_modes(is_draft_model, spec_method):
+    """Keep speculative decoding outside the target-only integration."""
+    with pytest.raises(ValueError, match='not available yet'):
+        MiMoV2FlashModelConfigBuilder.build(
+            _make_mimo_hf_config(),
+            tp=4,
+            is_draft_model=is_draft_model,
+            spec_method=spec_method,
+        )
+
+
+def test_mimo_swa_metadata_enforces_total_window_and_sequence_slots():
+    """SWA metadata retains 127 history tokens plus each current token."""
+    metadata = SimpleNamespace(
+        q_seqlens=torch.tensor([2, 1]),
+        kv_seqlens=torch.tensor([130, 1]),
+        max_q_seqlen=2,
+    )
+    context = SimpleNamespace(input_ids=torch.zeros((1, 3), dtype=torch.long), max_q_seqlen=2)
+
+    result = MiMoSWAAttentionMetadata.from_step_context(
+        metadata,
+        context,
+        state_slots=torch.tensor([3, -1]),
+        num_state_slots=4,
+        window_size=128,
+    )
+
+    assert result.start_positions.tolist() == [128, 0]
+    assert result.history_lens.tolist() == [127, 0]
+    assert result.kv_seqlens.tolist() == [129, 1]
+    assert result.cu_q_seqlens.tolist() == [0, 2, 3]
+    assert result.cu_kv_seqlens.tolist() == [0, 129, 130]
+    assert result.max_kv_seqlen == 129
+
+
+def test_mimo_blocked_fp8_dequantization_uses_serialized_scale_grid():
+    """Blocked FP8 fallback derives tiles from serialized scale shapes."""
+    weight = torch.ones((4, 4))
+    scale = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
+
+    result = _dequantize_blocked_fp8(weight, scale, torch.float32)
+
+    assert torch.equal(
+        result,
+        torch.tensor([
+            [1.0, 1.0, 2.0, 2.0],
+            [1.0, 1.0, 2.0, 2.0],
+            [3.0, 3.0, 4.0, 4.0],
+            [3.0, 3.0, 4.0, 4.0],
+        ]),
+    )
+
+
+def test_mimo_blocked_fp8_dequantization_rejects_misaligned_scale_grid():
+    """Reject scale grids that cannot tile the serialized weight."""
+    with pytest.raises(ValueError, match='Invalid blocked-FP8'):
+        _dequantize_blocked_fp8(torch.ones((5, 4)), torch.ones((2, 2)), torch.float32)
+
+
+def test_mimo_dense_mlp_keeps_framework_dp_tp_reduction():
+    """Dense down projection must keep framework DP+TP reduction semantics."""
+    config = SimpleNamespace(hidden_size=8, intermediate_size=16, quantization_config=None)
+    captured = {}
+    gate_up = nn.Identity()
+    down = nn.Identity()
+
+    def fake_down(*args, **kwargs):
+        captured.update(kwargs)
+        return down
+
+    with patch('lmdeploy.pytorch.models.mimo_v2_flash.build_gateup_linear',
+               return_value=gate_up), patch(
+                   'lmdeploy.pytorch.models.mimo_v2_flash.build_down_linear',
+                   side_effect=fake_down), patch(
+                       'lmdeploy.pytorch.models.mimo_v2_flash.SiluAndMul',
+                       return_value=nn.Identity()):
+        mlp = MiMoV2MLP(config)
+
+    value = torch.randn(2, 3, 8)
+    assert captured['all_reduce'] is True
+    assert mlp(value) is value
+
+
+def test_mimo_tp_reduce_helper_skips_tp1():
+    """A row-parallel output must skip the collective at TP=1."""
+    linear = SimpleNamespace(tp=1)
+    output = torch.randn(2, 3)
+    with patch('lmdeploy.pytorch.models.mimo_v2_flash._all_reduce_mimo') as reduce_mock:
+        assert _reduce_tp_output(linear, output) is output
+    reduce_mock.assert_not_called()
+
+
+def test_mimo_tp_reduce_helper_uses_explicit_group():
+    """A row-parallel output must reduce over its own TP group."""
+    group = object()
+    linear = SimpleNamespace(tp=4, tp_group=group)
+    output = torch.randn(2, 3)
+    with patch('lmdeploy.pytorch.models.mimo_v2_flash._all_reduce_mimo',
+               return_value=output) as reduce_mock:
+        assert _reduce_tp_output(linear, output) is output
+    reduce_mock.assert_called_once_with(output, group=group)
+
+
+def test_mimo_all_reduce_uses_requested_group():
+    """MiMo collectives must not silently fall back to a global group."""
+    group = object()
+    output = torch.randn(2, 3)
+    with patch('lmdeploy.pytorch.models.mimo_v2_flash.dist.all_reduce') as all_reduce:
+        assert _all_reduce_mimo(output, group=group) is output
+    all_reduce.assert_called_once_with(output, group=group)


### PR DESCRIPTION
## Motivation

Add target-model inference support for XiaomiMiMo/MiMo-V2-Flash. The model combines full attention and fixed-window sliding-window attention (SWA), asymmetric Q/K and V head dimensions, attention sinks, partial RoPE, blocked-FP8 checkpoint weights, and MoE layers. These contracts are not represented by an existing LMDeploy model implementation.

This first PR intentionally covers target-only autoregressive inference. Native MTP/speculative decoding will be submitted separately so that its draft-cache and CUDA Graph lifecycle can be reviewed independently.

## Modification

- Register `MiMoV2FlashForCausalLM` and add its model/configuration implementation.
- Implement the checkpoint's 48-layer hybrid full-attention/SWA pattern.
- Add named paged KV caches for full-attention layers and sequence-scoped 128-token state rings for SWA layers.
- Add Triton kernels that flatten chronological SWA history, update ring slots, and preserve prefix-cache semantics.
- Support partial RoPE, learnable attention sinks, asymmetric Q/K=192 and V=128 heads, dense/MoE layers, and TP KV-head replication.
- Load blocked-FP8 checkpoint tensors safely. QKV weights currently use a BF16 dequantization fallback because their head-aware TP partitions do not match LMDeploy's packed 128-row FP8 partition contract.
- Allow full attention to use FA3 only when the installed wheel exposes the required asymmetric 192/128 instantiation; otherwise fall back to the Triton implementation.
- Correct Triton flash-attention launch metadata for split, non-power-of-two Q/K head dimensions such as 192.

## BC-breaking

No backward-incompatible behavior is intended. The FA3 capability check preserves existing symmetric-head behavior and only avoids dispatching unsupported asymmetric instantiations.

## Use cases

```bash
lmdeploy serve api_server XiaomiMiMo/MiMo-V2-Flash \
  --backend pytorch \
  --trust-remote-code \
  --tp 4
```

TP4 and TP8 target-only configurations are supported. FA3 is optional and is selected only when the installed package was built with the required head-dimension templates.

## Scope and follow-ups

- Native three-layer MTP/speculative decoding is deliberately excluded from this PR.
- Native blocked-FP8 QKV GEMM is a performance follow-up; the current BF16 dequantization path preserves checkpoint semantics.
- No custom FA3 wheel is included. Unsupported builds safely use Triton.

## Validation

- MiMo target/config/cache/TP unit tests: `14 passed`
- MiMo target plus Triton split-head attention tests: `19 passed`
- Ruff checks passed for all modified Python files.
- `git diff --check` passed.

## Checklist

1. [x] Linting checks were run.
2. [x] Target-only behavior is covered by focused unit and CUDA kernel tests.
3. [x] Optional FA3 capability is detected at runtime and has a safe Triton fallback.
4. [x] New public modules, classes, and functions include docstrings.
