### PR TITLE
build: remove flashinfer from CUDA runtime requirements

### DIFF
--- a/requirements/runtime_cuda.txt
+++ b/requirements/runtime_cuda.txt
@@ -4,7 +4,6 @@ accelerate>=0.29.3
 aiohttp
 apache-tvm-ffi==0.1.11; sys_platform == "linux" and "aarch64" not in platform_machine and "arm" not in platform_machine
 flash-linear-attention
-flashinfer-python==0.6.15.post1
 opencv-python-headless
 peft<=0.14.0
 prometheus_client


### PR DESCRIPTION
## Motivation

FlashInfer's unified communication API is an optional all-reduce backend. Installing `flashinfer-python` for every CUDA runtime installation makes that optional integration a mandatory dependency.

## Modification

Remove the pinned `flashinfer-python` package from the CUDA runtime requirements.

## BC-breaking

No.

## Validation

- `pre-commit run --files requirements/runtime_cuda.txt`

## Assistance

Assisted with Codex + GPT-5.6-Sol xHigh, reviewed manually
