### PR TITLE
Fix AWQ checkpoint loading for Qwen3.5 fused GDN QKV projection

### DIFF
--- a/lmdeploy/pytorch/models/qwen3_5.py
+++ b/lmdeploy/pytorch/models/qwen3_5.py
@@ -496,6 +496,23 @@ class Qwen3_5GatedDeltaNet(nn.Module):
                 return default_weight_loader(param, loaded_weight)
 
             world_size, rank = mod.get_tp_world_rank()
+
+            # AWQ stores the output features on the *last* dim, not dim0:
+            # qweight is (in_features, out_features // elem_per_int), scales is
+            # (in_features // group_size, out_features) and qzeros matches
+            # qweight. Split along that dim instead, scaling the sections by the
+            # packing factor for the int32-packed tensors. Mirrors
+            # MergedAwqLinear.weight_loader.
+            if hasattr(mod, 'elem_per_int'):
+                if getattr(param, '_weight_type', None) in ('scales', 'bias'):
+                    split_sections = sections
+                else:
+                    # qweight / qzeros are packed along the output dim
+                    split_sections = [s // mod.elem_per_int for s in sections]
+                parts = loaded_weight.split(split_sections, dim=-1)
+                parts = [p.chunk(world_size, -1)[rank] for p in parts]
+                return default_weight_loader(param, torch.cat(parts, dim=-1))
+
             split_sections = sections
             # scale tensor has dim0 shrunk by block_size
             if (loaded_weight.dim() == 2


### PR DESCRIPTION
## Motivation

Fixes #4899.

Loading an AWQ checkpoint for a Qwen3.5 hybrid-GDN model with `--backend pytorch --tp 2` kills the engine subprocess during weight loading:

```
File ".../lmdeploy/pytorch/models/qwen3_5.py", line 503, in qkv_weight_loader
    bs = mod.block_size
AttributeError: 'AwqLinear' object has no attribute 'block_size'
```

`Qwen3_5GatedDeltaNet._patch_qkv_weight_loader` patches `weight_loader` to do the non-uniform `[key_dim, key_dim, value_dim]` TP split. It was written for the default/fp8 layouts, where the output features live on dim0 and a scale tensor is dim0-shrunk by `block_size`. `AwqLinear` has neither `block_size` nor that layout, so the scale branch raises.

Fixing only the attribute would leave a second, quieter problem. AWQ keeps output features on the **last** dim: `qweight` is `(in_features, out_features // elem_per_int)`, `scales` is `(in_features // group_size, out_features)`, `qzeros` matches `qweight`. With `key_dim=512`, `value_dim=1024`, `in_features=2048`, `qweight` is `(2048, 256)` — the `shape[0] < sum(sections)` heuristic is False, so the old code splits it along dim0, i.e. along `in_features`. That is the wrong axis and corrupts weights silently rather than raising.

## Modification

Add an AWQ branch to `qkv_weight_loader` that splits along the last dim and scales the sections by the packing factor for the int32-packed tensors, following the existing `MergedAwqLinear.weight_loader` convention:

- `scales` / `bias` -> split by the raw sections
- `qweight` / `qzeros` -> split by `section // elem_per_int`
- chunk along `dim=-1`

AWQ is detected via `hasattr(mod, 'elem_per_int')`. That is mutually exclusive with the fp8 path: `AwqLinear` defines `elem_per_int` and `group_size` but no `block_size`, and the blocked-fp8 linear defines `block_size` but neither of the others. The existing non-AWQ code path is untouched.

## BC-breaking (Optional)

No. Only adds a branch for AWQ modules, which previously raised `AttributeError` on this path.

## Use cases (Optional)

Serving an AWQ (w4a16) Qwen3.5 hybrid-GDN checkpoint on the PyTorch engine with `tp > 1`. `tp=1` was unaffected (`mod.is_tp == False` short-circuits to `default_weight_loader`).

## Checklist

1. `ruff check` passes on the modified file. (`ruff format` was not run, as it would reformat unrelated pre-existing code; pre-commit runs `ruff-check`.)
2. Verified without GPU by driving the patched `qkv_weight_loader` with stub modules matching real `AwqLinear` / blocked-fp8 attributes and tensor shapes: all four AWQ parameter types produce correct per-rank shard shapes and reassemble exactly per section at `tp=2`; the fp8 path produces identical output to before; and reverting the change reproduces the reported `AttributeError`. I do not have the reporter's hardware or checkpoint, so a confirmation run on the failing artifact would be welcome — the reporter offered one in the issue.
3. No downstream version dependency.
4. No documentation change needed.
