### PR TITLE
fix: initialize MLA KV-B after online FP8 quantization

### DIFF
--- a/lmdeploy/pytorch/backends/dlinfer/linear.py
+++ b/lmdeploy/pytorch/backends/dlinfer/linear.py
@@ -18,6 +18,12 @@ class DlinferLinearImpl(LinearImpl):
             weight = weight.data.t().contiguous()
         return weight, bias
 
+    def get_unquantized_weight(self, weight: torch.Tensor):
+        """Return weight in ``[out_features, in_features]`` layout."""
+        if os.getenv('DLINFER_LINEAR_USE_NN_LAYOUT', '0') == '1':
+            weight = weight.t()
+        return weight
+
     def forward(self,
                 x,
                 weight: torch.Tensor,

--- a/lmdeploy/pytorch/backends/linear.py
+++ b/lmdeploy/pytorch/backends/linear.py
@@ -12,6 +12,10 @@ class LinearImpl(ABC):
         """Update weights."""
         return weight, bias
 
+    def get_unquantized_weight(self, weight: torch.Tensor):
+        """Return weight in ``[out_features, in_features]`` layout."""
+        return weight
+
     @abstractmethod
     def forward(self,
                 x,

--- a/lmdeploy/pytorch/engine/model_agent/agent.py
+++ b/lmdeploy/pytorch/engine/model_agent/agent.py
@@ -32,7 +32,11 @@ from lmdeploy.pytorch.spec_decode import build_spec_agent
 from lmdeploy.pytorch.strategies import build_strategy_factory
 from lmdeploy.pytorch.strategies.base.model_agent import ExtraInputs, ExtraOutputs, StoppingCriteria
 from lmdeploy.pytorch.utils import get_gpu_memory, monkey_patch_hf_modules_cache, wait_for_async_tasks
-from lmdeploy.pytorch.weight_loader.model_weight_loader import ModelWeightLoader, load_model_weights
+from lmdeploy.pytorch.weight_loader.model_weight_loader import (
+    ModelWeightLoader,
+    load_model_weights,
+    process_weights_after_loading,
+)
 from lmdeploy.serve.openai.protocol import (
     DestroyWeightsUpdateGroupRequest,
     InitWeightsUpdateGroupRequest,
@@ -1460,9 +1464,7 @@ class BaseModelAgent:
 
             if request.finished:
                 for m in filter(None, [model, spec_model]):
-                    for _, mod in m.named_modules():
-                        if hasattr(mod, 'update_weights'):
-                            mod.update_weights()
+                    process_weights_after_loading(m)
 
                     torch.cuda.synchronize()
                     self._update_params_ipc_event = None
@@ -1556,9 +1558,7 @@ class BaseModelAgent:
 
                 if request.finished:
                     for m in filter(None, [model, spec_model]):
-                        for _, mod in m.named_modules():
-                            if hasattr(mod, 'update_weights'):
-                                mod.update_weights()
+                        process_weights_after_loading(m)
                         torch.cuda.synchronize()
                     # FusedMoE.update_weights() above replaces the gate_up / down
                     # Parameter objects (LinearWeights.update_weight registers a new

--- a/lmdeploy/pytorch/models/deepseek_mtp.py
+++ b/lmdeploy/pytorch/models/deepseek_mtp.py
@@ -210,7 +210,6 @@ class DeepseekMTPModel(nn.Module, CudaGraphMixin):
     ):
         super().__init__()
         self.config = config
-        self.quantization_config = getattr(config, 'quantization_config', None)
         self.dtype = dtype
         self.ctx_mgr = ctx_mgr
         self.model = DeepSeekMultiTokenPredictor(config,
@@ -218,8 +217,6 @@ class DeepseekMTPModel(nn.Module, CudaGraphMixin):
                                                  device=device,
                                                  decoder_layer_cls=decoder_layer_cls,
                                                  build_rotary_embedding_func=build_rotary_embedding_func)
-
-        self._load_buffers = dict()
 
     def get_logits(self, hidden_states: torch.Tensor, spec_step_idx: int = 0):
         """Compute logits of the model output."""
@@ -321,53 +318,6 @@ class DeepseekMTPModel(nn.Module, CudaGraphMixin):
             weight = weight.flatten(0, 1)
             return weight
 
-        def __load_kcvc(name: str, weight: torch.Tensor):
-            """Load kc and vc from weight."""
-            config = self.config
-            v_head_dim = config.v_head_dim
-            qk_nope_head_dim = config.qk_nope_head_dim
-            w_kc, w_vc = weight.unflatten(0, (-1, qk_nope_head_dim + v_head_dim)).split([qk_nope_head_dim, v_head_dim],
-                                                                                        dim=1)
-            w_vc = w_vc.transpose(1, 2).contiguous()
-            kc_param_name = name.replace('.kv_b_proj', '.kc')
-            param_kc = params_dict[kc_param_name]
-            load_weight(param_kc, w_kc)
-            vc_param_name = name.replace('.kv_b_proj', '.vc')
-            param_vc = params_dict[vc_param_name]
-            load_weight(param_vc, w_vc)
-
-        def __dequant_weight(weight: torch.Tensor, scale: torch.Tensor, dtype: torch.dtype):
-            """Dequant weight."""
-            dim_w0, dim_w1 = weight.shape
-            dim_s0, dim_s1 = scale.shape
-            assert dim_w0 % dim_s0 == 0
-            assert dim_w1 % dim_s1 == 0
-            group0 = dim_w0 // dim_s0
-            group1 = dim_w1 // dim_s1
-            weight = weight.reshape(dim_s0, group0, dim_s1, group1)
-            scale = scale.reshape(dim_s0, 1, dim_s1, 1)
-            weight = weight.to(scale.dtype) * scale
-            weight = weight.to(dtype)
-            weight = weight.reshape(dim_w0, dim_w1)
-            return weight
-
-        def __load_kcvc_blocked_fp8(name: str, loaded_weight: torch.Tensor):
-            """Dequant weight."""
-            if name.endswith('.weight'):
-                weight_name = name
-                scale_name = name.replace('.weight', '.scale')
-            elif name.endswith('.weight_scale_inv'):
-                weight_name = name.replace('.weight_scale_inv', '.weight')
-                scale_name = name
-            self._load_buffers[name] = loaded_weight
-            if (weight_name in self._load_buffers and scale_name in self._load_buffers):
-                weight = self._load_buffers.pop(weight_name)
-                scale = self._load_buffers.pop(scale_name)
-                kc_param_name = weight_name.replace('.kv_b_proj', '.kc')
-                dtype = params_dict[kc_param_name].dtype
-                weight = __dequant_weight(weight, scale, dtype)
-                __load_kcvc(weight_name, weight)
-
         for (mod_name, head_dim, pe_dim_offset) in update_pe_mapping:
             if mod_name not in name:
                 continue
@@ -380,21 +330,8 @@ class DeepseekMTPModel(nn.Module, CudaGraphMixin):
             load_weight(param, weight)
             break
         else:
-            if '.kv_b_proj' in name:
-                quantization_config = self.quantization_config
-                quant_method = None
-                if quantization_config is not None:
-                    quant_method = quantization_config.get('quant_method')
-
-                loaded_weight = loaded_weight.to(device)
-                if quant_method == 'fp8':
-                    # update blocked fp8 weight
-                    __load_kcvc_blocked_fp8(name, loaded_weight)
-                else:
-                    __load_kcvc(name, loaded_weight)
-            else:
-                param = params_dict[name]
-                load_weight(param, loaded_weight)
+            param = params_dict[name]
+            load_weight(param, loaded_weight)
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]):
         """Load weights."""

--- a/lmdeploy/pytorch/models/deepseek_v2.py
+++ b/lmdeploy/pytorch/models/deepseek_v2.py
@@ -444,6 +444,15 @@ class DeepseekV2Attention(nn.Module):
                                       quant_config=quantization_config,
                                       dtype=dtype,
                                       device=device)
+        self.kv_b_proj = build_colwise_linear(
+            config.kv_lora_rank,
+            self.num_heads * (config.qk_nope_head_dim + self.v_head_dim),
+            bias=False,
+            dtype=dtype,
+            device=device,
+            is_tp=True,
+            quant_config=quantization_config,
+        )
         self.kc = DeepseekV2BMM(self.num_heads,
                                 config.qk_nope_head_dim,
                                 config.kv_lora_rank,
@@ -480,6 +489,18 @@ class DeepseekV2Attention(nn.Module):
             is_tp=True,
             quant_config=quantization_config,
         )
+
+    def process_weights_after_loading(self):
+        """Build the local MLA BMM weights from the effective KV-B weight."""
+        # MLA executes the absorbed kc/vc BMMs instead of kv_b_proj directly.
+        # With online FP8, the standard linear loader first quantizes the BF16
+        # checkpoint weight and creates its scales. Absorbing that effective
+        # post-quantization weight keeps the BMM path equivalent to the linear.
+        weight = self.kv_b_proj.get_unquantized_weight(self.kc.weight.dtype)
+        weight = weight.unflatten(0, (-1, self.qk_nope_head_dim + self.v_head_dim))
+        w_kc, w_vc = weight.split([self.qk_nope_head_dim, self.v_head_dim], dim=1)
+        self.kc.weight.copy_(w_kc)
+        self.vc.weight.copy_(w_vc.transpose(1, 2).contiguous())
 
     def _q_proj(self, hidden_states, num_heads: int, nope_size: int, pe_size: int):
         """Q proj."""
@@ -1134,7 +1155,6 @@ class DeepseekV2ForCausalLM(nn.Module, CudaGraphMixin):
                  device: torch.device = None):
         super().__init__()
         self.config = config
-        self.quantization_config = getattr(config, 'quantization_config', None)
         self.dtype = dtype
         self.ctx_mgr = ctx_mgr
         self.model = DeepseekV2Model(config, dtype=dtype, device=device)
@@ -1146,7 +1166,6 @@ class DeepseekV2ForCausalLM(nn.Module, CudaGraphMixin):
                                       device=device)
         if config.tie_word_embeddings:
             self.lm_head.tie_weights(self.model.get_input_embeddings())
-        self._load_buffers = dict()
 
     def forward(
         self,
@@ -1234,53 +1253,6 @@ class DeepseekV2ForCausalLM(nn.Module, CudaGraphMixin):
             weight = weight.flatten(0, 1)
             return weight
 
-        def __load_kcvc(name: str, weight: torch.Tensor):
-            """Load kc and vc from weight."""
-            config = self.config
-            v_head_dim = config.v_head_dim
-            qk_nope_head_dim = config.qk_nope_head_dim
-            w_kc, w_vc = weight.unflatten(0, (-1, qk_nope_head_dim + v_head_dim)).split([qk_nope_head_dim, v_head_dim],
-                                                                                        dim=1)
-            w_vc = w_vc.transpose(1, 2).contiguous()
-            kc_param_name = name.replace('.kv_b_proj', '.kc')
-            param_kc = params_dict[kc_param_name]
-            load_weight(param_kc, w_kc)
-            vc_param_name = name.replace('.kv_b_proj', '.vc')
-            param_vc = params_dict[vc_param_name]
-            load_weight(param_vc, w_vc)
-
-        def __dequant_weight(weight: torch.Tensor, scale: torch.Tensor, dtype: torch.dtype):
-            """Dequant weight."""
-            dim_w0, dim_w1 = weight.shape
-            dim_s0, dim_s1 = scale.shape
-            assert dim_w0 % dim_s0 == 0
-            assert dim_w1 % dim_s1 == 0
-            group0 = dim_w0 // dim_s0
-            group1 = dim_w1 // dim_s1
-            weight = weight.reshape(dim_s0, group0, dim_s1, group1)
-            scale = scale.reshape(dim_s0, 1, dim_s1, 1)
-            weight = weight.to(scale.dtype) * scale
-            weight = weight.to(dtype)
-            weight = weight.reshape(dim_w0, dim_w1)
-            return weight
-
-        def __load_kcvc_blocked_fp8(name: str, loaded_weight: torch.Tensor):
-            """Dequant weight."""
-            if name.endswith('.weight'):
-                weight_name = name
-                scale_name = name.replace('.weight', '.scale')
-            elif name.endswith('.weight_scale_inv'):
-                weight_name = name.replace('.weight_scale_inv', '.weight')
-                scale_name = name
-            self._load_buffers[name] = loaded_weight
-            if (weight_name in self._load_buffers and scale_name in self._load_buffers):
-                weight = self._load_buffers.pop(weight_name)
-                scale = self._load_buffers.pop(scale_name)
-                kc_param_name = weight_name.replace('.kv_b_proj', '.kc')
-                dtype = params_dict[kc_param_name].dtype
-                weight = __dequant_weight(weight, scale, dtype)
-                __load_kcvc(weight_name, weight)
-
         for (mod_name, head_dim, pe_dim_offset) in update_pe_mapping:
             if mod_name not in name:
                 continue
@@ -1293,23 +1265,8 @@ class DeepseekV2ForCausalLM(nn.Module, CudaGraphMixin):
             load_weight(param, weight)
             break
         else:
-            if '.kv_b_proj' in name:
-                quantization_config = self.quantization_config
-                quant_method = None
-                fp8_quant_scope = None
-                if quantization_config is not None:
-                    quant_method = quantization_config.get('quant_method')
-                    fp8_quant_scope = quantization_config.get('fp8_quant_scope')
-
-                loaded_weight = loaded_weight.to(device)
-                if quant_method == 'fp8' and fp8_quant_scope != 'moe_only':
-                    # update blocked fp8 weight
-                    __load_kcvc_blocked_fp8(name, loaded_weight)
-                else:
-                    __load_kcvc(name, loaded_weight)
-            else:
-                param = params_dict[name]
-                load_weight(param, loaded_weight)
+            param = params_dict[name]
+            load_weight(param, loaded_weight)
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]):
         """Load weights."""

--- a/lmdeploy/pytorch/models/deepseek_v32.py
+++ b/lmdeploy/pytorch/models/deepseek_v32.py
@@ -323,6 +323,15 @@ class DeepseekV32Attention(DeepseekV2Attention):
                                       quant_config=quantization_config,
                                       dtype=torch.float32,
                                       device=device)
+        self.kv_b_proj = build_colwise_linear(
+            config.kv_lora_rank,
+            self.num_heads * (config.qk_nope_head_dim + self.v_head_dim),
+            bias=False,
+            dtype=dtype,
+            device=device,
+            is_tp=True,
+            quant_config=quantization_config,
+        )
         self.kc = DeepseekV2BMM(self.num_heads,
                                 config.qk_nope_head_dim,
                                 config.kv_lora_rank,

--- a/lmdeploy/pytorch/nn/linear/base.py
+++ b/lmdeploy/pytorch/nn/linear/base.py
@@ -182,6 +182,17 @@ class LinearBase(nn.Module):
         """Update weights."""
         raise NotImplementedError('This method should be implemented in subclasses.')
 
+    def get_unquantized_weight(self, out_dtype: torch.dtype) -> torch.Tensor:
+        """Return the local weight in ``[out_features, in_features]``
+        layout."""
+        param = next(self.parameters())
+        inputs = torch.eye(self.in_features, dtype=out_dtype, device=param.device)
+        outputs = self._forward_default(inputs, all_reduce=False, tp_sizes=None)
+        bias = getattr(self, 'bias', None)
+        if bias is not None:
+            outputs = outputs - bias
+        return outputs.T.to(out_dtype)
+
     def _forward_default(self, x, all_reduce: bool, tp_sizes: list[int]):
         """Default forward implement."""
         raise NotImplementedError('This method should be implemented in subclasses.')

--- a/lmdeploy/pytorch/nn/linear/blocked_fp8.py
+++ b/lmdeploy/pytorch/nn/linear/blocked_fp8.py
@@ -147,6 +147,20 @@ class BlockedF8Linear(LinearBase):
         weight, weight_scale_inv, bias = self.impl.update_weights(self.weight, self.weight_scale_inv, self.bias)
         self.register_all_parameters(weight, weight_scale_inv, bias)
 
+    def get_unquantized_weight(self, out_dtype: torch.dtype) -> torch.Tensor:
+        """Return the local dequantized weight."""
+        out_features, in_features = self.weight.shape
+        scale_rows, scale_cols = self.weight_scale_inv.shape
+        aligned_shape = (scale_rows * self.block_size, scale_cols * self.block_size)
+        weight = self.weight
+        if weight.shape != aligned_shape:
+            weight = weight.new_zeros(aligned_shape)
+            weight[:out_features, :in_features].copy_(self.weight)
+        weight = weight.reshape(scale_rows, self.block_size, scale_cols, self.block_size)
+        scale = self.weight_scale_inv[:, None, :, None]
+        weight = (weight.to(scale.dtype) * scale).to(out_dtype).reshape(aligned_shape)
+        return weight[:out_features, :in_features]
+
     def _forward_default(self, x, all_reduce, tp_sizes):
         """Default forward implement."""
         if self.tp_mode == TPMode.DP_TP:

--- a/lmdeploy/pytorch/nn/linear/default.py
+++ b/lmdeploy/pytorch/nn/linear/default.py
@@ -117,7 +117,7 @@ class BaseLinear(LinearBase):
 
     def get_unquantized_weight(self, out_dtype: torch.dtype) -> torch.Tensor:
         """Return the local unquantized weight."""
-        return self.weight.to(out_dtype)
+        return self.impl.get_unquantized_weight(self.weight).to(out_dtype)
 
     def _forward_default(self, x, all_reduce, tp_sizes):
         """Default forward implement."""

--- a/lmdeploy/pytorch/nn/linear/default.py
+++ b/lmdeploy/pytorch/nn/linear/default.py
@@ -115,6 +115,10 @@ class BaseLinear(LinearBase):
         weight, bias = self.impl.update_weights(self.weight, self.bias)
         self.register_all_parameters(weight, bias)
 
+    def get_unquantized_weight(self, out_dtype: torch.dtype) -> torch.Tensor:
+        """Return the local unquantized weight."""
+        return self.weight.to(out_dtype)
+
     def _forward_default(self, x, all_reduce, tp_sizes):
         """Default forward implement."""
         if self.tp_mode == TPMode.DP_TP:

--- a/lmdeploy/pytorch/weight_loader/model_weight_loader.py
+++ b/lmdeploy/pytorch/weight_loader/model_weight_loader.py
@@ -190,12 +190,26 @@ class ModelWeightLoader:
 
 
 @torch.inference_mode()
+def process_weights_after_loading(model: torch.nn.Module):
+    """Run module weight updates followed by dependent post-load hooks."""
+    for _, mod in model.named_modules():
+        if not hasattr(mod, 'update_weights'):
+            continue
+        mod.update_weights()
+
+    # Keep this as a second pass. Standard loading creates online-FP8 weights
+    # and scales, then update_weights() finalizes their backend representation.
+    # MLA can only absorb kv_b_proj into kc/vc after both steps are complete.
+    for _, mod in model.named_modules():
+        if not hasattr(mod, 'process_weights_after_loading'):
+            continue
+        mod.process_weights_after_loading()
+
+
+@torch.inference_mode()
 def load_model_weights(model: torch.nn.Module, checkpoint_path: str, prefix: str = None, device: torch.device = None):
     """Loading model weights."""
     loader = ModelWeightLoader(checkpoint_path, prefix=prefix)
     loader.load_model_weights(model, device=device)
     model.eval()
-    for _, mod in model.named_modules():
-        if not hasattr(mod, 'update_weights'):
-            continue
-        mod.update_weights()
+    process_weights_after_loading(model)


### PR DESCRIPTION
## Summary

- load MLA `kv_b_proj` through the standard quant-aware linear path
- materialize the absorbed `kc`/`vc` BMM weights after linear weight processing completes
- reuse the two-phase post-load lifecycle for initial loading and online weight updates

## Motivation

When online FP8 is applied to a BF16 checkpoint, the previous special KV-B loader treated `kv_b_proj.weight` as serialized FP8 and waited for a checkpoint `weight_scale_inv`. Online quantization generates that scale instead, so the expected checkpoint scale never arrived and the derived `kc`/`vc` weights could remain uninitialized.

Routing KV-B through the standard linear loader lets it create the effective FP8 weight and scales. A second post-load pass then materializes the BF16 MLA BMM weights from that effective representation, matching the lifecycle used by vLLM.

## Validation

- existing focused PyTorch tests: 15 passed
- pre-commit hooks on all changed files: passed

## Assistance

Assisted with Codex + GPT-5.6-Sol xHigh, reviewed manually
