### PR TITLE
fix: fall back to model generation config

### DIFF
--- a/lmdeploy/messages.py
+++ b/lmdeploy/messages.py
@@ -229,8 +229,7 @@ class GenerationConfig:
         if tokenizer_eos_token_id is not None:
             stop_token_ids.add(tokenizer_eos_token_id)
 
-        # add eos_token_id from model's generation_config.json file if there
-        # is any.
+        # add eos_token_id from the model's generation config, if any.
         eos_token_id = generation_config.get('eos_token_id')
         if eos_token_id is not None:
             if isinstance(eos_token_id, int):

--- a/lmdeploy/utils.py
+++ b/lmdeploy/utils.py
@@ -247,9 +247,17 @@ def get_hf_gen_cfg(path: str, trust_remote_code: bool = False):
     from transformers import GenerationConfig
     try:
         cfg = GenerationConfig.from_pretrained(path, trust_remote_code=trust_remote_code)
-        return cfg.to_dict()
     except OSError:
-        return {}
+        try:
+            # Some checkpoints keep generation attributes such as EOS IDs only
+            # in config.json.
+            model_cfg, _ = PretrainedConfig.get_config_dict(path)
+            if not model_cfg:
+                return {}
+            cfg = GenerationConfig.from_model_config(PretrainedConfig.from_dict(model_cfg))
+        except OSError:
+            return {}
+    return cfg.to_dict()
 
 
 def get_model(pretrained_model_name_or_path: str, download_dir: str = None, revision: str = None, token: str = None):

--- a/lmdeploy/utils.py
+++ b/lmdeploy/utils.py
@@ -254,7 +254,9 @@ def get_hf_gen_cfg(path: str, trust_remote_code: bool = False):
             model_cfg, _ = PretrainedConfig.get_config_dict(path)
             if not model_cfg:
                 return {}
-            cfg = GenerationConfig.from_model_config(PretrainedConfig.from_dict(model_cfg))
+            from lmdeploy.hf_configs import config_from_pretrained
+            model_cfg = config_from_pretrained(path, trust_remote_code=trust_remote_code)
+            cfg = GenerationConfig.from_model_config(model_cfg)
         except OSError:
             return {}
     return cfg.to_dict()


### PR DESCRIPTION
## Summary

- fall back to model config when generation_config.json is absent
- preserve generation attributes such as multiple EOS token IDs
- retain the existing empty result when neither configuration is available

## Validation

- verified that a checkpoint without generation_config.json loads all EOS IDs from config.json
- verified that a directory without either configuration still returns an empty result
- pre-commit checks passed

## Assistance

Assisted with Codex + GPT-5.6-Sol xHigh, reviewed manually