### PR TITLE
docs: sync ja README quickstart python version with en/zh (3.10 -> 3.12)

### DIFF
--- a/README_ja.md
+++ b/README_ja.md
@@ -195,7 +195,7 @@ LMDeployは、[TurboMind](./docs/en/inference/turbomind.md)および[PyTorch](./
 クリーンなconda環境（Python 3.10 - 3.13）でlmdeployをインストールすることをお勧めします。
 
 ```shell
-conda create -n lmdeploy python=3.10 -y
+conda create -n lmdeploy python=3.12 -y
 conda activate lmdeploy
 pip install lmdeploy
 ```


### PR DESCRIPTION
The en and zh quickstart commands were bumped to `python=3.12` in #4476; the ja README still created a 3.10 environment, so the three quickstarts no longer matched. (Opened as draft due to the non-collaborator open-PR limit; happy to mark ready for review.)