### PR TITLE
fix(disagg): make zmq_disconnect synchronous so p2p_drop_connect actually closes the sockets

### DIFF
--- a/lmdeploy/pytorch/disagg/conn/engine_conn.py
+++ b/lmdeploy/pytorch/disagg/conn/engine_conn.py
@@ -67,8 +67,7 @@ class EngineP2PConnection:
 
     def p2p_drop_connect(self, drop_conn_request: DistServeDropConnectionRequest):
         # TODO (JimyMa): drop RDMA Connection
-        event_loop = asyncio.get_event_loop()
-        event_loop.create_task(self.zmq_disconnect(drop_conn_request.remote_engine_id))
+        self.zmq_disconnect(drop_conn_request.remote_engine_id)
         return {'success': True}
 
     async def zmq_send(self, remote_engine_id: str, remote_session_id: int):
@@ -87,7 +86,7 @@ class EngineP2PConnection:
             else:
                 raise ValueError(f'Unsupported zmq request {type(req)}')
 
-    async def zmq_disconnect(self, remote_engine_id: str):
+    def zmq_disconnect(self, remote_engine_id: str):
         self.p2p_receiver[remote_engine_id].close()
         self.p2p_sender[remote_engine_id].close()
         self.p2p_conn_ctx[remote_engine_id].term()

--- a/lmdeploy/pytorch/disagg/conn/engine_conn.py
+++ b/lmdeploy/pytorch/disagg/conn/engine_conn.py
@@ -67,7 +67,8 @@ class EngineP2PConnection:
 
     def p2p_drop_connect(self, drop_conn_request: DistServeDropConnectionRequest):
         # TODO (JimyMa): drop RDMA Connection
-        self.zmq_disconnect(drop_conn_request.remote_engine_id)
+        event_loop = asyncio.get_event_loop()
+        event_loop.create_task(self.zmq_disconnect(drop_conn_request.remote_engine_id))
         return {'success': True}
 
     async def zmq_send(self, remote_engine_id: str, remote_session_id: int):


### PR DESCRIPTION
## Problem

`EngineP2PConnection.zmq_disconnect` is `async def`, but `p2p_drop_connect` is a plain
sync method and calls it bare:

```python
def p2p_drop_connect(self, drop_conn_request: DistServeDropConnectionRequest):
    # TODO (JimyMa): drop RDMA Connection
    self.zmq_disconnect(drop_conn_request.remote_engine_id)
    return {'success': True}
```

That builds a coroutine object and drops it on the floor. The body of
`zmq_disconnect` — `p2p_receiver.close()`, `p2p_sender.close()`,
`p2p_conn_ctx.term()` — never runs, so **`/distserve/p2p_drop_connect` closes
nothing and still reports `{'success': True}`**. Every dropped P2P connection
leaks a PUSH socket, a PULL socket and a `zmq.asyncio.Context`, and Python emits
`RuntimeWarning: coroutine 'EngineP2PConnection.zmq_disconnect' was never awaited`.

The whole call chain into it is synchronous
(`distserve.py` endpoint → `AsyncEngine.p2p_drop_connect` → `Engine.p2p_drop_connect`
→ `EngineP2PConnection.p2p_drop_connect`), so there is no `await` anywhere that
could have picked the coroutine up.

## Fix

Schedule it, exactly the way `p2p_connect` eight lines above already schedules
`handle_zmq_recv`:

```python
event_loop = asyncio.get_event_loop()
event_loop.create_task(self.zmq_disconnect(drop_conn_request.remote_engine_id))
```

`p2p_connect` is the sibling baseline here — same class, same sync-RPC-method
shape, same need to launch a coroutine — so this keeps the two paths symmetric
and leaves `zmq_disconnect`'s signature untouched.

## Verification

I don't have a CUDA box, so instead of a smoke test I exec'd the **real,
unmodified** `engine_conn.py` with the heavy imports stubbed (`zmq`,
`zmq.asyncio`, `lmdeploy.logger`, the `protocol` models, `dist_utils`), drove
`EngineP2PConnection` directly on a live event loop, and compared old vs new:

```
--- UNPATCHED ---
  p2p_drop_connect returned : {'success': True}
  receiver.close() called   : False
  sender.close() called     : False
  context.term() called     : False
  'never awaited' warnings  : 1
      coroutine 'EngineP2PConnection.zmq_disconnect' was never awaited
--- PATCHED ---
  p2p_drop_connect returned : {'success': True}
  receiver.close() called   : True
  sender.close() called     : True
  context.term() called     : True
  'never awaited' warnings  : 0
```

`ruff check` with the repo's `pyproject.toml` (pinned `v0.15.4` from
`.pre-commit-config.yaml`) passes on the file before and after.

## Scope

+2/−1 in one file. I deliberately did **not** touch the neighbouring issues so
this stays reviewable — happy to follow up on either if you'd like:

- the `p2p_conn_ctx` / `p2p_sender` / `p2p_receiver` entries are not popped on
  drop, so the dicts still grow per remote engine;
- the `handle_zmq_recv` task created in `p2p_connect` is not retained and so
  cannot be cancelled when its socket goes away.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
