### PR TITLE
feat: support structural_tag response_format for turbomind and pytorch engines

### DIFF
--- a/lmdeploy/pytorch/engine/guided_process.py
+++ b/lmdeploy/pytorch/engine/guided_process.py
@@ -52,6 +52,10 @@ class GuidedDecodingManager:
                     schema = _format.get('regex_schema', '')
                 elif schema_type == 'json_object':
                     schema = '{"type" : "object", "additionalProperties": true}'
+                elif schema_type == 'structural_tag':
+                    schema = _format.get('structural_tag', {})
+                    if isinstance(schema, dict):
+                        schema = json.dumps(schema, ensure_ascii=False)
                 else:
                     raise ValueError(f'unsupported format type: {schema_type}')
 
@@ -79,6 +83,8 @@ class GuidedDecodingManager:
             compiled = self.compiler.compile_regex(schema)
         elif type == 'json_object':
             compiled = self.compiler.compile_json_schema(schema)
+        elif type == 'structural_tag':
+            compiled = self.compiler.compile_structural_tag(schema)
         else:
             assert False, f'Do not support schema type {type}'
 

--- a/lmdeploy/turbomind/turbomind.py
+++ b/lmdeploy/turbomind/turbomind.py
@@ -733,6 +733,8 @@ class TurboMindInstance:
                     decode_grammar = gen_config.response_format[decode_grammar_type]
                 elif decode_grammar_type == 'json_object':
                     decode_grammar = '{"type" : "object", "additionalProperties": true}'
+                elif decode_grammar_type == 'structural_tag':
+                    decode_grammar = gen_config.response_format[decode_grammar_type]
 
                 if decode_grammar_type == 'json_schema':
                     decode_grammar = json.dumps(decode_grammar)
@@ -743,12 +745,15 @@ class TurboMindInstance:
                 elif decode_grammar_type == 'json_object':
                     decode_grammar = str(decode_grammar)
                     grammar = compiler.compile_json_schema(decode_grammar)
+                elif decode_grammar_type == 'structural_tag':
+                    decode_grammar = json.dumps(decode_grammar)
+                    grammar = compiler.compile_structural_tag(decode_grammar)
                 else:
                     assert False, f'Decode grammar type {decode_grammar_type} should be in ' \
-                                   '["json_schema", "regex_schema", "json_object"]'
+                                   '["json_schema", "regex_schema", "json_object", "structural_tag"]'
 
                 self.model_inst.set_grammar(grammar)
-            except ValueError as e:
+            except (ValueError, KeyError) as e:
                 logger.warning(f'Failed to initialize guided decoding, '
                                f'disable guided decoding: {e}')
                 gen_config.response_format = None

--- a/src/turbomind/python/xgrammar_bind.cpp
+++ b/src/turbomind/python/xgrammar_bind.cpp
@@ -130,5 +130,9 @@ PYBIND11_MODULE(_xgrammar, m)
         .def("compile_regex",
              &GrammarCompiler::CompileRegex,
              py::call_guard<py::gil_scoped_release>(),
-             py::arg("schema"));
+             py::arg("schema"))
+        .def("compile_structural_tag",
+             &GrammarCompiler::CompileStructuralTag,
+             py::call_guard<py::gil_scoped_release>(),
+             py::arg("structural_tag_json"));
 }

--- a/tests/test_lmdeploy/test_grammar.py
+++ b/tests/test_lmdeploy/test_grammar.py
@@ -53,6 +53,15 @@ SCHEMA_MAP = {
     },
     'regex_schema': 'call me [A-Za-z]{1,10}',
     'json_object': None,
+    'structural_tag': {
+        'type': 'structural_tag',
+        'format': {
+            'type': 'tag',
+            'begin': '<answer>',
+            'content': {'type': 'regex', 'pattern': '[0-9]{1,3}'},
+            'end': '</answer>'
+        }
+    },
 }
 
 MIXED_SCHEMA = {
@@ -91,7 +100,8 @@ def test_guided_matrix(model_id, backend_name, backend_factory, schema_type):
             response_format[schema_type] = dict(name='test', schema=schema)
         elif schema_type == 'regex_schema':
             response_format[schema_type] = schema
-
+        elif schema_type == 'structural_tag':
+            response_format[schema_type] = schema
     try:
         if enable_guide:
             gen_config = GenerationConfig(response_format=response_format)
@@ -108,6 +118,10 @@ def test_guided_matrix(model_id, backend_name, backend_factory, schema_type):
                 validate(instance=json.loads(response[0].text), schema={'type': 'object', 'additionalProperties': True})
             elif schema_type == 'regex_schema':
                 assert re.fullmatch(schema, response[0].text)
+            elif schema_type == 'structural_tag':
+                pattern = r'<answer>([0-9]{1,3})</answer>'
+                m = re.fullmatch(pattern, response[0].text)
+                assert m, f'structural_tag output {response[0].text!r} does not match {pattern}'
     finally:
         pipe.close()
 


### PR DESCRIPTION
## Motivation

xgrammar (vendored in `build/_deps/xgrammar-src`) provides `GrammarCompiler::CompileStructuralTag` for structural-tag-based guided generation, but the lmdeploy `_xgrammar` pybind binding and both inference engines (turbomind, pytorch) only exposed `compile_json_schema`, `compile_regex`, and `compile_json_object`. This PR wires up `structural_tag` end-to-end so users can constrain output with xgrammar structural tags (e.g. `<answer>...</answer>` wrappers) via `response_format`.

## Modification

1. **`src/turbomind/python/xgrammar_bind.cpp`** — Expose `GrammarCompiler::CompileStructuralTag(const std::string&)` as `compile_structural_tag` in the `_xgrammar` pybind module, mirroring the existing `compile_regex` binding (GIL-released, named arg `structural_tag_json`).

2. **`lmdeploy/turbomind/turbomind.py`** — Add a `structural_tag` branch to the guided-decode grammar compilation path: extracts `response_format['structural_tag']`, serializes to JSON, and calls `compiler.compile_structural_tag()`. Widened the `try/except` from `ValueError` to `(ValueError, KeyError)` so a malformed `response_format` gracefully disables guided decoding instead of crashing.

3. **`lmdeploy/pytorch/engine/guided_process.py`** — Add symmetric `structural_tag` branches in `GuidedDecodingManager.get_processors` (extracts + JSON-serializes the schema) and `get_processor` (calls `compile_structural_tag`). The spec-decoding path inherits this via `GuidedSpecHelper.get_processors` delegation.

4. **`tests/test_lmdeploy/test_grammar.py`** — Add a `structural_tag` entry to `SCHEMA_MAP` (a `<answer>[0-9]{1,3}</answer>` tag format) and wire it into the existing `test_guided_matrix` parametrization (build, run, and validate against the exact schema).

**Usage:**

```python
from lmdeploy import pipeline, GenerationConfig

response_format = {
    "type": "structural_tag",
    "structural_tag": {
        "type": "structural_tag",
        "format": {
            "type": "tag",
            "begin": "<answer>",
            "content": {"type": "regex", "pattern": "[0-9]{1,3}"},
            "end": "</answer>"
        }
    }
}
gen_config = GenerationConfig(response_format=response_format)
```

## BC-breaking (Optional)

None. The change is purely additive — a new `structural_tag` value for `response_format['type']`. Existing `json_schema` / `regex_schema` / `json_object` paths are untouched.

## Use cases (Optional)

- Constrain model output to wrap reasoning in custom XML-like tags (e.g. `<answer>`, `<tool_call>`) with structured content inside.
- Agentic workflows requiring tagged structured output without full JSON schema overhead.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
   — All pre-commit hooks pass (clang-format, docformatter, check copyright, etc.).
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
   — `test_guided_matrix` extended with `structural_tag` parametrization for both `tm` and `pt` backends. Verified locally: both pass on `Qwen/Qwen3-0.6B`.
3. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
   — Depends on `CompileStructuralTag` being available in the vendored xgrammar; no new external dependency.
4. The documentation has been modified accordingly, like docstring or example tutorials.
   — `response_format` docstring intentionally left unchanged per reviewer request; the structural_tag spec follows the xgrammar `StructuralTag` pydantic model.