### PR TITLE
[Fix] Isolate Mooncake KV-store keys by cache identity

### DIFF
--- a/lmdeploy/cli/utils.py
+++ b/lmdeploy/cli/utils.py
@@ -843,10 +843,14 @@ class ArgumentHelper:
             default=None,
             help='External KV-cache connector configuration for the PyTorch engine. '
             'Mooncake Store requires MOONCAKE_CONFIG_PATH (or '
-            'kv_connector_extra_config.mooncake_config_path) and does not support '
+            'kv_connector_extra_config.mooncake_config_path), plus explicit '
+            'kv_connector_extra_config.cache_prefix and weights_version values, '
+            'and does not support '
             'distributed_executor_backend="mp". '
             'Example: '
-            "'{\"kv_connector\":\"MooncakeStoreConnector\",\"kv_role\":\"kv_both\"}'.")
+            "'{\"kv_connector\":\"MooncakeStoreConnector\",\"kv_role\":\"kv_both\","
+            "\"kv_connector_extra_config\":{\"cache_prefix\":\"tenant-a\","
+            "\"weights_version\":\"model-v1\"}}'.")
 
 
 # adapted from https://github.com/vllm-project/vllm/blob/main/vllm/utils/__init__.py

--- a/lmdeploy/pytorch/engine/engine.py
+++ b/lmdeploy/pytorch/engine/engine.py
@@ -154,6 +154,7 @@ class Engine(EngineBase):
             model_path=model_path,
             dist_config=dist_config,
             distributed_executor_backend=distributed_executor_backend,
+            model_revision=engine_config.revision,
         )
         memdecode_config = ConfigBuilder.build_memdecode_config(model_path,
                                                                 engine_config,

--- a/lmdeploy/pytorch/engine/model_agent/agent.py
+++ b/lmdeploy/pytorch/engine/model_agent/agent.py
@@ -27,7 +27,12 @@ from lmdeploy.pytorch.engine.cache_engine.plan import build_block_cache_plan
 from lmdeploy.pytorch.engine.cache_inputs import CacheCheckpointInputs
 from lmdeploy.pytorch.engine.guided_process import GuidedDecodingManager
 from lmdeploy.pytorch.engine.logits_process import FusedLogitsProcessor, SamplingInputs, _torch_topk
-from lmdeploy.pytorch.kv_connector import KVConnectorOutput, KVConnectorRole, build_kv_connector
+from lmdeploy.pytorch.kv_connector import (
+    KVConnectorOutput,
+    KVConnectorRole,
+    build_kv_connector,
+    prepare_kv_connector_model_identity,
+)
 from lmdeploy.pytorch.memdecode import build_memdecode_agent
 from lmdeploy.pytorch.model_inputs import ModelInputs, ModelInputsDelta, step_ctx_manager
 from lmdeploy.pytorch.models.patch import BuildModelContext, add_adapters, build_patched_model, update_custom_module_map
@@ -388,6 +393,7 @@ class BaseModelAgent:
 
         # disaggregated weight-update process groups, keyed by group_name
         self._model_update_group: dict[str, dist.ProcessGroup] = {}
+        self._weights_generation = 0
 
         # microbatch
         self.enable_microbatch = self.dist_config.enable_microbatch
@@ -1445,6 +1451,12 @@ class BaseModelAgent:
                                             block_cache_plan=self.block_cache_plan)
             self.state_cache_engine = StateCacheEngine(self.cache_config, self.model_config)
 
+            prepare_kv_connector_model_identity(
+                self.cache_config,
+                self.model_config,
+                weights_generation=getattr(self, '_weights_generation', 0),
+            )
+
             self.kv_connector = build_kv_connector(
                 KVConnectorRole.WORKER,
                 self.cache_config,
@@ -1460,6 +1472,19 @@ class BaseModelAgent:
             if self.memdecode_agent is not None:
                 self.memdecode_agent.set_cache_config(self.cache_config)
                 self.memdecode_agent.build_cache_engine(self.cache_stream)
+
+    def _advance_kv_connector_weights_generation(self) -> None:
+        """Move external KV operations past entries from the previous
+        weights."""
+        weights_generation = getattr(self, '_weights_generation', 0) + 1
+        self._weights_generation = weights_generation
+        prepare_kv_connector_model_identity(
+            self.cache_config,
+            self.model_config,
+            weights_generation=weights_generation,
+        )
+        if self.kv_connector is not None:
+            self.kv_connector.set_weights_generation(weights_generation)
 
     def _forward_impl(self, inputs: ModelInputs, cache_inputs: CacheCheckpointInputs | None = None):
         output = model_forward(
@@ -1593,6 +1618,8 @@ class BaseModelAgent:
                     self._update_params_ipc_event = None
                     self._update_params_ipc_tensor = None
 
+                self._advance_kv_connector_weights_generation()
+
             torch.cuda.empty_cache()
 
     def init_weights_update_group(self, request: InitWeightsUpdateGroupRequest):
@@ -1691,6 +1718,7 @@ class BaseModelAgent:
                     # still references the freed old pointers. Drop the captured
                     # graphs so the next forward re-captures with the new params.
                     self.reset_graph_runner()
+                    self._advance_kv_connector_weights_generation()
 
                 torch.cuda.empty_cache()
                 return True, 'Succeeded to update parameter online.'

--- a/lmdeploy/pytorch/kv_connector/__init__.py
+++ b/lmdeploy/pytorch/kv_connector/__init__.py
@@ -10,7 +10,11 @@ from .base import (
     KVOperationId,
     KVSaveBlockLease,
 )
-from .factory import build_kv_connector, prepare_kv_connector_config
+from .factory import (
+    build_kv_connector,
+    prepare_kv_connector_config,
+    prepare_kv_connector_model_identity,
+)
 
 __all__ = [
     'KVConnectorBase',
@@ -24,4 +28,5 @@ __all__ = [
     'KVSaveBlockLease',
     'build_kv_connector',
     'prepare_kv_connector_config',
+    'prepare_kv_connector_model_identity',
 ]

--- a/lmdeploy/pytorch/kv_connector/base.py
+++ b/lmdeploy/pytorch/kv_connector/base.py
@@ -242,6 +242,10 @@ class KVConnectorBase(ABC):
         """Return rank-local terminal transfer progress since the last poll."""
         return KVConnectorOutput()
 
+    def set_weights_generation(self, weights_generation: int) -> None:
+        """Rotate connector identity after an online weights update."""
+        return None
+
     def shutdown(self) -> None:
         """Drain asynchronous work and release connector resources."""
         return None

--- a/lmdeploy/pytorch/kv_connector/factory.py
+++ b/lmdeploy/pytorch/kv_connector/factory.py
@@ -3,13 +3,14 @@
 
 from __future__ import annotations
 
+import json
 import os
 from typing import TYPE_CHECKING
 
 from .base import KVConnectorBase, KVConnectorRole
 
 if TYPE_CHECKING:
-    from lmdeploy.pytorch.config import CacheConfig, DistConfig
+    from lmdeploy.pytorch.config import CacheConfig, DistConfig, ModelConfig
 
 
 def prepare_kv_connector_config(
@@ -18,6 +19,7 @@ def prepare_kv_connector_config(
     model_path: str | None = None,
     dist_config: DistConfig | None = None,
     distributed_executor_backend: str | None = None,
+    model_revision: str | None = None,
 ) -> None:
     """Prepare runtime values before the config is copied to workers."""
     transfer_config = cache_config.kv_transfer_config
@@ -36,9 +38,18 @@ def prepare_kv_connector_config(
                 raise ValueError('Mooncake Store requires lookup_async=true')
             extra_config['lookup_async'] = True
 
-        cache_prefix = extra_config.get('cache_prefix', '')
-        if not isinstance(cache_prefix, str):
-            raise TypeError('cache_prefix must be a string')
+        cache_prefix = extra_config.get('cache_prefix')
+        if not isinstance(cache_prefix, str) or not cache_prefix.strip():
+            raise ValueError(
+                'Mooncake Store requires an explicit non-empty cache_prefix '
+                'to isolate shared-store tenants')
+
+        weights_version = extra_config.get('weights_version', model_revision)
+        if not isinstance(weights_version, str) or not weights_version.strip():
+            raise ValueError(
+                'Mooncake Store requires an explicit non-empty weights_version '
+                'or model revision')
+        extra_config['weights_version'] = weights_version
 
         if 'model_name' in extra_config:
             model_name = extra_config['model_name']
@@ -61,6 +72,38 @@ def prepare_kv_connector_config(
                 dp_rank=dp_rank,
                 dp_size=dp_size,
             )
+
+
+def prepare_kv_connector_model_identity(
+    cache_config: CacheConfig,
+    model_config: ModelConfig,
+    *,
+    weights_generation: int = 0,
+) -> None:
+    """Bind the resolved KV format and weights generation to Mooncake keys."""
+    transfer_config = cache_config.kv_transfer_config
+    if (transfer_config is None or not transfer_config.is_kv_transfer_instance
+            or transfer_config.kv_connector != 'MooncakeStoreConnector'):
+        return
+    if (isinstance(weights_generation, bool)
+            or not isinstance(weights_generation, int)
+            or weights_generation < 0):
+        raise ValueError('weights_generation must be a non-negative integer')
+
+    kv_cache_format = json.dumps(
+        {
+            'device_type': cache_config.device_type,
+            'mla_kv_cache_dtype': str(
+                getattr(model_config, 'mla_kv_cache_dtype', None)),
+            'model_dtype': str(model_config.dtype),
+            'quant_policy': int(cache_config.quant_policy),
+        },
+        sort_keys=True,
+        separators=(',', ':'),
+    )
+    extra_config = transfer_config.kv_connector_extra_config
+    extra_config['kv_cache_format'] = kv_cache_format
+    extra_config['weights_generation'] = weights_generation
 
 
 def build_kv_connector(

--- a/lmdeploy/pytorch/kv_connector/mooncake/store/connector.py
+++ b/lmdeploy/pytorch/kv_connector/mooncake/store/connector.py
@@ -138,6 +138,9 @@ class MooncakeStoreConnector(KVConnectorBase):
     def get_finished(self) -> KVConnectorOutput:
         return self._require_worker().get_finished()
 
+    def set_weights_generation(self, weights_generation: int) -> None:
+        return self._require_worker().set_weights_generation(weights_generation)
+
     def shutdown(self) -> None:
         if self.connector_scheduler is not None:
             return self.connector_scheduler.shutdown()

--- a/lmdeploy/pytorch/kv_connector/mooncake/store/data.py
+++ b/lmdeploy/pytorch/kv_connector/mooncake/store/data.py
@@ -9,7 +9,7 @@ import os
 import re
 import struct
 from collections.abc import Mapping, Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, field, replace
 from functools import lru_cache
 from typing import Any, Literal
 
@@ -23,6 +23,7 @@ MOONCAKE_CONFIG_PATH_ENV = 'MOONCAKE_CONFIG_PATH'
 MOONCAKE_BLOCK_HASH_BYTES = hashlib.sha256().digest_size
 
 _BLOCK_HASH_SCHEMA = b'lmdeploy-mooncake-prefix-block-v1\x00'
+_STORE_KEY_NAMESPACE_SCHEMA = b'lmdeploy-mooncake-store-namespace-v2\x00'
 
 MooncakeMode = Literal['embedded']
 
@@ -166,17 +167,56 @@ class MooncakeStoreKeyMetadata:
 
     model_name: str
     cache_prefix: str
+    kv_cache_format: str
+    weights_version: str
     tp_size: int
     block_size: int
     kv_head_replica_num: int = 1
+    weights_generation: int = 0
+    namespace_hash: str = field(init=False, repr=False)
 
     def __post_init__(self) -> None:
         validate_kv_head_replica_num(self.kv_head_replica_num, self.tp_size)
+        identity_fields = (
+            ('model_name', self.model_name),
+            ('cache_prefix', self.cache_prefix),
+            ('kv_cache_format', self.kv_cache_format),
+            ('weights_version', self.weights_version),
+        )
+        for field_name, value in identity_fields:
+            if not isinstance(value, str) or not value.strip():
+                raise ValueError(f'{field_name} must be a non-empty string')
+        if (isinstance(self.weights_generation, bool)
+                or not isinstance(self.weights_generation, int)
+                or self.weights_generation < 0):
+            raise ValueError('weights_generation must be a non-negative integer')
+
+        namespace = json.dumps(
+            {
+                'cache_prefix': self.cache_prefix,
+                'kv_cache_format': self.kv_cache_format,
+                'model_name': self.model_name,
+                'weights_generation': self.weights_generation,
+                'weights_version': self.weights_version,
+            },
+            sort_keys=True,
+            separators=(',', ':'),
+        ).encode('utf-8')
+        namespace_hash = hashlib.sha256(
+            _STORE_KEY_NAMESPACE_SCHEMA + namespace).hexdigest()
+        object.__setattr__(self, 'namespace_hash', namespace_hash)
 
     @property
     def num_kv_head_shards(self) -> int:
         """Return the number of distinct KV-head namespaces."""
         return self.tp_size // self.kv_head_replica_num
+
+    def with_weights_generation(
+        self,
+        weights_generation: int,
+    ) -> MooncakeStoreKeyMetadata:
+        """Return metadata for a newer in-process weights generation."""
+        return replace(self, weights_generation=weights_generation)
 
 
 def build_store_key(
@@ -189,9 +229,8 @@ def build_store_key(
     if len(block_hash) != MOONCAKE_BLOCK_HASH_BYTES:
         raise ValueError(f'block_hash must contain {MOONCAKE_BLOCK_HASH_BYTES} bytes')
 
-    prefix = f'{metadata.cache_prefix}@' if metadata.cache_prefix else ''
     return (
-        f'{prefix}{metadata.model_name}'
+        f'lmdeploy@namespace:{metadata.namespace_hash}'
         f'@tp_rank:{kv_head_rank}'
         '@group:0'
         f'@{block_hash.hex()}'

--- a/lmdeploy/pytorch/kv_connector/mooncake/store/worker.py
+++ b/lmdeploy/pytorch/kv_connector/mooncake/store/worker.py
@@ -106,10 +106,13 @@ class MooncakeStoreWorker:
         extra_config = kv_transfer_config.kv_connector_extra_config
         self.key_metadata = MooncakeStoreKeyMetadata(
             model_name=extra_config.get('model_name', 'unnamed-model'),
-            cache_prefix=extra_config.get('cache_prefix', ''),
+            cache_prefix=extra_config.get('cache_prefix'),
+            kv_cache_format=extra_config.get('kv_cache_format'),
+            weights_version=extra_config.get('weights_version'),
             tp_size=tp_size,
             block_size=cache_config.block_size,
             kv_head_replica_num=kv_head_replica_num,
+            weights_generation=extra_config.get('weights_generation', 0),
         )
 
         config_path = extra_config.get('mooncake_config_path')
@@ -121,6 +124,22 @@ class MooncakeStoreWorker:
 
     def _rank_fields(self) -> tuple[int, int, int]:
         return self.global_rank, self.tp_rank, self.tp_size
+
+    def set_weights_generation(self, weights_generation: int) -> None:
+        """Rotate subsequent lookups and transfers to a new weights
+        namespace."""
+        current_generation = self.key_metadata.weights_generation
+        if weights_generation == current_generation:
+            return
+        if weights_generation < current_generation:
+            raise ValueError(
+                f'weights_generation cannot move backwards from '
+                f'{current_generation} to {weights_generation}')
+        key_metadata = self.key_metadata.with_weights_generation(weights_generation)
+        for transfer_thread in (self.kv_recv_thread, self.kv_send_thread):
+            if transfer_thread is not None:
+                transfer_thread.key_metadata = key_metadata
+        self.key_metadata = key_metadata
 
     def _start_lookup_server(self) -> None:
         if (self.kv_role in ('kv_consumer', 'kv_both')

--- a/tests/pytorch/engine/test_kv_connector_wiring.py
+++ b/tests/pytorch/engine/test_kv_connector_wiring.py
@@ -1,4 +1,5 @@
 # Copyright (c) OpenMMLab. All rights reserved.
+from types import SimpleNamespace
 from unittest.mock import Mock
 
 import pytest
@@ -7,7 +8,10 @@ from lmdeploy.messages import KVTransferConfig, PytorchEngineConfig
 from lmdeploy.pytorch.config import CacheConfig, DistConfig
 from lmdeploy.pytorch.engine.config_builder import ConfigBuilder
 from lmdeploy.pytorch.engine.engine import Engine
-from lmdeploy.pytorch.kv_connector import prepare_kv_connector_config
+from lmdeploy.pytorch.kv_connector import (
+    prepare_kv_connector_config,
+    prepare_kv_connector_model_identity,
+)
 from lmdeploy.pytorch.paging.scheduler import Scheduler
 
 
@@ -26,6 +30,10 @@ def _make_mooncake_cache_config(role='kv_both'):
         KVTransferConfig(
             kv_connector='MooncakeStoreConnector',
             kv_role=role,
+            kv_connector_extra_config={
+                'cache_prefix': 'test-tenant',
+                'weights_version': 'test-weights',
+            },
         ))
 
 
@@ -58,6 +66,8 @@ def test_prepare_mooncake_namespace_and_async_constraints():
     extra_config = cache_config.kv_transfer_config.kv_connector_extra_config
     assert extra_config['model_name'] == 'glm-5.2'
     assert extra_config['lookup_async'] is True
+    assert extra_config['cache_prefix'] == 'test-tenant'
+    assert extra_config['weights_version'] == 'test-weights'
 
     invalid = _make_mooncake_cache_config()
     invalid.kv_transfer_config.kv_connector_extra_config['lookup_async'] = False
@@ -124,7 +134,63 @@ def test_prepare_producer_does_not_create_lookup_endpoint():
     prepare_kv_connector_config(cache_config)
 
     extra_config = cache_config.kv_transfer_config.kv_connector_extra_config
-    assert extra_config == {'lookup_async': False}
+    assert extra_config == {
+        'cache_prefix': 'test-tenant',
+        'lookup_async': False,
+        'weights_version': 'test-weights',
+    }
+
+
+@pytest.mark.parametrize(
+    ('extra_config', 'model_revision', 'match'),
+    [
+        ({'weights_version': 'v1'}, None, 'cache_prefix'),
+        ({'cache_prefix': 'tenant-a'}, None, 'weights_version'),
+    ],
+)
+def test_prepare_mooncake_requires_explicit_namespace_identity(
+    extra_config,
+    model_revision,
+    match,
+):
+    cache_config = _make_mooncake_cache_config()
+    cache_config.kv_transfer_config.kv_connector_extra_config = extra_config
+
+    with pytest.raises(ValueError, match=match):
+        prepare_kv_connector_config(
+            cache_config,
+            model_revision=model_revision,
+        )
+
+
+def test_prepare_mooncake_uses_model_revision_as_weights_version():
+    cache_config = _make_mooncake_cache_config()
+    extra_config = cache_config.kv_transfer_config.kv_connector_extra_config
+    extra_config.pop('weights_version')
+
+    prepare_kv_connector_config(cache_config, model_revision='revision-abc')
+
+    assert extra_config['weights_version'] == 'revision-abc'
+
+
+def test_prepare_mooncake_binds_resolved_kv_format_and_generation():
+    cache_config = _make_mooncake_cache_config()
+    model_config = SimpleNamespace(
+        dtype='torch.bfloat16',
+        mla_kv_cache_dtype=None,
+    )
+
+    prepare_kv_connector_model_identity(
+        cache_config,
+        model_config,
+        weights_generation=3,
+    )
+
+    extra_config = cache_config.kv_transfer_config.kv_connector_extra_config
+    assert extra_config['weights_generation'] == 3
+    assert extra_config['kv_cache_format'] == (
+        '{"device_type":"cuda","mla_kv_cache_dtype":"None",'
+        '"model_dtype":"torch.bfloat16","quant_policy":0}')
 
 
 def test_engine_rejects_effective_mp_backend_before_executor_build(
@@ -183,6 +249,10 @@ def test_runtime_lookup_path_does_not_mutate_reused_engine_config():
         kv_transfer_config=KVTransferConfig(
             kv_connector='MooncakeStoreConnector',
             kv_role='kv_both',
+            kv_connector_extra_config={
+                'cache_prefix': 'test-tenant',
+                'weights_version': 'test-weights',
+            },
         ),
     )
     first = ConfigBuilder.build_cache_config(engine_config)
@@ -194,7 +264,10 @@ def test_runtime_lookup_path_does_not_mutate_reused_engine_config():
     first_path = first.kv_transfer_config.kv_connector_extra_config['lookup_rpc_path']
     second_path = second.kv_transfer_config.kv_connector_extra_config['lookup_rpc_path']
     assert first_path != second_path
-    assert engine_config.kv_transfer_config.kv_connector_extra_config == {}
+    assert engine_config.kv_transfer_config.kv_connector_extra_config == {
+        'cache_prefix': 'test-tenant',
+        'weights_version': 'test-weights',
+    }
 
 
 @pytest.mark.parametrize(

--- a/tests/pytorch/engine/test_model_agent_kv_connector.py
+++ b/tests/pytorch/engine/test_model_agent_kv_connector.py
@@ -28,7 +28,15 @@ def _cache_config(transfer_config=None):
 
 
 def _enabled_config(connector='MooncakeStoreConnector'):
-    return _cache_config(KVTransferConfig(kv_connector=connector, kv_role='kv_both'))
+    return _cache_config(
+        KVTransferConfig(
+            kv_connector=connector,
+            kv_role='kv_both',
+            kv_connector_extra_config={
+                'cache_prefix': 'test-tenant',
+                'weights_version': 'test-weights-v1',
+            },
+        ))
 
 
 def test_factory_disabled_does_not_import_mooncake(monkeypatch):
@@ -87,13 +95,104 @@ def _bare_model_agent():
     agent = BaseModelAgent.__new__(BaseModelAgent)
     agent.all_context = nullcontext
     agent.cache_config = _enabled_config()
-    agent.model_config = SimpleNamespace(num_replicate_key_value_heads=4)
+    agent.model_config = SimpleNamespace(
+        dtype='torch.float16',
+        mla_kv_cache_dtype=None,
+        num_replicate_key_value_heads=4,
+    )
+    agent._weights_generation = 0
     agent.rank = 7
     agent.cache_stream = object()
     agent.block_cache_plan = object()
     agent.dist_config = SimpleNamespace(attn_tp=8)
     agent.memdecode_agent = None
     return agent
+
+
+def test_weights_update_rotates_mooncake_namespace():
+    agent = _bare_model_agent()
+    connector = SimpleNamespace(set_weights_generation_calls=[])
+    connector.set_weights_generation = connector.set_weights_generation_calls.append
+    agent.kv_connector = connector
+
+    agent._advance_kv_connector_weights_generation()
+
+    extra_config = agent.cache_config.kv_transfer_config.kv_connector_extra_config
+    assert agent._weights_generation == 1
+    assert extra_config['weights_generation'] == 1
+    assert '"model_dtype":"torch.float16"' in extra_config['kv_cache_format']
+    assert connector.set_weights_generation_calls == [1]
+
+
+def test_finished_serialized_weight_update_rotates_mooncake_namespace(monkeypatch):
+    from lmdeploy.pytorch.engine.model_agent import agent as agent_module
+
+    events = []
+    agent = _bare_model_agent()
+    model = SimpleNamespace(
+        load_weights=lambda weights: None,
+        named_modules=lambda: (),
+    )
+    agent.dist_ctx = SimpleNamespace(tp_group=SimpleNamespace(rank=0))
+    agent.patched_model = SimpleNamespace(get_model=lambda: model)
+    agent.spec_agent = SimpleNamespace(
+        get_model=lambda: None,
+        is_enabled=lambda: False,
+        method=None,
+    )
+    agent._update_params_ipc_event = None
+    agent._update_params_ipc_tensor = None
+    agent._advance_kv_connector_weights_generation = lambda: events.append('rotate')
+    monkeypatch.setattr(agent_module.pybase64, 'b64decode', lambda value: b'')
+    monkeypatch.setattr(agent_module.ForkingPickler, 'loads', lambda value: [])
+    monkeypatch.setattr(agent_module.torch.cuda, 'synchronize', lambda: None)
+    monkeypatch.setattr(agent_module.torch.cuda, 'empty_cache', lambda: None)
+    request = SimpleNamespace(
+        serialized_named_tensors='payload',
+        load_format='default',
+        finished=True,
+    )
+
+    agent.update_params(request)
+
+    assert events == ['rotate']
+
+
+def test_finished_distributed_weight_update_rotates_mooncake_namespace(monkeypatch):
+    from lmdeploy.pytorch.engine.model_agent import agent as agent_module
+
+    events = []
+    agent = _bare_model_agent()
+    model = SimpleNamespace(
+        load_weights=lambda weights: None,
+        named_modules=lambda: (),
+    )
+    agent._model_update_group = {'test-group': object()}
+    agent.patched_model = SimpleNamespace(get_model=lambda: model)
+    agent.spec_agent = SimpleNamespace(
+        get_model=lambda: None,
+        is_enabled=lambda: False,
+        method=None,
+    )
+    agent.reset_graph_runner = lambda: events.append('reset-graph')
+    agent._advance_kv_connector_weights_generation = lambda: events.append('rotate')
+    monkeypatch.setattr(agent_module.torch.cuda, 'current_device', lambda: 0)
+    monkeypatch.setattr(agent_module.torch.cuda, 'synchronize', lambda: None)
+    monkeypatch.setattr(agent_module.torch.cuda, 'empty_cache', lambda: None)
+    request = SimpleNamespace(
+        group_name='test-group',
+        names=[],
+        dtypes=[],
+        shapes=[],
+        load_format='default',
+        finished=True,
+    )
+
+    success, message = agent.update_weights_from_distributed(request)
+
+    assert success
+    assert message == 'Succeeded to update parameter online.'
+    assert events == ['reset-graph', 'rotate']
 
 
 def test_build_cache_engine_replaces_connector_and_registers_row_mapping(monkeypatch):

--- a/tests/pytorch/kv_connector/test_mooncake_store_connector.py
+++ b/tests/pytorch/kv_connector/test_mooncake_store_connector.py
@@ -53,7 +53,13 @@ def cache_config(tmp_path, monkeypatch):
         kv_transfer_config=KVTransferConfig(
             kv_connector='MooncakeStoreConnector',
             kv_role='kv_both',
-            kv_connector_extra_config={'mooncake_config_path': str(config_path)},
+            kv_connector_extra_config={
+                'cache_prefix': 'test-tenant',
+                'kv_cache_format': 'dtype=float16;quant=none',
+                'mooncake_config_path': str(config_path),
+                'weights_generation': 0,
+                'weights_version': 'test-weights-v1',
+            },
         ),
     )
 
@@ -212,6 +218,7 @@ def test_worker_methods_delegate_arguments_and_results(cache_config):
     worker.register_kv_caches = MagicMock(return_value=None)
     worker.start_load_kv = MagicMock(return_value=None)
     worker.start_save_kv = MagicMock(return_value=None)
+    worker.set_weights_generation = MagicMock(return_value=None)
     output = KVConnectorOutput(completed_save_ids={1}, finished_receiving={2})
     worker.get_finished = MagicMock(return_value=output)
     worker.shutdown = MagicMock(return_value=None)
@@ -226,6 +233,8 @@ def test_worker_methods_delegate_arguments_and_results(cache_config):
     worker.start_save_kv.assert_called_once_with(metadata)
     assert connector.get_finished() is output
     worker.get_finished.assert_called_once_with()
+    assert connector.set_weights_generation(2) is None
+    worker.set_weights_generation.assert_called_once_with(2)
 
     assert connector.shutdown() is None
     worker.shutdown.assert_called_once_with()

--- a/tests/pytorch/kv_connector/test_mooncake_store_worker.py
+++ b/tests/pytorch/kv_connector/test_mooncake_store_worker.py
@@ -1,6 +1,7 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import json
 import sys
+from types import SimpleNamespace
 
 import pytest
 import torch
@@ -236,7 +237,12 @@ def make_cache_config(
     num_gpu_blocks=1,
     role='kv_both',
 ):
-    extra_config = {}
+    extra_config = {
+        'cache_prefix': 'test-tenant',
+        'kv_cache_format': 'dtype=float16;quant=none',
+        'weights_generation': 0,
+        'weights_version': 'test-weights-v1',
+    }
     if config_path is not None:
         extra_config['mooncake_config_path'] = str(config_path)
     return CacheConfig(
@@ -559,6 +565,8 @@ def test_store_key_uses_lmdeploy_namespace_without_unsupported_geometry():
     metadata = MooncakeStoreKeyMetadata(
         model_name='test-model',
         cache_prefix='tenant-a',
+        kv_cache_format='dtype=float16;quant=none',
+        weights_version='weights-v1',
         tp_size=8,
         block_size=4,
         kv_head_replica_num=4,
@@ -566,7 +574,54 @@ def test_store_key_uses_lmdeploy_namespace_without_unsupported_geometry():
     block_hash = build_prefix_block_hashes(range(4), 4)[0]
 
     assert build_store_key(metadata, 1, block_hash) == (
-        f'tenant-a@test-model@tp_rank:1@group:0@{block_hash.hex()}')
+        f'lmdeploy@namespace:{metadata.namespace_hash}'
+        f'@tp_rank:1@group:0@{block_hash.hex()}')
+
+
+def test_store_keys_partition_tenant_format_and_weights_identity():
+    block_hash = build_prefix_block_hashes(range(4), 4)[0]
+    base = {
+        'model_name': 'test-model',
+        'cache_prefix': 'tenant-a',
+        'kv_cache_format': 'dtype=float16;quant=none',
+        'weights_version': 'weights-v1',
+        'tp_size': 1,
+        'block_size': 4,
+    }
+    variants = (
+        MooncakeStoreKeyMetadata(**base),
+        MooncakeStoreKeyMetadata(**{**base, 'cache_prefix': 'tenant-b'}),
+        MooncakeStoreKeyMetadata(
+            **{**base, 'kv_cache_format': 'dtype=uint8;quant=fp8'}),
+        MooncakeStoreKeyMetadata(**{**base, 'weights_version': 'weights-v2'}),
+        MooncakeStoreKeyMetadata(**base, weights_generation=1),
+    )
+
+    keys = {build_store_key(metadata, 0, block_hash) for metadata in variants}
+
+    assert len(keys) == len(variants)
+
+
+def test_worker_rotates_active_transfer_threads_to_new_weights_generation(tmp_path):
+    worker, _ = make_worker(tmp_path)
+    recv_thread = SimpleNamespace(key_metadata=worker.key_metadata)
+    send_thread = SimpleNamespace(key_metadata=worker.key_metadata)
+    worker.kv_recv_thread = recv_thread
+    worker.kv_send_thread = send_thread
+    old_namespace = worker.key_metadata.namespace_hash
+
+    worker.set_weights_generation(2)
+
+    assert worker.key_metadata.weights_generation == 2
+    assert worker.key_metadata.namespace_hash != old_namespace
+    assert recv_thread.key_metadata is worker.key_metadata
+    assert send_thread.key_metadata is worker.key_metadata
+    worker.set_weights_generation(2)
+    with pytest.raises(ValueError, match='cannot move backwards'):
+        worker.set_weights_generation(1)
+    worker.kv_recv_thread = None
+    worker.kv_send_thread = None
+    worker.shutdown()
 
 
 def test_lookup_server_start_failure_propagates_without_cleanup(tmp_path, monkeypatch):


### PR DESCRIPTION
# Local PR draft - F2 Mooncake KV-store key identity

Related issue: [#4930](https://github.com/InternLM/lmdeploy/issues/4930)

## Motivation

Mooncake external KV-cache keys currently identify entries by model name, an
optional cache prefix, shard rank, and token-prefix hash. The key does not bind
the stored bytes to the resolved KV-cache format or the model weights lineage.
The default empty cache prefix also leaves deployments sharing a Mooncake store
without a required tenant partition.

This can advertise stale same-dtype KV after a weight revision or online weight
update. Mixed KV formats can produce false external-cache hits and unnecessary
transfer work, and deployments with colliding default configuration can share a
keyspace unintentionally. See #4930 for the production-code probe and impact
analysis.

## Modification

- Require a non-empty `cache_prefix` for Mooncake deployments.
- Accept `weights_version`, using the engine model revision when available, and
  reject configurations without a usable weights identity.
- Compute a canonical resolved KV-format identity from device type, model dtype,
  `quant_policy`, and MLA KV-cache dtype.
- Hash the model name, tenant prefix, KV format, weights version, and a
  versioned weights generation into the Mooncake namespace.
- Rotate the namespace after each completed online weight update, including both
  serialized and distributed update paths, and propagate the new metadata to
  active Mooncake transfer workers.
- Add focused tests for namespace partitioning, configuration validation,
  generation rotation, and sender/receiver metadata propagation.
- Update CLI help with the required Mooncake identity configuration and example.

The change is intentionally limited to F2 external-store key identity. KV-head
shard schema negotiation (F8), local prefix-cache invalidation (F1), and
adapter-weight fingerprinting are not part of this PR.

The documented update-weights workflow drains/sleeps the engine before loading
new weights. This PR rotates the active connector identity after the completed
update; ordering for transfer tasks that are intentionally left queued across an
update remains part of the separate cache-lifecycle work.

## BC-breaking (Optional)

Yes, for the unreleased Mooncake connector configuration. Enabling
`MooncakeStoreConnector` now requires an explicit non-empty `cache_prefix` and a
non-empty `weights_version`, unless the engine provides a model revision. Old
unscoped remote entries are no longer read by the new namespace, which is
intentional because their format and weights lineage cannot be verified.

Non-Mooncake connectors, local KV caching, and the public inference request API
are unchanged.

## Use cases (Optional)

- PD disaggregation deployments sharing one Mooncake cluster with separate
  tenant prefixes.
- Restarted or hot-updated deployments that must not consume KV produced by an
  older weights generation.
- Deployments using different KV-cache dtypes or quantization policies against
  the same external store.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
   - [x] `git diff --check` passes.
   - [x] `pre-commit run --files <changed-files>` passes.
2. The modification is covered by complete unit tests.
   - [x] Focused tests were added under `tests/pytorch/kv_connector/` and
     `tests/pytorch/engine/`.
   - [x] Focused pytest passes in the installed CPU environment (`125 passed`).
3. If the modification has a dependency on downstream projects of a newer
   version, this PR should be tested with all supported versions of downstream
   projects.
   - [x] No downstream API dependency is introduced.
4. The documentation has been modified accordingly, like docstring or example
   tutorials.
   - [x] Mooncake CLI help and relevant implementation docstrings describe the
     new identity requirements.

### Verification command

```shell
pytest -q tests/pytorch/kv_connector \
  tests/pytorch/engine/test_kv_connector_wiring.py \
  tests/pytorch/engine/test_model_agent_kv_connector.py
```

Current result: `125 passed in 6.31s` in the local CPU environment and `125
passed in 11.32s` on `rtx4080` with `CUDA_VISIBLE_DEVICES=0`, `torch
2.12.1+cu130`, and 8x RTX 4080 available. Related engine regression tests also
pass on the GPU host: `14 passed in 8.68s`. `compileall`, `ruff check`,
`git diff --check`, and all configured pre-commit hooks pass. A live Mooncake
Store integration was not run because no Mooncake Store service/configuration
was provided.
