### PR TITLE
fix(proxy): interpolate node_url in the terminate_node failure response

### DIFF
--- a/lmdeploy/serve/proxy/proxy.py
+++ b/lmdeploy/serve/proxy/proxy.py
@@ -534,7 +534,7 @@ def terminate_node(node: Node):
         return 'Terminated successfully'
     except:  # noqa
         logger.error(f'Terminate node {node_url} failed.')
-        return 'Failed to terminate node {node_url}, please check the input url.'
+        return f'Failed to terminate node {node_url}, please check the input url.'
 
 
 @app.get('/nodes/terminate_all', dependencies=[Depends(validate_json_request)])


### PR DESCRIPTION
### Problem

`POST /nodes/terminate` returns the placeholder verbatim when termination throws:

https://github.com/InternLM/lmdeploy/blob/main/lmdeploy/serve/proxy/proxy.py#L528-L537

```python
    except:  # noqa
        logger.error(f'Terminate node {node_url} failed.')
        return 'Failed to terminate node {node_url}, please check the input url.'   # <- no f
```

The string has no `f` prefix, so the HTTP client is handed the literal text
`Failed to terminate node {node_url}, please check the input url.` and never learns
which node actually failed — which is exactly the information the message promises.

### Why this is a typo and not a deliberate literal

`proxy.py` contains 30 string literals with `{...}` interpolation. **29 carry the `f`
prefix; this line is the only one that does not** — including its two immediate
neighbours in the same function:

```python
        if not success:
            return f'Failed to terminate node {node_url}'          # L533, has f
        ...
    except:  # noqa
        logger.error(f'Terminate node {node_url} failed.')          # L536, has f
        return 'Failed to terminate node {node_url}, please ...'    # L537, missing f
```

### Verification

I extracted `terminate_node` verbatim from the file with `ast`, stubbed
`node_manager`/`logger`, and exercised both branches — the healthy sibling is the
control row:

```
[node_manager.terminate_node returns False  -> L533, has f-prefix]
   returned -> 'Failed to terminate node http://10.0.0.7:23333'
   contains literal '{node_url}': False

[node_manager.terminate_node raises         -> L537, no f-prefix]
   [logger.error] Terminate node http://10.0.0.7:23333 failed.
   returned -> 'Failed to terminate node {node_url}, please check the input url.'
   contains literal '{node_url}': True
```

### Change

One character: add the `f` prefix. No behaviour change on any other path.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
