### PR TITLE
Assert the logprobs count in the restful return checks

### DIFF
--- a/autotest/utils/restful_return_check.py
+++ b/autotest/utils/restful_return_check.py
@@ -57,7 +57,7 @@ def assert_chat_completions_batch_return(output, model_name, check_logprobs: boo
             isinstance(reasoning, str) and len(reasoning) > 0)
         assert msg.get('role') == 'assistant'
         if check_logprobs:
-            len(message.get('logprobs').get('content')) == output.get('usage').get('completion_tokens')
+            assert len(message.get('logprobs').get('content')) == output.get('usage').get('completion_tokens')
             for logprob in message.get('logprobs').get('content'):
                 assert_logprobs(logprob, logprobs_num)
 
@@ -74,7 +74,7 @@ def assert_completions_batch_return(output, model_name, check_logprobs: bool = F
         assert message.get('index') == 0
         assert len(message.get('text')) > 0
         if check_logprobs:
-            len(message.get('logprobs').get('content')) == output.get('usage').get('completion_tokens')
+            assert len(message.get('logprobs').get('content')) == output.get('usage').get('completion_tokens')
             for logprob in message.get('logprobs').get('content'):
                 assert_logprobs(logprob, logprobs_num)
 


### PR DESCRIPTION
## Motivation

Two logprobs checks in `autotest/utils/restful_return_check.py` never check anything. They are written as bare comparisons rather than assertions:

```python
if check_logprobs:
    len(message.get('logprobs').get('content')) == output.get('usage').get('completion_tokens')
    for logprob in message.get('logprobs').get('content'):
        assert_logprobs(logprob, logprobs_num)
```

Python evaluates the comparison and throws the result away, so the check passes unconditionally — a response whose `logprobs.content` length disagreed with `usage.completion_tokens` would sail through. Every other check in both functions is an `assert`, so the intent is unambiguous.

Affects `assert_chat_completions_batch_return` (line 60) and `assert_completions_batch_return` (line 77), i.e. the `check_logprobs=True` path of the restful API tests for both chat and text completions.

`ruff --select B015` flags both: *"Pointless comparison. Did you mean to assign a value? Otherwise, prepend `assert` or remove it."*

## Modification

Prepend `assert` at both sites. Lines stay within the configured 120-char limit (110 each).

## BC-breaking

No — test-only.

## Use cases

None; this restores a check rather than adding one.

## Note

Since these assertions have never actually run, it is possible one of them now fails against current behaviour. I can't run the restful autotests here — they need a served model — so someone with a runner should confirm the counts do line up. If `logprobs.content` is legitimately allowed to differ from `completion_tokens` in some mode, the right fix is to delete these two lines instead of asserting them, and I'm happy to switch to that.
