### PR TITLE
fix(pytorch): avoid Triton miscompile in paged attention reduction

### DIFF
--- a/lmdeploy/pytorch/kernels/cuda/pagedattention.py
+++ b/lmdeploy/pytorch/kernels/cuda/pagedattention.py
@@ -592,14 +592,19 @@ def _reduce_split_kernel(
     cur_batch = tl.program_id(1)
     cur_head = tl.program_id(0)
 
+    # Apply the scalar batch/head offsets before constructing the K x DV
+    # tensor offsets. Broadcasting the scalar base into that tensor can make
+    # Triton miscompile 128 x 128 reductions when launched with two warps.
+    acc_ptr += cur_batch * stride_abs + cur_head * stride_ah
+    out_ptr += cur_batch * stride_obs + cur_head * stride_oh
+
     # initialize offsets
     offs_dv = tl.arange(0, BLOCK_DV)
     offs_k = tl.arange(0, SPLIT_K)
     mask_dv = offs_dv < head_size_v
 
-    offs_acc = (cur_batch * stride_abs + cur_head * stride_ah + offs_k[:, None] * stride_ak +
-                offs_dv[None, :] * stride_ad)
-    offs_mi = (cur_batch * stride_abs + cur_head * stride_ah + stride_ak * offs_k + head_size_v)
+    offs_acc = offs_k[:, None] * stride_ak + offs_dv[None, :] * stride_ad
+    offs_mi = stride_ak * offs_k + head_size_v
 
     if USE_PDL:
         tl.extra.cuda.gdc_wait()
@@ -622,7 +627,7 @@ def _reduce_split_kernel(
         l_sum = l_sum + tl.exp2(sink * tl_log2(math.e) - m_max)
     acc = acc / (l_sum + 1e-10)
 
-    out_offs = (cur_batch * stride_obs + cur_head * stride_oh + offs_dv * stride_od)
+    out_offs = offs_dv * stride_od
     tl.store(out_ptr + out_offs, acc, mask=mask_dv)
 
 

--- a/tests/pytorch/kernel/test_paged_attention.py
+++ b/tests/pytorch/kernel/test_paged_attention.py
@@ -352,6 +352,51 @@ class TestPagedAttention(TestPagedAttentionBase):
         torch.testing.assert_close(out, window_gt, atol=1e-3, rtol=1e-5)
 
 
+class TestPagedAttentionLongContext(TestPagedAttentionBase):
+    """Regression tests for split-K reduction with a long KV cache."""
+
+    @pytest.fixture
+    def dtype(self):
+        yield torch.bfloat16
+
+    @pytest.fixture
+    def batched_q(self, seq_len, kv_seqlens, num_heads_q, feat_dim, dtype):
+        torch.manual_seed(123)
+        batch_size = len(kv_seqlens)
+        yield torch.randn(batch_size, seq_len, num_heads_q, feat_dim, dtype=dtype, device='cuda')
+
+    @pytest.fixture
+    def batched_kv(self, kv_seqlens, num_heads_k, feat_dim, feat_dim_v, dtype):
+        torch.manual_seed(456)
+        batch_size = len(kv_seqlens)
+        max_seq_len = kv_seqlens.max().item()
+        k = torch.randn(batch_size, max_seq_len, num_heads_k, feat_dim, dtype=dtype, device='cuda')
+        v = torch.randn(batch_size, max_seq_len, num_heads_k, feat_dim_v, dtype=dtype, device='cuda')
+        yield k, v
+
+    @pytest.mark.parametrize('feat_dim', [128], indirect=True)
+    @pytest.mark.parametrize('feat_dim_v', [128], indirect=True)
+    @pytest.mark.parametrize(['num_heads_q', 'num_heads_k'], [(16, 1)], indirect=True)
+    @pytest.mark.parametrize('history_lens', [(20547, )], indirect=True)
+    @pytest.mark.parametrize('block_size', [16], indirect=True)
+    @pytest.mark.parametrize('layout', ['bshd'], indirect=True)
+    def test_split_k_reduction(self, conti_q, blocked_kv, block_offsets, kv_seqlens, layout, conti_gt, monkeypatch):
+        from lmdeploy.pytorch.kernels.cuda import pagedattention
+
+        # H200 selects SPLIT_K=128 for this shape. Force the same reduction
+        # tile so that GPUs with fewer SMs do not miss the regression.
+        monkeypatch.setattr(pagedattention, '_get_split_k', lambda *args, **kwargs: 128)
+
+        blocked_k, blocked_v = blocked_kv
+        out = pagedattention.flash_attn_with_kvcache(conti_q,
+                                                     blocked_k,
+                                                     blocked_v,
+                                                     page_table=block_offsets,
+                                                     cache_seqlens=kv_seqlens,
+                                                     kv_layout=layout)
+        torch.testing.assert_close(out, conti_gt, atol=1e-3, rtol=1e-5)
+
+
 class TestPagedAttentionSink(TestPagedAttentionBase):
 
     @pytest.fixture


### PR DESCRIPTION
## Motivation

Intern-S1 can produce corrupted output during long-context decoding when paged attention selects a 128 x 128 split-K reduction. The reducer's original address expression is miscompiled with two warps by Triton 3.5.x and 3.6.0.

The issue is in Triton's layout lowering/code generation: keeping the batch/head base offset inside the broadcast K x DV integer offset tensor produces incorrect results. Four warps happens to avoid the faulty lowering, but changing the warp count only masks the root cause.

## Modification

- Apply scalar batch/head offsets directly to the accumulator and output pointers before constructing tensor offsets.
- Keep the existing two-warp launch configuration.
- Add a BF16 long-context regression test that forces `SPLIT_K=128` with a 128-dimensional value head and a 20,548-token KV cache.

## BC-breaking

No backward-incompatible changes.

## Validation

- Compared the original and rewritten reducers against a PyTorch reference on an NVIDIA H200 with PyTorch 2.10.0+cu128.
- Tested every stable Triton release from 3.4.0 through 3.8.0:
  - Original expression is correct on 3.4.0 and 3.7.0+.
  - Original expression with two warps fails on 3.5.0, 3.5.1, and 3.6.0 (all 16 heads fail; max absolute error 0.426554).
  - Rewritten expression is correct with both two and four warps on all tested versions (max absolute error <= 2.38e-7).
- Compiled and ran the patched LMDeploy reducer with 1, 2, 4, 8, 16, and 32 heads on all tested Triton versions; all cases passed (max absolute error <= 3.58e-7).
- Long-context BF16 reference comparison passed with max absolute error 3.05e-4.
- Reproduced the original Intern-S1 `/v1/chat/completions` request under Triton 3.6.0 after the rewrite: HTTP 200, valid 13,976-token completion and tool call, with no corrupted output.
- `git diff --check` passes.

The added pytest regression was not executed through pytest locally because pytest is not installed in the reproduction environment; the equivalent test path was run directly against the PyTorch reference.
