### PR TITLE
Migrate TurboMind to C++20

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,16 +12,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 3.25 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.25.2 FATAL_ERROR)
 cmake_policy(SET CMP0074 NEW)
 cmake_policy(SET CMP0104 OLD)
 project(TurboMind LANGUAGES CXX CUDA)
+
+if(CMAKE_CUDA_COMPILER_VERSION VERSION_LESS "12.0")
+    message(FATAL_ERROR "TurboMind C++20 requires CUDA 12.0 or newer")
+endif()
 
 if (MSVC)
     # use standard conformant preprocessor
     add_compile_options($<$<COMPILE_LANGUAGE:CXX>:/Zc:preprocessor>)
     add_compile_options($<$<COMPILE_LANGUAGE:CXX>:/Zc:__cplusplus>)
     set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Xcompiler=/Zc:preprocessor -Xcompiler=/Zc:__cplusplus")
+    # C++20 enables MSVC's strict template lookup, which rejects NVCC-generated
+    # CuTe code. Preserve the previous lookup mode only for the CUDA host pass.
+    set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Xcompiler=/Zc:twoPhase-")
     # nvcc's front-end has a known bug (fixed in NVCC 13.1) where the fmt 11.x
     # literal-encoding probe (fmt/base.h:is_utf8_enabled) always returns false,
     # causing a static_assert failure.  Disable fmt's Unicode check project-wide;
@@ -178,7 +185,6 @@ if(BUILD_MULTI_GPU)
 endif()
 
 
-set(CXX_STD "17" CACHE STRING "C++ standard")
 set(CUDA_PATH ${CUDA_TOOLKIT_ROOT_DIR})
 
 set(CUSPARSELT_PATH "" CACHE STRING "cuSPARSELt path")
@@ -194,7 +200,6 @@ endif()
 
 # setting compiler flags
 set(CMAKE_C_FLAGS    "${CMAKE_C_FLAGS}")
-set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -Xcompiler -Wall -ldl") # -Xptxas -v
 
 if(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
@@ -277,11 +282,8 @@ set(CMAKE_CXX_FLAGS_DEBUG  "${CMAKE_CXX_FLAGS_DEBUG}  -Wall -O0")
 # set(CMAKE_CUDA_FLAGS_DEBUG "${CMAKE_CUDA_FLAGS_DEBUG} -O0 -G -Xcompiler -Wall  --ptxas-options=-v --resource-usage")
 set(CMAKE_CUDA_FLAGS_DEBUG "${CMAKE_CUDA_FLAGS_DEBUG} -O0 -G -Xcompiler -Wall")
 
-set(CMAKE_CXX_STANDARD "${CXX_STD}")
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --expt-extended-lambda")
 set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --expt-relaxed-constexpr")
-set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} --std=c++${CXX_STD}")
 # Suppress nvcc warning 128 (loop not reachable) in fmt headers - nvcc false positive
 # Suppress nvcc warning 27 (character value out of range) from fmt/format.h's
 # fractional_part_rounding_thresholds which uses U32 string literals with values
@@ -360,6 +362,14 @@ include_directories(
 link_directories(
   ${COMMON_LIB_DIRS}
 )
+
+# Apply TurboMind's language requirements after configuring external dependencies.
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+set(CMAKE_CUDA_STANDARD 20)
+set(CMAKE_CUDA_STANDARD_REQUIRED ON)
+set(CMAKE_CUDA_EXTENSIONS OFF)
 
 add_subdirectory(src)
 

--- a/builder/windows/README.md
+++ b/builder/windows/README.md
@@ -2,9 +2,13 @@
 
 ## Requirements
 
-- [CMake 3.25+](https://github.com/Kitware/CMake/releases)
-- [Visual Studio 2019+](https://visualstudio.microsoft.com/downloads/)
-- [CUDA Toolkit 11.8+](https://developer.nvidia.com/cuda-toolkit-archive)
+- [CMake 3.25.2+](https://github.com/Kitware/CMake/releases)
+- [Visual Studio 2022](https://visualstudio.microsoft.com/downloads/), with a toolset supported by the selected CUDA Toolkit
+- [CUDA Toolkit 12.0+](https://developer.nvidia.com/cuda-toolkit-archive)
+
+TurboMind requires C++20 for both host C++ and CUDA compilation.
+
+CMake applies `/Zc:twoPhase-` to NVCC's host pass to work around CuTe template parsing with MSVC.
 
 ## Build lmdeploy wheel
 

--- a/docs/en/get_started/installation.md
+++ b/docs/en/get_started/installation.md
@@ -3,7 +3,7 @@
 LMDeploy is a python library for compressing, deploying, and serving Large Language Models(LLMs) and Vision-Language Models(VLMs).
 Its core inference engines include TurboMind Engine and PyTorch Engine. The former is developed by C++ and CUDA, striving for ultimate optimization of inference performance, while the latter, developed purely in Python, aims to decrease the barriers for developers.
 
-It supports LLMs and VLMs deployment on both Linux and Windows platform, with minimum requirement of CUDA version 11.3. Furthermore, it is compatible with the following NVIDIA GPUs:
+It supports LLMs and VLMs deployment on both Linux and Windows platforms. Furthermore, it is compatible with the following NVIDIA GPUs:
 
 - Volta(sm70): V100
 - Turing(sm75): 20 series, T4
@@ -22,7 +22,7 @@ pip install lmdeploy
 
 ## Install from source
 
-By default, LMDeploy will build with NVIDIA CUDA support, utilizing both the Turbomind and PyTorch backends. Before installing LMDeploy, ensure you have successfully installed the CUDA Toolkit.
+By default, LMDeploy will build with NVIDIA CUDA support, utilizing both the Turbomind and PyTorch backends. TurboMind requires C++20 for both host C++ and CUDA compilation, CMake 3.25.2 or newer, and CUDA Toolkit 12.0 or newer. Use a C++20-capable host compiler supported by your CUDA Toolkit, such as GCC 10 or newer on Linux or Visual Studio 2022 on Windows.
 
 Once the CUDA toolkit is successfully set up, you can build and install LMDeploy with a single command:
 

--- a/docs/zh_cn/get_started/installation.md
+++ b/docs/zh_cn/get_started/installation.md
@@ -3,7 +3,7 @@
 LMDeploy 是一个用于大型语言模型（LLMs）和视觉-语言模型（VLMs）压缩、部署和服务的 Python 库。
 其核心推理引擎包括 TurboMind 引擎和 PyTorch 引擎。前者由 C++ 和 CUDA 开发，致力于推理性能的优化，而后者纯 Python 开发，旨在降低开发者的门槛。
 
-LMDeploy 支持在 Linux 和 Windows 平台上部署 LLMs 和 VLMs，最低要求 CUDA 版本为 11.3。此外，它还与以下 NVIDIA GPU 兼容：
+LMDeploy 支持在 Linux 和 Windows 平台上部署 LLMs 和 VLMs。此外，它还与以下 NVIDIA GPU 兼容：
 
 Volta(sm70): V100
 Turing(sm75): 20 系列，T4
@@ -22,7 +22,7 @@ pip install lmdeploy
 
 ## 从源码安装
 
-默认情况下，LMDeploy 将面向 NVIDIA CUDA 环境进行编译安装，并同时启用 Turbomind 和 PyTorch 两种后端引擎。在安装 LMDeploy 之前，请确保已成功安装 CUDA 工具包。
+默认情况下，LMDeploy 将面向 NVIDIA CUDA 环境进行编译安装，并同时启用 Turbomind 和 PyTorch 两种后端引擎。TurboMind 的主机 C++ 和 CUDA 代码均要求使用 C++20，并需要 CMake 3.25.2 或更新版本以及 CUDA 工具包 12.0 或更新版本。主机编译器必须支持 C++20，且受所选 CUDA 工具包支持，例如 Linux 上的 GCC 10 或更新版本，或 Windows 上的 Visual Studio 2022。
 
 成功安装 CUDA 工具包后，您可以使用以下单行命令构建并安装 LMDeploy：
 

--- a/requirements/build.txt
+++ b/requirements/build.txt
@@ -1,3 +1,3 @@
 cmake_build_extension
-pybind11<=2.13.1
+pybind11>=2.13.6
 setuptools

--- a/src/turbomind/comm/gloo/CMakeLists.txt
+++ b/src/turbomind/comm/gloo/CMakeLists.txt
@@ -8,15 +8,13 @@ FetchContent_Declare(
   GIT_TAG c7b7b022c124d9643957d9bd55f57ac59fce8fa2 # pytorch-v2.8.0-rc4
 )
 
-# Keep Gloo's BUILD_TEST and transport options local to its configuration.
-block(SCOPE_FOR VARIABLES PROPAGATE gloo_SOURCE_DIR gloo_BINARY_DIR)
-    set(GLOO_INSTALL OFF CACHE BOOL "" FORCE)
-    set(GLOO_STATIC_OR_SHARED STATIC CACHE STRING "" FORCE)
-    set(USE_NCCL OFF)
-    set(BUILD_TEST OFF)
-    set(USE_IBVERBS OFF)
-    FetchContent_MakeAvailable(gloo)
-endblock()
+# some settings of gloo,
+set(GLOO_INSTALL OFF CACHE BOOL "" FORCE)
+set(GLOO_STATIC_OR_SHARED STATIC CACHE STRING "" FORCE)
+set(USE_NCCL OFF)
+set(BUILD_TEST OFF)
+set(USE_IBVERBS OFF)
+FetchContent_MakeAvailable(gloo)
 
 # gloo build doesn't add include directories as a target property...
 target_include_directories(gloo PUBLIC

--- a/src/turbomind/comm/gloo/CMakeLists.txt
+++ b/src/turbomind/comm/gloo/CMakeLists.txt
@@ -8,14 +8,8 @@ FetchContent_Declare(
   GIT_TAG c7b7b022c124d9643957d9bd55f57ac59fce8fa2 # pytorch-v2.8.0-rc4
 )
 
-# Keep Gloo's build settings local so TurboMind's wrappers inherit C++20.
+# Keep Gloo's BUILD_TEST and transport options local to its configuration.
 block(SCOPE_FOR VARIABLES PROPAGATE gloo_SOURCE_DIR gloo_BINARY_DIR)
-    set(CMAKE_CXX_STANDARD 17)
-    set(CMAKE_CXX_STANDARD_REQUIRED ON)
-    set(CMAKE_CXX_EXTENSIONS ON)
-    set(CMAKE_CUDA_STANDARD 17)
-    set(CMAKE_CUDA_STANDARD_REQUIRED ON)
-
     set(GLOO_INSTALL OFF CACHE BOOL "" FORCE)
     set(GLOO_STATIC_OR_SHARED STATIC CACHE STRING "" FORCE)
     set(USE_NCCL OFF)

--- a/src/turbomind/comm/gloo/CMakeLists.txt
+++ b/src/turbomind/comm/gloo/CMakeLists.txt
@@ -8,13 +8,21 @@ FetchContent_Declare(
   GIT_TAG c7b7b022c124d9643957d9bd55f57ac59fce8fa2 # pytorch-v2.8.0-rc4
 )
 
-# some settings of gloo,
-set(GLOO_INSTALL OFF CACHE BOOL "" FORCE)
-set(GLOO_STATIC_OR_SHARED STATIC CACHE STRING "" FORCE)
-set(USE_NCCL OFF)
-set(BUILD_TEST OFF)
-set(USE_IBVERBS OFF)
-FetchContent_MakeAvailable(gloo)
+# Keep Gloo's build settings local so TurboMind's wrappers inherit C++20.
+block(SCOPE_FOR VARIABLES PROPAGATE gloo_SOURCE_DIR gloo_BINARY_DIR)
+    set(CMAKE_CXX_STANDARD 17)
+    set(CMAKE_CXX_STANDARD_REQUIRED ON)
+    set(CMAKE_CXX_EXTENSIONS ON)
+    set(CMAKE_CUDA_STANDARD 17)
+    set(CMAKE_CUDA_STANDARD_REQUIRED ON)
+
+    set(GLOO_INSTALL OFF CACHE BOOL "" FORCE)
+    set(GLOO_STATIC_OR_SHARED STATIC CACHE STRING "" FORCE)
+    set(USE_NCCL OFF)
+    set(BUILD_TEST OFF)
+    set(USE_IBVERBS OFF)
+    FetchContent_MakeAvailable(gloo)
+endblock()
 
 # gloo build doesn't add include directories as a target property...
 target_include_directories(gloo PUBLIC

--- a/src/turbomind/comm/nccl/deepep/CMakeLists.txt
+++ b/src/turbomind/comm/nccl/deepep/CMakeLists.txt
@@ -55,8 +55,6 @@ find_package(Threads REQUIRED)
 
 add_library(turbomind_nccl_stub SHARED nccl_stub.cc)
 set_target_properties(turbomind_nccl_stub PROPERTIES
-    CXX_STANDARD 17
-    CXX_STANDARD_REQUIRED ON
     CXX_VISIBILITY_PRESET hidden
     VISIBILITY_INLINES_HIDDEN ON
     OUTPUT_NAME turbomind_nccl_stub
@@ -69,11 +67,6 @@ add_library(token_dispatcher STATIC
     token_dispatcher.cc
     moe_a2a_utils.cu
 )
-set_target_properties(token_dispatcher PROPERTIES
-    CXX_STANDARD 20
-    CXX_STANDARD_REQUIRED ON
-    CUDA_STANDARD 17
-    CUDA_STANDARD_REQUIRED ON)
 target_compile_options(token_dispatcher PRIVATE
     $<$<COMPILE_LANGUAGE:CUDA>:--diag-suppress=2417>
     $<$<COMPILE_LANGUAGE:CUDA>:-Wno-deprecated-gpu-targets>)

--- a/src/turbomind/core/logger.h
+++ b/src/turbomind/core/logger.h
@@ -6,6 +6,7 @@
 
 #include <cstdlib>
 #include <string>
+#include <utility>
 
 #include "src/turbomind/core/check.h"
 
@@ -34,11 +35,39 @@ public:
     Logger(const Logger&) = delete;
     Logger& operator=(const Logger&) = delete;
 
+    void Log(Level level, const std::string& message)
+    {
+        if (level_ <= level) {
+            Enqueue(level, nullptr, 0, message);
+        }
+    }
+
+    void Log(Level level, std::string&& message)
+    {
+        if (level_ <= level) {
+            Enqueue(level, nullptr, 0, std::move(message));
+        }
+    }
+
     template<typename... Args>
     void Log(Level level, fmt::format_string<Args...> fmt_str, Args&&... args)
     {
         if (level_ <= level) {
             Enqueue(level, nullptr, 0, fmt::format(fmt_str, std::forward<Args>(args)...));
+        }
+    }
+
+    void Log(Level level, SourceLocation loc, const std::string& message)
+    {
+        if (level_ <= level) {
+            Enqueue(level, loc.file, loc.line, message);
+        }
+    }
+
+    void Log(Level level, SourceLocation loc, std::string&& message)
+    {
+        if (level_ <= level) {
+            Enqueue(level, loc.file, loc.line, std::move(message));
         }
     }
 

--- a/src/turbomind/kernels/attention/CMakeLists.txt
+++ b/src/turbomind/kernels/attention/CMakeLists.txt
@@ -42,5 +42,6 @@ if (BUILD_TEST)
         --generate-line-info -O3 -use_fast_math --expt-relaxed-constexpr)
     target_link_libraries(test_quant PRIVATE
         nvidia::cutlass::cutlass
+        ${CMAKE_DL_LIBS}
     )
 endif ()

--- a/src/turbomind/kernels/attention/registry.cu
+++ b/src/turbomind/kernels/attention/registry.cu
@@ -56,8 +56,8 @@ const Kernel* Registry::Find(const AttnDesc& desc) const
 {
     const int threshold = static_cast<int>(kMaxWasteRatio * desc.query_group_sz);
 
-    const Kernel*             best = nullptr;
-    std::tuple<int, int, int> cost{};
+    const Kernel*              best = nullptr;
+    std::tuple<bool, int, int> cost{};
 
     for (const auto* k : ptrs_) {
         const auto& d = k->desc();

--- a/src/turbomind/memory/test_memory.cc
+++ b/src/turbomind/memory/test_memory.cc
@@ -10,8 +10,8 @@
 
 #include <algorithm>
 #include <cstdint>
-#include <cstdlib>
 #include <map>
+#include <new>
 #include <random>
 #include <vector>
 
@@ -21,16 +21,14 @@ namespace {
 
 // RAII for a heap region whose base is aligned to `alignment` bytes.
 struct AlignedRegion {
-    AlignedRegion(size_t alignment, size_t bytes): bytes_{bytes}
+    AlignedRegion(size_t alignment, size_t bytes): bytes_{bytes}, alignment_{alignment}
     {
-        // std::aligned_alloc requires bytes to be a multiple of alignment.
-        size_t rounded = (bytes + alignment - 1) / alignment * alignment;
-        ptr_           = std::aligned_alloc(alignment, rounded);
+        ptr_ = ::operator new(bytes, alignment_, std::nothrow);
         TM_CHECK_NOTNULL(ptr_);
     }
     ~AlignedRegion()
     {
-        std::free(ptr_);
+        ::operator delete(ptr_, alignment_);
     }
     AlignedRegion(const AlignedRegion&) = delete;
     AlignedRegion& operator=(const AlignedRegion&) = delete;
@@ -45,8 +43,9 @@ struct AlignedRegion {
     }
 
 private:
-    void*  ptr_;
-    size_t bytes_;
+    void*            ptr_;
+    size_t           bytes_;
+    std::align_val_t alignment_;
 };
 
 inline bool ranges_overlap(const void* a, size_t na, const void* b, size_t nb)

--- a/src/turbomind/python/CMakeLists.txt
+++ b/src/turbomind/python/CMakeLists.txt
@@ -21,7 +21,6 @@ target_link_libraries(${PROJECT_NAME} PRIVATE turbomind xgrammar)
 
 pybind11_add_module(_xgrammar xgrammar_bind.cpp)
 target_link_libraries(_xgrammar PRIVATE core xgrammar)
-target_compile_features(_xgrammar PRIVATE cxx_std_14)
 
 if (CALL_FROM_SETUP_PY)
   string(REPLACE "." ";" _ver ${CMAKE_CUDA_COMPILER_VERSION})


### PR DESCRIPTION
## Motivation

Consolidate TurboMind’s mixed language-standard settings so all owned host C++ and CUDA targets consistently compile as C++20, including Python bindings and communication wrappers.

## Modification

- Centralize C++20 requirements in CMake, remove conflicting overrides.
- Add `const std::string&` and `std::string&&` logger overloads for preformatted messages.
- Match the attention registry’s cost tuple types for C++20 comparisons.
- Apply `/Zc:twoPhase-` to NVCC’s MSVC host pass for CuTe compatibility.
- Fix existing test portability: link `test_quant` with `${CMAKE_DL_LIBS}` and use aligned allocation/deallocation supported by MSVC.
- Update build requirements and migration documentation.

## BC-breaking

TurboMind now requires CMake 3.25.2+, CUDA Toolkit 12.0+, and a CUDA-supported C++20 host compiler, such as GCC 10+ or Visual Studio 2022. The `CXX_STD` configuration option is removed.

## Validation

- Full Linux builds passed with CUDA 12.8 and 13.0, including Python bindings, communication targets, and existing tests.
- Native Windows compilation/linking passed with CUDA 12.8.1 and MSVC 19.38.
- Compile-command audits confirmed C++20 without conflicting standard flags.
- Logger tests: 12 cases / 115 assertions passed.
- Targeted memory tests: 12 cases / 671 assertions passed.
- Single-GPU `Qwen/Qwen3-8B` smoke generated 256 coherent, relevant tokens; generation reached the token limit during thinking.

Windows GPU runtime remains unvalidated because no Windows NVIDIA GPU host is available.

## Checklist

- [x] Formatting checks passed.
- [x] Existing tests exercised the affected logger and memory code.
- [x] Linux and Windows build configurations validated.
- [x] Documentation updated.