### PR TITLE
fix: exclude glm-5.2 mtp projection from online fp8

### DIFF
--- a/lmdeploy/pytorch/models/glm_moe_dsa_mtp.py
+++ b/lmdeploy/pytorch/models/glm_moe_dsa_mtp.py
@@ -46,7 +46,6 @@ class GlmMoeDsaMultiTokenPredictorLayer(nn.Module):
         device: torch.device = None,
     ) -> None:
         super().__init__()
-        quantization_config = getattr(config, 'quantization_config', None)
         self.enorm = RMSNorm(config.hidden_size,
                              config.rms_norm_eps,
                              dtype=dtype,
@@ -55,7 +54,8 @@ class GlmMoeDsaMultiTokenPredictorLayer(nn.Module):
                              config.rms_norm_eps,
                              dtype=dtype,
                              device=device)
-        # Keep the recurrent MTP projection replicated across TP ranks.
+        # Keep the recurrent MTP projection unquantized and replicated across
+        # TP ranks.
         self.eh_proj = build_colwise_linear(
             config.hidden_size * 2,
             config.hidden_size,
@@ -63,7 +63,6 @@ class GlmMoeDsaMultiTokenPredictorLayer(nn.Module):
             dtype=dtype,
             device=device,
             is_tp=False,
-            quant_config=quantization_config,
         )
         self.shared_head = GlmMoeDsaSharedHead(config,
                                                dtype=dtype,


### PR DESCRIPTION
## Summary

- keep GLM-5.2 MTP `eh_proj` unquantized during online FP8 quantization
- preserve its replicated layout across tensor-parallel ranks
- align online quantization with the official GLM-5.2 FP8 checkpoint and vLLM

## Validation

- `pre-commit run --files lmdeploy/pytorch/models/glm_moe_dsa_mtp.py`
- `pytest tests/pytorch/spec_decode/test_glm_moe_dsa_mtp.py -q`

## Assistance

Assisted with Codex + GPT-5.6-Sol xHigh, reviewed manually
