### PR TITLE
fix(deps): pin xgrammar below 0.2.5.post1 to unbreak unit-test CI

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -20,4 +20,4 @@ shortuuid
 tiktoken
 transformers >= 4.56.0, != 5.0.*, != 5.1.*, != 5.2.*, != 5.3.*, != 5.4.*, != 5.5.0, !=5.7.*, !=5.8.*, !=5.9.*
 uvicorn
-xgrammar >= 0.1.33
+xgrammar >= 0.1.33, != 0.2.5.post1


### PR DESCRIPTION
## Motivation

Since 2026-09-03 ~07:02 UTC, every PR's `unit-test` workflow fails with:

```
ImportError: please install latest transformers by pip install git+https://github.com/huggingface/transformers.git
```

- 8 errors in `tests/test_lmdeploy/test_mtp_guided_decoding.py`: building `Qwen/Qwen3.5-0.8B` calls `check_transformers()` in `lmdeploy/vl/model/qwen3_5.py`, which requires `transformers.models.qwen3_5.*` (transformers >= 5.16).
- 1 failure in `tests/pytorch/config/test_hf_overrides.py:26`: `hf_config.text_config.rope_parameters` was renamed from `rope_scaling` in transformers 5.x.

Root cause: xgrammar **0.2.5.post1** was published at 2026-09-03 07:02 UTC and introduced `transformers<5` as a hard dependency ([PyPI metadata](https://pypi.org/project/xgrammar/0.2.5.post1/)):

| | xgrammar <= 0.2.5 | xgrammar 0.2.5.post1 | xgrammar 0.2.6rc* |
|---|---|---|---|
| transformers dep | `>=4.38.0` | `<5,>=4.38.0` | `>=4.38.0` (reverted) |

Because `requirements/common.txt` pins `xgrammar >= 0.1.33` with no constraint on the upper side, pip always picks the newest xgrammar and is then forced to downgrade transformers to **4.57.6** (the newest <5 release), which lacks the `qwen3_5` module and breaks `test_hf_overrides`.

Verified against two unit-test runs from the same day: the run at 06:49 UTC resolved `xgrammar-0.2.3 + transformers-5.16.1` (2066 passed); runs after 07:02 UTC resolved `xgrammar-0.2.5.post1 + transformers-4.57.6` (8 errors, 1 failure).

## Modification

Exclude only the broken release instead of adding an upper bound, so future releases resolve automatically once they fix the dependency (0.2.6rc already reverts to `transformers>=4.38.0`); no follow-up PR needed. Style follows the `transformers` line in the same file.

```diff
--- requirements/common.txt
-xgrammar >= 0.1.33
+xgrammar >= 0.1.33, != 0.2.5.post1
```

## Checklist

1. ✅ No lint issues introduced (one-line dependency pin change).
2. ✅ Covered by existing unit tests — this fix restores the environment the existing suite already expects (transformers 5.16.1, as in the 06:49 UTC run).
3. ✅ Verified via `packaging` specifier check: `0.1.33`–`0.2.5` and hypothetical `0.2.6` are allowed, only `0.2.5.post1` is excluded.
4. ✅ No documentation changes needed (no user-facing API change).