### PR TITLE
[ascend] update attn op_backend

### DIFF
--- a/lmdeploy/pytorch/backends/dlinfer/ascend/op_backend.py
+++ b/lmdeploy/pytorch/backends/dlinfer/ascend/op_backend.py
@@ -121,6 +121,7 @@ class AscendOpsBackend(DlinferOpsBackend):
     total_slots = None
     max_batches = None
     dist_meta: DistMeta = None
+    fia_causal_masks: dict[torch.device, torch.Tensor] = {}
 
     @staticmethod
     def get_name() -> str:
@@ -189,6 +190,14 @@ class AscendOpsBackend(DlinferOpsBackend):
                 cls.total_slots = cls.total_slots.view(block_num, block_size)
             return cls.total_slots
 
+        def get_fia_causal_mask():
+            device = step_context.block_offsets.device
+            mask = cls.fia_causal_masks.get(device)
+            if mask is None:
+                mask = torch.triu(torch.ones(2048, 2048, dtype=torch.int8, device=device), diagonal=1)
+                cls.fia_causal_masks[device] = mask
+            return mask
+
         def get_cpu_seqlens(is_decoding, is_prefill_no_cache):
             """Get sequence lengths on CPU.
 
@@ -255,17 +264,10 @@ class AscendOpsBackend(DlinferOpsBackend):
                     slots = slot_tables[history_length:kv_seq_len]
                     kv_start_indices.append(slots)
 
-                if is_prefill_no_cache:
-                    attention_mask.append(
-                        torch.triu(torch.ones(max_q_seq_len,
-                                              max_kv_seq_len,
-                                              dtype=step_context.kv_caches[0][0].dtype,
-                                              device=step_context.block_offsets.device),
-                                   diagonal=max_kv_seq_len - max_q_seq_len + 1))
-                else:
-                    attention_mask.append(
-                        torch.triu(torch.ones(2048, 2048, dtype=torch.bool, device=step_context.block_offsets.device),
-                                   diagonal=1))
+                # Standard GQA/MHA, MLA and paged prefill all use FIA sparse
+                # mode 3. Reuse the fixed split-fuse causal-mask template
+                # across all steps, following vllm-ascend.
+                attention_mask.append(get_fia_causal_mask())
 
                 kv_start_indices = torch.cat(kv_start_indices)
 
@@ -516,7 +518,8 @@ class AscendOpsBackend(DlinferOpsBackend):
         AscendOpsBackend.enable_graph = not backend_config.eager_mode
         AscendOpsBackend.max_batches = cache_config.max_batches
         from dlinfer.framework.lmdeploy_ext.cudagraph.ascend_cudagraph import AscendGraphRunner
-        return AscendGraphRunner(model, model_config, cache_config, backend_config, device)
+        is_mla = model_config.k_head_dim != model_config.v_head_dim
+        return AscendGraphRunner(model, model_config, cache_config, backend_config, device, is_mla=is_mla)
 
     @staticmethod
     def init():
@@ -526,6 +529,10 @@ class AscendOpsBackend(DlinferOpsBackend):
         linear attention (e.g. Qwen3.5 35B). If triton-ascend is not installed, a warning
         is emitted but non-linear-attention models are unaffected.
         """
+
+        from dlinfer.vendor.ascend.version import ensure_ascend_runtime
+
+        ensure_ascend_runtime()
 
         try:
             from torch_npu.contrib import transfer_to_npu  # noqa: F401


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily receiving feedbacks. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

DLINFER has updated the Ascend attention implementation from the legacy ATB
path to FIA/FIA v2 and unified graph replay with `torch.npu.NPUGraph.update()`.

This PR adds the corresponding LMDeploy-side adaptations.
Dlinfer pr: https://github.com/DeepLink-org/dlinfer/pull/350

## Changes

- Cache and reuse a fixed FIA causal mask per NPU device to avoid allocating
  the attention mask on every execution.
- Use the fixed split-fuse causal mask for Dense, GQA, MLA and paged-prefill
  attention with `sparse_mode=3`.
- Detect MLA models through `k_head_dim != v_head_dim` and explicitly pass
  `is_mla` to the DLINFER Ascend graph runner.
- Validate the torch/torch-npu runtime when initializing the Ascend backend.

The companion DLINFER update includes:

- Migrating prefill and paged attention to FIA/FIA v2.
- Adding MLA paged-prefill support.
- Removing unnecessary `.tolist()` calls from attention hot paths.
- Removing the legacy ATB graph-task attention path.
- Unifying graph replay through `NPUGraph.update()`.

## Dependency

This PR depends on the corresponding DLINFER attention update. The DLINFER PR
should be merged first, or both PRs should reference each other.

Required runtime:

- `torch >= 2.8.0`
- `torch-npu >= 2.8.0.post1`

## Test

- DeepSeek-V2-Lite MLA graph capture/replay
- Qwen3.5 Dense graph capture/replay
- Dense and MLA prefill/decode attention tests
- MLA paged-prefill path test
