### PR TITLE
docs: fix dead heading anchors in CONTRIBUTING and get_started pages

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -113,7 +113,7 @@ git pull upstream main
   pytest tests/test_runner/test_runner.py
   ```
 
-  If the unit test fails for lack of dependencies, you can install the dependencies referring to the [guidance](#unit-test)
+  If the unit test fails for lack of dependencies, you can install the dependencies referring to the [guidance](#4-commit-the-code-and-pass-the-unit-test)
 
 - If the documents are modified/added, we should check the rendering result referring to [guidance](#document-rendering)
 

--- a/docs/en/get_started/ascend/get_started.md
+++ b/docs/en/get_started/ascend/get_started.md
@@ -4,7 +4,7 @@ We currently support running lmdeploy on **Atlas 800T A3, Atlas 800T A2 and Atla
 The usage of lmdeploy on a Huawei Ascend device is almost the same as its usage on CUDA with PytorchEngine in lmdeploy.
 Please read the original [Get Started](../get_started.md) guide before reading this tutorial.
 
-Here is the [supported model list](../../supported_models/supported_models.md#PyTorchEngine-on-Other-Platforms).
+Here is the [supported model list](../../supported_models/supported_models.md#pytorchengine-on-other-platforms).
 
 > \[!IMPORTANT\]
 > We have uploaded a docker image with KUNPENG CPU to aliyun.

--- a/docs/en/get_started/camb/get_started.md
+++ b/docs/en/get_started/camb/get_started.md
@@ -3,7 +3,7 @@
 The usage of lmdeploy on a Cambricon device is almost the same as its usage on CUDA with PytorchEngine in lmdeploy.
 Please read the original [Get Started](../get_started.md) guide before reading this tutorial.
 
-Here is the [supported model list](../../supported_models/supported_models.md#PyTorchEngine-on-Other-Platforms).
+Here is the [supported model list](../../supported_models/supported_models.md#pytorchengine-on-other-platforms).
 
 > \[!IMPORTANT\]
 > We have uploaded a docker image to aliyun.

--- a/docs/en/get_started/maca/get_started.md
+++ b/docs/en/get_started/maca/get_started.md
@@ -3,7 +3,7 @@
 The usage of lmdeploy on a MetaX-tech device is almost the same as its usage on CUDA with PytorchEngine in lmdeploy.
 Please read the original [Get Started](../get_started.md) guide before reading this tutorial.
 
-Here is the [supported model list](../../supported_models/supported_models.md#PyTorchEngine-on-Other-Platforms).
+Here is the [supported model list](../../supported_models/supported_models.md#pytorchengine-on-other-platforms).
 
 > \[!IMPORTANT\]
 > We have uploaded a docker image to aliyun.

--- a/docs/zh_cn/get_started/ascend/get_started.md
+++ b/docs/zh_cn/get_started/ascend/get_started.md
@@ -2,7 +2,7 @@
 
 我们基于 LMDeploy 的 PytorchEngine，增加了华为昇腾设备的支持，目前支持的型号是**Atlas 800T A3，Atlas 800T A2和Atlas 300I Duo**。在华为昇腾上使用 LMDeploy 的方法与在英伟达 GPU 上使用 PytorchEngine 后端的方法几乎相同。在阅读本教程之前，请先阅读原版的[快速开始](../get_started.md)。
 
-支持的模型列表在[这里](../../supported_models/supported_models.md#PyTorchEngine-其他平台).
+支持的模型列表在[这里](../../supported_models/supported_models.md#pytorchengine-其他平台).
 
 > \[!IMPORTANT\]
 > 我们已经在阿里云上提供了构建完成的鲲鹏CPU版本的镜像。

--- a/docs/zh_cn/get_started/camb/get_started.md
+++ b/docs/zh_cn/get_started/camb/get_started.md
@@ -2,7 +2,7 @@
 
 我们基于 LMDeploy 的 PytorchEngine，增加了寒武纪云端加速卡设备的支持。所以，在寒武纪云端加速卡上使用 LMDeploy 的方法与在英伟达 GPU 上使用 PytorchEngine 后端的方法几乎相同。在阅读本教程之前，请先阅读原版的[快速开始](../get_started.md)。
 
-支持的模型列表在[这里](../../supported_models/supported_models.md#PyTorchEngine-其他平台).
+支持的模型列表在[这里](../../supported_models/supported_models.md#pytorchengine-其他平台).
 
 > \[!IMPORTANT\]
 > 我们已经在阿里云上提供了构建完成的寒武纪云端加速卡镜像。

--- a/docs/zh_cn/get_started/maca/get_started.md
+++ b/docs/zh_cn/get_started/maca/get_started.md
@@ -2,7 +2,7 @@
 
 我们基于 LMDeploy 的 PytorchEngine，增加了沐曦C500设备的支持。所以，在沐曦上使用 LMDeploy 的方法与在英伟达 GPU 上使用 PytorchEngine 后端的方法几乎相同。在阅读本教程之前，请先阅读原版的[快速开始](../get_started.md)。
 
-支持的模型列表在[这里](../../supported_models/supported_models.md#PyTorchEngine-其他平台).
+支持的模型列表在[这里](../../supported_models/supported_models.md#pytorchengine-其他平台).
 
 > \[!IMPORTANT\]
 > 我们已经在阿里云上提供了构建完成的沐曦的镜像。


### PR DESCRIPTION
Seven dead anchors, all outside CI's link-checker coverage (`doc_link_checker.py` only checks the two READMEs, and markdown-link-check's `file-path` omits `.github/`):

1. `.github/CONTRIBUTING.md`: the unit-test guidance link used `#unit-test`, which matches no heading; the guidance is `#### 4. Commit the code and pass the unit test` → `#4-commit-the-code-and-pass-the-unit-test` (the same file already links that slug correctly at line 156).
2. Six `get_started` pages (ascend/camb/maca × en/zh_cn) linked `supported_models.md#PyTorchEngine-on-Other-Platforms` / `#PyTorchEngine-其他平台` — heading fragments are lowercased, so the correct slugs are `#pytorchengine-on-other-platforms` / `#pytorchengine-其他平台`.