### PR TITLE
feat(metrics): expose prefix-cache eviction count as a Prometheus counter

### DIFF
--- a/lmdeploy/messages.py
+++ b/lmdeploy/messages.py
@@ -787,6 +787,7 @@ class ScheduleMetrics:
     cache_usage: float = 0.0
     prefix_cache_hit_rate: float = 0
     scheduler_tick: int = 0
+    num_evicted_blocks: int = 0
 
 
 @dataclass

--- a/lmdeploy/metrics/loggers.py
+++ b/lmdeploy/metrics/loggers.py
@@ -296,6 +296,16 @@ class PrometheusStatLogger(StatLoggerBase):
                 documentation='Total prefix-cached input tokens served.',
                 labelnames=labelnames).labels(*labelvalues)
 
+        self.counter_evicted_blocks_total = \
+            prometheus_client.Counter(
+                name='lmdeploy:evicted_blocks_total',
+                documentation='Total prefix-cache blocks evicted.',
+                labelnames=labelnames).labels(*labelvalues)
+        # schedule_metrics polls the cumulative eviction total, so track the
+        # last seen value and inc the counter only by the delta to avoid
+        # double-counting across polls.
+        self._last_num_evicted_blocks = 0
+
         self.histogram_iteration_tokens = \
             prometheus_client.Histogram(
                 name='lmdeploy:iteration_tokens_total',
@@ -385,6 +395,9 @@ class PrometheusStatLogger(StatLoggerBase):
         self.gauge_scheduler_waiting.set(stats.num_waiting_reqs)
         self.gauge_gpu_cache_usage.set(stats.gpu_cache_usage)
         self.gauge_prefix_cache_hit_rate.set(stats.prefix_cache_hit_rate)
+        delta = stats.num_evicted_blocks - self._last_num_evicted_blocks
+        self.counter_evicted_blocks_total.inc(delta)
+        self._last_num_evicted_blocks = stats.num_evicted_blocks
 
     def record_iteration(self, stats: IterationStats) -> None:
         """Report token-related metrics to prometheus."""

--- a/lmdeploy/metrics/stats.py
+++ b/lmdeploy/metrics/stats.py
@@ -54,6 +54,7 @@ class SchedulerStats:
     num_waiting_reqs: int = 0
     gpu_cache_usage: float = 0.0
     prefix_cache_hit_rate: float = 0.0
+    num_evicted_blocks: int = 0
 
     @property
     def num_failed_reqs(self) -> int:
@@ -85,6 +86,7 @@ class SchedulerStats:
                 f'  num_waiting_reqs={self.num_waiting_reqs},\n'
                 f'  gpu_cache_usage={self.gpu_cache_usage:.6f},\n'
                 f'  prefix_cache_hit_rate={self.prefix_cache_hit_rate:.6f},\n'
+                f'  num_evicted_blocks={self.num_evicted_blocks},\n'
                 ')')
 
     def update_from_schedule_metrics(self, scheduled_metrics: ScheduleMetrics):
@@ -92,6 +94,7 @@ class SchedulerStats:
         self.num_waiting_reqs = scheduled_metrics.waiting_seqs
         self.gpu_cache_usage = scheduled_metrics.cache_usage
         self.prefix_cache_hit_rate = scheduled_metrics.prefix_cache_hit_rate
+        self.num_evicted_blocks = scheduled_metrics.num_evicted_blocks
 
 
 class RequestStats:

--- a/lmdeploy/pytorch/paging/block_trie/trie.py
+++ b/lmdeploy/pytorch/paging/block_trie/trie.py
@@ -103,6 +103,10 @@ class PrefixCacheStats:
     """Prefix caching stats."""
     num_query_tokens: int = 0
     num_hit_tokens: int = 0
+    # Cumulative count of trie-owned blocks freed by eviction. Excluded from
+    # reset/snapshot/restore: evictions are real side effects, not tentative
+    # match state that can be rolled back.
+    num_evicted_blocks: int = 0
 
     def reset(self):
         self.num_query_tokens = 0
@@ -645,4 +649,5 @@ class BlockTrie:
         evicted = self._state_checkpoints.evict_frozen_checkpoints(max_num_blocks)
         if evicted < max_num_blocks:
             evicted += self._kv_lifecycle.evict(max_num_blocks - evicted)
+        self.stats.num_evicted_blocks += evicted
         return evicted

--- a/lmdeploy/pytorch/paging/scheduler.py
+++ b/lmdeploy/pytorch/paging/scheduler.py
@@ -1537,4 +1537,5 @@ class Scheduler:
             cache_usage=cache_usage,
             prefix_cache_hit_rate=self.block_trie.stats.hit_rate(),
             scheduler_tick=self.scheduler_tick,
+            num_evicted_blocks=self.block_trie.stats.num_evicted_blocks,
         )

--- a/tests/test_lmdeploy/test_metrics_loggers.py
+++ b/tests/test_lmdeploy/test_metrics_loggers.py
@@ -4,7 +4,12 @@ import pytest
 
 from lmdeploy.messages import EngineOutput, RequestMetrics, ResponseType
 from lmdeploy.metrics.loggers import PrometheusStatLogger
-from lmdeploy.metrics.stats import IterationStats, RequestStats, SpeculativeDecodingStats
+from lmdeploy.metrics.stats import (
+    IterationStats,
+    RequestStats,
+    SchedulerStats,
+    SpeculativeDecodingStats,
+)
 
 prometheus_client = pytest.importorskip('prometheus_client')
 
@@ -62,3 +67,15 @@ def test_zero_token_finish_records_request_reason():
     assert req_stats.decode_time_interval == 0
     assert iteration_stats.prompt_tokens == 4
     assert iteration_stats.ttft is None
+def test_evicted_blocks_counter_increments_by_delta():
+    """The eviction counter must track the cumulative eviction total by its
+    delta, not by re-adding the cumulative value on every poll."""
+    logger = PrometheusStatLogger('test-model', max_model_len=16, dp_rank=0)
+    labels = {'model_name': 'test-model', 'engine': '0'}
+
+    # schedule_metrics is polled with the cumulative eviction total; the
+    # counter must equal that total, not the sum of every polled value.
+    for cumulative in (0, 5, 12, 12):
+        stats = SchedulerStats(num_evicted_blocks=cumulative)
+        logger.record_schedule(stats)
+        assert _get_sample_value('lmdeploy:evicted_blocks_total', labels) == cumulative


### PR DESCRIPTION
## Motivation

Issue #1942 asked for prefix-cache hit/miss/**eviction** statistics to detect cache thrashing. PR #4670 landed the hit side (`lmdeploy:cached_tokens_total` / `lmdeploy:prompt_tokens_total`), but the eviction half was never implemented: `KVBlockLifecycle.evict` / `BlockTrie.evict` compute the real evicted-block count, yet the eviction-helper call sites discard it (returning only a `success` bool), so the count never reaches the metrics layer. Operators cannot write a thrashing alert on evictions today.

This adds `lmdeploy:evicted_blocks_total`, completing the eviction half of #1942.

A dedicated counter is preferred over deriving evictions from `gpu_cache_usage_perc` swings or the free-block delta: those conflate evictions with admission/usage changes and don't expose an eviction *rate*. A dedicated counter gives a direct, low-noise signal, e.g. `rate(lmdeploy:evicted_blocks_total[5m]) / rate(lmdeploy:cached_tokens_total[5m])`. PR #4670 established the dedicated-counter precedent for prefix-cache stats.

Refs #1942.

## Modification

Wires the eviction count through the **existing** stats bridge that `prefix_cache_hit_rate` already uses (the paging layer stays metrics-free — no `lmdeploy.metrics` import is added to paging):

- `block_trie/trie.py`: `BlockTrie.evict` accumulates `self.stats.num_evicted_blocks += evicted` (the real count is in hand there); field added to `PrefixCacheStats`.
- `messages.py`: `num_evicted_blocks` field on `ScheduleMetrics`.
- `paging/scheduler.py`: populated in `schedule_metrics` from `self.block_trie.stats.num_evicted_blocks` (mirrors the existing `prefix_cache_hit_rate` read).
- `metrics/stats.py`: `num_evicted_blocks` on `SchedulerStats` (+ copy in `update_from_schedule_metrics`, + `repr`).
- `metrics/loggers.py`: `lmdeploy:evicted_blocks_total` Counter (mirroring `cached_tokens_total`); `record_schedule` increments the **delta** vs `_last_num_evicted_blocks` (cumulative→counter idiom — `schedule_metrics` is polled ~every 10 s with the cumulative total, so a naive `.inc(cumulative)` would double-count).

`num_evicted_blocks` is deliberately excluded from `PrefixCacheStats.snapshot/restore`: evictions are an irreversible physical side-effect (freed blocks cannot be un-evicted), so evictions occurring during a subsequently-rolled-back admission attempt must be preserved rather than rolled back with the tentative match state.

No file-level overlap with the in-flight CacheEngine redesign (#4862): that PR touches the `cache_engine`/`backends`/`executor`/`spec_agent` layers and `block_trie/README.md`, but not `block_trie/trie.py`, `scheduler.py`, `messages.py`, `metrics/stats.py`, or `metrics/loggers.py`.

## BC-breaking

None. Both new fields (`PrefixCacheStats.num_evicted_blocks`, `SchedulerStats.num_evicted_blocks`) default to `0`; `ScheduleMetrics` consumers that omit the keyword argument are unaffected. The Turbomind backend constructs `ScheduleMetrics` without the field, so the counter simply stays `0` there (this change targets the PyTorch prefix-cache path).

## Use cases

```promql
# eviction rate
rate(lmdeploy:evicted_blocks_total[5m])
# thrashing ratio (evictions relative to cache hits)
rate(lmdeploy:evicted_blocks_total[5m]) / rate(lmdeploy:cached_tokens_total[5m])
```

## Checklist

1. `ruff check` passes on all changed files (line-length 120, repo config).
2. New `test_evicted_blocks_counter_increments_by_delta` (red on master — field absent → `TypeError`; green on branch — counter increments by delta across polled cumulative `0→5→12→12`, no double-count). Existing `tests/test_lmdeploy/test_metrics_loggers.py` and `tests/pytorch/paging/test_block_trie/` (94 tests) still pass.
3. No new downstream dependency.
4. Counter name documented inline; the broader metrics catalog can be documented separately.
