### PR TITLE
feat(pytorch): prototype TurboMind W4A16 backend for AWQ linear

### DIFF
--- a/lmdeploy/pytorch/backends/cuda/awq_modules.py
+++ b/lmdeploy/pytorch/backends/cuda/awq_modules.py
@@ -3,8 +3,48 @@
 import torch
 
 import lmdeploy.pytorch.distributed as dist
+from lmdeploy.pytorch import envs as _envs
+from lmdeploy.utils import get_logger
 
 from ..awq_modules import LinearW4A16Builder, LinearW4A16Impl
+
+logger = get_logger('lmdeploy')
+
+
+def _is_turbomind_gemm_capability_supported(capability: tuple[int, int]):
+    """Limit the prototype to the SM90 architecture validated end to end."""
+    return capability == (9, 0)
+
+
+def _turbomind_support_reason(in_features: int,
+                              out_features: int,
+                              w_bit: int,
+                              group_size: int,
+                              dtype: torch.dtype = None) -> str | None:
+    """Return why the bundled TurboMind provider cannot serve this layer."""
+    if w_bit != 4:
+        return f'w_bit must be 4, but got {w_bit}'
+    if group_size != 128:
+        return f'group_size must be 128, but got {group_size}'
+    if in_features % 128 != 0:
+        return f'K must be divisible by 128, but got {in_features}'
+    if out_features % 32 != 0:
+        return f'N must be divisible by 32, but got {out_features}'
+    if dtype not in (None, torch.float16):
+        return f'dtype must be float16, but got {dtype}'
+    if not torch.cuda.is_available():
+        return 'CUDA is unavailable'
+
+    capability = torch.cuda.get_device_capability()
+    if not _is_turbomind_gemm_capability_supported(capability):
+        return f'CUDA capability {capability} is unsupported'
+
+    from .turbomind_awq_modules import _load_turbomind
+    try:
+        _load_turbomind()
+    except RuntimeError as error:
+        return str(error)
+    return None
 
 
 def wq_gemm_forward(
@@ -75,4 +115,27 @@ class AwqLinearW4A16Builder(LinearW4A16Builder):
               bias: bool = False,
               dtype: torch.dtype = None):
         """build."""
-        return AwqLinearW4A16Impl(in_features, out_features, w_bit, group_size)
+        provider = _envs.w4a16_gemm_backend
+
+        if provider == 'auto':
+            reason = _turbomind_support_reason(in_features, out_features,
+                                               w_bit, group_size, dtype)
+            if reason is None:
+                from .turbomind_awq_modules import TurbomindAwqLinearW4A16Impl
+                impl_cls = TurbomindAwqLinearW4A16Impl
+            else:
+                impl_cls = AwqLinearW4A16Impl
+        elif provider == 'turbomind':
+            reason = _turbomind_support_reason(in_features, out_features,
+                                               w_bit, group_size, dtype)
+            if reason is not None:
+                raise RuntimeError(
+                    'TurboMind W4A16 linear was requested but is unavailable '
+                    f'or incompatible: {reason}.')
+            from .turbomind_awq_modules import TurbomindAwqLinearW4A16Impl
+            impl_cls = TurbomindAwqLinearW4A16Impl
+        else:
+            impl_cls = AwqLinearW4A16Impl
+
+        logger.debug('Build LinearW4A16 with %s.', impl_cls.__name__)
+        return impl_cls(in_features, out_features, w_bit, group_size)

--- a/lmdeploy/pytorch/backends/cuda/turbomind_awq_modules.py
+++ b/lmdeploy/pytorch/backends/cuda/turbomind_awq_modules.py
@@ -1,0 +1,319 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+"""Optional W4A16 backend backed by LMDeploy's bundled TurboMind.
+
+The backend owns an architecture-specific weight layout while preserving LMDeploy's canonical AWQ parameters.
+"""
+
+import functools
+import importlib
+import sys
+import weakref
+from dataclasses import dataclass
+from pathlib import Path
+from types import ModuleType
+
+import torch
+
+import lmdeploy
+import lmdeploy.pytorch.distributed as dist
+
+from ..awq_modules import LinearW4A16Impl
+from .awq_modules import _is_turbomind_gemm_capability_supported
+
+
+class _LinearRuntime:
+    """Share one existing LlamaLinear workspace per CUDA stream."""
+
+    def __init__(self, tm: ModuleType, device: torch.device,
+                 stream: torch.cuda.Stream):
+        self.device = device
+        self.stream = stream
+        self.context = tm.create_device_context(stream.cuda_stream)
+        with torch.cuda.device(device), self.context:
+            self.linear = tm.LlamaLinear()
+
+    def forward(self, tm: ModuleType, x, weight, out):
+        with torch.cuda.device(self.device), self.context:
+            self.linear.forward_dense(
+                tm.from_dlpack(x, stream=-1),
+                weight,
+                tm.from_dlpack(out, stream=-1),
+            )
+
+    def __del__(self):
+        linear, self.linear = getattr(self, 'linear', None), None
+        if linear is None:
+            return
+        try:
+            with torch.cuda.device(self.device), self.context:
+                del linear
+        except Exception:
+            pass
+
+
+_runtime_pool = weakref.WeakValueDictionary()
+
+
+def _get_runtime(tm: ModuleType, device: torch.device,
+                 stream: torch.cuda.Stream):
+    key = (device.index, stream.cuda_stream)
+    runtime = _runtime_pool.get(key)
+    if runtime is None:
+        if torch.cuda.is_current_stream_capturing():
+            raise RuntimeError('Run one eager TurboMind W4A16 forward on this '
+                               'CUDA stream before graph capture.')
+        runtime = _LinearRuntime(tm, device, stream)
+        _runtime_pool[key] = runtime
+    return runtime
+
+
+@dataclass
+class _PreparedLinear:
+    weight: object | None
+    context: object
+    stream: torch.cuda.Stream
+    runtimes: dict[int, _LinearRuntime]
+    device: torch.device
+
+    def close(self):
+        """Destroy Context-dependent objects under their original Context."""
+        if self.weight is None:
+            return
+        weight, self.weight = self.weight, None
+        with torch.cuda.device(self.device):
+            for runtime in self.runtimes.values():
+                if runtime.stream.cuda_stream != self.stream.cuda_stream:
+                    self.stream.wait_stream(runtime.stream)
+            self.runtimes.clear()
+            with torch.cuda.stream(self.stream), self.context:
+                del weight
+
+
+@functools.lru_cache(maxsize=1)
+def _load_turbomind() -> ModuleType:
+    """Load the _turbomind extension built and shipped by LMDeploy."""
+    lib_dir = (Path(lmdeploy.__file__).resolve().parent / 'lib').resolve()
+    lib_dir_str = str(lib_dir)
+    if lib_dir_str not in sys.path:
+        sys.path.insert(0, lib_dir_str)
+
+    try:
+        tm = importlib.import_module('_turbomind')
+    except (ImportError, OSError) as error:
+        raise RuntimeError(
+            'The TurboMind W4A16 backend requires LMDeploy\'s bundled '
+            '_turbomind extension. Rebuild/install LMDeploy with TurboMind '
+            f'enabled. Import error: {error}') from error
+
+    module_file = getattr(tm, '__file__', None)
+    if module_file is None or Path(module_file).resolve().parent != lib_dir:
+        raise RuntimeError(
+            'Loaded _turbomind is not LMDeploy\'s bundled extension: '
+            f'{module_file!r}. Expected it under {lib_dir}. Remove the '
+            'external turbomind package from this process and retry.')
+
+    return tm
+
+
+def _prepare_turbomind_linear(tm: ModuleType, in_features: int,
+                              out_features: int, group_size: int,
+                              qweight: torch.Tensor, scales: torch.Tensor,
+                              qzeros: torch.Tensor):
+    """Feed canonical AWQ weights to TurboMind's existing prepare path."""
+    # Keep this import lazy so provider discovery does not require loading the
+    # bundled TurboMind extension.
+    from lmdeploy.turbomind.weight_format import AWQFormat
+
+    weight_format = AWQFormat(block_in=group_size)
+    source_params = {
+        'weight': qweight,
+        'scales': scales,
+        'zeros': qzeros,
+    }
+    packed_params = {
+        kind: weight_format.pack(
+            weight_format.normalize(tensor.detach(), kind), kind)
+        for kind, tensor in source_params.items()
+    }
+    buffers = {
+        kind: packed.tensor.contiguous()
+        for kind, packed in packed_params.items()
+    }
+
+    stream = torch.cuda.current_stream(qweight.device)
+    stream_ptr = stream.cuda_stream
+    context = tm.create_device_context(stream_ptr)
+    with context:
+        config = tm.LinearConfig()
+        config.input_dim = in_features
+        config.output_dim = out_features
+        config.data_type = tm.DataType.TYPE_FP16
+        config.format = weight_format.make_data_format(config.data_type)
+        config.has_bias = False
+
+        weight = tm.LinearWeight(config)
+        for kind, packed in packed_params.items():
+            src = tm.from_dlpack(buffers[kind], stream=-1)
+            if packed.alloc_shape is not None:
+                src = src.reinterpret(packed.alloc_dtype, packed.alloc_shape)
+            weight.param(kind).set(src)
+        weight.prepare()
+
+    # Publish the private layout only after all normalization and prepare work
+    # on the loading stream has completed. Forward streams therefore need no
+    # weight-readiness event or cross-stream wait.
+    stream.synchronize()
+    return _PreparedLinear(weight=weight,
+                           context=context,
+                           stream=stream,
+                           runtimes={},
+                           device=qweight.device)
+
+
+class TurbomindAwqLinearW4A16Impl(LinearW4A16Impl):
+    """AWQ linear using LMDeploy's bundled TurboMind W4A16 operator."""
+
+    def __init__(self, in_features: int, out_features: int, w_bit: int,
+                 group_size: int):
+        self.in_features = in_features
+        self.out_features = out_features
+        self.w_bit = w_bit
+        self.group_size = group_size
+        self._prepared: _PreparedLinear | None = None
+
+    def _release_prepared(self):
+        prepared, self._prepared = self._prepared, None
+        if prepared is not None:
+            prepared.close()
+
+    def __del__(self):
+        try:
+            self._release_prepared()
+        except Exception:
+            # CUDA/Python may already be shutting down.
+            pass
+
+    def _validate_weights(self, qweight: torch.Tensor, scales: torch.Tensor,
+                          qzeros: torch.Tensor, bias: torch.Tensor | None):
+        if (self.w_bit != 4 or self.group_size != 128
+                or self.in_features % 128 != 0 or self.out_features % 32 != 0):
+            raise ValueError('The TurboMind prototype requires W4A16, group '
+                             'size 128, K divisible by 128, and N divisible '
+                             'by 32.')
+        if qweight.device.type != 'cuda':
+            raise ValueError('TurboMind weights must be CUDA tensors.')
+        capability = torch.cuda.get_device_capability(qweight.device)
+        if not _is_turbomind_gemm_capability_supported(capability):
+            raise RuntimeError(f'Unsupported CUDA capability: {capability}.')
+
+        expected = (
+            ('qweight', qweight, (self.in_features, self.out_features // 8),
+             torch.int32),
+            ('scales', scales, (self.in_features // 128, self.out_features),
+             torch.float16),
+            ('qzeros', qzeros, (self.in_features // 128,
+                                self.out_features // 8), torch.int32),
+        )
+        for name, tensor, shape, dtype in expected:
+            if (tuple(tensor.shape) != shape or tensor.dtype != dtype
+                    or tensor.device != qweight.device):
+                raise ValueError(f'Invalid TurboMind {name}: expected shape '
+                                 f'{shape}, dtype {dtype}, and device '
+                                 f'{qweight.device}.')
+        if bias is not None and (tuple(bias.shape) != (self.out_features, )
+                                 or bias.dtype != torch.float16
+                                 or bias.device != qweight.device):
+            raise ValueError('Invalid TurboMind bias tensor.')
+
+    def update_weights(self,
+                       qweight: torch.Tensor,
+                       scales: torch.Tensor,
+                       qzeros: torch.Tensor,
+                       bias: torch.Tensor | None = None):
+        """Build a private TurboMind layout while preserving AWQ parameters."""
+        self._release_prepared()
+        self._validate_weights(qweight, scales, qzeros, bias)
+
+        tm = _load_turbomind()
+        device = qweight.device
+        with torch.cuda.device(device):
+            self._prepared = _prepare_turbomind_linear(
+                tm,
+                self.in_features,
+                self.out_features,
+                self.group_size,
+                qweight,
+                scales,
+                qzeros,
+            )
+
+        # The model/state_dict must remain in canonical checkpoint layout.
+        return qweight, scales, qzeros, bias
+
+    def forward(self,
+                x,
+                qweight: torch.Tensor,
+                scales: torch.Tensor,
+                qzeros: torch.Tensor,
+                bias: torch.Tensor | None = None,
+                all_reduce: bool = False,
+                group: torch.distributed.ProcessGroup | None = None):
+        """Run the prepared operator and preserve the CUDA AWQ API contract."""
+        prepared = self._prepared
+        if prepared is None:
+            raise RuntimeError(
+                'TurboMind W4A16 weights are not prepared; call update_weights() after loading weights.'
+            )
+        if x.size(-1) != self.in_features:
+            raise ValueError(
+                f'Expected input dim {self.in_features}, but got {x.size(-1)}.'
+            )
+        if x.device != prepared.device:
+            raise ValueError(
+                f'Input must be on {prepared.device}, but got {x.device}.')
+
+        input_dtype = x.dtype
+        out_shape = x.shape[:-1] + (self.out_features, )
+
+        with torch.cuda.device(prepared.device):
+            op_input = x if input_dtype == torch.float16 else x.to(
+                dtype=torch.float16)
+            op_input = op_input.reshape(-1, self.in_features)
+            if (not op_input.is_contiguous()
+                    or op_input.storage_offset() != 0):
+                op_input = op_input.clone(
+                    memory_format=torch.contiguous_format)
+            # TurboMind's native kernel and the canonical AWQ bias path both
+            # operate in FP16.  Cast back only after applying bias so BF16 or
+            # FP32 inputs do not promote a mixed BF16/FP16 add to FP32.
+            if op_input.size(0) == 0:
+                out = torch.empty((0, self.out_features),
+                                  dtype=torch.float16,
+                                  device=prepared.device)
+            else:
+                out = torch.empty((op_input.size(0), self.out_features),
+                                  dtype=torch.float16,
+                                  device=prepared.device)
+                tm = _load_turbomind()
+                stream = torch.cuda.current_stream(prepared.device)
+                stream_ptr = stream.cuda_stream
+                if op_input.is_cuda:
+                    op_input.record_stream(stream)
+                    out.record_stream(stream)
+                runtime = prepared.runtimes.get(stream_ptr)
+                if runtime is None:
+                    runtime = _get_runtime(tm, prepared.device, stream)
+                    prepared.runtimes[stream_ptr] = runtime
+                runtime.forward(tm, op_input, prepared.weight, out)
+            if bias is not None:
+                out = out + bias
+            out = out.reshape(out_shape)
+
+            # Match the existing CUDA AWQ backend's 2D compatibility contract.
+            if out.ndim == 2:
+                out = out.unsqueeze(0)
+            if input_dtype != torch.float16:
+                out = out.to(dtype=input_dtype)
+            if all_reduce:
+                dist.all_reduce(out, group=group)
+        return out

--- a/lmdeploy/pytorch/envs.py
+++ b/lmdeploy/pytorch/envs.py
@@ -180,6 +180,10 @@ with set_envs():
     blocked_fp8_gemm_backend = env_to_choice('LMDEPLOY_BLOCKED_FP8_GEMM_BACKEND', 'auto',
                                              {'auto', 'deepgemm', 'gluon', 'triton'})
 
+    # W4A16 GEMM
+    w4a16_gemm_backend = env_to_choice('LMDEPLOY_W4A16_GEMM_BACKEND', 'auto',
+                                       {'auto', 'triton', 'turbomind'})
+
     # model agent
     skip_warmup = env_to_bool('LMDEPLOY_SKIP_WARMUP', False)
 

--- a/lmdeploy/pytorch/nn/linear/awq.py
+++ b/lmdeploy/pytorch/nn/linear/awq.py
@@ -1,4 +1,5 @@
 # Copyright (c) OpenMMLab. All rights reserved.
+from contextlib import nullcontext
 from typing import Any
 
 import torch
@@ -38,12 +39,15 @@ class AwqLinear(LinearBase):
         qweight, scales, qzeros, bias = self.create_weights(in_features, out_features, w_bit, group_size, bias,
                                                             self.dtype, self.device)
         impl_builder = get_backend().get_layer_impl_builder(OpType.LinearW4A16)
-        self.impl = impl_builder.build(in_features,
-                                       out_features,
-                                       w_bit,
-                                       group_size,
-                                       bias is not None,
-                                       dtype=scales.dtype)
+        # Provider checks must inspect the device that owns these weights.
+        device_guard = torch.cuda.device(scales.device) if scales.is_cuda else nullcontext()
+        with device_guard:
+            self.impl = impl_builder.build(in_features,
+                                           out_features,
+                                           w_bit,
+                                           group_size,
+                                           bias is not None,
+                                           dtype=scales.dtype)
         self.register_all_parameters(qweight, scales, qzeros, bias)
 
         self.in_features = in_features

--- a/src/turbomind/core/stream.h
+++ b/src/turbomind/core/stream.h
@@ -9,15 +9,19 @@ namespace turbomind::core {
 
 class StreamImpl {
 public:
-    StreamImpl(int priority): stream_{}
+    StreamImpl(int priority): stream_{}, owns_stream_{true}
     {
         TM_CUDA_CHECK(cudaStreamCreateWithPriority(&stream_, cudaStreamNonBlocking, priority));
     }
 
+    explicit StreamImpl(cudaStream_t stream): stream_{stream}, owns_stream_{false} {}
+
     ~StreamImpl()
     {
-        if (auto ec = cudaStreamDestroy(stream_); ec != cudaSuccess) {
-            TM_LOG_ERROR("{}", cudaGetErrorString(ec));
+        if (owns_stream_) {
+            if (auto ec = cudaStreamDestroy(stream_); ec != cudaSuccess) {
+                TM_LOG_ERROR("{}", cudaGetErrorString(ec));
+            }
         }
         stream_ = {};
     }
@@ -36,6 +40,7 @@ public:
 
 public:
     cudaStream_t stream_;
+    bool         owns_stream_;
 };
 
 class Stream {
@@ -43,6 +48,14 @@ public:
     Stream() = default;
 
     static Stream create(int priority = 0);
+
+    /// Wrap an externally owned CUDA stream without taking ownership.
+    static Stream borrow(cudaStream_t stream)
+    {
+        Stream ret;
+        ret.impl_ = std::make_shared<StreamImpl>(stream);
+        return ret;
+    }
 
     void Sync()
     {

--- a/src/turbomind/python/bind.cpp
+++ b/src/turbomind/python/bind.cpp
@@ -702,11 +702,29 @@ PYBIND11_MODULE(_turbomind, m)
                  auto device = getDLDevice(self);
                  return std::tuple<int, int>(int(device.device_type), device.device_id);
              })
-        .def("t", [](const Tensor& self) { return std::make_shared<Tensor>(self.t()); });
+        .def("t", [](const Tensor& self) { return std::make_shared<Tensor>(self.t()); })
+        .def(
+            "reinterpret",
+            [](const Tensor& self, ft::DataType dtype, std::vector<ft::core::ssize_t> shape) {
+                ft::core::Layout layout{std::move(shape)};
+                auto             buffer = self.buffer().view(dtype);
+                if (buffer.size() != layout.cosize()) {
+                    throw py::value_error("reinterpret requires the source and destination to have the same byte size");
+                }
+                return std::make_shared<Tensor>(std::move(buffer), std::move(layout));
+            },
+            "dtype"_a,
+            "shape"_a);
     m.def(
         "from_dlpack",
-        [](py::object obj) {
-            py::capsule      cap = obj.attr("__dlpack__")();
+        [](py::object obj, py::object stream) {
+            py::capsule cap;
+            if (stream.is_none()) {
+                cap = obj.attr("__dlpack__")();
+            }
+            else {
+                cap = obj.attr("__dlpack__")("stream"_a = stream);
+            }
             DLManagedTensor* dlmt =
                 static_cast<DLManagedTensor*>(PyCapsule_GetPointer(cap.ptr(), kDlTensorCapsuleName));
             auto ret = DLManagedTensorToTritonTensor(dlmt);
@@ -714,7 +732,8 @@ PYBIND11_MODULE(_turbomind, m)
             cap.set_name("used_dltensor");
             return ret;
         },
-        "dl_managed_tensor"_a);
+        "dl_managed_tensor"_a,
+        "stream"_a = py::none());
     m.def(
         "from_dlpack_with_strides",
         [](py::object obj) {
@@ -843,12 +862,18 @@ PYBIND11_MODULE(_turbomind, m)
 
     m.def(
         "create_device_context",
-        []() {
-            auto stream = ft::core::Stream::create();
+        [](py::object stream_ptr) {
+            const bool use_external_stream = !stream_ptr.is_none();
+            auto       stream =
+                use_external_stream ?
+                          ft::core::Stream::borrow(reinterpret_cast<cudaStream_t>(py::cast<std::uintptr_t>(stream_ptr))) :
+                          ft::core::Stream::create();
             return std::make_unique<PyContextGuard>(
-                stream, ft::core::Allocator{ft::kCPU}, ft::core::Allocator{stream, false});
+                stream, ft::core::Allocator{ft::kCPU}, ft::core::Allocator{stream, use_external_stream});
         },
-        "Create a ContextGuard with stream + host + device allocators.\n\n"
+        "stream_ptr"_a = py::none(),
+        "Create a ContextGuard with stream + host + device allocators. When "
+        "stream_ptr is provided, borrow that externally owned CUDA stream.\n\n"
         "Objects that use core::Context::stream() in their constructor or destructor "
         "(notably LlamaLinear) must be destroyed before this context exits.");
 


### PR DESCRIPTION
## Motivation

LMDeploy's PyTorch engine currently uses Triton for CUDA AWQ W4A16 linear.
This prototype evaluates the existing W4A16 GEMM under `src/turbomind`,
compiled into LMDeploy's own `lmdeploy/lib/_turbomind` extension. It does not
import or depend on the older standalone TurboMind repository/wheel and does
not add another native linear implementation.

## Modification

- Add `auto`, `triton`, and `turbomind` provider selection through
  `LMDEPLOY_W4A16_GEMM_BACKEND`. `auto` prefers TurboMind when the layer,
  bundled extension, and end-to-end validated SM90 architecture are compatible,
  then falls back to Triton. Explicit `turbomind` raises an actionable error
  instead of silently falling back.
- Load `_turbomind` only when it resolves inside this LMDeploy installation's
  `lmdeploy/lib` directory; an external TurboMind Python package is rejected.
- Reuse the existing bundled pybind objects directly:

  ```python
  weight = tm.LinearWeight(config)
  weight.param('weight').set(qweight)
  weight.param('scales').set(scales)
  weight.param('zeros').set(qzeros)
  weight.prepare()

  linear = tm.LlamaLinear()
  linear.forward_dense(x, weight, out)
  ```

- Normalize canonical LMDeploy AWQ nibble order before the existing
  `LinearWeight::prepare()` layout conversion. Canonical checkpoint tensors
  remain registered on the LMDeploy module.
- Add only the minimal native bridges required by the PyTorch caller:
  - borrow the caller-owned CUDA stream without destroying it;
  - create a TurboMind context on that stream;
  - reinterpret packed `int32 [K, N/8]` bytes as `uint4 [K, N]` without a
    copy;
  - keep the generic single-argument DLPack API unchanged and use a private
    CUDA-only bridge with `stream=-1`, avoiding both raw stream-pointer plumbing
    and cross-stream event/wait insertion.
- Share one existing `LlamaLinear` workspace per `(device, CUDA stream)`.
  A workspace is about 65 MiB, so allocating one per model layer would add
  several GiB and distort the prototype profile.
- Preserve FP16 bias ordering, input dtype restoration, output shape, CUDA
  Graph capture, and TP all-reduce behavior used by the PyTorch backend.

No `W4A16Linear` C++ class, standalone `tm.Linear` wrapper, API-version
protocol, or sleep/wakeup integration is added.

## Call path

```text
LMDeploy canonical AWQ tensors
  -> Python nibble normalization
  -> existing LinearWeight.param(...).set(...)
  -> existing LinearWeight::prepare()              # TurboMind layout pack
  -> existing LlamaLinear::Forward()
  -> existing gemm::Gemm::Run()
  -> existing architecture-selected UINT4 CUDA kernel
```

## Compatibility

- `auto` selects TurboMind on compatible SM90 layers and otherwise falls back
  to Triton. Set `LMDEPLOY_W4A16_GEMM_BACKEND=triton` to retain the previous
  implementation explicitly, or `turbomind` to require this provider.
- The prototype currently accepts only CUDA capability 9.0. Other
  architectures fail before launching a native kernel.
- No standalone TurboMind repository, Python package, or wheel is used.
  `lmdeploy/lib/_turbomind` must be built and packaged from this LMDeploy
  source tree.
- The private prepared layout increases GPU memory use relative to Triton.
- CUDA Graph capture/replay is supported for unchanged weights after one eager
  forward initializes the TurboMind runtime on the capture stream.
- PyTorch 2.9.1 maps a no-argument `Tensor.__dlpack__()` call to the legacy
  default stream; the [upstream capture-safety fix](https://github.com/pytorch/pytorch/commit/5d0f63923465e9bfd5add969263938bf8662eb1b)
  changed the default to `stream=-1`. The private
  W4A16 bridge passes `-1` explicitly so the same-stream path remains
  capture-safe across LMDeploy's supported PyTorch range. The generic DLPack
  bridge remains unchanged for NumPy and CPU producers.
- Online parameter replacement rebuilds the private TurboMind layout when
  `update_weights()` runs, but graph invalidation/recapture is not wired
  consistently across every online-update path. Updating weights after CUDA
  Graph capture is therefore not supported by this prototype; existing graphs
  must be reset and recaptured before inference.
- Sleep/wakeup integration is not included. The private TurboMind layout and
  workspace are not registered model parameters/buffers and are not explicitly
  released/rebuilt by the current sleep/wakeup hooks. Consequently, expected
  GPU-memory reclamation and wakeup behavior are not guaranteed with this
  provider.

## Validation

- [x] Bundled `_turbomind` Release build succeeds.
- [x] Rebuilt module exposes `LinearWeight`, `LlamaLinear`, and
  `Tensor.reinterpret`, and does not expose `W4A16Linear`.
- [x] External provider/fallback smoke checks pass.
- [x] H200 native tests on PyTorch 2.9.1 and 2.13 cover canonical-weight
  preservation, numeric output,
  non-contiguous input, separate preparation/forward streams, unchanged-weight
  CUDA Graph capture/replay, and explicit release.
- [x] Two-H200 test covers device guard and release.
- [x] Multi-GPU provider-selection test verifies that the builder inspects the
  resolved weight device, `auto` falls back on an unsupported target GPU,
  explicit `turbomind` reports that target capability, and the caller's current
  device is restored.
- [x] Ruff, docformatter, clang-format 11, Python compile, and
  `git diff --check` pass.
- [x] Formal same-H200 4K/8K prefill, decode-5 Triton comparison on the
  final bundled implementation: three paired repeats, plus deterministic
  greedy token comparison.

## Performance

On Qwen3-8B-AWQ, one H200, TP=1, concurrency=1, exact 4K/8K input and five
decoded tokens, three paired repeats (three warm-up and 20 measured requests
per process) show:

- 4K: input throughput +7.87%, E2E latency -7.31% (1.0788x), TTFT is
  effectively unchanged (+0.12% speedup), and TPOT is -48.94% (1.9583x).
- 8K: input throughput +1.07%, E2E latency -1.06% (1.0107x), TTFT is 2.90%
  slower, and TPOT is -47.68% (1.9112x).

All 12 measured runs completed 20/20 requests. Separate fixed-input greedy
checks produced exactly matching Triton and TurboMind token IDs at 4K/5 and
8K/5.

An interleaved 4096x4096 operator microbenchmark shows that the final private
`stream=-1` bridge reduces DLPack bridge host overhead by 77.74%-80.22% and
full forward host enqueue overhead by 67.80%-74.40% relative to passing the
raw current-stream pointer. Outputs are bitwise identical at M=1, 32, 4096,
and 8192. For M=4096/8192, CUDA-event time improves by 3.83%/0.68%; the kernel
itself is unchanged.

The measured gain is concentrated in decode rather than long-prefill TTFT.
Other GPU architectures are rejected until validated; tensor-parallel sizes
and concurrency regimes also need broader validation.
