### PR TITLE
fix(build): correct GEMM kernel archive link order

### DIFF
--- a/src/turbomind/comm/test_comm.cu
+++ b/src/turbomind/comm/test_comm.cu
@@ -150,7 +150,13 @@ struct TestComm {
         return std::make_tuple(h_comm, std::move(d_comm), h_split, d_split);
     }
 
-    void Run(int hidden_dim, int vocab_size, int tp, int warmup, int iters, std::vector<int> tokens)
+    void Run(int                hidden_dim,
+             int                vocab_size,
+             int                tp,
+             int                warmup,
+             int                iters,
+             std::vector<int>   tokens,
+             const std::string& backend)
     {
         int device_num{};
         cudaGetDeviceCount(&device_num);
@@ -161,7 +167,7 @@ struct TestComm {
             tp = device_num;
         }
 
-        std::tie(h_comm_, d_comm_, h_split_, d_split_) = Init(device_num, 4, "cuda-ipc");
+        std::tie(h_comm_, d_comm_, h_split_, d_split_) = Init(device_num, 4, backend);
 
         TM_CHECK_GT(h_comm_.size(), 0);
         TM_CHECK_GT(d_comm_.size(), 0);
@@ -175,13 +181,13 @@ struct TestComm {
         const int g = 0;
 
         TestAllReduce<half>(hidden_dim, 0);
-        // TestAllreduceResidualBiasRMSnorm<half>(hidden_dim, g);
-        // TestAllreduceResidualBiasRMSnormEx<half>(hidden_dim, 0, 0);
-        // TestAllreduceResidualBiasRMSnormEx<half>(hidden_dim, 1, 0);
-        // TestAllreduceResidualBiasRMSnormEx<half>(hidden_dim, 0, 1);
-        // TestAllGather<half>(hidden_dim / tp, g);  // tp embedding
-        // TestAllGather<half>(vocab_size / tp, g);
-        // TestBroadcast<half>(32768, g);
+        TestAllreduceResidualBiasRMSnorm<half>(hidden_dim, g);
+        TestAllreduceResidualBiasRMSnormEx<half>(hidden_dim, 0, 0);
+        TestAllreduceResidualBiasRMSnormEx<half>(hidden_dim, 1, 0);
+        TestAllreduceResidualBiasRMSnormEx<half>(hidden_dim, 0, 1);
+        TestAllGather<half>(hidden_dim / tp, g);  // tp embedding
+        TestAllGather<half>(vocab_size / tp, g);
+        TestBroadcast<half>(32768, g);
     }
 
     template<class T>
@@ -965,6 +971,14 @@ struct TestComm {
 
 int main(int argc, char* argv[])
 {
+    std::string backend("cuda-ipc");
+    if (argc > 1) {
+        backend = argv[argc - 1];
+    }
+    if (backend != "cuda-ipc" && backend != "nccl") {
+        printf("Invalid communicator: %s\n", backend.c_str());
+        return -1;
+    }
 
     TestComm test;
 
@@ -983,7 +997,8 @@ int main(int argc, char* argv[])
              //   {8192, 16384, 32768});
              //  {1, 2, 4, 8, 16, 24, 32, 48, 64, 96, 128, 192, 256, 384, 512, 768, 1024, 8192});
              {1,   2,   4,   6,   8,   12,   16,   24,   32,   48,   64,   96,   128,
-              192, 256, 384, 512, 768, 1024, 1536, 2048, 3072, 4096, 6144, 8192, 16384});
+              192, 256, 384, 512, 768, 1024, 1536, 2048, 3072, 4096, 6144, 8192, 16384},
+             backend);
 
     return 0;
 }

--- a/src/turbomind/kernels/gemm/CMakeLists.txt
+++ b/src/turbomind/kernels/gemm/CMakeLists.txt
@@ -136,10 +136,13 @@ add_library(gemm2
 
 target_link_libraries(gemm2 PRIVATE parser nvidia::cutlass::cutlass CUDA::cuda_driver)
 
-# Retain file-scope Registrar objects (self-registration). Same pattern as attention_kernels.
-foreach(target IN LISTS GEMM2_KERNEL_TARGETS)
-    target_link_libraries(gemm2 PUBLIC $<LINK_LIBRARY:WHOLE_ARCHIVE,${target}>)
-endforeach()
+# Registry/kernel TUs are static plugins: they must be linked before libgemm2.a so
+# Kernel base symbols (vtable/GetName) resolve when consumers link executables.
+# INTERFACE_LINK_LIBRARIES_DIRECT places them ahead of gemm2 (same as linear_attn).
+# Keep every archive in one WHOLE_ARCHIVE expression.
+list(JOIN GEMM2_KERNEL_TARGETS "," GEMM2_KERNEL_TARGET_LIST)
+set_property(TARGET gemm2 PROPERTY INTERFACE_LINK_LIBRARIES_DIRECT
+        "$<LINK_LIBRARY:WHOLE_ARCHIVE,${GEMM2_KERNEL_TARGET_LIST}>")
 
 # cublasGemmGroupedBatchedEx (CUDA 12.5+): grouped batched GEMM for MoE on SM100
 set(_archs_100 "${CMAKE_CUDA_ARCHITECTURES}")


### PR DESCRIPTION

## Motivation

GEMM kernels are compiled into architecture-specific static archives and registered through file-scope Registrar objects. Linking these archives after libgemm2.a can leave kernel base symbols unresolved or discard
registration objects, causing executable and Python extension build failures.

The communication test utility also only exercised the CUDA IPC all-reduce path, making it difficult to validate other collective operations and the NCCL backend.

## Modification

- Inject all architecture-specific GEMM kernel archives before gemm2 using INTERFACE_LINK_LIBRARIES_DIRECT.
- Keep the kernel archives in a single WHOLE_ARCHIVE expression so their static registration objects are retained consistently.
- Add cuda-ipc and nccl backend selection to test_comm.
- Re-enable fused all-reduce/RMSNorm, all-gather, and broadcast test coverage.