### PR TITLE
Fix TurboMind vision workspace overflows

### DIFF
--- a/src/turbomind/models/internvit/internvit.cc
+++ b/src/turbomind/models/internvit/internvit.cc
@@ -28,6 +28,27 @@
 
 namespace turbomind {
 
+struct InternVitMicroBatchPlan {
+    core::ssize_t hidden_elements_per_tile{};
+    core::ssize_t projector_elements_per_tile{};
+    core::ssize_t workspace_elements_per_tile{};
+    core::ssize_t max_tiles_per_chunk{};
+};
+
+InternVitMicroBatchPlan PlanInternVitMicroBatch(core::ssize_t capacity_elements,
+                                                int           vision_seq_len,
+                                                int           vision_hidden_dim,
+                                                int           image_seq_len,
+                                                int           output_hidden_dim)
+{
+    const auto hidden_elements    = static_cast<core::ssize_t>(vision_seq_len) * vision_hidden_dim;
+    const auto projector_elements = static_cast<core::ssize_t>(image_seq_len) * output_hidden_dim;
+    const auto workspace_elements = std::max(hidden_elements, projector_elements);
+    const auto max_tiles          = workspace_elements > 0 ? capacity_elements / workspace_elements : 0;
+
+    return {hidden_elements, projector_elements, workspace_elements, max_tiles};
+}
+
 struct InternVit::Impl {
     const InternVitWeight&       weights_;
     const core::InternVitConfig& config_;
@@ -448,7 +469,7 @@ struct InternVit::Impl {
         AllReduceSum(output, stream);
     }
 
-    Tensor Projector(Tensor& hidden, Data& d, Buffer symm_buf)
+    void Projector(Tensor& hidden, Data& d, Buffer symm_buf, Tensor& result)
     {
         const auto& cfg    = config_;
         auto        stream = core::Context::stream().handle();
@@ -480,26 +501,28 @@ struct InternVit::Impl {
         TM_SCOPE_CALL(linear_.Forward(inter, *weights_.projector_fc2, output));
         AllReduceSum(output, stream);
 
-        Tensor result = empty_like(output);
+        TM_CHECK(result.shape() == output.shape());
+        TM_CHECK_EQ(result.dtype(), output.dtype());
         TM_SCOPE_CALL(ApplyBias(result, output, weights_.projector_fc2->bias, stream));
-
-        return result;
     }
 
-    void Forward(int phase, TensorMap& args)
+    Data MakeMicroBatchData(const Data& d, int tile_offset, int tile_count) const
     {
-        TM_FUNCTION_SCOPE();
+        Data micro;
+        micro.batch_input     = d.batch_input.slice(tile_offset, tile_count);
+        micro.batch_size      = tile_count;
+        micro.attn_cu_seqlens = d.attn_cu_seqlens.slice(0, tile_count + 1);
+        micro.attn_finished   = d.attn_finished.slice(0, tile_count);
+        micro.seq_len         = d.seq_len;
+        micro.token_num       = tile_count * d.seq_len;
+        return micro;
+    }
 
+    void ForwardMicroBatch(Data& d, Buffer symm_buf, Tensor& image_embeds)
+    {
         const auto& cfg = config_;
-        auto&       d   = data_.at(phase);
-        if (d.batch_size == 0) {
-            return;
-        }
 
-        auto stream   = core::Context::stream().handle();
         auto residual = PatchEmbedding(d);
-
-        Buffer symm_buf = args.contains("symm_buf") ? args.at("symm_buf").buffer() : Buffer{};
 
         Tensor hidden_states = [&]() {
             if (symm_buf) {
@@ -540,7 +563,57 @@ struct InternVit::Impl {
                               is_last_layer ? NormType::kNone : config_.norm_type);
         }
 
-        Tensor image_embeds = Projector(residual, d, symm_buf);
+        Projector(residual, d, symm_buf, image_embeds);
+    }
+
+    void Forward(int phase, TensorMap& args)
+    {
+        TM_FUNCTION_SCOPE();
+
+        const auto& cfg = config_;
+        auto&       d   = data_.at(phase);
+        if (d.batch_size == 0) {
+            return;
+        }
+
+        Buffer symm_buf = args.contains("symm_buf") ? args.at("symm_buf").buffer() : Buffer{};
+
+        int micro_batch_size = d.batch_size;
+        if (tp_size_ > 1) {
+            TM_CHECK(symm_buf) << "InternViT TP requires a symmetric communication buffer";
+
+            const auto plan = PlanInternVitMicroBatch(symm_buf.view(cfg.data_type).size(),
+                                                      d.seq_len,
+                                                      cfg.hidden_dim,
+                                                      cfg.image_seq_length,
+                                                      weights_.projector_fc2->output_dim);
+            TM_CHECK_GT(plan.max_tiles_per_chunk, 0)
+                << "InternViT symmetric buffer cannot hold one image tile: available_bytes=" << symm_buf.byte_size()
+                << ", required_bytes=" << byte_size(cfg.data_type, plan.workspace_elements_per_tile)
+                << ", vision_seq_len=" << d.seq_len << ", vision_hidden_dim=" << cfg.hidden_dim
+                << ", image_seq_len=" << cfg.image_seq_length
+                << ", output_hidden_dim=" << weights_.projector_fc2->output_dim;
+            micro_batch_size = static_cast<int>(std::min<core::ssize_t>(d.batch_size, plan.max_tiles_per_chunk));
+
+            if (micro_batch_size < d.batch_size && h_tp_group->rank() == 0) {
+                const int micro_batch_count = cdiv(d.batch_size, micro_batch_size);
+                TM_LOG_INFO("InternViT micro-batch: tiles={} chunk_tiles={} chunks={} symm_bytes={}",
+                            d.batch_size,
+                            micro_batch_size,
+                            micro_batch_count,
+                            symm_buf.byte_size());
+            }
+        }
+
+        Tensor image_embeds{
+            {d.batch_size * cfg.image_seq_length, weights_.projector_fc2->output_dim}, cfg.data_type, kDEVICE};
+        for (int tile_offset = 0; tile_offset < d.batch_size; tile_offset += micro_batch_size) {
+            const int tile_count = std::min(micro_batch_size, d.batch_size - tile_offset);
+            auto      micro      = MakeMicroBatchData(d, tile_offset, tile_count);
+            auto output = image_embeds.slice(tile_offset * cfg.image_seq_length, tile_count * cfg.image_seq_length);
+            ForwardMicroBatch(micro, symm_buf, output);
+        }
+
         EnsureFloatDtype(image_embeds, engine_data_type_);
 
         args.produce("multimodal",

--- a/src/turbomind/models/qwenvit/qwenvit.cc
+++ b/src/turbomind/models/qwenvit/qwenvit.cc
@@ -23,6 +23,25 @@
 
 namespace turbomind {
 
+struct QwenVitWorkspacePlan {
+    core::ssize_t hidden_required_elements{};
+    core::ssize_t merger_required_elements{};
+    bool          hidden_fits{};
+    bool          merger_fits{};
+};
+
+QwenVitWorkspacePlan PlanWorkspace(core::ssize_t available_elements,
+                                   int           raw_token_num,
+                                   int           vision_hidden_dim,
+                                   int           merged_token_num,
+                                   int           output_hidden_dim)
+{
+    const auto hidden_required = static_cast<core::ssize_t>(raw_token_num) * vision_hidden_dim;
+    const auto merger_required = static_cast<core::ssize_t>(merged_token_num) * output_hidden_dim;
+    return {
+        hidden_required, merger_required, hidden_required <= available_elements, merger_required <= available_elements};
+}
+
 struct QwenVit::Impl {
     const QwenVitWeight&        weights_;
     const core::QwenVitConfig&  config_;
@@ -31,6 +50,7 @@ struct QwenVit::Impl {
     comm::DeviceCommImpl* const d_comm_;
     const int                   tp_group_;
     const DataType              engine_data_type_;
+    const std::string           communicator_;
 
     Buffer_<int> grid_thws_buf_;     // (t, h, w)
     Buffer_<int> grid_offsets_buf_;  // (token offset, natural offset)
@@ -104,7 +124,8 @@ struct QwenVit::Impl {
         h_tp_group{ctx.comm.h_comm},
         d_comm_{ctx.comm.d_comm},
         tp_group_{ctx.comm.d_tp_group},
-        engine_data_type_{engine.data_type}
+        engine_data_type_{engine.data_type},
+        communicator_{engine.communicator}
     {
         for (int i = 0; i < phases; ++i) {
             auto& d              = data_.emplace_back();
@@ -760,6 +781,26 @@ struct QwenVit::Impl {
 
         auto& cfg = weights_.config();
 
+        Buffer     symm_buf  = args.contains("symm_buf") ? args.at("symm_buf").buffer() : Buffer{};
+        const auto workspace = PlanWorkspace(symm_buf ? symm_buf.view(cfg.data_type).size() : 0,
+                                             d.batch_size,
+                                             cfg.hidden_dim,
+                                             d.merge_unit_count,
+                                             weights_.merger_fc2->output_dim);
+        const bool can_use_regular = !d_comm_ || communicator_ == "nccl";
+        TM_CHECK(can_use_regular || (workspace.hidden_fits && workspace.merger_fits))
+            << "QwenVit communicator requires registered symmetric buffers, but the language-model buffer is too "
+               "small: communicator="
+            << communicator_ << ", available_bytes=" << symm_buf.byte_size()
+            << ", hidden_required_bytes=" << byte_size(cfg.data_type, workspace.hidden_required_elements)
+            << ", merger_required_bytes=" << byte_size(cfg.data_type, workspace.merger_required_elements)
+            << ", raw_tokens=" << d.batch_size << ", merged_tokens=" << d.merge_unit_count
+            << ", vision_hidden_dim=" << cfg.hidden_dim << ", output_hidden_dim=" << weights_.merger_fc2->output_dim
+            << ". Use the NCCL communicator.";
+
+        const bool hidden_use_symm = workspace.hidden_fits;
+        const bool merger_use_symm = workspace.merger_fits;
+
         auto residual       = PatchEmbedding(d);
         auto rotary_pos_emb = args.consume("rotary_pos_emb");
         auto stream         = core::Context::stream().handle();
@@ -792,10 +833,8 @@ struct QwenVit::Impl {
             residual = std::move(reordered);
         }
 
-        Buffer symm_buf = args.contains("symm_buf") ? args.at("symm_buf").buffer() : Buffer{};
-
         Tensor hidden_states = [&]() {
-            if (symm_buf) {
+            if (hidden_use_symm) {
                 return Tensor{symm_buf.view(cfg.data_type), {d.batch_size, cfg.hidden_dim}};
             }
             else {
@@ -831,7 +870,7 @@ struct QwenVit::Impl {
             ResidualBiasNorm(hidden_states, residual, block->mlp_fc2->bias, *next_norm, cfg.norm_type);
         }
 
-        Tensor image_embeds = Merger(hidden_states, symm_buf);
+        Tensor image_embeds = Merger(hidden_states, merger_use_symm ? symm_buf : Buffer{});
         if (cfg.use_window_attention) {
             Tensor reordered{{d.merge_unit_count, cfg.out_hidden_dim}, image_embeds.dtype(), kDEVICE};
             TM_SCOPE_CALL(
@@ -992,7 +1031,7 @@ struct QwenVit::Impl {
         TM_SCOPE_CALL(invokeAddBiasActivation(inter, weights_.merger_fc1->bias, ActivationType::kGelu, stream));
 
         Tensor output;
-        if (d_comm_) {
+        if (symm_buf) {
             output = {symm_buf.view(config_.data_type), {inter.shape(0), weights_.merger_fc2->output_dim}};
         }
         TM_SCOPE_CALL(linear_.Forward(inter, *weights_.merger_fc2, output));


### PR DESCRIPTION
  ## Summary

  This PR prevents InternViT and QwenViT from exceeding the language model's shared symmetric buffer.

  ## Changes

  ### InternViT

  - Calculate how many image tiles fit in symm_buf.
  - Split oversized vision batches into tile-based micro-batches.
  - Write each chunk directly into the final image embedding tensor.
  - Fail clearly if the buffer cannot hold one tile.

  ### QwenViT

  - Check hidden-state and merger workspace sizes before ViT execution.
  - Continue using symm_buf when capacity is sufficient.
  - With NCCL, fall back per stage to regular device buffers when necessary.
  - With CUDA IPC/native, fail early with detailed capacity information.

  The QwenViT change covers Qwen2-VL, Qwen2.5-VL, and Qwen3.5/3.6/3.8 VLMs.
