### PR TITLE
fix: cherry-pick #4926, #4929, and #4931 into v0.17.0post1

### DIFF
--- a/lmdeploy/messages.py
+++ b/lmdeploy/messages.py
@@ -229,8 +229,7 @@ class GenerationConfig:
         if tokenizer_eos_token_id is not None:
             stop_token_ids.add(tokenizer_eos_token_id)
 
-        # add eos_token_id from model's generation_config.json file if there
-        # is any.
+        # add eos_token_id from the model's generation config, if any.
         eos_token_id = generation_config.get('eos_token_id')
         if eos_token_id is not None:
             if isinstance(eos_token_id, int):

--- a/lmdeploy/pipeline.py
+++ b/lmdeploy/pipeline.py
@@ -91,7 +91,6 @@ class Pipeline:
         self.limiter: asyncio.Semaphore = None
         self.session_mgr = self.async_engine.session_mgr
         self.backend_config = self.async_engine.backend_config
-        self.allowed_media_domains = allowed_media_domains
         self.async_engine.start_loop(self.internal_thread.loop, use_async_api=False)
 
     def infer(self,
@@ -117,7 +116,7 @@ class Pipeline:
         """
         is_single = self._is_single(prompts)
         # format prompts to openai message format, which is a list of dicts
-        prompts = MultimodalProcessor.format_prompts(prompts, allowed_media_domains=self.allowed_media_domains)
+        prompts = MultimodalProcessor.format_prompts(prompts)
         pbar = tqdm.tqdm(total=len(prompts)) if use_tqdm else None
         outputs = []
         try:
@@ -167,7 +166,7 @@ class Pipeline:
         Returns:
             Iterator: A generator that yields the output (i.e. instance of class ``Response``) of the inference.
         """
-        prompts = MultimodalProcessor.format_prompts(prompts, allowed_media_domains=self.allowed_media_domains)
+        prompts = MultimodalProcessor.format_prompts(prompts)
         requests = self._request_generator(prompts,
                                            sessions=sessions,
                                            gen_config=gen_config,
@@ -183,11 +182,10 @@ class Pipeline:
         self.async_engine.close()
 
     @staticmethod
-    def _history_to_messages(history, prompt, allowed_media_domains=None):
+    def _history_to_messages(history, prompt):
         def _messages(prompt):
             messages = []
-            for item in MultimodalProcessor.format_prompts(
-                    prompt, allowed_media_domains=allowed_media_domains):
+            for item in MultimodalProcessor.format_prompts(prompt):
                 if isinstance(item, str):
                     messages.append({'role': 'user', 'content': item})
                 elif isinstance(item, dict):
@@ -227,8 +225,7 @@ class Pipeline:
             session = self.session_mgr.get()
         session.update(prompt=prompt, response=None)
 
-        messages = self._history_to_messages(
-            session.history, prompt, allowed_media_domains=self.allowed_media_domains)
+        messages = self._history_to_messages(session.history, prompt)
         generator = self.stream_infer(prompts=messages,
                                       sessions=session,
                                       gen_config=gen_config,

--- a/lmdeploy/serve/processors/multimodal.py
+++ b/lmdeploy/serve/processors/multimodal.py
@@ -282,7 +282,7 @@ class MultimodalProcessor:
             raise RuntimeError(f'unsupported prompt type: {type(prompt)}')
 
     @staticmethod
-    def format_prompts(prompts: Any, allowed_media_domains: list[str] | None = None) -> list[dict]:
+    def format_prompts(prompts: Any) -> list[dict]:
         """Format prompts."""
         if not isinstance(prompts, list):
             prompts = [prompts]
@@ -295,8 +295,7 @@ class MultimodalProcessor:
         if all(MultimodalProcessor._is_str_images_pair(prompt) for prompt in prompts):
             # batch of (prompt, image or [images]) or (image or [images], prompt) ->
             # [[openai_gpt4v_message], [openai_gpt4v_message], ...]
-            return [[MultimodalProcessor._re_format_prompt_images_pair(prompt, allowed_media_domains)]
-                    for prompt in prompts]
+            return [[MultimodalProcessor._re_format_prompt_images_pair(prompt)] for prompt in prompts]
         raise ValueError(f'Unsupported prompts: {prompts}. Only support str, openai message format, '
                          'or (prompt, image or [images]) or (image or [images], prompt) pair.')
 
@@ -327,7 +326,7 @@ class MultimodalProcessor:
         return isinstance(obj, list) and all(MultimodalProcessor._is_image(img) for img in obj)
 
     @staticmethod
-    def _re_format_prompt_images_pair(prompt: tuple, allowed_media_domains: list[str] | None = None) -> dict:
+    def _re_format_prompt_images_pair(prompt: tuple) -> dict:
         """Reformat the prompt to openai message format."""
         messages = {'role': 'user', 'content': []}
         prompt, images = prompt
@@ -341,8 +340,7 @@ class MultimodalProcessor:
             # 'image_url': means url or local path to image.
             # 'image_data': means PIL.Image.Image object.
             if isinstance(image, str):
-                image = load_from_url(image, ImageMediaIO(), allowed_media_domains=allowed_media_domains)
-                item = {'type': 'image_data', 'image_data': {'data': image}}
+                item = {'type': 'image_url', 'image_url': {'url': image}}
             elif isinstance(image, PIL.Image.Image):
                 item = {'type': 'image_data', 'image_data': {'data': image}}
             else:

--- a/lmdeploy/utils.py
+++ b/lmdeploy/utils.py
@@ -247,9 +247,17 @@ def get_hf_gen_cfg(path: str, trust_remote_code: bool = False):
     from transformers import GenerationConfig
     try:
         cfg = GenerationConfig.from_pretrained(path, trust_remote_code=trust_remote_code)
-        return cfg.to_dict()
     except OSError:
-        return {}
+        try:
+            # Some checkpoints keep generation attributes such as EOS IDs only
+            # in config.json.
+            model_cfg, _ = PretrainedConfig.get_config_dict(path)
+            if not model_cfg:
+                return {}
+            cfg = GenerationConfig.from_model_config(PretrainedConfig.from_dict(model_cfg))
+        except OSError:
+            return {}
+    return cfg.to_dict()
 
 
 def get_model(pretrained_model_name_or_path: str, download_dir: str = None, revision: str = None, token: str = None):

--- a/lmdeploy/utils.py
+++ b/lmdeploy/utils.py
@@ -254,7 +254,9 @@ def get_hf_gen_cfg(path: str, trust_remote_code: bool = False):
             model_cfg, _ = PretrainedConfig.get_config_dict(path)
             if not model_cfg:
                 return {}
-            cfg = GenerationConfig.from_model_config(PretrainedConfig.from_dict(model_cfg))
+            from lmdeploy.hf_configs import config_from_pretrained
+            model_cfg = config_from_pretrained(path, trust_remote_code=trust_remote_code)
+            cfg = GenerationConfig.from_model_config(model_cfg)
         except OSError:
             return {}
     return cfg.to_dict()

--- a/lmdeploy/version.py
+++ b/lmdeploy/version.py
@@ -1,6 +1,6 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 
-__version__ = '0.17.0'
+__version__ = '0.17.0.post1'
 short_version = __version__
 
 

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -20,4 +20,4 @@ shortuuid
 tiktoken
 transformers >= 4.56.0, != 5.0.*, != 5.1.*, != 5.2.*, != 5.3.*, != 5.4.*, != 5.5.0, !=5.7.*, !=5.8.*, !=5.9.*
 uvicorn
-xgrammar >= 0.1.33
+xgrammar >= 0.1.33, != 0.2.5.post1

--- a/tests/test_lmdeploy/test_content_merge.py
+++ b/tests/test_lmdeploy/test_content_merge.py
@@ -387,25 +387,19 @@ def test_async_parse_multimodal_item_passes_allowed_media_domains(monkeypatch):
     ]
 
 
-def test_format_prompts_passes_allowed_media_domains(monkeypatch):
-    """Tuple prompt URL loading should honor the configured domain
-    allowlist."""
-    image = Image.new('RGB', (1, 1))
-    load_calls = []
+def test_format_prompts_defers_image_loading(monkeypatch):
+    """Tuple prompt formatting should not load image data."""
+    monkeypatch.setattr(multimodal_module, 'load_from_url', lambda *args, **kwargs: pytest.fail('unexpected load'))
 
-    def fake_load_from_url(data_src, media_io, allowed_media_domains=None):
-        load_calls.append((data_src, type(media_io).__name__, allowed_media_domains))
-        return image
+    prompts = MultimodalProcessor.format_prompts(('describe', 'https://example.com/a.png'))
 
-    monkeypatch.setattr(multimodal_module, 'load_from_url', fake_load_from_url)
-
-    prompts = MultimodalProcessor.format_prompts(('describe', 'https://example.com/a.png'),
-                                                 allowed_media_domains=['example.com'])
-
-    assert load_calls == [('https://example.com/a.png', 'ImageMediaIO', ['example.com'])]
     assert prompts[0][0]['content'][0] == {'type': 'text', 'text': 'describe'}
-    assert prompts[0][0]['content'][1]['type'] == 'image_data'
-    assert prompts[0][0]['content'][1]['image_data']['data'] is image
+    assert prompts[0][0]['content'][1] == {
+        'type': 'image_url',
+        'image_url': {
+            'url': 'https://example.com/a.png'
+        }
+    }
 
 
 def test_async_parse_multimodal_item_preserves_tool_image_content(monkeypatch):

--- a/tests/test_lmdeploy/test_pipeline.py
+++ b/tests/test_lmdeploy/test_pipeline.py
@@ -40,7 +40,6 @@ def test_chat_clears_response_before_streaming_and_records_history():
         pass
 
     pipe = Pipeline.__new__(Pipeline)
-    pipe.allowed_media_domains = None
     pipe.seen_prompts = []
     pipe.response_at_stream_start = None
 


### PR DESCRIPTION
## Summary

- Backport model generation-config fallback behavior from #4929.
- Backport deferred pipeline media loading from #4926.
- Retain the text-model multimodal request rejection already present on the target branch.
- Backport the broken XGrammar `0.2.5.post1` exclusion from #4931.
- Bump the package version to `0.17.0.post1`.

## Backport details

The first functional commit from #4926 is already present on `v0.17.0post1` as `ae15b7d0`, so this PR includes only its remaining pipeline-media commit. The merge-from-`main` synchronization commit from #4929 is intentionally excluded to avoid bringing unrelated main-branch history into the release branch. PR #4931's dependency constraint is backported with its original authorship and rationale preserved.

## Validation

- 30 multimodal and pipeline tests passed.
- 5 generation-configuration tests passed.
- Focused generation-config fallback smoke test passed.
- Package version import reports `0.17.0.post1`.
- XGrammar requirement parsing confirms `0.2.5.post1` is excluded while `0.2.5` and `0.2.6` remain allowed.
- Pre-commit hooks passed for all changed files.
- `git diff --check` passed.

## Assistance

Assisted with Codex + GPT-5.6-Sol xHigh, reviewed manually
