### PR TITLE
fix(serve): wait for XML tool name before streaming arguments

### DIFF
--- a/lmdeploy/serve/parsers/tool_parser/xml_tool_parser.py
+++ b/lmdeploy/serve/parsers/tool_parser/xml_tool_parser.py
@@ -85,21 +85,27 @@ class XmlToolParser(ToolParser):
 
         should_close = is_closed or (final and self._close_json_on_final())
 
+        # An Anthropic tool block must be opened with a non-empty id/name.
+        # Argument-only deltas are valid after the name delta, but emitting one
+        # before the name would make the streaming adapter create an invalid
+        # ``content_block_start`` event. Keep the parsed arguments in the
+        # incremental state until the function name has been emitted.
         json_fragments: list[str] = []
-        if not self._xml_has_emitted_json_start and (args_dict or should_close):
-            json_fragments.append('{')
-            self._xml_has_emitted_json_start = True
+        if self._name_emitted:
+            if not self._xml_has_emitted_json_start and (args_dict or should_close):
+                json_fragments.append('{')
+                self._xml_has_emitted_json_start = True
 
-        for key, value in args_dict.items():
-            if key in self._xml_emitted_param_names:
-                continue
-            prefix = ', ' if len(self._xml_emitted_param_names) > 0 else ''
-            json_fragments.append(f'{prefix}\"{key}\": {json.dumps(value, ensure_ascii=False)}')
-            self._xml_emitted_param_names.add(key)
+            for key, value in args_dict.items():
+                if key in self._xml_emitted_param_names:
+                    continue
+                prefix = ', ' if len(self._xml_emitted_param_names) > 0 else ''
+                json_fragments.append(f'{prefix}\"{key}\": {json.dumps(value, ensure_ascii=False)}')
+                self._xml_emitted_param_names.add(key)
 
-        if should_close and self._xml_has_emitted_json_start and not self._xml_json_closed:
-            json_fragments.append('}')
-            self._xml_json_closed = True
+            if should_close and self._xml_has_emitted_json_start and not self._xml_json_closed:
+                json_fragments.append('}')
+                self._xml_json_closed = True
 
         if json_fragments:
             out.append(

--- a/tests/test_lmdeploy/serve/anthropic/test_endpoints.py
+++ b/tests/test_lmdeploy/serve/anthropic/test_endpoints.py
@@ -12,7 +12,7 @@ from pydantic import ValidationError
 from lmdeploy.serve.anthropic.protocol import CountTokensRequest, MessagesRequest
 from lmdeploy.serve.anthropic.router import create_anthropic_router
 from lmdeploy.serve.anthropic.streaming import stream_messages_response
-from lmdeploy.serve.core.chat_runner import ChatStreamChunk
+from lmdeploy.serve.core.chat_runner import ChatStreamChunk, should_validate_complete
 from lmdeploy.serve.core.exceptions import ErrorCode, RequestError
 from lmdeploy.serve.openai.protocol import (
     ChatCompletionRequest,
@@ -22,6 +22,9 @@ from lmdeploy.serve.openai.protocol import (
     FunctionCall,
     ToolCall,
 )
+from lmdeploy.serve.parsers import ResponseParserManager
+from lmdeploy.serve.parsers.reasoning_parser import ReasoningParserManager
+from lmdeploy.serve.parsers.tool_parser import ToolParserManager
 from lmdeploy.serve.utils.server_utils import protocol_error_response
 
 ANTHROPIC_HEADERS = {'anthropic-version': '2023-06-01'}
@@ -333,6 +336,24 @@ class _IncompleteToolParser(_ToolAndReasoningParser):
         return False
 
 
+def _build_qwen_streaming_parser():
+    """Build an isolated response parser for the Qwen3Coder XML protocol."""
+    parser_cls = ResponseParserManager.get('default')
+
+    class _QwenResponseParser(parser_cls):
+        reasoning_parser_cls = ReasoningParserManager.get('default')
+        tool_parser_cls = ToolParserManager.get('qwen3coder')
+
+    request = ChatCompletionRequest(
+        model='fake-model',
+        messages=DEFAULT_MESSAGES,
+        stream=True,
+        tool_choice='auto',
+        chat_template_kwargs={'enable_thinking': True},
+    )
+    return _QwenResponseParser(request=request)
+
+
 def _make_client(response_parser_cls=_BasicParser,
                  *,
                  server_context=None,
@@ -443,7 +464,7 @@ def _sse_payloads(body: str):
     ]
 
 
-async def _parsed_stream(result_generator, response_parser):
+async def _parsed_stream(result_generator, response_parser, request):
     streaming_tools = False
     async for res in result_generator:
         token_ids = res.token_ids if getattr(res, 'token_ids', None) is not None else []
@@ -456,6 +477,11 @@ async def _parsed_stream(result_generator, response_parser):
             if res.finish_reason is None and not token_ids:
                 continue
             stream_deltas = [(DeltaMessage(role='assistant', content=''), False)]
+
+        # Mirror ChatRunner.stream(): a terminal chunk whose parser state is
+        # incomplete downgrades the finish reason to 'parse_error'.
+        if (should_validate_complete(request, res.finish_reason) and not response_parser.validate_complete()):
+            res.finish_reason = 'parse_error'
 
         for delta_index, (delta_message, tool_emitted) in enumerate(stream_deltas):
             if tool_emitted:
@@ -480,16 +506,18 @@ async def _parsed_stream(result_generator, response_parser):
 
 
 def _collect_stream_response_payloads(result_generator, response_parser, **kwargs):
+    request = ChatCompletionRequest(
+        model='fake-model',
+        messages=[],
+        **kwargs,
+    )
+
     async def _collect_events():
         return [
             event async for event in stream_messages_response(
-                _parsed_stream(result_generator, response_parser),
+                _parsed_stream(result_generator, response_parser, request),
                 request_id='msg_test',
-                request=ChatCompletionRequest(
-                    model='fake-model',
-                    messages=[],
-                    **kwargs,
-                ),
+                request=request,
             )
         ]
 
@@ -751,6 +779,38 @@ def test_messages_streaming_with_reasoning_and_tool_use_events():
     assert '"type": "input_json_delta"' in body
     assert '"type": "tool_use"' in body
     assert '"output_ids": [102]' in body
+
+
+def test_messages_streaming_rejects_unidentified_xml_tool_call():
+    """Malformed XML must not become an Anthropic tool block with empty
+    identity."""
+
+    async def _result_generator():
+        yield SimpleNamespace(
+            response='<tool_call><parameter=query>nvd zabbix</parameter>',
+            token_ids=[101],
+            input_token_len=8,
+            generate_token_len=1,
+            finish_reason='stop',
+            routed_experts=[[[1, 2, 3]]],
+            logprobs=None,
+        )
+
+    payloads = _collect_stream_response_payloads(
+        _result_generator(),
+        _build_qwen_streaming_parser(),
+        return_routed_experts=True,
+    )
+
+    tool_starts = [
+        item for item in payloads
+        if item['type'] == 'content_block_start'
+        and item['content_block']['type'] == 'tool_use'
+    ]
+    assert tool_starts == []
+
+    message_delta = next(item for item in payloads if item['type'] == 'message_delta')
+    assert message_delta['delta']['stop_reason'] == 'parse_error'
 
 
 def test_messages_streaming_validate_complete_marks_parse_error():

--- a/tests/test_lmdeploy/serve/anthropic/test_endpoints.py
+++ b/tests/test_lmdeploy/serve/anthropic/test_endpoints.py
@@ -787,7 +787,7 @@ def test_messages_streaming_rejects_unidentified_xml_tool_call():
 
     async def _result_generator():
         yield SimpleNamespace(
-            response='<tool_call><parameter=query>nvd zabbix</parameter>',
+            response='</think><tool_call><parameter=query>nvd zabbix</parameter>',
             token_ids=[101],
             input_token_len=8,
             generate_token_len=1,

--- a/tests/test_lmdeploy/serve/parsers/test_qwen3_5_parser.py
+++ b/tests/test_lmdeploy/serve/parsers/test_qwen3_5_parser.py
@@ -164,6 +164,19 @@ class TestQwen3_5ResponseParserStreaming:
 
         assert calls == []
 
+    def test_incremental_incomplete_function_header_does_not_emit_arguments(self):
+        """An unfinished function header cannot open an argument stream."""
+        parser = Qwen3CoderToolParser()
+        parser.start_tool_call()
+
+        assert parser.decode_tool_incremental('<function', final=False) == []
+        calls = parser.decode_tool_incremental(
+            '<parameter=query>nvd</parameter>',
+            final=True,
+        )
+
+        assert calls == []
+
     def test_parse_complete_parallel_tool_calls_keep_distinct_arguments(self):
         """Regression: parallel tool calls must not reuse the first call's args."""
         response_parser = _build_response_parser()

--- a/tests/test_lmdeploy/serve/parsers/test_qwen3_5_parser.py
+++ b/tests/test_lmdeploy/serve/parsers/test_qwen3_5_parser.py
@@ -127,6 +127,43 @@ class TestQwen3_5ResponseParserStreaming:
                 assert call.function.name == exp_function_name
                 assert call.function.arguments == exp_function_arguments
 
+    def test_incremental_arguments_wait_for_function_name(self):
+        """Do not expose an argument delta before the tool identity exists."""
+        parser = Qwen3CoderToolParser()
+        parser.start_tool_call()
+
+        # This represents an incomplete/unrecognised function header whose
+        # parameter is nevertheless complete. The arguments stay in parser
+        # state rather than becoming the first streamed tool delta.
+        calls = parser.decode_tool_incremental(
+            '<parameter=query>nvd zabbix</parameter>',
+            final=False,
+        )
+        assert calls == []
+
+        calls = parser.decode_tool_incremental('<function=WebSearch>', final=False)
+        assert len(calls) == 2
+        name_call, argument_call = calls
+        assert name_call.id
+        assert name_call.function is not None
+        assert name_call.function.name == 'WebSearch'
+        assert argument_call.id is None
+        assert argument_call.function is not None
+        assert argument_call.function.arguments == '{"query": "nvd zabbix"'
+
+    def test_incremental_empty_function_name_does_not_emit_arguments(self):
+        """Malformed function headers fail closed instead of creating a
+        block."""
+        parser = Qwen3CoderToolParser()
+        parser.start_tool_call()
+
+        calls = parser.decode_tool_incremental(
+            '<function=><parameter=query>nvd</parameter>',
+            final=True,
+        )
+
+        assert calls == []
+
     def test_parse_complete_parallel_tool_calls_keep_distinct_arguments(self):
         """Regression: parallel tool calls must not reuse the first call's args."""
         response_parser = _build_response_parser()


### PR DESCRIPTION
## Motivation

For the XML tool protocol (`qwen3coder` and friends), the streaming parser can emit
argument deltas before the function name has been parsed out of the incoming text.

This is harmless for the OpenAI-compatible endpoint, but it breaks the Anthropic
adapter: a `tool_use` content block must be opened with a non-empty `id` and `name`.
When an argument-only delta arrives first, the adapter opens a `content_block_start`
whose identity fields are empty, which Anthropic-compatible clients reject.

The failure is easy to hit with malformed or truncated XML, e.g. a `<tool_call>`
that carries `<parameter=...>` but never produces a well-formed function header:

```text
</think><tool_call><parameter=query>nvd zabbix</parameter>
```

## Modification

- `XmlToolParser.decode_tool_incremental`: keep parsed arguments in the incremental state
  until the function name has been emitted. Argument deltas are still emitted normally
  once the name delta has gone out, so well-formed streams are unaffected.
- Add regression tests:
  - `test_qwen3_5_parser.py`: incomplete XML function headers must not produce
    argument deltas ahead of the name.
  - `test_endpoints.py`: a malformed XML tool call must not open a `tool_use` block
    with empty identity, and the response is reported as `parse_error`.

## BC-breaking (Optional)

No. Well-formed tool calls produce the same delta sequence as before; only the
ordering of the first argument delta relative to the name delta changes, and only
for streams that previously produced an invalid Anthropic block.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests.
3. The documentation has been modified accordingly, like docstring or example tutorials.
