### PR TITLE
[Fix] Invalidate KV cache before weight updates

### DIFF
--- a/docs/en/advance/update_weights.md
+++ b/docs/en/advance/update_weights.md
@@ -35,6 +35,10 @@ response = requests.post(f"{BASE_URL}/wakeup", headers=headers, params=dict(tags
 assert response.status_code == 200, response.status_code
 ```
 
+The update endpoints reject requests while the KV cache is available. This
+ordering is required because KV states computed with the previous weights
+cannot be reused after a weight update.
+
 ## Step 3: Update weights
 
 Split model weights into multi segments and update through `update_weights` endpoint.

--- a/docs/zh_cn/advance/update_weights.md
+++ b/docs/zh_cn/advance/update_weights.md
@@ -35,6 +35,9 @@ response = requests.post(f"{BASE_URL}/wakeup", headers=headers, params=dict(tags
 assert response.status_code == 200, response.status_code
 ```
 
+当 KV 缓存仍可用时，权重更新接口会拒绝请求。必须遵循上述顺序，因为
+使用旧权重计算的 KV 状态不能在权重更新后继续复用。
+
 ## 步骤 3: 更新权重
 
 将模型权重切分后调用`update_weights`API进行更新。

--- a/lmdeploy/pytorch/engine/engine.py
+++ b/lmdeploy/pytorch/engine/engine.py
@@ -3,6 +3,7 @@ import asyncio
 import ctypes
 import gc
 import os
+import threading
 from dataclasses import dataclass
 from typing import Any
 
@@ -18,6 +19,7 @@ from lmdeploy.pytorch.disagg.conn.protocol import (
     DistServeDropConnectionRequest,
     DistServeInitRequest,
 )
+from lmdeploy.pytorch.exceptions import WeightUpdateError
 from lmdeploy.utils import get_logger, get_model
 
 from ..adapter.adapter import AdapterManager
@@ -237,6 +239,7 @@ class Engine(EngineBase):
         # resources and has its own weight-update workflow.
         self._sleeping_tags = set()
         self._weights_update_lock: asyncio.Lock | None = None
+        self._weights_update_sync_lock: Any = None
         self._multimodal_session_trim_count = max(0, _envs.multimodal_session_trim_count)
         self._multimodal_session_end_count = 0
 
@@ -538,7 +541,47 @@ class Engine(EngineBase):
 
     def update_params(self, request: Any):
         """Update params."""
-        self.executor.update_params(request)
+        with self._get_weights_update_sync_lock():
+            self._check_weight_update_state()
+            self.executor.update_params(request)
+
+    def _get_weights_update_sync_lock(self):
+        """Get the lock shared by synchronous and asynchronous updates."""
+        if getattr(self, '_weights_update_sync_lock', None) is None:
+            self._weights_update_sync_lock = threading.Lock()
+        return self._weights_update_sync_lock
+
+    def _check_weight_update_state(self):
+        """Ensure no request or KV cache can retain the previous weights."""
+        # A normal engine must explicitly offload its KV cache before a weight
+        # update. Empty-init starts without model weights and is the exception
+        # used by the initial loading workflow.
+        sleeping_tags = getattr(self, '_sleeping_tags', set())
+        misc_config = getattr(self, 'misc_config', None)
+        empty_init = getattr(misc_config, 'empty_init', False)
+        if (('kv_cache' not in sleeping_tags or 'weights' in sleeping_tags)
+                and not empty_init):
+            raise WeightUpdateError(
+                'Weight updates require the KV cache to be offloaded. '
+                'Call /sleep first, then /wakeup?tags=weights before updating.')
+
+        scheduler = self.scheduler
+        if getattr(scheduler, 'sessions', None):
+            raise WeightUpdateError(
+                'Weight updates require no active sessions. '
+                'Call /sleep first to stop inference and discard KV cache.')
+
+        block_trie = getattr(scheduler, 'block_trie', None)
+        if block_trie is not None and getattr(block_trie, 'leaves', None):
+            raise WeightUpdateError(
+                'Weight updates require an empty prefix cache. '
+                'Call /sleep first to discard cached KV blocks.')
+
+        has_unfinished = getattr(scheduler, 'has_unfinished', None)
+        if has_unfinished is not None and has_unfinished():
+            raise WeightUpdateError(
+                'Weight updates require the engine to be idle. '
+                'Wait for pending KV transfers to finish, then retry.')
 
     def _get_weights_update_lock(self):
         """Get the disaggregated weights-update lock."""
@@ -546,10 +589,20 @@ class Engine(EngineBase):
             self._weights_update_lock = asyncio.Lock()
         return self._weights_update_lock
 
-    async def _run_weights_update(self, func, request: Any):
+    async def _run_weights_update(self, func, request: Any, check_state: bool = False):
         """Run one serialized disaggregated weights-update operation."""
         async with self._get_weights_update_lock():
-            return await asyncio.to_thread(func, request)
+            return await asyncio.to_thread(self._run_weights_update_sync, func, request, check_state)
+
+    def _run_weights_update_sync(self, func, request: Any, check_state: bool = False):
+        """Run one weight-update RPC while excluding synchronous updates."""
+        with self._get_weights_update_sync_lock():
+            if check_state:
+                try:
+                    self._check_weight_update_state()
+                except WeightUpdateError as e:
+                    return False, str(e)
+            return func(request)
 
     async def init_weights_update_group(self, request: Any):
         """Init disaggregated weights-update process group."""
@@ -557,7 +610,9 @@ class Engine(EngineBase):
 
     async def update_weights_from_distributed(self, request: Any):
         """Receive weights through the disaggregated process group."""
-        return await self._run_weights_update(self.executor.update_weights_from_distributed, request)
+        return await self._run_weights_update(self.executor.update_weights_from_distributed,
+                                              request,
+                                              check_state=True)
 
     async def destroy_weights_update_group(self, request: Any):
         """Tear down a previously initialized weights-update process group."""
@@ -604,32 +659,37 @@ class Engine(EngineBase):
             logger.info('PyTorch engine loop drained for sleep.')
         # cancel all remain sessions
         self._cancel_and_end_all_sessions()
-        await self.executor.sleep(level)
-        self.scheduler.finish_deferred_kv_transfers_after_worker_drain()
+        with self._get_weights_update_sync_lock():
+            await self.executor.sleep(level)
+            self.scheduler.finish_deferred_kv_transfers_after_worker_drain()
+            clear_prefix_cache = getattr(self.scheduler, 'clear_prefix_cache', None)
+            if clear_prefix_cache is not None:
+                clear_prefix_cache()
         if self._engine_loop is not None:
             self._engine_loop.reset_runtime_state()
         logger.info('PyTorch engine entered sleep: level=%s, sleeping_tags=%s.', level, sorted(self._sleeping_tags))
 
     def wakeup(self, tags: list[str] | None = None):
         """Wakeup."""
-        wakeup_tags = tags
-        logger.info('PyTorch engine wakeup requested: tags=%s, sleeping_tags=%s.',
-                    wakeup_tags, sorted(self._sleeping_tags))
-        self.executor.wakeup(wakeup_tags)
-        if wakeup_tags is None:
-            self._sleeping_tags.clear()
-        else:
-            self._sleeping_tags.difference_update(wakeup_tags)
-        # The engine would resume only when all sleep tags have been cleared.
-        if not self._sleeping_tags:
-            # enable ADD_MESSAGE and ADD_SESSION
-            self._unblock_new_inputs()
-            if self._engine_loop is not None:
-                self._engine_loop.resume_from_sleep()
-            logger.info('PyTorch engine wakeup complete; inference requests are enabled.')
-        else:
-            logger.info('PyTorch engine partial wakeup; blocked tags=%s.',
-                        sorted(self._sleeping_tags))
+        with self._get_weights_update_sync_lock():
+            wakeup_tags = tags
+            logger.info('PyTorch engine wakeup requested: tags=%s, sleeping_tags=%s.',
+                        wakeup_tags, sorted(self._sleeping_tags))
+            self.executor.wakeup(wakeup_tags)
+            if wakeup_tags is None:
+                self._sleeping_tags.clear()
+            else:
+                self._sleeping_tags.difference_update(wakeup_tags)
+            # The engine would resume only when all sleep tags have been cleared.
+            if not self._sleeping_tags:
+                # enable ADD_MESSAGE and ADD_SESSION
+                self._unblock_new_inputs()
+                if self._engine_loop is not None:
+                    self._engine_loop.resume_from_sleep()
+                logger.info('PyTorch engine wakeup complete; inference requests are enabled.')
+            else:
+                logger.info('PyTorch engine partial wakeup; blocked tags=%s.',
+                            sorted(self._sleeping_tags))
 
     async def async_loop(self):
         engine_loop = None

--- a/lmdeploy/pytorch/engine/executor/mp_executor.py
+++ b/lmdeploy/pytorch/engine/executor/mp_executor.py
@@ -376,6 +376,10 @@ class MPExecutor(ExecutorBase):
         """Build cache engine."""
         self.collective_rpc('warmup')
 
+    def update_params(self, request: Any):
+        """Update model parameters on every worker."""
+        self.collective_rpc('update_params', args=(request, ))
+
     async def sleep(self, level: int = 1):
         """Sleep."""
         await self.collective_rpc_async('sleep', args=(level, ), return_mask=0)

--- a/lmdeploy/pytorch/engine/model_agent/agent.py
+++ b/lmdeploy/pytorch/engine/model_agent/agent.py
@@ -1389,7 +1389,10 @@ class BaseModelAgent:
         def _construct(item, require_clone: bool = True):
             func, args = item
             args = list(args)
-            args[6] = torch.cuda.current_device()  # device id.
+            # CPU tensor reducers do not carry a device argument. CUDA
+            # reducers use this slot to remap producer-local device ids.
+            if len(args) > 6:
+                args[6] = torch.cuda.current_device()  # device id.
             ipc_tensor = func(*args)
             return ipc_tensor.clone() if require_clone else ipc_tensor
 

--- a/lmdeploy/pytorch/exceptions.py
+++ b/lmdeploy/pytorch/exceptions.py
@@ -1,0 +1,6 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+"""Exceptions raised by the PyTorch engine."""
+
+
+class WeightUpdateError(RuntimeError):
+    """Raised when model weights are updated in an unsafe engine state."""

--- a/lmdeploy/pytorch/paging/block_trie/trie.py
+++ b/lmdeploy/pytorch/paging/block_trie/trie.py
@@ -646,3 +646,18 @@ class BlockTrie:
         if evicted < max_num_blocks:
             evicted += self._kv_lifecycle.evict(max_num_blocks - evicted)
         return evicted
+
+    def clear(self):
+        """Release all unpinned prefix-cache blocks owned by the trie.
+
+        Weight updates invalidate every KV entry. Repeatedly evicting leaves also walks back through the trie, so
+        allocator references and optional SSM checkpoints follow the normal lifecycle release path.
+        """
+        evicted = 0
+        while self.leaves:
+            released = self.evict(len(self.leaves))
+            evicted += released
+            if released == 0:
+                break
+        self.stats.reset()
+        return evicted

--- a/lmdeploy/pytorch/paging/scheduler.py
+++ b/lmdeploy/pytorch/paging/scheduler.py
@@ -899,6 +899,10 @@ class Scheduler:
         if connector is not None:
             connector.shutdown()
 
+    def clear_prefix_cache(self):
+        """Release scheduler-owned prefix-cache KV before a weight update."""
+        return self.block_trie.clear()
+
     def _ensure_runtime_state_available(self):
         """Make one state-cache slot available for an SSM runtime state.
 

--- a/lmdeploy/serve/openai/endpoints/management.py
+++ b/lmdeploy/serve/openai/endpoints/management.py
@@ -8,6 +8,7 @@ from fastapi import APIRouter, Depends, Request
 from fastapi.encoders import jsonable_encoder
 from fastapi.responses import JSONResponse, Response
 
+from lmdeploy.pytorch.exceptions import WeightUpdateError
 from lmdeploy.serve.openai.errors import create_error_response
 from lmdeploy.serve.openai.protocol import (
     AbortRequest,
@@ -17,6 +18,22 @@ from lmdeploy.serve.openai.protocol import (
     UpdateWeightsFromDistributedRequest,
 )
 from lmdeploy.serve.utils.server_utils import validate_json_request
+
+_WEIGHT_UPDATE_STATE_MESSAGE = (
+    'Weight updates require the KV cache to be offloaded. '
+    'Call /sleep first, then /wakeup?tags=weights before updating.')
+
+
+def _check_weight_update_state(async_engine):
+    """Reject PyTorch weight updates while inference KV is still available."""
+    if getattr(async_engine, 'backend', None) != 'pytorch':
+        return None
+    sleeping_tags = getattr(async_engine, 'sleeping_tags', None)
+    empty_init = getattr(getattr(async_engine, 'backend_config', None), 'empty_init', False)
+    if (sleeping_tags is not None
+            and ('kv_cache' not in sleeping_tags or ('weights' in sleeping_tags and not empty_init))):
+        return create_error_response(HTTPStatus.CONFLICT, _WEIGHT_UPDATE_STATE_MESSAGE)
+    return None
 
 
 def register(router: APIRouter, server_context) -> None:
@@ -55,7 +72,14 @@ def register(router: APIRouter, server_context) -> None:
     def update_params(request: UpdateParamsRequest,
                       raw_request: Request = None):
         """Update weights for the model."""
-        server_context.async_engine.engine.update_params(request)
+        async_engine = server_context.async_engine
+        error = _check_weight_update_state(async_engine)
+        if error is not None:
+            return error
+        try:
+            async_engine.engine.update_params(request)
+        except WeightUpdateError as e:
+            return create_error_response(HTTPStatus.CONFLICT, str(e))
         return JSONResponse(content=None)
 
     def _check_pytorch_backend_for_disagg_weight_update():
@@ -96,6 +120,9 @@ def register(router: APIRouter, server_context) -> None:
         """Receive a bucket of weights through a previously initialized
         weights- update group and load them into the running model."""
         err = _check_pytorch_backend_for_disagg_weight_update()
+        if err is not None:
+            return err
+        err = _check_weight_update_state(server_context.async_engine)
         if err is not None:
             return err
         success, message = await server_context.async_engine.engine.update_weights_from_distributed(

--- a/lmdeploy/turbomind/turbomind.py
+++ b/lmdeploy/turbomind/turbomind.py
@@ -345,7 +345,8 @@ class TurboMind:
             """
             func, args = item
             args = list(args)
-            args[6] = torch.cuda.current_device()  # device id.
+            if len(args) > 6:
+                args[6] = torch.cuda.current_device()  # device id.
             return func(*args).clone()
 
         with torch.cuda.device(self.devices[0]):

--- a/tests/pytorch/engine/test_engine_sleep.py
+++ b/tests/pytorch/engine/test_engine_sleep.py
@@ -9,6 +9,7 @@ from lmdeploy.pytorch.engine.engine import Engine
 from lmdeploy.pytorch.engine.engine_instance import EngineInstance
 from lmdeploy.pytorch.engine.executor.mp_executor import MPExecutor
 from lmdeploy.pytorch.engine.request import RequestManager, RequestType, Response
+from lmdeploy.pytorch.exceptions import WeightUpdateError
 
 
 class _FakeSequence:
@@ -28,6 +29,7 @@ class _FakeScheduler:
     def __init__(self, session):
         self.sessions = {1: session}
         self.ended_sessions = []
+        self.clear_prefix_cache_calls = 0
 
     def end_session(self, session_id):
         self.ended_sessions.append(session_id)
@@ -35,6 +37,9 @@ class _FakeScheduler:
 
     def finish_deferred_kv_transfers_after_worker_drain(self):
         pass
+
+    def clear_prefix_cache(self):
+        self.clear_prefix_cache_calls += 1
 
 
 class _FakeEngineLoop:
@@ -125,6 +130,7 @@ def test_engine_sleep_blocks_inputs_cancels_sessions_then_sleeps(event_loop):
     assert resp.is_done
     assert resp.event.is_set()
     assert engine.scheduler.ended_sessions == [1]
+    assert engine.scheduler.clear_prefix_cache_calls == 1
     assert engine.executor.sleep_calls == [1]
     assert engine.events == ['drain', 'sleep', 'reset_engine_loop']
 
@@ -186,6 +192,77 @@ def test_mp_executor_wakeup_waits_for_kv_cache():
         ('wakeup', (['kv_cache'], ), 0xff),
         ('wakeup', (None, ), 0xff),
     ]
+
+
+def test_mp_executor_update_params_forwards_to_workers():
+    executor = MPExecutor.__new__(MPExecutor)
+    calls = []
+
+    def _collective_rpc(method, args=None, return_mask=0xff):
+        calls.append((method, args, return_mask))
+
+    executor.collective_rpc = _collective_rpc
+    request = object()
+
+    executor.update_params(request)
+
+    assert calls == [('update_params', (request, ), 0xff)]
+
+
+def test_engine_rejects_weight_update_without_offloaded_kv(event_loop):
+    engine = Engine.__new__(Engine)
+    engine._sleeping_tags = set()
+    engine.misc_config = SimpleNamespace(empty_init=False)
+    engine.scheduler = SimpleNamespace(sessions={}, block_trie=SimpleNamespace(leaves=set()),
+                                       has_unfinished=lambda: False)
+    engine.executor = SimpleNamespace(update_params=lambda _: pytest.fail('update should be rejected'))
+
+    with pytest.raises(WeightUpdateError, match='KV cache to be offloaded'):
+        engine.update_params(object())
+
+
+def test_engine_allows_weight_update_after_cache_offload(event_loop):
+    calls = []
+    engine = Engine.__new__(Engine)
+    engine._sleeping_tags = {'kv_cache'}
+    engine.misc_config = SimpleNamespace(empty_init=False)
+    engine.scheduler = SimpleNamespace(sessions={}, block_trie=SimpleNamespace(leaves=set()),
+                                       has_unfinished=lambda: False)
+    engine.executor = SimpleNamespace(update_params=lambda request: calls.append(request))
+    request = object()
+
+    engine.update_params(request)
+
+    assert calls == [request]
+
+
+def test_engine_rejects_weight_update_with_cached_prefix(event_loop):
+    engine = Engine.__new__(Engine)
+    engine._sleeping_tags = {'kv_cache'}
+    engine.misc_config = SimpleNamespace(empty_init=False)
+    engine.scheduler = SimpleNamespace(sessions={}, block_trie=SimpleNamespace(leaves={object()}),
+                                       has_unfinished=lambda: False)
+    engine.executor = SimpleNamespace(update_params=lambda _: pytest.fail('update should be rejected'))
+
+    with pytest.raises(WeightUpdateError, match='empty prefix cache'):
+        engine.update_params(object())
+
+
+def test_engine_distributed_weight_update_rejects_unsafe_state(event_loop):
+    engine = Engine.__new__(Engine)
+    engine._sleeping_tags = set()
+    engine.misc_config = SimpleNamespace(empty_init=False)
+    engine.scheduler = SimpleNamespace(sessions={}, block_trie=SimpleNamespace(leaves=set()),
+                                       has_unfinished=lambda: False)
+    engine._weights_update_lock = None
+    engine.executor = SimpleNamespace(update_weights_from_distributed=lambda _: pytest.fail(
+        'update should be rejected'))
+    request = object()
+
+    success, message = event_loop.run_until_complete(engine.update_weights_from_distributed(request))
+
+    assert not success
+    assert 'KV cache to be offloaded' in message
 
 
 def test_engine_instance_new_request_after_sleep_returns_cancel(event_loop):

--- a/tests/pytorch/paging/test_block_trie/test_kv_lifecycle.py
+++ b/tests/pytorch/paging/test_block_trie/test_kv_lifecycle.py
@@ -46,3 +46,22 @@ def test_evict_prunes_stale_non_leaf_entry(block_trie, scheduler, num_gpu_blocks
     assert block_trie.evict(2) == 2
     assert len(block_trie.leaves) == 0
     assert block_mgr.get_num_free_gpu_blocks() == num_gpu_blocks
+
+
+def test_clear_releases_all_trie_owned_blocks(block_trie, scheduler, num_gpu_blocks):
+    block_mgr = scheduler.block_manager
+    sess = scheduler.add_session(0)
+    block_size = sess.seq_meta.block_size
+    seq = sess.add_sequence([1] * block_size * 2 + [2])
+
+    block_mgr.allocate(seq)
+    block_trie.allocate(seq)
+    block_mgr.free(seq)
+    seq.set_step(0)
+
+    assert len(block_trie.leaves) == 1
+    assert block_trie.clear() == 2
+    assert len(block_trie.leaves) == 0
+    assert block_mgr.get_num_free_gpu_blocks() == num_gpu_blocks
+    assert block_trie.stats.num_query_tokens == 0
+    assert block_trie.stats.num_hit_tokens == 0

--- a/tests/test_lmdeploy/serve/openai/test_management.py
+++ b/tests/test_lmdeploy/serve/openai/test_management.py
@@ -1,0 +1,101 @@
+import asyncio
+import json
+import subprocess
+import sys
+from types import SimpleNamespace
+
+from fastapi import APIRouter
+
+from lmdeploy.serve.openai.endpoints.management import register
+from lmdeploy.serve.openai.protocol import UpdateParamsRequest
+
+
+class _Context:
+
+    def __init__(self, *, sleeping_tags, empty_init=False):
+        self.async_engine = SimpleNamespace(
+            backend='pytorch',
+            sleeping_tags=sleeping_tags,
+            backend_config=SimpleNamespace(empty_init=empty_init),
+            engine=SimpleNamespace(update_params=self._update_params),
+        )
+        self.health_monitor = None
+        self.allow_terminate_by_client = False
+        self.enable_abort_handling = False
+        self.calls = []
+
+    def _update_params(self, request):
+        self.calls.append(request)
+
+
+def _endpoint(context, path):
+    router = APIRouter()
+    register(router, context)
+    return next(route.endpoint for route in router.routes if route.path == path)
+
+
+def test_management_import_does_not_load_pytorch_engine():
+    code = (
+        'import sys\n'
+        'import lmdeploy.serve.openai.endpoints.management\n'
+        "assert 'lmdeploy.pytorch.engine.engine' not in sys.modules\n")
+
+    subprocess.run([sys.executable, '-c', code], check=True)
+
+
+def test_update_weights_rejects_when_kv_cache_is_available():
+    context = _Context(sleeping_tags=set())
+    endpoint = _endpoint(context, '/update_weights')
+
+    response = endpoint(UpdateParamsRequest(serialized_named_tensors='payload'))
+
+    assert response.status_code == 409
+    assert 'KV cache' in json.loads(response.body)['message']
+    assert context.calls == []
+
+
+def test_update_weights_runs_after_only_weights_are_woken():
+    context = _Context(sleeping_tags={'kv_cache'})
+    endpoint = _endpoint(context, '/update_weights')
+    request = UpdateParamsRequest(serialized_named_tensors='payload')
+
+    response = endpoint(request)
+
+    assert response.status_code == 200
+    assert context.calls == [request]
+
+
+def test_update_weights_rejects_before_weights_are_woken():
+    context = _Context(sleeping_tags={'weights', 'kv_cache'})
+    endpoint = _endpoint(context, '/update_weights')
+
+    response = endpoint(UpdateParamsRequest(serialized_named_tensors='payload'))
+
+    assert response.status_code == 409
+    assert context.calls == []
+
+
+def test_update_weights_allows_empty_init_loading():
+    context = _Context(sleeping_tags={'weights', 'kv_cache'}, empty_init=True)
+    endpoint = _endpoint(context, '/update_weights')
+
+    response = endpoint(UpdateParamsRequest(serialized_named_tensors='payload'))
+
+    assert response.status_code == 200
+    assert len(context.calls) == 1
+
+
+def test_distributed_update_rejects_when_kv_cache_is_available():
+    context = _Context(sleeping_tags=set())
+    endpoint = _endpoint(context, '/update_weights_from_distributed')
+
+    async def _run():
+        from lmdeploy.serve.openai.protocol import UpdateWeightsFromDistributedRequest
+
+        return await endpoint(UpdateWeightsFromDistributedRequest(
+            names=[], dtypes=[], shapes=[], group_name='group'))
+
+    response = asyncio.run(_run())
+
+    assert response.status_code == 409
+    assert 'KV cache' in json.loads(response.body)['message']


### PR DESCRIPTION
## Motivation

Fixes #4917.

Hot model-weight updates could leave prefix-cache KV blocks computed with the previous weights. Subsequent requests then mixed stale prefix KV with the new model weights, producing incorrect output without an error.

## Modification

- Require the PyTorch engine to offload KV cache and have no active sessions or pending KV work before a weight update.
- Serialize synchronous and distributed weight updates with sleep and wakeup operations.
- Clear scheduler-owned prefix-cache entries when the engine enters sleep.
- Add the missing multi-process `update_params` path and guard serialized tensor payload handling.
- Keep weight-update errors in a lightweight module so management endpoint imports do not load the PyTorch/disaggregated engine.
- Document the required sleep/wakeup sequence in English and Chinese update-weight guides.

## BC-breaking

Weight updates that are attempted while KV cache or active sessions remain available are now rejected with a conflict/error response. Clients must call `/sleep` first and then `/wakeup?tags=weights` before updating weights, as documented.

## Use cases

This protects RLHF and other workflows that hot-update model weights while prefix caching is enabled.

## Tests

- `128Core`: `19 passed` for `tests/pytorch/engine/test_engine_sleep.py`, `tests/pytorch/paging/test_block_trie/test_kv_lifecycle.py`, and `tests/test_lmdeploy/serve/openai/test_management.py`.
- Chinese and English Sphinx HTML builds: passed.
- Repository pre-commit hooks: passed.

## Checklist

- [x] Pre-commit and lint checks passed.
- [x] Unit tests cover the modified behavior.
- [x] Documentation updated for the new update-weight lifecycle.
- [x] No downstream dependency changes.
