### PR TITLE
feat(pytorch): add CuTeDSL W4A16 MoE backend

### DIFF
--- a/lmdeploy/pytorch/backends/cuda/moe/compressed_tensors.py
+++ b/lmdeploy/pytorch/backends/cuda/moe/compressed_tensors.py
@@ -2,6 +2,7 @@
 import torch
 import torch.distributed as dist
 
+from lmdeploy.pytorch import envs
 from lmdeploy.pytorch.backends.cuda.token_dispatcher import (
     DeepEPBuffer,
     DeepEPTokenDispatcherLowLatency,
@@ -17,6 +18,7 @@ from lmdeploy.pytorch.kernels.cuda.compressed_tensors_w4a16 import (
 )
 from lmdeploy.pytorch.kernels.cuda.moe.fused_moe import _renormalize
 from lmdeploy.pytorch.model_inputs import get_step_ctx_manager
+from lmdeploy.utils import get_logger
 
 from .default import dispatch_ll
 from .ep_utils import gather_outputs_by_attn_tp, split_inputs_by_attn_tp
@@ -93,6 +95,7 @@ class DeepEPFusedMoEW4A16Impl(FusedMoEW4A16Impl):
         out_dtype: torch.dtype,
         num_max_dispatch_tokens_per_rank: int,
         layer_idx: int,
+        local_backend: str = 'triton',
     ):
         if top_k < 1 or num_experts < 1 or top_k > num_experts:
             raise ValueError(
@@ -139,6 +142,17 @@ class DeepEPFusedMoEW4A16Impl(FusedMoEW4A16Impl):
         self.num_max_dispatch_tokens_per_rank = (
             num_max_dispatch_tokens_per_rank)
         self.layer_idx = layer_idx
+        self._fused_moe = fused_moe_w4a16
+        self._fused_moe_masked = fused_moe_w4a16_masked
+        if local_backend == 'cute':
+            from lmdeploy.pytorch.kernels.cuda.compressed_tensors_w4a16_cute import (
+                fused_moe_w4a16_cute,
+                fused_moe_w4a16_cute_masked,
+            )
+            self._fused_moe = fused_moe_w4a16_cute
+            self._fused_moe_masked = fused_moe_w4a16_cute_masked
+        elif local_backend != 'triton':
+            raise ValueError(f'Unsupported DeepEP W4A16 local backend: {local_backend}')
 
         get_deepep_state().enable()
         if hasattr(DeepEPBuffer, 'set_explicitly_destroy'):
@@ -211,7 +225,7 @@ class DeepEPFusedMoEW4A16Impl(FusedMoEW4A16Impl):
             # [0, E_local) IDs and marks non-local slots as -1/zero.  The W4
             # kernel must filter those invalid routes instead of remapping
             # them to a real expert.
-            out_states = fused_moe_w4a16(
+            out_states = self._fused_moe(
                 recv_hidden_states,
                 gate_up_packed,
                 gate_up_scale,
@@ -252,7 +266,7 @@ class DeepEPFusedMoEW4A16Impl(FusedMoEW4A16Impl):
         )
         recv_tensor = DisposibleTensor.maybe_unwrap(recv_hidden_states)
         try:
-            out_states = fused_moe_w4a16_masked(
+            out_states = self._fused_moe_masked(
                 recv_tensor,
                 gate_up_packed,
                 gate_up_scale,
@@ -316,8 +330,59 @@ class DeepEPFusedMoEW4A16Impl(FusedMoEW4A16Impl):
         return gather_outputs_by_attn_tp(out_states, split_size)
 
 
+class CuteFusedMoEW4A16Impl(TritonFusedMoEW4A16Impl):
+    """Hopper BF16 WGMMA RS with TMA and register-side INT4 dequantization."""
+
+    def __init__(self, top_k: int, num_experts: int, renormalize: bool, num_bits: int, group_size: int):
+        super().__init__(top_k, num_experts, renormalize, num_bits, group_size)
+        from lmdeploy.pytorch.kernels.cuda.compressed_tensors_w4a16_cute import fused_moe_w4a16_cute
+        self._fused_moe = fused_moe_w4a16_cute
+
+    def forward(self, hidden_states: torch.Tensor, topk_weights: torch.Tensor, topk_ids: torch.Tensor,
+                gate_up_packed: torch.Tensor, gate_up_scale: torch.Tensor, down_packed: torch.Tensor,
+                down_scale: torch.Tensor) -> torch.Tensor:
+        """Run local experts with the canonical packed W4A16 layout."""
+        if gate_up_packed.shape[0] != self.num_experts:
+            raise ValueError(f'Expected {self.num_experts} experts, got {gate_up_packed.shape[0]}')
+        return self._fused_moe(hidden_states, gate_up_packed, gate_up_scale,
+                               down_packed, down_scale, topk_weights, topk_ids,
+                               self.top_k, self.renormalize)
+
+
+def _build_fused_moe_cute(spec: FusedMoEW4A16BuildSpec) -> FusedMoEW4A16Impl:
+    """Build the Hopper provider while preserving TP and DeepEP contracts."""
+    if spec.num_bits != 4 or spec.group_size != 32:
+        raise ValueError('cute supports only INT4 group-size 32')
+    if spec.output_dtype != torch.bfloat16 or spec.hidden_dim < 32 or spec.hidden_dim % 32:
+        raise ValueError('cute requires BF16 and hidden_dim divisible by 32')
+    if not torch.cuda.is_available() or torch.cuda.get_device_capability()[0] != 9:
+        raise RuntimeError('cute requires a Hopper SM90 GPU')
+    impl: FusedMoEW4A16Impl
+    try:
+        if spec.ep_size > 1:
+            impl = DeepEPFusedMoEW4A16Impl(
+                top_k=spec.top_k, num_experts=spec.num_experts, hidden_dim=spec.hidden_dim,
+                ep_size=spec.ep_size, ep_group=spec.ep_group, renormalize=spec.renormalize,
+                num_bits=spec.num_bits, group_size=spec.group_size, out_dtype=spec.output_dtype,
+                num_max_dispatch_tokens_per_rank=spec.num_max_dispatch_tokens_per_rank,
+                layer_idx=spec.layer_idx, local_backend='cute')
+        else:
+            impl = CuteFusedMoEW4A16Impl(
+                top_k=spec.top_k, num_experts=spec.num_experts,
+                renormalize=spec.renormalize, num_bits=spec.num_bits,
+                group_size=spec.group_size)
+    except ImportError as exc:
+        raise ImportError('cute requires nvidia-cutlass-dsl and cuda-python; EP additionally requires DeepEP') from exc
+    if spec.layer_idx in (0, 1):
+        get_logger('lmdeploy').info('Using cute compressed-tensors MoE provider '
+                                   '(CuTe DSL BF16 WGMMA RS, TMA double buffer)')
+    return impl
+
+
 def _build_fused_moe_w4a16(spec: FusedMoEW4A16BuildSpec) -> FusedMoEW4A16Impl:
     """Build the selected CUDA compressed-tensors W4A16 MoE."""
+    if envs.w4a16_moe_backend == 'cute':
+        return _build_fused_moe_cute(spec)
     if spec.ep_size > 1:
         return DeepEPFusedMoEW4A16Impl(
             top_k=spec.top_k,

--- a/lmdeploy/pytorch/backends/cuda/moe/compressed_tensors.py
+++ b/lmdeploy/pytorch/backends/cuda/moe/compressed_tensors.py
@@ -379,10 +379,31 @@ def _build_fused_moe_cute(spec: FusedMoEW4A16BuildSpec) -> FusedMoEW4A16Impl:
     return impl
 
 
+def _supports_cute(spec: FusedMoEW4A16BuildSpec) -> bool:
+    """Check build-time compatibility without constructing an EP dispatcher."""
+    if (spec.num_bits != 4 or spec.group_size != 32 or spec.output_dtype != torch.bfloat16
+            or spec.hidden_dim < 32 or spec.hidden_dim % 32):
+        return False
+    if not torch.cuda.is_available() or torch.cuda.get_device_capability()[0] != 9:
+        return False
+    try:
+        from lmdeploy.pytorch.kernels.cuda.compressed_tensors_w4a16_cute import fused_moe_w4a16_cute  # noqa: F401
+    except ImportError:
+        return False
+    return True
+
+
 def _build_fused_moe_w4a16(spec: FusedMoEW4A16BuildSpec) -> FusedMoEW4A16Impl:
-    """Build the selected CUDA compressed-tensors W4A16 MoE."""
-    if envs.w4a16_moe_backend == 'cute':
+    """Build the requested provider or the best compatible provider."""
+    provider = envs.w4a16_moe_backend
+
+    if provider == 'auto':
+        provider = 'cute' if _supports_cute(spec) else 'triton'
+
+    if provider == 'cute':
         return _build_fused_moe_cute(spec)
+    if provider != 'triton':
+        raise ValueError(f'Unsupported compressed-tensors W4A16 MoE provider: {provider}')
     if spec.ep_size > 1:
         return DeepEPFusedMoEW4A16Impl(
             top_k=spec.top_k,

--- a/lmdeploy/pytorch/envs.py
+++ b/lmdeploy/pytorch/envs.py
@@ -184,6 +184,10 @@ with set_envs():
     w4a16_gemm_backend = env_to_choice('LMDEPLOY_W4A16_GEMM_BACKEND', 'auto',
                                        {'auto', 'triton', 'turbomind'})
 
+    # Compressed-tensors routed experts (independent of AWQ linear GEMM).
+    w4a16_moe_backend = env_to_choice('LMDEPLOY_W4A16_MOE_BACKEND', 'cute',
+                                      {'auto', 'triton', 'cute'})
+
     # model agent
     skip_warmup = env_to_bool('LMDEPLOY_SKIP_WARMUP', False)
 

--- a/lmdeploy/pytorch/kernels/cuda/compressed_tensors_w4a16_cute.py
+++ b/lmdeploy/pytorch/kernels/cuda/compressed_tensors_w4a16_cute.py
@@ -1,0 +1,569 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+"""Hopper W4A16: TMA double buffering, register dequantization, BF16 WGMMA RS.
+
+Weights retain compressed-tensors' offset-binary INT4 / group-32 layout.
+Routing is padded once to make activation tiles TMA addressable. Swapping
+GEMM A/B puts dequantized weights in registers and BF16 activations in shared
+memory. No FP8 rounding or expanded weight cache is used.
+"""
+from functools import lru_cache
+
+import cuda.bindings.driver as cuda
+import cutlass
+import cutlass.cute as cute
+import cutlass.utils as utils
+import cutlass.utils.hopper_helpers as sm90_utils
+import torch
+import triton
+import triton.language as tl
+from cutlass import Float32, Int32, Int64
+from cutlass._mlir.dialects import llvm
+from cutlass.cute.nvgpu import cpasync, warpgroup
+from cutlass.cute.runtime import from_dlpack, make_fake_tensor
+from cutlass.cutlass_dsl import T, dsl_user_op
+
+from .moe.fused_moe import _get_sorted_idx_blocks, _renormalize, moe_reduce
+
+
+@dsl_user_op
+def _dequant_pair(word, shift, scale, *, loc=None, ip=None):
+    """Two adjacent INT4 codes -> BF16x2, with exact -8 then BF16 scale.
+
+    The 128+bias bit construction follows Marlin's BF16 conversion strategy;
+    our canonical nibble layout additionally moves the high nibble to bit 16.
+    Do not fuse bias subtraction with scaling: that changes rounding.
+    """
+    return Int32(
+        llvm.inline_asm(T.i32(), [
+            Int32(word).ir_value(loc=loc, ip=ip),
+            Int32(shift).ir_value(loc=loc, ip=ip),
+            Float32(scale).ir_value(loc=loc, ip=ip)
+        ], '{ .reg .b32 v, hi, pair, ss, bias; .reg .b16 s; '
+                        'shr.u32 v, $1, $2; shl.b32 hi, v, 12; '
+                        'lop3.b32 pair, hi, 0x000f0000, 0x43004300, 0xea; '
+                        'lop3.b32 pair, v, 0x0000000f, pair, 0xea; '
+                        'mov.b32 bias, 0x43084308; sub.rn.bf16x2 pair, pair, bias; '
+                        'cvt.rn.bf16.f32 s, $3; mov.b32 ss, {s, s}; '
+                        'mul.rn.bf16x2 $0, pair, ss; }',
+                        '=r,r,r,f',
+                        has_side_effects=False,
+                        is_align_stack=False,
+                        loc=loc,
+                        ip=ip))
+
+
+@triton.jit
+def _gather(X, Y, ROUTES, ENDS, BLOCK_END, EXPERTS, OFFSETS, K: tl.constexpr, STRIDE: tl.constexpr, TOPK: tl.constexpr,
+            BM: tl.constexpr, NB: tl.constexpr, BK: tl.constexpr):
+    block = tl.program_id(0)
+    cols = tl.program_id(1) * BK + tl.arange(0, BK)
+    rows = tl.arange(0, BM)
+    active = block < tl.load(BLOCK_END + NB - 1)
+    expert = tl.load(EXPERTS + block, active, 0)
+    start = tl.load(OFFSETS + block, active, 0)
+    end = tl.load(ENDS + expert, active, 0)
+    valid = active & (start + rows < end)
+    route = tl.load(ROUTES + start + rows, valid, 0)
+    x = tl.load(X + (route // TOPK)[:, None] * STRIDE + cols[None, :], valid[:, None] & (cols[None, :] < K), 0)
+    tl.store(Y + (block * BM + rows[:, None]) * K + cols[None, :], x, active & (cols[None, :] < K))
+
+
+class CuteW4A16Gemm:
+    """One warpgroup consumes a two-stage TMA pipeline (weights +
+    activations)."""
+
+    def __init__(self,
+                 block_m=8,
+                 block_k=128,
+                 stages=2,
+                 split_k=1,
+                 fast_dequant=False,
+                 single_route=False,
+                 n_major=False):
+        self.bm = block_m
+        self.bk = block_k
+        self.stages = stages
+        self.split_k = split_k
+        self.fast_dequant = fast_dequant
+        self.single_route = single_route
+        self.n_major = n_major
+
+    @cute.kernel
+    def kernel(self, q: cute.Tensor, w: cute.Tensor, s: cute.Tensor, out: cute.Tensor, routes: cute.Tensor,
+               ends: cute.Tensor, block_end: cute.Tensor, experts: cute.Tensor, offsets: cute.Tensor,
+               scatter: cutlass.Constexpr, mma: cute.TiledMma, atom_q: cute.CopyAtom, atom_w: cute.CopyAtom,
+               b_layout: cute.ComposedLayout, w_layout: cute.Layout, ts: cute.Tensor, atom_s: cute.CopyAtom,
+               s_layout: cute.Layout, stage_scales: cutlass.Constexpr):
+        bid, tile_n, split = cute.arch.block_idx()
+        if cutlass.const_expr(self.n_major):
+            tile_n, bid, split = cute.arch.block_idx()
+        tid, _, _ = cute.arch.thread_idx()
+        smem = utils.SmemAllocator()
+        barriers = smem.allocate_array(cutlass.Int64, self.stages)
+        b = smem.allocate_tensor(cutlass.BFloat16, b_layout.outer, byte_alignment=128, swizzle=b_layout.inner)
+        wp = smem.allocate_tensor(Int32, w_layout, byte_alignment=128)
+        if cutlass.const_expr(stage_scales):
+            sp = smem.allocate_tensor(s.element_type, s_layout, byte_alignment=128)
+        if bid < block_end[block_end.shape[0] - 1]:
+            # The predicate is CTA-uniform. Inactive capacity tiles need
+            # neither initialized barriers nor a CTA synchronization.
+            if tid == 0:
+                for stage in cutlass.range_constexpr(self.stages):
+                    cute.arch.mbarrier_init(barriers + stage, 1)
+            cute.arch.mbarrier_init_fence()
+            cute.arch.sync_threads()
+            expert = Int64(experts[bid])
+            gq = cute.local_tile(q, (self.bm, self.bk), (bid, None))
+            gw = cute.local_tile(w, (64, self.bk // 8, 1), (tile_n, None, expert))
+            gw = gw[None, None, 0, None]
+            tb, tq = cpasync.tma_partition(atom_q, 0, cute.make_layout(1), cute.group_modes(b, 0, 2),
+                                           cute.group_modes(gq, 0, 2))
+            tw, tg = cpasync.tma_partition(atom_w, 0, cute.make_layout(1), cute.group_modes(wp, 0, 2),
+                                           cute.group_modes(gw, 0, 2))
+            if cutlass.const_expr(stage_scales):
+                gs = cute.local_tile(ts, (64, self.bk // 32, 1), (tile_n, None, expert))
+                gs = gs[None, None, 0, None]
+                tss, tsg = cpasync.tma_partition(atom_s, 0, cute.make_layout(1), cute.group_modes(sp, 0, 2),
+                                                 cute.group_modes(gs, 0, 2))
+            total_tiles = cute.ceil_div(s.shape[2] * 32, self.bk)
+            per_split = cute.ceil_div(total_tiles, self.split_k)
+            first_tile = split * per_split
+            tiles = min(per_split, total_tiles - first_tile)
+            tx_bytes = self.bm * self.bk * 2 + 64 * self.bk // 2
+            if cutlass.const_expr(stage_scales):
+                tx_bytes += 64 * (self.bk // 32) * (s.element_type.width // 8)
+            # Prime the pipeline. Each transaction completes the stage's
+            # mbarrier; CTA sync + WGMMA wait protect it against early reuse.
+            if tid // 32 == 0:
+                for stage in cutlass.range_constexpr(self.stages):
+                    if stage < tiles:
+                        with cute.arch.elect_one():
+                            cute.arch.mbarrier_arrive_and_expect_tx(barriers + stage, tx_bytes)
+                        cute.copy(atom_q, tq[None, first_tile + stage], tb[None, stage], tma_bar_ptr=barriers + stage)
+                        cute.copy(atom_w, tg[None, first_tile + stage], tw[None, stage], tma_bar_ptr=barriers + stage)
+                        if cutlass.const_expr(stage_scales):
+                            cute.copy(atom_s,
+                                      tsg[None, first_tile + stage],
+                                      tss[None, stage],
+                                      tma_bar_ptr=barriers + stage)
+            thr = mma.get_slice(tid)
+            ca = thr.partition_A(cute.make_identity_tensor((64, self.bk)))
+            cc = thr.partition_C(cute.make_identity_tensor((64, self.bm)))
+            ra = mma.make_fragment_A(ca.shape)
+            tmp = cute.make_rmem_tensor(ra.shape, Float32)
+            rb = mma.make_fragment_B(thr.partition_B(b))
+            acc = cute.make_rmem_tensor(mma.partition_shape_C((64, self.bm)), Float32)
+            acc.fill(0)
+            atom = cute.make_mma_atom(mma.op)
+            atom.set(warpgroup.Field.ACCUMULATE, True)
+            for tile in range(tiles):
+                stage = tile % self.stages
+                phase = (tile // self.stages) % 2
+                cute.arch.mbarrier_wait(barriers + stage, phase)
+                if cutlass.const_expr(self.fast_dequant and s.element_type == cutlass.BFloat16):
+                    ra32 = cute.recast_tensor(ra, Int32)
+                    for i in cutlass.range_constexpr(cute.size(ra32)):
+                        n, k = ca[2 * i]
+                        value = Int32(0)
+                        valid = True
+                        if cutlass.const_expr(s.shape[1] % 64 != 0):
+                            valid = tile_n * 64 + n < s.shape[1]
+                        if cutlass.const_expr((s.shape[2] * 32) % self.bk != 0):
+                            valid = valid and (first_tile + tile) * self.bk + k < s.shape[2] * 32
+                        if valid:
+                            if cutlass.const_expr(stage_scales):
+                                scale = sp[n, k // 32, stage]
+                            else:
+                                scale = s[expert, tile_n * 64 + n, ((first_tile + tile) * self.bk + k) // 32]
+                            value = _dequant_pair(wp[n, k // 8, stage], (k % 8) * 4, scale)
+                        ra32[i] = value
+                else:
+                    for i in cutlass.range_constexpr(cute.size(ra)):
+                        n, k = ca[i]
+                        value = Float32(0)
+                        valid = True
+                        if cutlass.const_expr(s.shape[1] % 64 != 0):
+                            valid = tile_n * 64 + n < s.shape[1]
+                        if cutlass.const_expr((s.shape[2] * 32) % self.bk != 0):
+                            valid = valid and (first_tile + tile) * self.bk + k < s.shape[2] * 32
+                        if valid:
+                            word = wp[n, k // 8, stage]
+                            code = ((word >> ((k % 8) * 4)) & 15) - 8
+                            if cutlass.const_expr(stage_scales):
+                                scale = sp[n, k // 32, stage]
+                            else:
+                                scale = s[expert, tile_n * 64 + n, ((first_tile + tile) * self.bk + k) // 32]
+                            value = Float32(code) * Float32(scale)
+                        tmp[i] = value
+                    ra.store(tmp.load().to(cutlass.BFloat16))
+                warpgroup.fence()
+                for sub in cutlass.range_constexpr(self.bk // 16):
+                    cute.mma_atom_call(atom, acc[None, 0, 0], ra[None, 0, sub], rb[None, 0, sub, stage], acc[None, 0,
+                                                                                                             0])
+                warpgroup.commit_group()
+                warpgroup.wait_group(0)
+                cute.arch.sync_threads()
+                # TMA for the recycled slot overlaps the next tile's unpack,
+                # scale multiplication and asynchronous BF16 tensor-core MMA.
+                if tid // 32 == 0 and tile + self.stages < tiles:
+                    with cute.arch.elect_one():
+                        cute.arch.mbarrier_arrive_and_expect_tx(barriers + stage, tx_bytes)
+                    cute.copy(atom_q,
+                              tq[None, first_tile + tile + self.stages],
+                              tb[None, stage],
+                              tma_bar_ptr=barriers + stage)
+                    cute.copy(atom_w,
+                              tg[None, first_tile + tile + self.stages],
+                              tw[None, stage],
+                              tma_bar_ptr=barriers + stage)
+                    if cutlass.const_expr(stage_scales):
+                        cute.copy(atom_s,
+                                  tsg[None, first_tile + tile + self.stages],
+                                  tss[None, stage],
+                                  tma_bar_ptr=barriers + stage)
+            for i in cutlass.range_constexpr(cute.size(acc)):
+                n = tile_n * 64 + cc[i][0]
+                row = cc[i][1]
+                if n < s.shape[1]:
+                    if cutlass.const_expr(scatter):
+                        if cutlass.const_expr(self.single_route):
+                            if row == 0:
+                                out[bid, n] = out.element_type(acc[i])
+                        else:
+                            sorted_row = offsets[bid] + row
+                            if sorted_row < ends[expert]:
+                                route = Int32(routes[sorted_row])
+                                out[route, n] = out.element_type(acc[i])
+                    else:
+                        out[split * (out.shape[0] // self.split_k) + bid * self.bm + row, n] = out.element_type(acc[i])
+
+    @cute.jit
+    def __call__(self, q: cute.Tensor, packed: cute.Tensor, s: cute.Tensor, out: cute.Tensor, routes: cute.Tensor,
+                 ends: cute.Tensor, block_end: cute.Tensor, experts: cute.Tensor, offsets: cute.Tensor,
+                 scatter: cutlass.Constexpr, stream: cuda.CUstream):
+        mma = cute.make_tiled_mma(
+            warpgroup.MmaF16BF16Op(cutlass.BFloat16, Float32, (64, self.bm, 16), warpgroup.OperandSource.RMEM,
+                                   warpgroup.OperandMajorMode.K, warpgroup.OperandMajorMode.K))
+        b_layout = sm90_utils.make_smem_layout_b(utils.LayoutEnum.ROW_MAJOR, (64, self.bm, self.bk), cutlass.BFloat16,
+                                                 self.stages)
+        w_layout = cute.make_layout((64, self.bk // 8, self.stages), stride=(self.bk // 8, 1, 64 * self.bk // 8))
+        w = cute.make_tensor(
+            packed.iterator,
+            cute.make_layout((packed.shape[1], packed.shape[2], packed.shape[0]),
+                             stride=(packed.stride[1], packed.stride[2], packed.stride[0])))
+        atom_q, tq = cpasync.make_tiled_tma_atom(cpasync.CopyBulkTensorTileG2SOp(), q,
+                                                 cute.slice_(b_layout, (None, None, 0)), (self.bm, self.bk))
+        atom_w, tw = cpasync.make_tiled_tma_atom(cpasync.CopyBulkTensorTileG2SOp(), w,
+                                                 cute.slice_(w_layout, (None, None, 0)), (64, self.bk // 8))
+        # TMA requires at least 16 contiguous bytes. Smaller K tiles retain
+        # direct scale loads, including unaligned/tail test shapes.
+        stage_scales = (self.bk // 32 * (s.element_type.width // 8) >= 16
+                        and s.stride[1] * (s.element_type.width // 8) % 16 == 0)
+        s_layout = cute.make_layout((64, self.bk // 32, self.stages), stride=(self.bk // 32, 1, 64 * self.bk // 32))
+        ts, atom_s = s, atom_w
+        if cutlass.const_expr(stage_scales):
+            sv = cute.make_tensor(
+                s.iterator,
+                cute.make_layout((s.shape[1], s.shape[2], s.shape[0]), stride=(s.stride[1], s.stride[2], s.stride[0])))
+            atom_s, ts = cpasync.make_tiled_tma_atom(cpasync.CopyBulkTensorTileG2SOp(), sv,
+                                                     cute.slice_(s_layout, (None, None, 0)), (64, self.bk // 32))
+        grid = (experts.shape[0], cute.ceil_div(s.shape[1], 64), self.split_k)
+        if cutlass.const_expr(self.n_major):
+            grid = (grid[1], grid[0], grid[2])
+        self.kernel(tq, tw, s, out, routes, ends, block_end, experts, offsets, scatter, mma, atom_q, atom_w, b_layout,
+                    w_layout, ts, atom_s, s_layout, stage_scales).launch(grid=grid, block=(128, 1, 1), stream=stream)
+
+
+@lru_cache(maxsize=128)
+def _compile_gemm(layouts, device_index, scatter, block_m, block_k, stages, split_k, fast_dequant, single_route,
+                  n_major):
+    dtypes = {torch.int32: Int32, torch.int64: Int64, torch.bfloat16: cutlass.BFloat16, torch.float32: Float32}
+    tensors = [
+        make_fake_tensor(dtypes[dtype], shape, stride=stride, assumed_align=16) for shape, stride, dtype in layouts
+    ]
+    with torch.cuda.device(device_index):
+        return cute.compile(CuteW4A16Gemm(block_m, block_k, stages, split_k, fast_dequant, single_route, n_major),
+                            *tensors, scatter, cuda.CUstream(0))
+
+
+def _launch_gemm(x,
+                 packed,
+                 scales,
+                 out,
+                 metadata,
+                 scatter=True,
+                 block_m=8,
+                 block_k=128,
+                 stages=2,
+                 split_k=1,
+                 fast_dequant=False,
+                 reduce_split=True,
+                 single_route=False,
+                 n_major=False):
+    routes, _, ends, block_end, experts, offsets = metadata
+    if scatter and split_k != 1:
+        raise ValueError('split-K is supported only for the padded gate/up output')
+    target = out if split_k == 1 else torch.empty(
+        (out.shape[0] * split_k, out.shape[1]), device=out.device, dtype=torch.float32)
+    tensors = (x, packed, scales, target, routes, ends, block_end, experts, offsets)
+    layouts = tuple((tuple(t.shape), tuple(t.stride()), t.dtype) for t in tensors)
+    fn = _compile_gemm(layouts, x.device.index, scatter, block_m, block_k, stages, split_k, fast_dequant, single_route,
+                       n_major)
+    fn(*(from_dlpack(t, assumed_align=16) for t in tensors),
+       cuda.CUstream(torch.cuda.current_stream(x.device).cuda_stream))
+    if split_k != 1 and reduce_split:
+        _sum_split[(triton.cdiv(out.numel(), 512), )](target, out, block_end, out.shape[0], out.shape[1],
+                                                      block_end.numel(), block_m, split_k, 512)
+    return out if reduce_split else target
+
+
+@triton.jit
+def _sum_split(X, Y, BLOCK_END, M: tl.constexpr, N: tl.constexpr, E: tl.constexpr, BM: tl.constexpr,
+               SPLIT: tl.constexpr, BLOCK: tl.constexpr):
+    idx = tl.program_id(0) * BLOCK + tl.arange(0, BLOCK)
+    active_rows = tl.load(BLOCK_END + E - 1) * BM
+    valid = (idx < M * N) & (idx // N < active_rows)
+    value = tl.full((BLOCK, ), 0, tl.float32)
+    for part in range(SPLIT):
+        value += tl.load(X + part * M * N + idx, valid, 0)
+    tl.store(Y + idx, value, idx < M * N)
+
+
+def gather_routed(x, metadata, topk, block_m=8):
+    routes, _, ends, block_end, experts, offsets = metadata
+    padded = x.new_empty((experts.numel() * block_m, x.shape[1]))
+    _gather[(experts.numel(), triton.cdiv(x.shape[1], 128))](x, padded, routes, ends, block_end, experts,
+                                                             offsets, x.shape[1], x.stride(0), topk, block_m,
+                                                             block_end.numel(), 128)
+    return padded
+
+
+@triton.jit
+def _gather_single(X, Y, BLOCK_END, K: tl.constexpr, TOPK: tl.constexpr, BM: tl.constexpr, BLOCK: tl.constexpr):
+    """One token: each route owns a block; sorting/counting is unnecessary."""
+    block = tl.program_id(0)
+    idx = tl.program_id(1) * BLOCK + tl.arange(0, BLOCK)
+    value = tl.load(X + idx % K, (idx < BM * K) & (idx < K), 0)
+    tl.store(Y + block * BM * K + idx, value, idx < BM * K)
+    if block == 0 and tl.program_id(1) == 0:
+        tl.store(BLOCK_END, TOPK)
+
+
+@triton.jit
+def _activate_padded(X,
+                     Y,
+                     BLOCK_END,
+                     M: tl.constexpr,
+                     F: tl.constexpr,
+                     E: tl.constexpr,
+                     BM: tl.constexpr,
+                     BLOCK: tl.constexpr,
+                     SPLIT: tl.constexpr = 1):
+    idx = tl.program_id(0) * BLOCK + tl.arange(0, BLOCK)
+    row, col = idx // F, idx % F
+    valid = (row < M) & (row < tl.load(BLOCK_END + E - 1) * BM)
+    gate = tl.load(X + row * 2 * F + col, valid, 0).to(tl.float32)
+    up = tl.load(X + row * 2 * F + F + col, valid, 0).to(tl.float32)
+    for part in range(1, SPLIT):
+        gate += tl.load(X + part * M * 2 * F + row * 2 * F + col, valid, 0)
+        up += tl.load(X + part * M * 2 * F + row * 2 * F + F + col, valid, 0)
+    # Preserve the original GEMM -> BF16 -> SiLU rounding boundary.
+    gate = gate.to(Y.dtype.element_ty).to(tl.float32)
+    up = up.to(Y.dtype.element_ty).to(tl.float32)
+    value = gate / (1 + tl.exp(-gate)) * up
+    tl.store(Y + idx, value, valid)
+
+
+def _validate_inputs(hidden_states, gate_up_packed, gate_up_scale, down_packed, down_scale):
+    x = hidden_states
+    if x.ndim != 2 or not x.is_cuda or x.dtype != torch.bfloat16:
+        raise ValueError('cute requires 2D CUDA BF16 activations')
+    if x.stride(1) != 1:
+        raise ValueError('cute requires contiguous activation channels')
+    if gate_up_packed.ndim != 3 or down_packed.ndim != 3:
+        raise ValueError('cute requires 3D packed expert weights')
+    if torch.cuda.get_device_capability(x.device)[0] != 9:
+        raise ValueError('cute requires Hopper SM90')
+    e, n, _ = gate_up_packed.shape
+    m, k = x.shape
+    if e < 1 or k < 32 or k % 32 or n < 64 or n % 64:
+        raise ValueError('cute requires positive experts, group-size 32 and aligned gate/up channels')
+    for packed, scale, out_dim, in_dim in ((gate_up_packed, gate_up_scale, n, k), (down_packed, down_scale, k, n // 2)):
+        if packed.shape != (e, out_dim, in_dim // 8) or scale.shape != (e, out_dim, in_dim // 32):
+            raise ValueError('cute requires packed [E,N,K/8] and scales [E,N,K/32]')
+        if packed.dtype != torch.int32 or scale.dtype not in (torch.bfloat16, torch.float32):
+            raise ValueError('cute requires INT32 packed weights and BF16/FP32 scales')
+        if packed.device != x.device or scale.device != x.device:
+            raise ValueError('cute weights and activations must be on the same CUDA device')
+        if not packed.is_contiguous() or not scale.is_contiguous():
+            raise ValueError('cute requires contiguous weights and scales')
+    return e, n, m, k
+
+
+def fused_moe_w4a16_cute(hidden_states: torch.Tensor,
+                         gate_up_packed: torch.Tensor,
+                         gate_up_scale: torch.Tensor,
+                         down_packed: torch.Tensor,
+                         down_scale: torch.Tensor,
+                         topk_weights: torch.Tensor,
+                         topk_ids: torch.Tensor,
+                         topk: int,
+                         renormalize: bool = False,
+                         num_bits: int = 4,
+                         group_size: int = 32,
+                         allow_invalid_routes: bool = False) -> torch.Tensor:
+    """Hopper TP / DeepEP normal provider; routing stays on GPU during
+    graphs."""
+    if num_bits != 4 or group_size != 32:
+        raise ValueError('cute supports only INT4 group-size 32')
+    if allow_invalid_routes and renormalize:
+        raise ValueError('Cannot renormalize an EP-local route subset')
+    x = hidden_states
+    e, n, m, k = _validate_inputs(x, gate_up_packed, gate_up_scale, down_packed, down_scale)
+    if topk < 1 or (topk > e and not allow_invalid_routes):
+        raise ValueError('cute requires 1 <= top_k <= E for global routes')
+    if topk_ids.shape != (m, topk) or topk_weights.shape != (m, topk):
+        raise ValueError('Routing dimensions must match token count and top_k')
+    if topk_ids.dtype not in (torch.int32,
+                              torch.int64) or topk_ids.device != x.device or topk_weights.device != x.device:
+        raise ValueError('Routing requires CUDA int32/int64 ids on the activation device')
+    if m == 0:
+        return torch.empty_like(x)
+    routing_ids, routing_e = topk_ids, e
+    if allow_invalid_routes:
+        valid = (topk_ids >= 0) & (topk_ids < e)
+        topk_weights = torch.where(valid, topk_weights, 0)
+        # The shared sorter requires nonnegative IDs and topk <= E. A private
+        # sentinel preserves route positions but is excluded from local GEMMs.
+        routing_ids = torch.where(valid, topk_ids, e).reshape(-1, 1)
+        routing_e += 1
+    single_route = m == 1 and not allow_invalid_routes
+    # Static shape selection is safe for CUDA graphs: routing remains on GPU.
+    bm = 8 if m * topk <= e * 8 else 16 if m * topk <= e * 16 else 32 if m * topk <= e * 32 else 64
+    split = 8 if m <= 1 and k >= 1024 else 4 if m <= 8 and k >= 1024 else 1
+    gate_bk = 256 if m > 1 and k % 256 == 0 else 128
+    if single_route:
+        ids = topk_ids.flatten().contiguous()
+        block_end = torch.empty(1, device=x.device, dtype=torch.int32)
+        # Unused general-route fields alias ids; the single-route epilogue
+        # indexes output by block, also correctly handling duplicate ids.
+        metadata = (ids, ids, ids, block_end, ids, ids)
+        padded = x.new_empty((topk * bm, k))
+        _gather_single[(topk, triton.cdiv(bm * k, 1024))](x, padded, block_end, k, topk, bm, 1024)
+    else:
+        metadata = _get_sorted_idx_blocks(routing_ids.contiguous(), routing_e, e, 0, bm)
+        padded = gather_routed(x, metadata, topk, bm)
+    # Invalid routes must be zero even if their supplied weight is NaN/nonzero.
+    out = x.new_zeros((m * topk, k)) if allow_invalid_routes else x.new_empty((m * topk, k))
+    _run_experts(padded, gate_up_packed, gate_up_scale, down_packed, down_scale, metadata, out, bm, gate_bk, split,
+                 single_route, m > 8)
+    return moe_reduce(out.view(m, topk, k), _renormalize(topk_weights, renormalize), fp32_acc=True)
+
+
+def _run_experts(padded,
+                 gate_up_packed,
+                 gate_up_scale,
+                 down_packed,
+                 down_scale,
+                 metadata,
+                 out,
+                 bm,
+                 gate_bk=256,
+                 split=1,
+                 single_route=False,
+                 n_major=True):
+    """Common padded gate/activation/down pipeline for TP and both EP modes."""
+    x, n = padded, gate_up_packed.shape[1]
+    gate_up = x.new_empty((padded.shape[0], n))
+    gate_up = _launch_gemm(padded,
+                           gate_up_packed,
+                           gate_up_scale,
+                           gate_up,
+                           metadata,
+                           False,
+                           bm,
+                           block_k=gate_bk,
+                           split_k=split,
+                           fast_dequant=True,
+                           reduce_split=False,
+                           single_route=single_route,
+                           n_major=n_major)
+    activated = x.new_empty((padded.shape[0], n // 2))
+    _activate_padded[(triton.cdiv(activated.numel(), 512), )](gate_up, activated, metadata[3], activated.shape[0],
+                                                              n // 2, metadata[3].numel(), bm, 512, split)
+    _launch_gemm(activated,
+                 down_packed,
+                 down_scale,
+                 out,
+                 metadata,
+                 True,
+                 bm,
+                 fast_dequant=True,
+                 single_route=single_route)
+
+
+@triton.jit
+def _masked_block_metadata(COUNTS, ENDS, BLOCK_END, EXPERTS, OFFSETS, E: tl.constexpr, CAP: tl.constexpr,
+                           BM: tl.constexpr, BE: tl.constexpr, BC: tl.constexpr):
+    expert = tl.program_id(0)
+    ids = tl.arange(0, BE)
+    counts = tl.minimum(tl.maximum(tl.load(COUNTS + ids, ids < E, 0), 0), CAP)
+    blocks = tl.cdiv(counts, BM)
+    start = tl.sum(tl.where(ids < expert, blocks, 0))
+    count = tl.sum(tl.where(ids == expert, counts, 0))
+    end = start + tl.cdiv(count, BM)
+    tl.store(ENDS + expert, expert * CAP + count)
+    tl.store(BLOCK_END + expert, end)
+    b = tl.arange(0, BC)
+    tl.store(EXPERTS + start + b, expert, start + b < end)
+    tl.store(OFFSETS + start + b, expert * CAP + b * BM, start + b < end)
+
+
+def fused_moe_w4a16_cute_masked(hidden_states: torch.Tensor,
+                                gate_up_packed: torch.Tensor,
+                                gate_up_scale: torch.Tensor,
+                                down_packed: torch.Tensor,
+                                down_scale: torch.Tensor,
+                                masked_m: torch.Tensor,
+                                num_bits: int = 4,
+                                group_size: int = 32) -> torch.Tensor:
+    """Unweighted [E_local, capacity, H] experts for DeepEP low-latency
+    combine.
+
+    Compact only valid tiles on device; never read uninitialized receive tails. DeepEP, not this kernel, applies router
+    weights at combine time.
+    """
+    if num_bits != 4 or group_size != 32:
+        raise ValueError('cute supports only INT4 group-size 32')
+    if hidden_states.ndim != 3 or not hidden_states.is_contiguous():
+        raise ValueError('masked cute requires contiguous [experts, capacity, hidden]')
+    e, capacity, k = hidden_states.shape
+    if capacity < 1 or masked_m.shape != (e, ) or masked_m.dtype not in (torch.int32, torch.int64):
+        raise ValueError('masked_m must contain one integer count per expert and capacity must be positive')
+    if masked_m.device != hidden_states.device or not masked_m.is_contiguous():
+        raise ValueError('masked_m must be contiguous on the activation device')
+    x = hidden_states.view(-1, k)
+    weight_e, _, _, _ = _validate_inputs(x, gate_up_packed, gate_up_scale, down_packed, down_scale)
+    if weight_e != e:
+        raise ValueError('masked weights must match the local expert count')
+    bm = 8
+    routes = torch.arange(e * capacity, device=x.device, dtype=torch.int32)
+    ends = torch.empty(e, device=x.device, dtype=torch.int32)
+    block_end = torch.empty_like(ends)
+    experts = torch.empty(e * triton.cdiv(capacity, bm), device=x.device, dtype=torch.int32)
+    offsets = torch.empty_like(experts)
+    _masked_block_metadata[(e, )](masked_m, ends, block_end, experts, offsets, e, capacity, bm,
+                                  triton.next_power_of_2(e), triton.next_power_of_2(triton.cdiv(capacity, bm)))
+    metadata = (routes, ends, ends, block_end, experts, offsets)
+    padded = gather_routed(x, metadata, 1, bm)
+    out = torch.zeros_like(x)
+    _run_experts(padded,
+                 gate_up_packed,
+                 gate_up_scale,
+                 down_packed,
+                 down_scale,
+                 metadata,
+                 out,
+                 bm,
+                 gate_bk=256 if k % 256 == 0 else 128)
+    return out.view_as(hidden_states)

--- a/tests/pytorch/config/test_w4a16_moe_backend.py
+++ b/tests/pytorch/config/test_w4a16_moe_backend.py
@@ -1,0 +1,164 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+import runpy
+from dataclasses import replace
+
+import pytest
+import torch
+
+from lmdeploy.pytorch import envs
+
+
+@pytest.mark.parametrize('value,expected', [(None, 'cute'), ('auto', 'auto'), ('triton', 'triton'),
+                                            ('cute', 'cute'), (' CUTE ', 'cute')])
+def test_w4a16_moe_backend_choices(monkeypatch, value, expected):
+    if value is None:
+        monkeypatch.delenv('LMDEPLOY_W4A16_MOE_BACKEND', raising=False)
+    else:
+        monkeypatch.setenv('LMDEPLOY_W4A16_MOE_BACKEND', value)
+    # Evaluate the actual declaration without replacing the process's envs module.
+    assert runpy.run_path(envs.__file__)['w4a16_moe_backend'] == expected
+
+
+@pytest.mark.parametrize('value', ['cutew4a8', 'cutew4a16', 'cutew', 'w4a8', 'unknown'])
+def test_w4a16_moe_backend_rejects_invalid_names(monkeypatch, value):
+    monkeypatch.setenv('LMDEPLOY_W4A16_MOE_BACKEND', value)
+    with pytest.raises(ValueError, match='LMDEPLOY_W4A16_MOE_BACKEND'):
+        runpy.run_path(envs.__file__)
+
+
+@pytest.fixture
+def build_spec():
+    from lmdeploy.pytorch.backends.moe import FusedMoEW4A16BuildSpec
+
+    return FusedMoEW4A16BuildSpec(top_k=2, num_experts=8, renormalize=False, num_bits=4, group_size=32,
+                                  hidden_dim=128, ep_size=1, ep_group=None, output_dtype=torch.bfloat16,
+                                  num_max_dispatch_tokens_per_rank=128, layer_idx=0)
+
+
+@pytest.mark.parametrize('compatible', [False, True])
+@pytest.mark.parametrize('ep_size', [1, 2])
+def test_auto_selects_compatible_provider(monkeypatch, build_spec, compatible, ep_size):
+    from lmdeploy.pytorch.backends.cuda.moe import compressed_tensors as backend
+
+    spec = replace(build_spec, ep_size=ep_size)
+    selected = object()
+    monkeypatch.setattr(envs, 'w4a16_moe_backend', 'auto')
+    monkeypatch.setattr(backend, '_supports_cute', lambda spec: compatible)
+
+    def build_cute(actual_spec):
+        assert compatible and actual_spec is spec
+        return selected
+
+    def build_triton(**kwargs):
+        assert not compatible
+        assert kwargs['top_k'] == spec.top_k
+        if ep_size > 1:
+            assert kwargs['ep_size'] == ep_size
+            assert kwargs.get('local_backend', 'triton') == 'triton'
+        return selected
+
+    monkeypatch.setattr(backend, '_build_fused_moe_cute', build_cute)
+    monkeypatch.setattr(backend, 'TritonFusedMoEW4A16Impl', build_triton)
+    monkeypatch.setattr(backend, 'DeepEPFusedMoEW4A16Impl', build_triton)
+    assert backend._build_fused_moe_w4a16(spec) is selected
+
+
+@pytest.mark.parametrize('provider', ['cute', 'triton'])
+def test_explicit_provider_does_not_probe_auto(monkeypatch, build_spec, provider):
+    from lmdeploy.pytorch.backends.cuda.moe import compressed_tensors as backend
+
+    monkeypatch.setattr(envs, 'w4a16_moe_backend', provider)
+
+    def unexpected_probe(spec):
+        raise AssertionError('explicit provider must not probe automatic compatibility')
+
+    monkeypatch.setattr(backend, '_supports_cute', unexpected_probe)
+    if provider == 'triton':
+        assert isinstance(backend._build_fused_moe_w4a16(build_spec), backend.TritonFusedMoEW4A16Impl)
+    else:
+        def unavailable_cute(spec):
+            raise ImportError('optional dependency unavailable')
+
+        monkeypatch.setattr(backend, '_build_fused_moe_cute', unavailable_cute)
+        with pytest.raises(ImportError, match='optional dependency unavailable'):
+            backend._build_fused_moe_w4a16(build_spec)
+
+
+@pytest.mark.parametrize('overrides', [dict(num_bits=8), dict(group_size=128), dict(output_dtype=torch.float16),
+                                       dict(hidden_dim=0), dict(hidden_dim=1), dict(hidden_dim=48)])
+def test_cute_rejects_incompatible_build_shapes(monkeypatch, build_spec, overrides):
+    from lmdeploy.pytorch.backends.cuda.moe import compressed_tensors as backend
+
+    def unexpected_cuda_probe():
+        raise AssertionError('reject incompatible formats before probing CUDA')
+
+    monkeypatch.setattr(torch.cuda, 'is_available', unexpected_cuda_probe)
+    assert not backend._supports_cute(replace(build_spec, **overrides))
+
+
+@pytest.mark.parametrize('cuda_available,major', [(False, 9), (True, 8), (True, 10)])
+def test_cute_rejects_incompatible_devices(monkeypatch, build_spec, cuda_available, major):
+    from lmdeploy.pytorch.backends.cuda.moe import compressed_tensors as backend
+
+    monkeypatch.setattr(torch.cuda, 'is_available', lambda: cuda_available)
+    monkeypatch.setattr(torch.cuda, 'get_device_capability', lambda: (major, 0))
+    assert not backend._supports_cute(build_spec)
+
+
+@pytest.mark.parametrize('provider', ['auto', 'cute'])
+@pytest.mark.parametrize('cuda_available,major', [(False, 9), (True, 8), (True, 10)])
+def test_builder_handles_unsupported_devices(monkeypatch, build_spec, provider, cuda_available, major):
+    from lmdeploy.pytorch.backends.cuda.moe import compressed_tensors as backend
+
+    monkeypatch.setattr(envs, 'w4a16_moe_backend', provider)
+    monkeypatch.setattr(torch.cuda, 'is_available', lambda: cuda_available)
+    monkeypatch.setattr(torch.cuda, 'get_device_capability', lambda: (major, 0))
+    if provider == 'auto':
+        assert isinstance(backend._build_fused_moe_w4a16(build_spec), backend.TritonFusedMoEW4A16Impl)
+    else:
+        with pytest.raises(RuntimeError, match='Hopper SM90'):
+            backend._build_fused_moe_w4a16(build_spec)
+
+
+@pytest.mark.parametrize('available', [False, True])
+def test_cute_probes_optional_kernel_import(monkeypatch, build_spec, available):
+    import builtins
+    from types import SimpleNamespace
+
+    from lmdeploy.pytorch.backends.cuda.moe import compressed_tensors as backend
+
+    original_import = builtins.__import__
+
+    def guarded_import(name, *args, **kwargs):
+        if name == 'lmdeploy.pytorch.kernels.cuda.compressed_tensors_w4a16_cute':
+            if not available:
+                raise ImportError('optional CuTe dependency missing')
+            return SimpleNamespace(fused_moe_w4a16_cute=object())
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(torch.cuda, 'is_available', lambda: True)
+    monkeypatch.setattr(torch.cuda, 'get_device_capability', lambda: (9, 0))
+    monkeypatch.setattr(builtins, '__import__', guarded_import)
+    assert backend._supports_cute(build_spec) is available
+
+
+def test_auto_does_not_hide_builder_errors(monkeypatch, build_spec):
+    from lmdeploy.pytorch.backends.cuda.moe import compressed_tensors as backend
+
+    monkeypatch.setattr(envs, 'w4a16_moe_backend', 'auto')
+    monkeypatch.setattr(backend, '_supports_cute', lambda spec: True)
+
+    def invalid_spec(spec):
+        raise ValueError('invalid EP configuration')
+
+    monkeypatch.setattr(backend, '_build_fused_moe_cute', invalid_spec)
+    with pytest.raises(ValueError, match='invalid EP configuration'):
+        backend._build_fused_moe_w4a16(build_spec)
+
+
+def test_builder_rejects_unknown_provider(monkeypatch, build_spec):
+    from lmdeploy.pytorch.backends.cuda.moe import compressed_tensors as backend
+
+    monkeypatch.setattr(envs, 'w4a16_moe_backend', 'unknown')
+    with pytest.raises(ValueError, match='Unsupported compressed-tensors W4A16 MoE provider'):
+        backend._build_fused_moe_w4a16(build_spec)

--- a/tests/pytorch/kernel/test_compressed_tensors_w4a16.py
+++ b/tests/pytorch/kernel/test_compressed_tensors_w4a16.py
@@ -865,10 +865,14 @@ def test_route_major_w4a16_rejects_partial_topk_row():
         )
 
 
-def test_cuda_backend_builds_direct_packed_w4a16():
+@pytest.mark.parametrize('provider', ['auto', 'triton'])
+def test_cuda_backend_builds_direct_packed_w4a16(monkeypatch, provider):
+    from lmdeploy.pytorch import envs
     from lmdeploy.pytorch.backends.cuda.op_backend import CudaOpsBackend
     from lmdeploy.pytorch.backends.moe import FusedMoEW4A16BuildSpec, FusedMoEW4A16Impl
 
+    # This legacy builder test uses a placeholder hidden_dim, not a CuTe GEMM shape.
+    monkeypatch.setattr(envs, 'w4a16_moe_backend', provider)
     spec_kwargs = dict(
         top_k=2,
         num_experts=4,

--- a/tests/pytorch/kernel/test_compressed_tensors_w4a16_cute.py
+++ b/tests/pytorch/kernel/test_compressed_tensors_w4a16_cute.py
@@ -1,0 +1,252 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+import pytest
+import torch
+import torch.nn.functional as F
+
+if not torch.cuda.is_available() or torch.cuda.get_device_capability()[0] != 9:
+    pytest.skip('requires Hopper SM90', allow_module_level=True)
+
+pytest.importorskip('cutlass.cute', reason='requires optional nvidia-cutlass-dsl')
+pytest.importorskip('cuda.bindings.driver', reason='requires optional cuda-python')
+
+
+def weights(e, n, k):
+    q = torch.randint(-8, 8, (e, n, k), device='cuda', dtype=torch.int32)
+    shifts = torch.arange(8, device='cuda', dtype=torch.int64) * 4
+    p = (((q.long() + 8).unflatten(-1, (-1, 8))) << shifts).sum(-1).int()
+    s = (torch.rand(e, n, k // 32, device='cuda') * 0.04 + .001).bfloat16()
+    ref = (q.float() * s.float().repeat_interleave(32, -1)).bfloat16()
+    return p, s, ref
+
+
+def nrmse(x, ref):
+    return ((x.float() - ref.float()).square().sum() / ref.float().square().sum().clamp_min(1e-20)).sqrt().item()
+
+
+@pytest.mark.parametrize('m,n,k,e,topk', [(1, 64, 128, 4, 2), (17, 96, 256, 8, 2), (9, 128, 7168, 4, 2),
+                                          (3, 64, 64, 1, 1), (2, 64, 32, 2, 1)])
+@pytest.mark.parametrize('stages', [1, 2])
+@pytest.mark.parametrize('fast', [False, True])
+def test_gemm(m, n, k, e, topk, stages, fast, record_property):
+    from lmdeploy.pytorch.kernels.cuda.compressed_tensors_w4a16_cute import _launch_gemm, gather_routed
+    from lmdeploy.pytorch.kernels.cuda.moe.fused_moe import _get_sorted_idx_blocks
+    torch.manual_seed(13)
+    packed, s, w = weights(e, n, k)
+    x = torch.randn(m, k, device='cuda', dtype=torch.bfloat16)
+    ids = torch.rand(m, e, device='cuda').topk(topk, -1).indices
+    meta = _get_sorted_idx_blocks(ids, e, e, 0, 8)
+    padded = gather_routed(x, meta, topk)
+    out = x.new_empty((m * topk, n))
+    _launch_gemm(padded, packed, s, out, meta, stages=stages, fast_dequant=fast)
+    ref = torch.stack([x[r // topk].float() @ w[expert].float().T for r, expert in enumerate(ids.flatten())])
+    err = nrmse(out, ref)
+    record_property('bf16_reference_nrmse', err)
+    assert err < .003
+
+
+@pytest.mark.parametrize('m,topk,renormalize', [(1, 2, False), (17, 2, True), (4, 8, False), (65, 8, False),
+                                                (0, 2, False)])
+def test_moe_graph(m, topk, renormalize):
+    from lmdeploy.pytorch.kernels.cuda.compressed_tensors_w4a16 import fused_moe_w4a16
+    from lmdeploy.pytorch.kernels.cuda.compressed_tensors_w4a16_cute import fused_moe_w4a16_cute
+    torch.manual_seed(42)
+    e, h, f = 8, 128, 64
+    gp, gs, gw = weights(e, 2 * f, h)
+    dp, ds, dw = weights(e, h, f)
+    x = torch.randn(m, h, device='cuda', dtype=torch.bfloat16)
+    ids = torch.rand(m, e, device='cuda').topk(topk, -1).indices.int()
+    tw = torch.rand(m, topk, device='cuda')
+
+    def run():
+        return fused_moe_w4a16_cute(x, gp, gs, dp, ds, tw, ids, topk, renormalize)
+
+    def reference():
+        gu = torch.stack([x[r // topk].float() @ gw[expert].float().T
+                          for r, expert in enumerate(ids.flatten())]).bfloat16()
+        act = (F.silu(gu[:, :f].float()) * gu[:, f:].float()).bfloat16()
+        y = torch.stack([act[r].float() @ dw[expert].float().T for r, expert in enumerate(ids.flatten())]).bfloat16()
+        rw = tw / tw.sum(-1, keepdim=True) if renormalize else tw
+        return (y.view(m, topk, h).float() * rw[..., None]).sum(1).bfloat16()
+
+    out = run()
+    if m == 0:
+        assert out.shape == x.shape
+        return
+    assert nrmse(out, reference()) < .008
+    assert nrmse(out, fused_moe_w4a16(x, gp, gs, dp, ds, tw, ids, topk, renormalize)) < .012
+    stream = torch.cuda.Stream()
+    stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(stream):
+        run()
+    torch.cuda.current_stream().wait_stream(stream)
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        gout = run()
+    ids.copy_((ids + 3) % e)
+    x.normal_()
+    tw.uniform_()
+    graph.replay()
+    assert nrmse(gout, reference()) < .008
+
+
+def test_zero_and_provider(monkeypatch):
+    from dataclasses import replace
+
+    from lmdeploy.pytorch import envs
+    from lmdeploy.pytorch.backends.cuda.moe.compressed_tensors import CuteFusedMoEW4A16Impl, _build_fused_moe_w4a16
+    from lmdeploy.pytorch.backends.moe import FusedMoEW4A16BuildSpec
+    monkeypatch.setattr(envs, 'w4a16_moe_backend', 'cute')
+    spec = FusedMoEW4A16BuildSpec(top_k=2,
+                                  num_experts=8,
+                                  renormalize=False,
+                                  num_bits=4,
+                                  group_size=32,
+                                  hidden_dim=128,
+                                  ep_size=1,
+                                  ep_group=None,
+                                  output_dtype=torch.bfloat16,
+                                  num_max_dispatch_tokens_per_rank=128,
+                                  layer_idx=0)
+    impl = _build_fused_moe_w4a16(spec)
+    assert isinstance(impl, CuteFusedMoEW4A16Impl)
+    for bad, message in [(replace(spec, ep_size=8), 'EP process group'), (replace(spec,
+                                                                                  group_size=128), 'group-size 32'),
+                         (replace(spec, output_dtype=torch.float16), 'BF16')]:
+        with pytest.raises(ValueError, match=message):
+            _build_fused_moe_w4a16(bad)
+    gp, gs, _ = weights(8, 128, 128)
+    dp, ds, _ = weights(8, 128, 64)
+    gs.zero_()
+    x = torch.randn(2, 128, device='cuda', dtype=torch.bfloat16)
+    ids = torch.tensor([[0, 7], [7, 0]], device='cuda')
+    tw = torch.ones(2, 2, device='cuda')
+    out = impl.forward(x, tw, ids, gp, gs, dp, ds)
+    assert torch.count_nonzero(out) == 0
+    with pytest.raises(ValueError, match='contiguous activation channels'):
+        impl.forward(torch.empty(2, 256, device='cuda', dtype=torch.bfloat16)[:, ::2], tw, ids, gp, gs, dp, ds)
+
+
+@pytest.mark.parametrize('m', [1, 17])
+def test_ep_normal_invalid_routes_graph(m):
+    from lmdeploy.pytorch.kernels.cuda.compressed_tensors_w4a16 import fused_moe_w4a16
+    from lmdeploy.pytorch.kernels.cuda.compressed_tensors_w4a16_cute import fused_moe_w4a16_cute
+    torch.manual_seed(37)
+    e, h, f, topk = 2, 128, 64, 4  # Global topk may exceed E_local.
+    gp, gs, _ = weights(e, 2 * f, h)
+    dp, ds, _ = weights(e, h, f)
+    x = torch.randn(m, h, device='cuda', dtype=torch.bfloat16)
+    ids = torch.tensor([0, -1, 1, e], device='cuda').expand(m, -1).clone()
+    tw = torch.rand(m, topk, device='cuda')
+    tw[:, 1] = float('nan')
+
+    def run(fn=fused_moe_w4a16_cute):
+        return fn(x, gp, gs, dp, ds, tw, ids, topk, allow_invalid_routes=True)
+
+    assert nrmse(run(), run(fused_moe_w4a16)) < .012
+    with pytest.raises(ValueError, match='renormalize'):
+        fused_moe_w4a16_cute(x, gp, gs, dp, ds, tw, ids, topk, True, allow_invalid_routes=True)
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        out = run()
+    for all_invalid in (True, False):
+        ids.fill_(-1)
+        if not all_invalid:
+            ids[:, 0] = 1
+        x.normal_()
+        graph.replay()
+        ref = run(fused_moe_w4a16)
+        assert torch.isfinite(out).all()
+        assert nrmse(out, ref) < .012
+
+
+@pytest.mark.parametrize('capacity', [5, 32])
+def test_ep_masked_graph(capacity):
+    from lmdeploy.pytorch.kernels.cuda.compressed_tensors_w4a16 import fused_moe_w4a16_masked
+    from lmdeploy.pytorch.kernels.cuda.compressed_tensors_w4a16_cute import fused_moe_w4a16_cute_masked
+    torch.manual_seed(38)
+    e, h, f = 3, 256, 128
+    gp, gs, _ = weights(e, 2 * f, h)
+    dp, ds, _ = weights(e, h, f)
+    x = torch.randn(e, capacity, h, device='cuda', dtype=torch.bfloat16)
+    counts = torch.tensor([capacity, 2, 0], device='cuda', dtype=torch.int32)
+
+    def run(fn=fused_moe_w4a16_cute_masked):
+        return fn(x, gp, gs, dp, ds, counts)
+
+    assert nrmse(run(), run(fused_moe_w4a16_masked)) < .012
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        out = run()
+    for values in ([0, 0, 0], [1, capacity, 2], [capacity + 3, -1, capacity]):
+        counts.copy_(torch.tensor(values, device='cuda', dtype=torch.int32))
+        x.normal_()
+        for expert, count in enumerate(values):
+            x[expert, max(0, min(count, capacity)):] = float('nan')
+        graph.replay()
+        assert torch.isfinite(out).all()
+        assert nrmse(out, run(fused_moe_w4a16_masked)) < .012
+
+
+@pytest.mark.parametrize('bm,bk,split', [(8, 64, 4), (8, 128, 8), (8, 256, 8), (16, 128, 4), (32, 128, 4),
+                                         (64, 128, 4)])
+@pytest.mark.parametrize('fast', [False, True])
+def test_split_k(bm, bk, split, fast):
+    from lmdeploy.pytorch.kernels.cuda.compressed_tensors_w4a16_cute import _launch_gemm, gather_routed
+    from lmdeploy.pytorch.kernels.cuda.moe.fused_moe import _get_sorted_idx_blocks
+    torch.manual_seed(24)
+    e, m, n, k, topk = 4, 37, 128, 7168, 2
+    packed, s, _ = weights(e, n, k)
+    x = torch.randn(m, k, device='cuda', dtype=torch.bfloat16)
+    ids = torch.rand(m, e, device='cuda').topk(topk, -1).indices
+    meta = _get_sorted_idx_blocks(ids, e, e, 0, bm)
+    padded = gather_routed(x, meta, topk, bm)
+    ref = x.new_empty((padded.shape[0], n))
+    out = torch.empty_like(ref)
+    _launch_gemm(padded, packed, s, ref, meta, False, bm, bk, 2, 1)
+    _launch_gemm(padded, packed, s, out, meta, False, bm, bk, 2, split, fast)
+    count = int(meta[3][-1]) * bm
+    assert nrmse(out[:count], ref[:count]) < .001
+
+
+@pytest.mark.parametrize('duplicate', [False, True])
+def test_single_token_split_activation_graph(duplicate):
+    from lmdeploy.pytorch.kernels.cuda.compressed_tensors_w4a16 import fused_moe_w4a16
+    from lmdeploy.pytorch.kernels.cuda.compressed_tensors_w4a16_cute import fused_moe_w4a16_cute
+    torch.manual_seed(124)
+    gp, gs, _ = weights(4, 128, 1024)
+    dp, ds, _ = weights(4, 1024, 64)
+    x = torch.randn(1, 1024, device='cuda', dtype=torch.bfloat16)
+    ids = torch.tensor([[1, 1] if duplicate else [3, 1]], device='cuda', dtype=torch.int32)
+    tw = torch.tensor([[.3, .7]], device='cuda')
+
+    def run(fn):
+        return fn(x, gp, gs, dp, ds, tw, ids, 2)
+
+    assert nrmse(run(fused_moe_w4a16_cute), run(fused_moe_w4a16)) < .012
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        output = run(fused_moe_w4a16_cute)
+    ids.copy_((ids + 1) % 4)
+    x.normal_()
+    graph.replay()
+    assert nrmse(output, run(fused_moe_w4a16)) < .012
+
+
+@pytest.mark.parametrize('k', [96, 128, 256])
+def test_fp32_scales(k):
+    from lmdeploy.pytorch.kernels.cuda.compressed_tensors_w4a16_cute import _launch_gemm, gather_routed
+    from lmdeploy.pytorch.kernels.cuda.moe.fused_moe import _get_sorted_idx_blocks
+    torch.manual_seed(9)
+    packed, _, _ = weights(2, 96, k)
+    s = torch.rand(2, 96, k // 32, device='cuda') * .03
+    shifts = torch.arange(8, device='cuda', dtype=torch.int32) * 4
+    q = (((packed[..., None] >> shifts) & 15) - 8).flatten(-2)
+    w = (q.float() * s.repeat_interleave(32, -1)).bfloat16()
+    x = torch.randn(3, k, device='cuda', dtype=torch.bfloat16)
+    ids = torch.tensor([[0], [1], [0]], device='cuda')
+    meta = _get_sorted_idx_blocks(ids, 2, 2, 0, 8)
+    padded = gather_routed(x, meta, 1)
+    out = x.new_empty((3, 96))
+    _launch_gemm(padded, packed, s, out, meta, fast_dequant=True)
+    ref = torch.stack([x[r].float() @ w[expert].float().T for r, expert in enumerate(ids.flatten())])
+    assert nrmse(out, ref) < .003


### PR DESCRIPTION
## Motivation

Add a Hopper CuTe DSL W4A16 provider for compressed-tensors MoE without expanding packed INT4 weights into a persistent BF16 cache.

## Modification

- Implement BF16 WGMMA RS with register-side INT4 dequantization, shared-memory BF16 activations and FP32 accumulation.
- Add two-stage TMA buffering, small-batch split-K and route-count-based tile selection.
- Keep `FusedMoEW4A16BuildSpec` and add provider selection through `LMDEPLOY_W4A16_MOE_BACKEND=auto|triton|cute`, defaulting to `auto`. `auto` prefers CuTe when the build-time format, device and optional kernel imports are compatible, and DeepEP is available when EP > 1; otherwise it selects the existing Triton builder. Explicit `cute` is strict; explicit `triton` retains the existing Triton path.
- Support local experts and EP through the existing DeepEP normal/low-latency dispatch and combine paths, including invalid routes and masked expert counts.

Production changes remain limited to three files: the CuTe kernel, CUDA compressed-tensors MoE backend and environment configuration. Three related test files now cover the legacy builder, provider compatibility and Hopper CuTe numerical/graph behavior. Communication optimizations, router changes, documentation, unrelated tests and benchmarks remain excluded.

## BC-breaking

The default is `auto`: unsupported CuTe environments retain the existing Triton builder without requiring a new environment setting. CuTe requires Hopper SM90, BF16 activations/output, INT4 group-size 32 and optional `nvidia-cutlass-dsl` / `cuda-python` dependencies. Explicit `cute` remains strict. Both providers require DeepEP for EP > 1; automatic local-kernel selection does not remove that communication dependency or hide invalid EP configuration errors.

## Use cases

Select the CuTe provider with `LMDEPLOY_W4A16_MOE_BACKEND=cute` for supported compressed-tensors W4A16 MoE models on Hopper. No TP all-reduce or DeepEP communication kernel is replaced by this PR.

## Benchmark

### LMDeploy native Triton W4A16 baseline



- Hardware/software: one NVIDIA H200, PyTorch `2.13.0+cu129`, Triton `3.7.1`, CuTe DSL `4.4.2`, CUDA Python `13.3.1`.
- Workload: Kimi TP8-shard shape, 384 experts, hidden size 7168, per-shard intermediate size 256, top-k 8, INT4 group-size 32. Both paths receive the same packed weights, BF16 activations/scales, FP32 routing weights and INT32 expert IDs, generated with seed `20260908`; `renormalize=False`.
- Timing: complete local MoE, including route preparation where needed, gate/up GEMM, SiLU, down GEMM and weighted reduction. Warm CUDA Graph replay via `triton.testing.do_bench_cudagraph(rep=150)`, no profiler; three samples per shape with alternating implementation order, taking the median of each implementation's samples. Each sample is the mean of ten graph replays. Compilation, input generation, router score/top-k computation and communication are excluded.

| Tokens | CuTe MoE latency (us) | Native Triton MoE latency (us) | Triton / CuTe | Latency reduction |
| -----: | --------------------: | -----------------------------: | ------------: | ----------------: |
|      1 |                22.690 |                         79.698 |        3.512x |            71.53% |
|      8 |                91.890 |                        335.377 |        3.650x |            72.60% |
|     32 |               269.418 |                        771.207 |        2.862x |            65.07% |
|    256 |               604.272 |                       1402.029 |        2.320x |            56.90% |
|   1024 |               844.461 |                       1642.910 |        1.946x |            48.60% |
|   2048 |              1280.327 |                       3015.663 |        2.355x |            57.54% |

CuTe is **1.946x–3.650x faster than the existing LMDeploy Triton implementation** in this sweep. All outputs are finite; maximum output NRMSE versus Triton is `0.003859` (the benchmark checks `< 0.02`). This is a numerical smoke check, not a model-quality evaluation or bitwise-equivalence claim.

This is a **single-GPU local-MoE benchmark at a TP8 shard shape**, not eight-rank TP8 service throughput or EP dispatch/combine performance. Benchmark scripts and raw results remain local, excluded from the PR's code diff. Do not conflate this native-Triton speedup with the separate SGLang Marlin comparison below.

### SGLang Marlin comparison


- Hardware: one NVIDIA H200; workload: Kimi TP8-shard shape, 384 experts, hidden size 7168, per-shard intermediate size 256, top-k 8, INT4 group-size 32, BF16 activations/scales.
- Software: PyTorch `2.13.0+cu129`, Triton `3.7.1`, CuTe DSL `4.4.2`, CUDA Python `13.3.1`. Reference: local SGLang Marlin checkout based on `9e692c9216c3b5e5c443fecf6b995700eb68d2e4`. That checkout has other local changes; the Marlin wrapper, GEMM, repacking and scale-permutation Python files are unmodified.
- Both implementations use identical synthetic weights, activations and precomputed routes, with seed `20260908`. Marlin weight repacking is setup-only.
- Timing: warm CUDA Graph replay using `triton.testing.do_bench_cudagraph(rep=150)`, no profiler; median of three runs, each reporting the mean of ten graph replays. The measured region includes route layout preparation, gather, gate/up GEMM, SiLU, down GEMM and weighted reduction. Router score/top-k computation, compilation, repacking and communication are excluded.

| Tokens | CuTe MoE latency (us) | SGLang Marlin MoE latency (us) | Marlin / CuTe | CuTe latency change |
| -----: | --------------------: | -----------------------------: | ------------: | ------------------: |
|      1 |                22.750 |                         24.005 |        1.055x |              -5.23% |
|      8 |                91.843 |                         80.129 |        0.872x |             +14.62% |
|     32 |               269.476 |                        213.688 |        0.793x |             +26.11% |
|    256 |               603.588 |                        483.793 |        0.802x |             +24.76% |

`Marlin / CuTe > 1` means CuTe is faster. CuTe currently wins only at one token in this sweep. Maximum output NRMSE versus Marlin across the completed runs is `0.008765`; results are not bitwise identical.

These are single-GPU MoE microbenchmarks at a TP8 shard shape, **not eight-rank TP8 service measurements or end-to-end throughput**. A separate 1024-token attempt did not complete the Marlin timing and remained in CUDA synchronization; its benchmark process was stopped. No completed 1024/2048-token Marlin comparison or speedup is reported, and no root cause is asserted for that incomplete run. Benchmark scripts and raw results remain local and are not included in the code diff.

## Validation

- **37 tests passed and one CuTe test module skipped** with the device-capability probe mocked to SM80. This checks A100 provider-selection and collection behavior only; it is not a real A100 numerical run.
- The legacy `hidden_dim=1` builder test explicitly checks `auto`/`triton`. Explicit `cute` still rejects unsupported hardware; CuTe numerical tests skip non-Hopper devices before importing optional CuTe dependencies. The default is now `auto` following review.
- On 2026-09-16, **141 tests passed on H200** in the local working tree after the review changes, covering provider configuration, Triton/CuTe W4A16 kernels and DeepEP regressions. New coverage includes DeepEP-aware compatibility, strict missing-DeepEP errors, NaN-poisoned empty split-K partitions, and full MoE CUDA Graph replay at K=1056. Before changing the kernel, all 12 targeted split/graph cases also passed: the existing epilogue already writes zero accumulators for empty K partitions. The kernel now explicitly clamps their tile count to zero and documents this invariant; no full-buffer zeroing launch was added. Historical benchmark numbers above have not been rerun for this change.
- Ruff, docformatter and `git diff --check` pass.
- The 2026-09-16 mocked-SM80 provider/collection check passed **45 tests**, with the CuTe numerical module skipped. This is not a real A100 GPU run.
- Full upstream CI and the dependency/platform matrix still require verification. No fresh TP8 service run or end-to-end SGLang speedup is claimed.

## Remaining CI / compatibility issues

- The previous PR CI run had 12 failures: one builder regression fixed by the test update above, plus 11 response-format/tool-parser failures also present on main. See the [previous PR job](https://github.com/InternLM/lmdeploy/actions/runs/34324940748/job/102379928988) and the [main-branch job](https://github.com/InternLM/lmdeploy/actions/runs/34338889822/job/102424719121).
- The earlier passing base job used XGrammar 0.2.3; both failing jobs used 0.2.6. These observations point to a separate dependency-compatibility issue. This CuTe PR does not change XGrammar pins or parser behavior, and fixing its builder regression alone does not guarantee a green full CI run.
- The default-provider review concern is addressed by selecting `auto`; explicit `cute` continues to require a compatible environment.
