### PR TITLE
feat: resolve oci:// model paths via llmman serve

### DIFF
--- a/lmdeploy/cli/entrypoint.py
+++ b/lmdeploy/cli/entrypoint.py
@@ -23,6 +23,7 @@ def run():
             args.model_path
 
     if 'run' in dir(args):
+        from lmdeploy.oci import is_oci_ref
         from lmdeploy.utils import get_model
         model_path = getattr(args, 'model_path', None)
         revision = getattr(args, 'revision', None)
@@ -30,8 +31,11 @@ def run():
         if model_path is not None and not os.path.exists(args.model_path):
             args.model_path = get_model(args.model_path, download_dir=download_dir, revision=revision)
         model_path_or_server = getattr(args, 'model_path_or_server', None)
-        if model_path_or_server is not None and (':' not in model_path_or_server
-                                                 and not os.path.exists(model_path_or_server)):
+        # A ':' normally marks a server address (host:port), but an oci://
+        # reference carries one in its tag, so it is matched before that check.
+        if model_path_or_server is not None and (is_oci_ref(model_path_or_server) or
+                                                 (':' not in model_path_or_server
+                                                  and not os.path.exists(model_path_or_server))):
             args.model_path_or_server = get_model(args.model_path_or_server,
                                                   download_dir=download_dir,
                                                   revision=revision)

--- a/lmdeploy/llmman.py
+++ b/lmdeploy/llmman.py
@@ -1,0 +1,212 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+"""Client for a running ``llmman serve`` daemon.
+
+Used to acquire models published as CNCF ModelPack
+(https://github.com/modelpack/model-spec) OCI artifacts. The daemon owns the
+registry work -- ModelPack media types, registry auth, resumable blob download
+and a content-addressed store -- so it is not reimplemented here.
+
+Contract (from llmman's src/cmd/serve.rs and src/daemon.rs):
+  - LLMMAN_HOST is ``[scheme://]host[:port][/path]``, default 127.0.0.1:17434.
+    A wildcard bind host (0.0.0.0, ::) is rewritten to loopback, since a client
+    cannot connect to "every interface".
+  - ``GET /api/version`` -> ``{"version":..., "exe":..., "pid":...}``.
+  - ``POST /api/pull`` ``{"model": ref}`` -> NDJSON stream of ``{"status":...}``
+    objects, terminated by ``{"status":"success"}`` or ``{"error":"..."}``.
+    An error can arrive in-band at HTTP 200.
+  - ``llmman resolve --no-pull <ref>`` -> one line of JSON carrying ``path``.
+"""
+
+import ipaddress
+import json
+import logging
+import os
+import shutil
+import subprocess
+import urllib.error
+import urllib.request
+
+logger = logging.getLogger(__name__)
+
+HOST_ENV = "LLMMAN_HOST"
+BIN_ENV = "LMDEPLOY_LLMMAN_BIN"
+
+DEFAULT_HOST = "127.0.0.1"
+DEFAULT_PORT = 17434
+
+PROBE_TIMEOUT_SECONDS = 5
+
+
+def _connectable_host(host: str) -> str:
+    """Rewrite a wildcard bind host to its loopback equivalent."""
+    try:
+        ip = ipaddress.ip_address(host.strip("[]"))
+    except ValueError:
+        return host
+    if not ip.is_unspecified:
+        return host
+    return "127.0.0.1" if ip.version == 4 else "::1"
+
+
+def endpoint() -> str:
+    """The http origin of the llmman daemon, honouring LLMMAN_HOST."""
+    raw = os.getenv(HOST_ENV, "").strip().strip("\"'")
+    if not raw:
+        return f"http://{DEFAULT_HOST}:{DEFAULT_PORT}"
+
+    if "://" in raw:
+        raw = raw.split("://", 1)[1]
+    raw = raw.split("/", 1)[0]
+
+    host, port = raw, DEFAULT_PORT
+    if raw.startswith("["):  # bracketed IPv6, optionally with :port
+        close = raw.find("]")
+        if close != -1:
+            host = raw[: close + 1]
+            rest = raw[close + 1 :]
+            if rest.startswith(":") and rest[1:].isdigit():
+                port = int(rest[1:])
+    elif raw.count(":") == 1:
+        maybe_host, maybe_port = raw.rsplit(":", 1)
+        if maybe_port.isdigit():
+            host, port = maybe_host, int(maybe_port)
+
+    host = host or DEFAULT_HOST
+    resolved = _connectable_host(host)
+    if ":" in resolved and not resolved.startswith("["):
+        resolved = f"[{resolved}]"
+    return f"http://{resolved}:{port}"
+
+
+def llmman_bin() -> str:
+    """The llmman executable name, overridable per project."""
+    return os.getenv(BIN_ENV, "").strip() or "llmman"
+
+
+def check_daemon(base: str) -> None:
+    """Confirm an llmman daemon is listening and is actually llmman."""
+    url = base + "/api/version"
+    try:
+        with urllib.request.urlopen(url, timeout=PROBE_TIMEOUT_SECONDS) as resp:
+            if resp.status != 200:
+                raise RuntimeError(f"llmman daemon at {base} answered /api/version with HTTP {resp.status}")
+            payload = json.loads(resp.read().decode("utf-8"))
+    except urllib.error.URLError as exc:
+        raise RuntimeError(
+            f"no llmman daemon reachable at {base} ({exc.reason}). Start one with "
+            f"`llmman serve`, or point {HOST_ENV} at an existing daemon."
+        ) from exc
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"the server at {base} is not an llmman daemon (unparseable /api/version)") from exc
+
+    if not isinstance(payload, dict) or not payload.get("version"):
+        raise RuntimeError(f"the server at {base} is not an llmman daemon (no version in /api/version)")
+
+
+def pull(base: str, reference: str, progress=None) -> None:
+    """Stream POST /api/pull until the daemon reports success.
+
+    ``progress`` receives ``(status, completed, total)``. An error can arrive
+    in-band at HTTP 200, and a stream that ends without ``success`` is also a
+    failure -- neither is treated as a completed pull.
+    """
+    body = json.dumps({"model": reference}).encode("utf-8")
+    req = urllib.request.Request(
+        base + "/api/pull",
+        data=body,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+
+    succeeded = False
+    try:
+        with urllib.request.urlopen(req) as resp:
+            if resp.status != 200:
+                raise RuntimeError(f"llmman pull of {reference!r} failed: HTTP {resp.status}")
+            for raw_line in resp:
+                line = raw_line.decode("utf-8").strip()
+                if not line:
+                    continue
+                try:
+                    obj = json.loads(line)
+                except json.JSONDecodeError:
+                    # Tolerate a non-JSON diagnostic rather than aborting a
+                    # pull that may still be progressing.
+                    continue
+                if not isinstance(obj, dict):
+                    continue
+                if obj.get("error"):
+                    raise RuntimeError(f"llmman pull of {reference!r} failed: {obj['error']}")
+                status = obj.get("status")
+                if status == "success":
+                    succeeded = True
+                    continue
+                if progress is not None and status:
+                    progress(status, obj.get("completed", 0), obj.get("total", 0))
+    except urllib.error.HTTPError as exc:
+        raise RuntimeError(f"llmman pull of {reference!r} failed: HTTP {exc.code}") from exc
+    except urllib.error.URLError as exc:
+        raise RuntimeError(f"llmman pull of {reference!r} failed: {exc.reason}") from exc
+
+    if not succeeded:
+        raise RuntimeError(f"llmman pull of {reference!r} ended without reporting success")
+
+
+def parse_resolve_output(stdout: str, reference: str) -> str:
+    """Parse ``llmman resolve`` stdout into the resolved local path."""
+    lines = [line.strip() for line in stdout.splitlines() if line.strip()]
+    if not lines:
+        raise RuntimeError(f"llmman resolve {reference!r}: no output on stdout")
+
+    try:
+        payload = json.loads(lines[-1])
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"llmman resolve {reference!r}: could not parse output as JSON: {lines[-1]}") from exc
+
+    if not isinstance(payload, dict):
+        raise RuntimeError(f"llmman resolve {reference!r}: expected a JSON object, got {lines[-1]}")
+
+    path = payload.get("path")
+    if not isinstance(path, str) or not path.strip():
+        raise RuntimeError(f"llmman resolve {reference!r}: returned an empty path")
+    if not os.path.exists(path):
+        raise RuntimeError(f"llmman resolve {reference!r}: reported path {path!r} does not exist")
+    return path
+
+
+def resolve(reference: str) -> str:
+    """Ask the CLI where the daemon's pull left the model on disk.
+
+    ``--no-pull`` guarantees this only reports on bytes ``/api/pull`` already
+    fetched, so the daemon stays the only thing that touches the network.
+    """
+    binary = llmman_bin()
+    if shutil.which(binary) is None and not os.path.isfile(binary):
+        raise RuntimeError(
+            f"{binary!r} not found. Install llmman "
+            "(https://github.com/llmmanorg/llmman) and put it on PATH, or set "
+            f"{BIN_ENV} to its location."
+        )
+
+    completed = subprocess.run(
+        [binary, "resolve", "--no-pull", reference],
+        capture_output=True,
+        stdin=subprocess.DEVNULL,
+        text=True,
+        check=False,
+    )
+    if completed.returncode != 0:
+        raise RuntimeError(
+            f"`{binary} resolve --no-pull {reference}` failed with exit code "
+            f"{completed.returncode}: {completed.stderr.strip()}"
+        )
+    return parse_resolve_output(completed.stdout, reference)
+
+
+def pull_and_resolve(reference: str, progress=None) -> str:
+    """Full acquisition: probe the daemon, pull through it, report the path."""
+    base = endpoint()
+    check_daemon(base)
+    logger.info("Pulling %s via llmman daemon at %s", reference, base)
+    pull(base, reference, progress)
+    return resolve(reference)

--- a/lmdeploy/oci.py
+++ b/lmdeploy/oci.py
@@ -1,0 +1,59 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+"""Resolve ``oci://`` model references to a local path.
+
+A model published as a CNCF ModelPack (https://github.com/modelpack/model-spec)
+artifact lives in an ordinary container registry, so it reuses the registry,
+credentials, mirroring and air-gap tooling a deployment already has for
+container images.
+
+Acquisition is delegated to a running ``llmman serve``
+(https://github.com/llmmanorg/llmman), which already implements the ModelPack
+media types, registry auth, resumable blob download and a content-addressed
+store. The daemon does the pull (POST /api/pull, streamed so a multi-gigabyte
+fetch is not silent) but deliberately exposes no local path, so
+``llmman resolve --no-pull`` reports where the bytes landed.
+
+An explicit ``oci://`` scheme is required rather than sniffing a bare
+``registry/name:tag``: that shape is indistinguishable from a HuggingFace repo
+id (``org/model``), so guessing would silently hijack existing deployments.
+"""
+
+import logging
+
+from lmdeploy import llmman
+
+# Plain logging rather than lmdeploy.utils.get_logger: utils imports this
+# module from get_model(), and this one is kept free of heavy imports.
+logger = logging.getLogger("lmdeploy")
+
+SCHEME = "oci://"
+
+
+def is_oci_ref(model_path) -> bool:
+    """Whether ``model_path`` carries the ``oci://`` scheme."""
+    if not model_path:
+        return False
+    return str(model_path).lower().startswith(SCHEME)
+
+
+def strip_scheme(model_path) -> str:
+    """Drop the ``oci://`` prefix, leaving the bare registry reference."""
+    text = str(model_path)
+    if is_oci_ref(text):
+        return text[len(SCHEME) :]
+    return text
+
+
+def get_oci_model(model_path: str) -> str:
+    """Pull an ``oci://`` reference through llmman and return the local path."""
+    reference = strip_scheme(model_path)
+    if not reference.strip():
+        raise ValueError(f"empty OCI model reference: {model_path!r}")
+
+    def _progress(status, completed, total):
+        if total:
+            logger.info(f"llmman: {status} ({completed}/{total} bytes)")
+        else:
+            logger.info(f"llmman: {status}")
+
+    return llmman.pull_and_resolve(reference.strip(), progress=_progress)

--- a/lmdeploy/utils.py
+++ b/lmdeploy/utils.py
@@ -253,8 +253,18 @@ def get_hf_gen_cfg(path: str, trust_remote_code: bool = False):
 
 
 def get_model(pretrained_model_name_or_path: str, download_dir: str = None, revision: str = None, token: str = None):
-    """Get model from huggingface, modelscope or openmind_hub."""
+    """Get model from huggingface, modelscope, openmind_hub or an OCI
+    registry."""
     import os
+
+    from lmdeploy.oci import get_oci_model, is_oci_ref
+
+    # A CNCF ModelPack artifact is pulled as a whole from a container registry;
+    # download_dir/revision/token are hub concepts with no counterpart there, so
+    # they are not forwarded. Every other path is unchanged.
+    if is_oci_ref(pretrained_model_name_or_path):
+        return get_oci_model(pretrained_model_name_or_path)
+
     if os.getenv('LMDEPLOY_USE_MODELSCOPE', 'False').lower() == 'true':
         from modelscope import snapshot_download
     elif os.getenv('LMDEPLOY_USE_OPENMIND_HUB', 'False').lower() == 'true':

--- a/tests/test_lmdeploy/test_llmman.py
+++ b/tests/test_lmdeploy/test_llmman.py
@@ -1,0 +1,118 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+"""The `llmman serve` client: the daemon protocol behind oci:// model paths.
+
+Exercised against a real HTTP server on a loopback port rather than mocks, so
+the NDJSON streaming contract is genuinely tested.
+"""
+
+import http.server
+import json
+import socketserver
+import threading
+
+import pytest
+
+from lmdeploy import llmman
+
+
+def _ndjson(*objs):
+    return "".join(json.dumps(o) + "\n" for o in objs)
+
+
+class _FakeDaemon:
+    """A minimal stand-in for `llmman serve`, on a real loopback port."""
+
+    def __init__(self):
+        self.version = {"version": "0.1.0", "pid": 1}
+        self.pull_body = _ndjson({"status": "success"})
+        self.pull_status = 200
+        self.last_request = None
+        daemon = self
+
+        class Handler(http.server.BaseHTTPRequestHandler):
+            def log_message(self, *args):
+                pass
+
+            def _send(self, status, body, ctype):
+                raw = body.encode()
+                self.send_response(status)
+                self.send_header("Content-Type", ctype)
+                self.send_header("Content-Length", str(len(raw)))
+                self.end_headers()
+                self.wfile.write(raw)
+
+            def do_GET(self):
+                self._send(200, json.dumps(daemon.version), "application/json")
+
+            def do_POST(self):
+                length = int(self.headers.get("Content-Length", 0))
+                daemon.last_request = json.loads(self.rfile.read(length))
+                self._send(daemon.pull_status, daemon.pull_body, "application/x-ndjson")
+
+        self._server = socketserver.TCPServer(("127.0.0.1", 0), Handler)
+        self.url = f"http://127.0.0.1:{self._server.server_address[1]}"
+        threading.Thread(target=self._server.serve_forever, daemon=True).start()
+
+    def close(self):
+        self._server.shutdown()
+        self._server.server_close()
+
+
+@pytest.fixture
+def daemon():
+    d = _FakeDaemon()
+    yield d
+    d.close()
+
+
+def test_accepts_a_llmman_daemon(daemon):
+    llmman.check_daemon(daemon.url)
+
+
+def test_rejects_a_non_llmman_server(daemon):
+    daemon.version = {"hello": "world"}
+    with pytest.raises(RuntimeError, match="not an llmman daemon"):
+        llmman.check_daemon(daemon.url)
+
+
+def test_reports_nothing_listening_actionably():
+    with pytest.raises(RuntimeError, match="llmman serve"):
+        llmman.check_daemon("http://127.0.0.1:1")
+
+
+def test_pull_succeeds_and_forwards_progress(daemon):
+    daemon.pull_body = _ndjson(
+        {"status": "pulling manifest"},
+        {"status": "pulling blobs", "completed": 50, "total": 100},
+        {"status": "success"},
+    )
+    seen = []
+    llmman.pull(daemon.url, "ghcr.io/org/model:tag", lambda *a: seen.append(a))
+
+    assert daemon.last_request == {"model": "ghcr.io/org/model:tag"}
+    assert seen == [("pulling manifest", 0, 0), ("pulling blobs", 50, 100)]
+
+
+def test_reports_an_in_band_error_at_http_200(daemon):
+    # The daemon streams errors in-band, so a 200 does not mean success.
+    daemon.pull_body = _ndjson({"status": "pulling"}, {"error": "unauthorized"})
+    with pytest.raises(RuntimeError, match="unauthorized"):
+        llmman.pull(daemon.url, "ref")
+
+
+def test_rejects_a_stream_that_ends_without_success(daemon):
+    daemon.pull_body = _ndjson({"status": "pulling blobs"})
+    with pytest.raises(RuntimeError, match="without reporting success"):
+        llmman.pull(daemon.url, "ref")
+
+
+def test_reports_a_non_ok_status(daemon):
+    daemon.pull_status = 400
+    daemon.pull_body = '{"error":"bad request"}'
+    with pytest.raises(RuntimeError):
+        llmman.pull(daemon.url, "ref")
+
+
+def test_tolerates_a_non_json_diagnostic_line(daemon):
+    daemon.pull_body = "not json\n" + _ndjson({"status": "success"})
+    llmman.pull(daemon.url, "ref")

--- a/tests/test_lmdeploy/test_oci.py
+++ b/tests/test_lmdeploy/test_oci.py
@@ -1,0 +1,141 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+"""``oci://`` model paths resolve to a local directory.
+
+The scheme is explicit on purpose: a bare ``registry/name:tag`` is the same
+shape as a HuggingFace repo id, so sniffing would hijack existing deployments.
+These pin that, the output contract llmman promises, and that every other path
+shape is untouched.
+"""
+
+import json
+import os
+import tempfile
+from unittest import mock
+
+import pytest
+
+from lmdeploy import llmman
+from lmdeploy.oci import get_oci_model, is_oci_ref, strip_scheme
+
+
+class TestScheme:
+    def test_recognizes_the_oci_scheme(self):
+        assert is_oci_ref("oci://ghcr.io/org/model:tag")
+        assert is_oci_ref("OCI://ghcr.io/org/model:tag")
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "internlm/internlm2-chat-7b",
+            "ghcr.io/org/model:tag",
+            "/local/path/to/model",
+            "s3://bucket/key",
+            "http://0.0.0.0:23333",
+            "",
+            None,
+        ],
+    )
+    def test_leaves_every_other_shape_alone(self, value):
+        # A bare HF repo id must never be claimed.
+        assert not is_oci_ref(value)
+
+    def test_strips_the_scheme_only_when_present(self):
+        assert strip_scheme("oci://ghcr.io/org/model:tag") == "ghcr.io/org/model:tag"
+        assert strip_scheme("OCI://ghcr.io/org/model:tag") == "ghcr.io/org/model:tag"
+        assert strip_scheme("internlm/internlm2-chat-7b") == "internlm/internlm2-chat-7b"
+
+
+class TestResolveContract:
+    """`llmman resolve --no-pull` reports where the daemon's pull landed."""
+
+    def test_parses_the_documented_contract(self):
+        with tempfile.TemporaryDirectory() as path:
+            line = json.dumps({"reference": "ghcr.io/org/model:tag", "path": path, "format": "safetensors"})
+            assert llmman.parse_resolve_output(line, "ref") == path
+
+    def test_tolerates_trailing_newline_and_leaked_diagnostics(self):
+        with tempfile.TemporaryDirectory() as path:
+            out = "pulling blobs...\n" + json.dumps({"path": path}) + "\n"
+            assert llmman.parse_resolve_output(out, "ref") == path
+
+    def test_ignores_unknown_fields_so_the_contract_can_grow(self):
+        with tempfile.TemporaryDirectory() as path:
+            line = json.dumps({"path": path, "format": "gguf", "mmproj": "/x", "future": 1})
+            assert llmman.parse_resolve_output(line, "ref") == path
+
+    @pytest.mark.parametrize(
+        "bad",
+        [
+            "",
+            "   \n\n",
+            "not json",
+            '["a", "list"]',
+            '{"no_path": 1}',
+            '{"path": ""}',
+            '{"path": 3}',
+            '{"path": "/nonexistent/xyzzy"}',
+        ],
+    )
+    def test_rejects_malformed_output(self, bad):
+        with pytest.raises(RuntimeError):
+            llmman.parse_resolve_output(bad, "ref")
+
+
+class TestEndpoint:
+    @pytest.mark.parametrize(
+        "host,want",
+        [
+            ("", "http://127.0.0.1:17434"),
+            ("1.2.3.4:9999", "http://1.2.3.4:9999"),
+            ("1.2.3.4", "http://1.2.3.4:17434"),
+            ("http://1.2.3.4:9999/ignored", "http://1.2.3.4:9999"),
+            # A wildcard bind is meaningful to the server but not to a client.
+            ("0.0.0.0:9999", "http://127.0.0.1:9999"),
+            ("[::]:9999", "http://[::1]:9999"),
+        ],
+    )
+    def test_parses_every_llmman_host_form(self, host, want):
+        with mock.patch.dict(os.environ, {llmman.HOST_ENV: host}):
+            assert llmman.endpoint() == want
+
+    def test_binary_default_and_override(self):
+        with mock.patch.dict(os.environ, {llmman.BIN_ENV: ""}):
+            assert llmman.llmman_bin() == "llmman"
+        with mock.patch.dict(os.environ, {llmman.BIN_ENV: "/opt/llmman"}):
+            assert llmman.llmman_bin() == "/opt/llmman"
+
+
+class TestGetOciModel:
+    def test_rejects_an_empty_reference_without_touching_the_daemon(self):
+        for ref in ("oci://", "oci://   "):
+            with pytest.raises(ValueError):
+                get_oci_model(ref)
+
+    def test_strips_the_scheme_before_handing_off_to_llmman(self):
+        with mock.patch("lmdeploy.oci.llmman.pull_and_resolve", return_value="/resolved") as acquire:
+            assert get_oci_model("oci://ghcr.io/org/model:tag") == "/resolved"
+        assert acquire.call_args[0][0] == "ghcr.io/org/model:tag"
+        assert acquire.call_args[1]["progress"] is not None
+
+    def test_reports_a_missing_binary(self):
+        with mock.patch.dict(os.environ, {llmman.BIN_ENV: "/definitely/not/here"}):
+            with pytest.raises(RuntimeError, match="not found"):
+                llmman.resolve("ref")
+
+
+class TestGetModelDispatch:
+    """get_model routes oci:// away from the hub downloaders."""
+
+    def test_oci_path_does_not_reach_snapshot_download(self):
+        from lmdeploy.utils import get_model
+
+        with mock.patch("lmdeploy.oci.get_oci_model", return_value="/resolved") as resolver:
+            assert get_model("oci://ghcr.io/org/model:tag") == "/resolved"
+        resolver.assert_called_once_with("oci://ghcr.io/org/model:tag")
+
+    def test_hf_repo_id_still_uses_snapshot_download(self):
+        from lmdeploy.utils import get_model
+
+        with mock.patch("huggingface_hub.snapshot_download", return_value="/hf") as snap:
+            assert get_model("internlm/internlm2-chat-7b") == "/hf"
+        snap.assert_called_once()


### PR DESCRIPTION
## Motivation

Model distribution is increasingly moving to OCI registries -- the same registries, credentials, mirroring and air-gap tooling a deployment already uses for container images. [CNCF ModelPack](https://github.com/modelpack/model-spec) is the spec for that.

This adds an `oci://` scheme so such a model works anywhere a HuggingFace repo id does:

```bash
lmdeploy serve api_server oci://ghcr.io/org/model:tag
lmdeploy chat oci://ghcr.io/org/model:tag
```

## Modification

- **`lmdeploy/llmman.py`** (new): a client for a running [`llmman serve`](https://github.com/llmmanorg/llmman) daemon. Acquisition is delegated rather than hand-rolled -- llmman already implements the ModelPack media types, registry auth, resumable blob download and a content-addressed store. Stdlib-only (`urllib`), **no new dependency**:
  - `GET /api/version` probes reachability *and* identity; a server answering without a `version` field is reported as "not an llmman daemon", worth distinguishing from nothing listening.
  - `POST /api/pull` streams NDJSON so a multi-gigabyte fetch is not silent. An error arrives **in-band at HTTP 200**, and a stream that ends without `success` is also a failure -- both are errors, not a completed pull.
  - `llmman resolve --no-pull` reports where the bytes landed. The daemon deliberately exposes no local path, so the CLI is the documented interface; `--no-pull` guarantees it only reports on what `/api/pull` already fetched.
  - `LLMMAN_HOST` is honoured with llmman's own parsing, including rewriting a wildcard bind (`0.0.0.0`, `[::]`) to loopback.

- **`lmdeploy/oci.py`** (new): scheme handling. Kept free of heavy imports and using plain `logging` rather than `lmdeploy.utils.get_logger`, since `utils` imports this module from `get_model()`.

- **`lmdeploy/utils.py`**: `get_model()` is the single dispatch point -- the CLI, `vl/model/builder.py` and `turbomind.py` all route through it, so one branch covers every entry point. `download_dir` / `revision` / `token` are hub concepts with no ModelPack counterpart and are deliberately not forwarded.

- **`lmdeploy/cli/entrypoint.py`**: `model_path_or_server` treats any `:` as marking a `host:port` server address. An `oci://ghcr.io/org/model:tag` carries one in its tag and would be misread as a server, so the scheme is matched before that check. `model_path` needed no change -- an `oci://` reference never satisfies `os.path.exists`, so it already falls through to `get_model`.

A pull needs **both** the daemon reachable and the binary on `PATH` (or `LMDEPLOY_LLMMAN_BIN`); each missing piece has its own actionable error. Neither is required unless an `oci://` reference is actually used.

## BC-breaking

No. Purely additive; the ModelScope / openmind_hub / HuggingFace branches are unchanged.

## Use cases

Pulling model weights in an air-gapped or registry-mirrored cluster without needing HuggingFace reachable, using the credentials already configured for container images. One daemon can serve many lmdeploy processes from a single content-addressed store.

## Checklist

- [x] Pre-commit or other linting tools are used to fix the potential lint issues -- `ruff format` and `ruff check` clean on all six touched files.
- [x] The modification is covered by complete unit tests.
- [ ] If this PR introduces a new feature, docs have been added.

### Testing

Two new files. `tests/test_lmdeploy/test_llmman.py` (8 cases) runs against a **real HTTP server on a loopback port**, not mocks, so the NDJSON streaming contract is genuinely exercised: `/api/version` accepted, a non-llmman server rejected, nothing-listening reported actionably; pull success with forwarded byte progress and the exact request body asserted; in-band error at HTTP 200; a stream ending without `success`; non-OK status; a non-JSON diagnostic tolerated.

`tests/test_lmdeploy/test_oci.py` (14 cases): scheme detection incl. case-insensitivity; that a HF repo id, a local path, `s3://` and an `http://host:port` server address are **not** claimed; `strip_scheme` round-trips; the resolve contract plus eight malformed-output cases; every `LLMMAN_HOST` form incl. wildcard-to-loopback; binary default/override and the missing-binary error; empty reference rejected without touching the daemon; the scheme stripped before hand-off with progress wired; and two dispatch tests asserting `oci://` never reaches `snapshot_download` while a HF repo id still does.

Verified honestly:

- [x] **19 logic assertions executed standalone against a live loopback daemon** (scheme handling, endpoint parsing incl. wildcard rewriting, `/api/version` accept/reject, pull success + progress + request body, in-band error, resolve contract) -- all pass
- [ ] The two pytest files were **not executed in-tree**: importing `lmdeploy.utils` needs torch and the full stack, unavailable here. The two `TestGetModelDispatch` cases in particular are unexercised. Flagging rather than implying coverage I do not have.
- [ ] No end-to-end serve against a live `llmman serve` backed by a real registry.
