### PR TITLE
Feat(Pytorch): add mimo-v2-flash support

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ LMDeploy is a toolkit for compressing, deploying, and serving LLM, developed by 
   <li>DeepSeek-V3 (685B)</li>
   <li>DeepSeek-V3.2 (685B)</li>
   <li>DeepSeek-V4 (284B, 1.6T)</li>
+  <li>MiMo-V2-Flash (309B-A15B)</li>
   <li>Hy3 (295B-A21B)</li>
   <li>Mixtral (8x7B, 8x22B)</li>
   <li>Gemma (2B - 7B)</li>

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -153,6 +153,7 @@ LMDeploy TurboMind 引擎拥有卓越的推理能力，在各种规模的模型�
   <li>DeepSeek-V3 (685B)</li>
   <li>DeepSeek-V3.2 (685B)</li>
   <li>DeepSeek-V4 (284B, 1.6T)</li>
+  <li>MiMo-V2-Flash (309B-A15B)</li>
   <li>Hy3 (295B-A21B)</li>
   <li>Mixtral (8x7B, 8x22B)</li>
   <li>Gemma (2B - 7B)</li>

--- a/docs/en/advance/spec_decoding.md
+++ b/docs/en/advance/spec_decoding.md
@@ -104,6 +104,29 @@ deepseek-ai/DeepSeek-V3 \
 --max-batch-size 128
 ```
 
+### MiMo-V2-Flash MTP
+
+MiMo-V2-Flash stores three MTP prediction layers in the target checkpoint, so no separate draft model is required. The following TP 4 configuration is a directly runnable example:
+
+```shell
+lmdeploy serve api_server \
+XiaomiMiMo/MiMo-V2-Flash \
+--backend pytorch \
+--trust-remote-code \
+--tp 4 \
+--session-len 262144 \
+--cache-max-entry-count 0.6 \
+--max-batch-size 128 \
+--speculative-algorithm mimo_mtp \
+--speculative-num-draft-tokens 3
+```
+
+MiMo MTP supports one to three draft tokens per step. TP 4 and TP 8 have been validated. CUDA Graph is enabled by default; prefix caching can be enabled with `--enable-prefix-caching` and uses paged verification without flattening the logical KV sequence.
+
+The full-attention path uses FlashAttention 3 only when the installed implementation supports MiMo's asymmetric Q/K and V head dimensions (192 and 128). Otherwise, LMDeploy selects its Triton implementation before execution.
+
+For an eight-GPU production deployment that combines data-parallel attention and expert parallelism, use `--tp 8 --dp 2 --ep 8 --distributed-executor-backend ray` together with an LMDeploy proxy. This topology has two attention groups of TP 4 while the MoE layers use EP 8.
+
 ## Guided Decoding with Speculative Decoding
 
 Speculative decoding (MTP) can be combined with [structured output](./structed_output.md) so that the draft tokens proposed by the spec model also respect the grammar constraints (e.g. JSON schema, regex). This significantly improves the acceptance rate compared to running spec decoding without grammar masks.

--- a/docs/en/llm/api_server_tools.md
+++ b/docs/en/llm/api_server_tools.md
@@ -1,11 +1,26 @@
 # Tools Calling
 
-LMDeploy supports tools for InternLM2, InternLM2.5, llama3.1 and Qwen2.5 models. Please use `--tool-call-parser` to specify
-which parser to use when launching the api_server. Supported names are:
+LMDeploy supports tool calling for multiple model families. Use `--tool-call-parser` to select the parser that matches the model when launching `api_server`. Common parser names include:
 
 1. internlm
 2. qwen
 3. llama3
+4. mimo
+
+## MiMo-V2-Flash
+
+Start MiMo-V2-Flash with its dedicated parser. The parser converts the model's `<tool_call>` output into the OpenAI-compatible `tool_calls` field and supports complete, streaming and multi-round responses.
+
+```shell
+lmdeploy serve api_server XiaomiMiMo/MiMo-V2-Flash \
+  --backend pytorch \
+  --trust-remote-code \
+  --tp 4 \
+  --reasoning-parser default \
+  --tool-call-parser mimo
+```
+
+The parser is also compatible with `mimo_mtp`; add `--speculative-algorithm mimo_mtp --speculative-num-draft-tokens 3` to enable MTP.
 
 ## Single Round Invocation
 

--- a/docs/en/supported_models/supported_models.md
+++ b/docs/en/supported_models/supported_models.md
@@ -129,7 +129,7 @@ The following tables detail the models supported by LMDeploy's TurboMind engine 
 
 ```{note}
 * [1] PyTorch engine removes the support of original llava models after v0.6.4. Please use their corresponding transformers models instead, which can be found in https://huggingface.co/llava-hf
-* [2] MiMo-V2-Flash is supported with attention TP 4 and TP 8. The checkpoint uses FP8 weights; runtime activations and KV caches require BF16 and the PyTorch CUDA backend.
+* [2] MiMo-V2-Flash currently supports attention TP=4 and TP=8 only. Its checkpoint uses FP8 weight-only quantization; runtime activations and KV cache must use BF16 with the PyTorch CUDA backend.
 Starting from version 0.11.1, PytorchEngine no longer provides support for mllama.
 ```
 

--- a/docs/en/supported_models/supported_models.md
+++ b/docs/en/supported_models/supported_models.md
@@ -92,6 +92,7 @@ The following tables detail the models supported by LMDeploy's TurboMind engine 
 |          DeepSeek-V3           |      685B       | LLM  |    Yes    |   No    |   No    |  No  |  No   |
 |         DeepSeek-V3.2          |      685B       | LLM  |    Yes    |   No    |   No    |  No  |  No   |
 |          DeepSeek-V4           |   284B, 1.6T    | LLM  |    Yes    |   No    |   No    |  No  |  No   |
+| MiMo-V2-Flash<sup>\[2\]</sup>  |    309B-A15B    | LLM  |   BF16    |   No    |   No    | Yes  |  No   |
 |              Hy3               |    295B-A21B    | LLM  |    Yes    |   No    |   No    | Yes  |  No   |
 |          DeepSeek-VL2          |    3B - 27B     | MLLM |    Yes    |   No    |   No    |  No  |  No   |
 |            MiniCPM3            |       4B        | LLM  |    Yes    |   Yes   |   Yes   |  No  |  No   |
@@ -128,6 +129,7 @@ The following tables detail the models supported by LMDeploy's TurboMind engine 
 
 ```{note}
 * [1] PyTorch engine removes the support of original llava models after v0.6.4. Please use their corresponding transformers models instead, which can be found in https://huggingface.co/llava-hf
+* [2] MiMo-V2-Flash is supported with attention TP 4 and TP 8. The checkpoint uses FP8 weights; runtime activations and KV caches require BF16 and the PyTorch CUDA backend.
 Starting from version 0.11.1, PytorchEngine no longer provides support for mllama.
 ```
 

--- a/docs/zh_cn/advance/spec_decoding.md
+++ b/docs/zh_cn/advance/spec_decoding.md
@@ -103,6 +103,29 @@ deepseek-ai/DeepSeek-V3 \
 --max-batch-size 128
 ```
 
+### MiMo-V2-Flash MTP
+
+MiMo-V2-Flash 的 target checkpoint 内含三层 MTP 预测层，因此不需要单独的 draft model。下面是可直接运行的 TP 4 配置：
+
+```shell
+lmdeploy serve api_server \
+XiaomiMiMo/MiMo-V2-Flash \
+--backend pytorch \
+--trust-remote-code \
+--tp 4 \
+--session-len 262144 \
+--cache-max-entry-count 0.6 \
+--max-batch-size 128 \
+--speculative-algorithm mimo_mtp \
+--speculative-num-draft-tokens 3
+```
+
+MiMo MTP 每步支持 1 至 3 个 draft token，TP 4 和 TP 8 均已验证。CUDA Graph 默认启用；可通过 `--enable-prefix-caching` 开启 prefix cache，此组合使用 paged verification，不会展开复制完整的逻辑 KV 序列。
+
+只有已安装的 FlashAttention 3 实现支持 MiMo 非对称的 Q/K 和 V head dimension（分别为 192 和 128）时，Full Attention 才会选择 FA3；否则 LMDeploy 会在执行前选择 Triton 实现。
+
+八卡生产部署如需同时使用 data-parallel attention 和 expert parallelism，请在 LMDeploy proxy 下配置 `--tp 8 --dp 2 --ep 8 --distributed-executor-backend ray`。此拓扑包含两个 attention TP 4 group，MoE 层使用 EP 8。
+
 ## 投机解码与结构化输出
 
 投机解码（MTP）可以与[结构化输出](./structed_output.md)结合使用，使草稿模型提出的 token 也遵循语法约束（如 JSON Schema、正则表达式），从而显著提高接受率。

--- a/docs/zh_cn/llm/api_server_tools.md
+++ b/docs/zh_cn/llm/api_server_tools.md
@@ -1,11 +1,26 @@
 # Tools
 
-LMDeploy 支持 InternLM2, InternLM2.5, Llama3.1 和 Qwen2.5模型的工具调用。请在启动 api_server 的时候使用 `--tool-call-parser` 指定
-parser 名字。以下是支持的名字:
+LMDeploy 支持多个模型系列的工具调用。启动 `api_server` 时，请使用 `--tool-call-parser` 选择与模型匹配的解析器。常用名称包括：
 
 1. internlm
 2. qwen
 3. llama3
+4. mimo
+
+## MiMo-V2-Flash
+
+请使用 MiMo-V2-Flash 专用解析器启动服务。解析器会将模型输出的 `<tool_call>` 转换为 OpenAI 兼容的 `tool_calls` 字段，并支持非流式、流式和多轮响应。
+
+```shell
+lmdeploy serve api_server XiaomiMiMo/MiMo-V2-Flash \
+  --backend pytorch \
+  --trust-remote-code \
+  --tp 4 \
+  --reasoning-parser default \
+  --tool-call-parser mimo
+```
+
+该解析器同样兼容 `mimo_mtp`；添加 `--speculative-algorithm mimo_mtp --speculative-num-draft-tokens 3` 即可开启 MTP。
 
 ## 单轮调用
 

--- a/docs/zh_cn/supported_models/supported_models.md
+++ b/docs/zh_cn/supported_models/supported_models.md
@@ -93,6 +93,7 @@
 |          DeepSeek-V3           |      685B       | LLM  |    Yes    |   No    |   No    |  No  |  No   |
 |         DeepSeek-V3.2          |      685B       | LLM  |    Yes    |   No    |   No    |  No  |  No   |
 |          DeepSeek-V4           |   284B, 1.6T    | LLM  |    Yes    |   No    |   No    |  No  |  No   |
+| MiMo-V2-Flash<sup>\[2\]</sup>  |    309B-A15B    | LLM  |   BF16    |   No    |   No    | Yes  |  No   |
 |              Hy3               |    295B-A21B    | LLM  |    Yes    |   No    |   No    | Yes  |  No   |
 |          DeepSeek-VL2          |    3B - 27B     | MLLM |    Yes    |   No    |   No    |  No  |  No   |
 |            MiniCPM3            |       4B        | LLM  |    Yes    |   Yes   |   Yes   |  No  |  No   |
@@ -129,6 +130,7 @@
 
 ```{note}
 * [1] 自 0.6.4 之后，PyTorch 引擎移除了对 llava 模型原始格式的支持。我们建议使用它们对应的 transformers 格式的模型。这些模型可以在 https://huggingface.co/llava-hf 中找到
+* [2] MiMo-V2-Flash 已验证支持 attention TP 4 和 TP 8。该 checkpoint 使用 FP8 权重；运行时激活和 KV cache 必须使用 BF16，且仅支持 PyTorch CUDA 后端。
 自 0.11.1 起，PytorchEngine 移除了 mllama 的支持
 ```
 

--- a/lmdeploy/cli/utils.py
+++ b/lmdeploy/cli/utils.py
@@ -802,7 +802,7 @@ class ArgumentHelper:
         spec_group.add_argument('--speculative-algorithm',
                                 type=str,
                                 default=None,
-                                choices=['eagle', 'eagle3', 'deepseek_mtp', 'hy3_mtp', 'qwen3_5_mtp'],
+                                choices=['eagle', 'eagle3', 'deepseek_mtp', 'hy3_mtp', 'mimo_mtp', 'qwen3_5_mtp'],
                                 help='The speculative algorithm to use. `None` means speculative decoding is disabled')
 
         spec_group.add_argument('--speculative-draft-model',

--- a/lmdeploy/pytorch/backends/cuda/attention/__init__.py
+++ b/lmdeploy/pytorch/backends/cuda/attention/__init__.py
@@ -7,6 +7,7 @@ from lmdeploy.pytorch.backends.attention import AttentionBuilder
 from lmdeploy.utils import get_logger
 
 from .default import TritonAttentionImpl, TritonAttentionMetadata
+from .fa3_capabilities import fa3_build_supports_head_dims
 from .v4 import TritonV4AttentionBuilder  # noqa: F401
 
 logger = get_logger('lmdeploy')
@@ -34,7 +35,11 @@ def use_fa3_warning():
 
 
 @functools.lru_cache
-def _enable_fa3(alibi: bool, learnable_sink: bool, block_sparse_size: int, head_size: int) -> bool:
+def _enable_fa3(alibi: bool,
+                learnable_sink: bool,
+                block_sparse_size: int,
+                head_size: int,
+                v_head_size: int | None = None) -> bool:
     """Check if FA3 should be enabled.
 
     FA3 is enabled when:
@@ -46,7 +51,8 @@ def _enable_fa3(alibi: bool, learnable_sink: bool, block_sparse_size: int, head_
     Returns:
         True if FA3 should be enabled, False otherwise.
     """
-    enable = not alibi and not learnable_sink and block_sparse_size == 1 and head_size <= 256
+    enable = (not alibi and not learnable_sink and block_sparse_size == 1
+              and fa3_build_supports_head_dims(head_size, v_head_size))
     if enable and not use_fa3_warning():
         enable = False
     return enable
@@ -92,6 +98,7 @@ class TritonAttentionBuilder(AttentionBuilder[TritonAttentionMetadata]):
         mla_index_topk: int | None = None,
         learnable_sink: bool = False,
         block_sparse_size: int = 1,
+        enable_fa3: bool = True,
         **kwargs,
     ) -> TritonAttentionImpl:
         """Build appropriate attention implementation.
@@ -110,6 +117,7 @@ class TritonAttentionBuilder(AttentionBuilder[TritonAttentionMetadata]):
             mla_index_topk: Sparse MLA top-k width, or ``None`` for dense MLA.
             learnable_sink: Whether to use learnable sink tokens.
             block_sparse_size: Block sparse attention size.
+            enable_fa3: Whether this attention configuration may use FA3.
             **kwargs: Additional arguments.
 
         Returns:
@@ -131,7 +139,8 @@ class TritonAttentionBuilder(AttentionBuilder[TritonAttentionMetadata]):
             causal=causal,
             **kwargs,
         )
-        enable_fa3 = _enable_fa3(alibi, learnable_sink, block_sparse_size, head_size)
+        enable_fa3 = enable_fa3 and _enable_fa3(
+            alibi, learnable_sink, block_sparse_size, head_size, v_head_size)
 
         if use_flash_mla is True:
             if mla_index_topk is not None:

--- a/lmdeploy/pytorch/backends/cuda/attention/default.py
+++ b/lmdeploy/pytorch/backends/cuda/attention/default.py
@@ -126,6 +126,7 @@ class TritonAttentionImpl(AttentionImpl[TritonAttentionMetadata]):
         logit_softcapping: float = 0.0,
         causal: bool = True,
         block_sparse_size: int = 1,
+        enable_paged_multi_token_decode: bool = False,
         **kwargs,
     ):
         super().__init__(
@@ -156,6 +157,10 @@ class TritonAttentionImpl(AttentionImpl[TritonAttentionMetadata]):
         self.flash_attention_fwd = flash_attn_varlen_func
 
         self.block_sparse_size = block_sparse_size
+        self.supports_paged_multi_token_decode = (
+            enable_paged_multi_token_decode
+            or getattr(type(self), 'supports_paged_multi_token_decode', False)
+        )
         self._step_meta_group: int | None = None
 
         register_step_metadata_impl(self)
@@ -188,6 +193,9 @@ class TritonAttentionImpl(AttentionImpl[TritonAttentionMetadata]):
     ) -> int:
         """Get max q seqlen."""
         if attn_metadata.is_decoding:
+            if self.supports_paged_multi_token_decode:
+                batch_size = attn_metadata.block_offsets.size(0)
+                return query.size(0) // batch_size
             max_q_seqlen = self.block_sparse_size
         else:
             if attn_metadata.max_q_seqlen is not None:
@@ -293,6 +301,7 @@ class TritonAttentionImpl(AttentionImpl[TritonAttentionMetadata]):
             quant_policy=quant_policy,
             k_scales_zeros=k_scales_zeros,
             v_scales_zeros=v_scales_zeros,
+            causal_multi_token=self.supports_paged_multi_token_decode and max_q_seqlen > 1,
         )
         return attn_output
 
@@ -418,6 +427,10 @@ class TritonAttentionImpl(AttentionImpl[TritonAttentionMetadata]):
         Returns:
             Attention output tensor.
         """
+        kernel_metadata = self.get_step_kernel_metadata(attn_metadata)
+        if kernel_metadata is not None:
+            attn_metadata = kernel_metadata
+
         # Shared preparation
         max_q_seqlen = self._get_max_q_seqlen(query, attn_metadata)
 

--- a/lmdeploy/pytorch/backends/cuda/attention/fa3.py
+++ b/lmdeploy/pytorch/backends/cuda/attention/fa3.py
@@ -263,6 +263,8 @@ class FA3Impl(TritonAttentionImpl):
     - Standard single-token decoding with paged attention
     """
 
+    supports_paged_multi_token_decode = True
+
     def __init__(
         self,
         num_heads: int,

--- a/lmdeploy/pytorch/backends/cuda/attention/fa3_capabilities.py
+++ b/lmdeploy/pytorch/backends/cuda/attention/fa3_capabilities.py
@@ -1,0 +1,53 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+"""FlashAttention-3 build capability detection."""
+
+
+def _get_build_flags() -> dict | None:
+    """Read build flags exported by recent FlashAttention-3 wheels."""
+    try:
+        from flash_attn_config import CONFIG
+        flags = CONFIG['build_flags']
+    except (ImportError, KeyError, TypeError):
+        return None
+    return flags if isinstance(flags, dict) else None
+
+
+def fa3_build_supports_head_dims(head_size: int, v_head_size: int | None = None) -> bool:
+    """Return whether the installed FA3 wheel contains a head shape.
+
+    FA3 wheels may omit template instantiations to reduce build time and binary size. Wheels without exported build
+    metadata are accepted only for symmetric head shapes, preserving compatibility with older packages while avoiding
+    unsafe asymmetric dispatch.
+    """
+    if v_head_size is None:
+        v_head_size = head_size
+
+    flags = _get_build_flags()
+    if flags is None:
+        return head_size == v_head_size and head_size <= 256
+
+    def _disabled(name: str) -> bool:
+        # Older generated configs used FLASH_ATTENTION for HDIMDIFF while the
+        # other flags use FLASHATTENTION. Accept both spellings.
+        aliases = (name, name.replace('FLASHATTENTION_DISABLE_HDIMDIFF',
+                                      'FLASH_ATTENTION_DISABLE_HDIMDIFF'))
+        return any(bool(flags.get(alias, False)) for alias in aliases)
+
+    if head_size <= 64:
+        if _disabled('FLASHATTENTION_DISABLE_HDIM64'):
+            return False
+        return v_head_size <= 64 or (
+            v_head_size <= 512 and not _disabled('FLASHATTENTION_DISABLE_HDIMDIFF64'))
+    if head_size <= 96:
+        return v_head_size <= 96 and not _disabled('FLASHATTENTION_DISABLE_HDIM96')
+    if head_size <= 128:
+        return v_head_size <= 128 and not _disabled('FLASHATTENTION_DISABLE_HDIM128')
+    if head_size <= 192:
+        if _disabled('FLASHATTENTION_DISABLE_HDIM192'):
+            return False
+        if v_head_size <= 128:
+            return not _disabled('FLASHATTENTION_DISABLE_HDIMDIFF192')
+        return v_head_size <= 192
+    if head_size <= 256:
+        return v_head_size <= 256 and not _disabled('FLASHATTENTION_DISABLE_HDIM256')
+    return False

--- a/lmdeploy/pytorch/backends/cuda/attention/swa_state_ring.py
+++ b/lmdeploy/pytorch/backends/cuda/attention/swa_state_ring.py
@@ -1,0 +1,252 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+"""Sliding-window attention backed by a sequence-scoped BF16 state ring."""
+
+from dataclasses import dataclass
+from typing import Any
+
+import torch
+
+
+@dataclass
+class SWAStateRingMetadata:
+    """Layer-invariant sequence layout for an SWA state ring."""
+
+    state_slots: torch.Tensor
+    start_positions: torch.Tensor
+    q_seqlens: torch.Tensor
+    cu_q_seqlens: torch.Tensor
+    history_lens: torch.Tensor
+    kv_seqlens: torch.Tensor
+    cu_kv_seqlens: torch.Tensor
+    max_q_seqlen: int
+    max_kv_seqlen: int
+    window_size: int
+    block_offsets: torch.Tensor
+
+    @classmethod
+    def from_step_context(
+        cls,
+        attn_metadata: Any,
+        step_context: Any,
+        state_slots: torch.Tensor,
+        num_state_slots: int,
+        window_size: int,
+    ) -> 'SWAStateRingMetadata':
+        """Build once per model step, then reuse for all SWA layers."""
+        if attn_metadata is None:
+            raise RuntimeError('SWA state-ring attention requires attention metadata.')
+        if not isinstance(window_size, int) or window_size <= 1:
+            raise ValueError(f'SWA state-ring window_size must be greater than one, got {window_size!r}.')
+
+        q_seqlens = getattr(attn_metadata, 'q_seqlens', None)
+        kv_seqlens = getattr(attn_metadata, 'kv_seqlens', None)
+        if q_seqlens is None or kv_seqlens is None:
+            raise RuntimeError('SWA state-ring attention requires q_seqlens and kv_seqlens.')
+        q_seqlens = q_seqlens.to(dtype=torch.int32)
+        kv_seqlens = kv_seqlens.to(device=q_seqlens.device, dtype=torch.int64)
+        state_slots = state_slots.to(device=q_seqlens.device, dtype=torch.int64)
+        if state_slots.dim() != 1 or state_slots.numel() != q_seqlens.numel():
+            raise ValueError(
+                f'SWA state_slots must have shape [{q_seqlens.numel()}], got {tuple(state_slots.shape)}.'
+            )
+
+        start_positions = kv_seqlens - q_seqlens.to(torch.int64)
+        history_limit = window_size - 1
+        valid_slots = (state_slots >= 0) & (state_slots < num_state_slots) & (start_positions >= 0)
+        history_lens = start_positions.clamp(min=0, max=history_limit).to(torch.int32)
+        history_lens = torch.where(valid_slots, history_lens, 0)
+
+        cu_q_seqlens = torch.zeros(q_seqlens.numel() + 1, dtype=torch.int32, device=q_seqlens.device)
+        torch.cumsum(q_seqlens, dim=0, out=cu_q_seqlens[1:])
+        ring_kv_seqlens = history_lens + q_seqlens
+        cu_kv_seqlens = torch.zeros_like(cu_q_seqlens)
+        torch.cumsum(ring_kv_seqlens, dim=0, out=cu_kv_seqlens[1:])
+
+        max_q_seqlen = getattr(step_context, 'max_q_seqlen', None)
+        if max_q_seqlen is None:
+            max_q_seqlen = getattr(attn_metadata, 'max_q_seqlen', None)
+        if max_q_seqlen is None:
+            # A synchronization-free upper bound.  It is exact for batch=1
+            # and only affects launch metadata for ragged batches.
+            max_q_seqlen = int(step_context.input_ids.numel())
+        max_q_seqlen = int(max_q_seqlen)
+
+        return cls(
+            state_slots=state_slots,
+            start_positions=start_positions,
+            q_seqlens=q_seqlens,
+            cu_q_seqlens=cu_q_seqlens,
+            history_lens=history_lens,
+            kv_seqlens=ring_kv_seqlens,
+            cu_kv_seqlens=cu_kv_seqlens,
+            max_q_seqlen=max_q_seqlen,
+            max_kv_seqlen=max_q_seqlen + history_limit,
+            window_size=window_size,
+            # A ring is one physical page per sequence slot.  Invalid graph
+            # padding slots use page zero; their outputs are discarded and
+            # scatter_swa_state_ring continues to mask their writes.
+            block_offsets=state_slots.clamp(min=0, max=num_state_slots - 1).unsqueeze(1),
+        )
+
+
+def _decode_swa_state_ring(
+    attention,
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    k_ring: torch.Tensor,
+    v_ring: torch.Tensor,
+    metadata: SWAStateRingMetadata,
+    sink: torch.Tensor | None,
+) -> torch.Tensor:
+    """Run single-token decode directly over one ring page per sequence."""
+    from lmdeploy.pytorch.kernels.cuda.swa_state_ring import scatter_swa_state_ring
+
+    # For q=1, overwriting the current modulo slot removes only the token just
+    # outside the causal window.  The remaining ring order is immaterial:
+    # attention has no ALiBi and softmax over one query is permutation
+    # invariant in K/V.  Multi-token chunks still require chronological
+    # flattening for their causal mask and are handled by the fallback below.
+    scatter_swa_state_ring(
+        key,
+        k_ring,
+        metadata.state_slots,
+        metadata.start_positions,
+        metadata.q_seqlens,
+        metadata.cu_q_seqlens,
+        max_q_seqlen=1,
+    )
+    scatter_swa_state_ring(
+        value,
+        v_ring,
+        metadata.state_slots,
+        metadata.start_positions,
+        metadata.q_seqlens,
+        metadata.cu_q_seqlens,
+        max_q_seqlen=1,
+    )
+
+    impl = attention.impl
+    attention._lazy_init(query.device)
+    return impl.paged_attention_fwd(
+        query,
+        k_ring,
+        v_ring,
+        cache_seqlens=metadata.kv_seqlens,
+        page_table=metadata.block_offsets,
+        cu_seqlens_q=metadata.cu_q_seqlens,
+        max_seqlen_q=1,
+        softmax_scale=impl.scale,
+        softcap=impl.logit_softcapping,
+        window_size=metadata.window_size - 1,
+        sinks=sink,
+    )
+
+
+def swa_state_ring_attention(
+    attention,
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    k_ring: torch.Tensor,
+    v_ring: torch.Tensor,
+    metadata: SWAStateRingMetadata,
+    sink: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Attend to chronological ring history plus current K/V, then update
+    it."""
+    if k_ring.size(0) != v_ring.size(0) or k_ring.size(1) != v_ring.size(1):
+        raise ValueError('SWA K/V state rings must have identical state-slot and window dimensions.')
+    if k_ring.size(1) != metadata.window_size:
+        raise ValueError(
+            f'SWA metadata window {metadata.window_size} does not match ring window {k_ring.size(1)}.'
+        )
+
+    impl = attention.impl
+    if not hasattr(impl, 'flash_attention_fwd'):
+        raise RuntimeError(f'SWA state ring requires Triton varlen attention, got {type(impl).__name__}.')
+    if getattr(impl, 'alibi', False):
+        raise RuntimeError('SWA state ring does not support ALiBi.')
+
+    if metadata.max_q_seqlen == 1:
+        return _decode_swa_state_ring(
+            attention,
+            query,
+            key,
+            value,
+            k_ring,
+            v_ring,
+            metadata,
+            sink,
+        )
+
+    # Delay CUDA/Triton kernel imports until a real SWA forward.  Model/config
+    # inspection on a CPU-only host must not initialize the Triton driver.
+    from lmdeploy.pytorch.kernels.cuda.swa_state_ring import (
+        flatten_swa_state_ring,
+        scatter_swa_state_ring,
+    )
+
+    flat_key = flatten_swa_state_ring(
+        k_ring,
+        key,
+        metadata.state_slots,
+        metadata.start_positions,
+        metadata.q_seqlens,
+        metadata.cu_q_seqlens,
+        metadata.history_lens,
+        metadata.cu_kv_seqlens,
+        metadata.max_q_seqlen,
+    )
+    flat_value = flatten_swa_state_ring(
+        v_ring,
+        value,
+        metadata.state_slots,
+        metadata.start_positions,
+        metadata.q_seqlens,
+        metadata.cu_q_seqlens,
+        metadata.history_lens,
+        metadata.cu_kv_seqlens,
+        metadata.max_q_seqlen,
+    )
+
+    attention._lazy_init(query.device)
+    output = impl.flash_attention_fwd(
+        query,
+        flat_key,
+        flat_value,
+        cu_seqlens_q=metadata.cu_q_seqlens,
+        cu_seqlens_k=metadata.cu_kv_seqlens,
+        max_seqlen_q=metadata.max_q_seqlen,
+        max_seqlen_k=metadata.max_kv_seqlen,
+        window_size=metadata.window_size - 1,
+        softmax_scale=impl.scale,
+        softcap=impl.logit_softcapping,
+        causal=True,
+        sinks=sink,
+        alibi_slopes=None,
+        block_sparse_size=impl.block_sparse_size,
+        kv_layout='shd',
+    )
+
+    # Preserve the old ring until the attention kernel has consumed it.  CUDA
+    # stream ordering then makes these writes visible to the next model step.
+    scatter_swa_state_ring(
+        key,
+        k_ring,
+        metadata.state_slots,
+        metadata.start_positions,
+        metadata.q_seqlens,
+        metadata.cu_q_seqlens,
+        max_q_seqlen=metadata.max_q_seqlen,
+    )
+    scatter_swa_state_ring(
+        value,
+        v_ring,
+        metadata.state_slots,
+        metadata.start_positions,
+        metadata.q_seqlens,
+        metadata.cu_q_seqlens,
+        max_q_seqlen=metadata.max_q_seqlen,
+    )
+    return output

--- a/lmdeploy/pytorch/backends/cuda/graph_runner.py
+++ b/lmdeploy/pytorch/backends/cuda/graph_runner.py
@@ -125,6 +125,38 @@ def _build_decode_model_forward(model: torch.nn.Module) -> Callable[..., Any]:
     )
 
 
+def _supports_non_fa3_speculative_graph(model: torch.nn.Module) -> bool:
+    """Resolve the model capability for non-FA3 speculative Graphs."""
+    capability = getattr(model, 'supports_non_fa3_speculative_graph', None)
+    return bool(capability()) if callable(capability) else False
+
+
+def _requires_fa3_for_spec_decode(model: torch.nn.Module, model_config: ModelConfig) -> bool:
+    """Return whether this speculative model requires FA3 CUDA Graphs."""
+    return (
+        model_config.model_paradigm == 'ar_spec'
+        and not getattr(model_config, 'use_flash_mla', False)
+        and not _supports_non_fa3_speculative_graph(model)
+    )
+
+
+def _snapshot_capture_cache(cache: list[torch.Tensor], block_offsets: torch.Tensor,
+                            batch_size: int) -> tuple[torch.Tensor, list[torch.Tensor]]:
+    """Copy request-visible cache blocks before stateful graph capture."""
+    block_ids = torch.unique(block_offsets[:batch_size]).long()
+    snapshot = [tensor.index_select(0, block_ids).clone() for tensor in cache]
+    return block_ids, snapshot
+
+
+def _restore_capture_cache(cache: list[torch.Tensor], block_ids: torch.Tensor,
+                           snapshot: list[torch.Tensor]) -> None:
+    """Restore request-visible cache blocks after graph warmup/capture."""
+    if len(cache) != len(snapshot):
+        raise RuntimeError(f'CUDA Graph cache changed from {len(snapshot)} to {len(cache)} tensors during capture.')
+    for tensor, saved in zip(cache, snapshot):
+        tensor.index_copy_(0, block_ids, saved)
+
+
 class CUDASingleGraphRunner:
     """Cuda single graph runner."""
 
@@ -253,13 +285,9 @@ class CUDAGraphRunner(GraphRunner):
         self.max_batches = cache_config.max_batches
         self.num_blocks = cache_config.num_gpu_blocks
 
-        # Speculative decoding on CUDA requires FlashAttention-3 (FA3),
-        # unless the model uses FlashMLA (e.g., DeepSeek MTP) which handles
-        # multi-token decoding queries natively.
-        # FA3 is available on SM80+ (Ampere and above) GPUs with CUDA >= 12.3.
-        # Without FA3, the Triton paged attention kernel cannot handle
-        # multi-token decoding queries (max_q_seqlen > 1) used in spec decoding.
-        if model_config.model_paradigm == 'ar_spec' and not getattr(model_config, 'use_flash_mla', False):
+        # Most speculative models require FA3 for multi-token decode. Models
+        # with a validated alternative backend may opt out explicitly.
+        if _requires_fa3_for_spec_decode(model, model_config):
             from .attention import use_fa3
             if not use_fa3:
                 sm = torch.cuda.get_device_capability()
@@ -375,7 +403,29 @@ class CUDAGraphRunner(GraphRunner):
                 model_config=self.model_config,
                 device=self.device,
             )
-            output = runner.capture(**kwargs)
+            cache = self.model.get_cudagraph_capture_cache(
+                kwargs['past_key_values'], spec_step_idx=int(kwargs.get('spec_step_idx', 0)))
+            cache_snapshot = None
+            if cache is not None:
+                runtime_meta = kwargs['attn_metadata']
+                batch_size = runtime_meta.q_seqlens.numel()
+                block_ids, cache_snapshot = _snapshot_capture_cache(
+                    cache, runtime_meta.block_offsets, batch_size)
+            try:
+                output = runner.capture(**kwargs)
+            finally:
+                if cache_snapshot is not None:
+                    # Warmup and capture both execute the model. Always undo
+                    # their writes, including when capture raises.
+                    _restore_capture_cache(cache, block_ids, cache_snapshot)
+            if cache_snapshot is not None:
+                try:
+                    # Perform exactly one semantic forward from the restored
+                    # state before making the captured graph discoverable.
+                    output = runner.forward(**kwargs)
+                except Exception:
+                    _restore_capture_cache(cache, block_ids, cache_snapshot)
+                    raise
             self._runner_map[graph_key] = runner
             # SSM would update the state in capture(warmup), replay the graph will leads unexpected state update.
             return output

--- a/lmdeploy/pytorch/configurations/mimo_v2_flash.py
+++ b/lmdeploy/pytorch/configurations/mimo_v2_flash.py
@@ -1,0 +1,206 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+import torch
+
+from lmdeploy.pytorch.config import ModelConfig, StateCacheSpec
+
+from .builder import AutoModelConfigBuilder
+
+
+def _get_mimo_cache_layers(hf_config):
+    """Validate the hybrid pattern and return full/SWA layer partitions."""
+    num_layers = hf_config.num_hidden_layers
+    pattern = list(hf_config.hybrid_layer_pattern)
+    if len(pattern) != num_layers:
+        raise ValueError(
+            'MiMo-V2-Flash hybrid_layer_pattern must contain one entry per layer, '
+            f'but got {len(pattern)} entries for num_hidden_layers={num_layers}.'
+        )
+
+    invalid = sorted(set(pattern) - {0, 1})
+    if invalid:
+        raise ValueError(
+            f'MiMo-V2-Flash hybrid_layer_pattern only supports 0 (full attention) and 1 (SWA), but got {invalid}.'
+        )
+
+    full_layers = [i for i, layer_type in enumerate(pattern) if layer_type == 0]
+    swa_layers = [i for i, layer_type in enumerate(pattern) if layer_type == 1]
+    if not full_layers or not swa_layers:
+        raise ValueError('MiMo-V2-Flash requires both full-attention and SWA layers.')
+    return full_layers, swa_layers
+
+
+def _num_kv_heads_per_rank(num_heads: int, tp: int, attention_type: str) -> int:
+    """Return local KV heads, including replication when TP exceeds KV
+    heads."""
+    if num_heads >= tp:
+        if num_heads % tp != 0:
+            raise ValueError(f'MiMo-V2-Flash {attention_type} KV heads ({num_heads}) must be divisible by TP ({tp}).')
+        return num_heads // tp
+    if tp % num_heads != 0:
+        raise ValueError(f'MiMo-V2-Flash TP ({tp}) must be divisible by {attention_type} KV heads ({num_heads}).')
+    return 1
+
+
+def _update_kv_heads_for_tp(hf_config, *, heads_attr: str, replicate_attr: str, tp: int, attention_type: str) -> int:
+    """Expand KV heads for runtime replication while retaining idempotence."""
+    current_heads = getattr(hf_config, heads_attr)
+    current_replicas = getattr(hf_config, replicate_attr, 1)
+    if current_replicas < 1 or current_heads % current_replicas:
+        raise ValueError(
+            f'Invalid {attention_type} KV replication metadata: '
+            f'heads={current_heads}, replicas={current_replicas}.'
+        )
+    original_heads = current_heads // current_replicas
+    _num_kv_heads_per_rank(original_heads, tp, attention_type)
+    replicas = tp // original_heads if tp > original_heads else 1
+    runtime_heads = original_heads * replicas
+    # Always overwrite both runtime fields. This keeps repeated config builds
+    # idempotent if the same HF config object is reused with a different TP.
+    setattr(hf_config, heads_attr, runtime_heads)
+    setattr(hf_config, replicate_attr, replicas)
+    return runtime_heads
+
+
+def _update_mimo_cache_config(cache_config):
+    """Keep all logical blocks and align named-cache allocation granularity."""
+    # Operator cache requests use the finalized kernel-block granularity.
+    cache_config.kernel_block_size = cache_config.block_size
+    # SWA masking is handled by the model backend. Using DefaultBlockManager
+    # preserves the full-attention history and keeps BlockTrie available.
+    cache_config.window_size = -1
+
+
+class MiMoV2FlashModelConfigBuilder(AutoModelConfigBuilder):
+    """Build MiMo-V2-Flash target or MTP configuration and cache policy."""
+
+    @classmethod
+    def condition(cls, hf_config):
+        """Match MiMo-V2-Flash Hugging Face configurations."""
+        return hf_config.model_type == 'mimo_v2_flash'
+
+    @classmethod
+    def build(
+        cls,
+        hf_config,
+        model_path: str | None = None,
+        tp: int = 1,
+        is_draft_model: bool = False,
+        spec_method: str | None = None,
+        **kwargs,
+    ):
+        """Build the target or three-depth draft model configuration."""
+        _, swa_layers = _get_mimo_cache_layers(hf_config)
+        supported_spec_methods = {'mimo_mtp'}
+        if spec_method is not None and spec_method not in supported_spec_methods:
+            raise ValueError(
+                f'MiMo-V2-Flash only supports speculative method mimo_mtp, got {spec_method!r}.'
+            )
+
+        if is_draft_model:
+            # The official config does not declare the MTP depth, while the
+            # checkpoint index contains model.mtp.layers.{0,1,2}. Keep this
+            # explicit until depth discovery is moved into the weight-index
+            # loader; silently falling back to one layer would load an
+            # incomplete draft model.
+            num_mtp_layers = getattr(hf_config, 'num_nextn_predict_layers', 3)
+            if num_mtp_layers != 3:
+                raise ValueError(f'MiMo-V2-Flash requires 3 MTP prediction-depth layers, got {num_mtp_layers}.')
+            hf_config.num_nextn_predict_layers = num_mtp_layers
+            hf_config.architectures = ['MiMoV2FlashMTPModel']
+            # Remote-code AutoModelForCausalLM still points at the target
+            # model and takes precedence over architectures in the patcher.
+            if hasattr(hf_config, 'auto_map'):
+                del hf_config.auto_map
+
+            num_key_value_heads = _update_kv_heads_for_tp(
+                hf_config,
+                heads_attr='swa_num_key_value_heads',
+                replicate_attr='swa_num_replicate_key_value_heads',
+                tp=tp,
+                attention_type='MTP SWA',
+            )
+            window_size = getattr(hf_config, 'sliding_window_size', getattr(hf_config, 'sliding_window', None))
+            if not isinstance(window_size, int) or window_size <= 0:
+                raise ValueError(f'MiMo-V2-Flash MTP requires a positive integer SWA window size, got {window_size!r}.')
+
+            # MTP owns a separate, rollback-safe paged KV cache. Do not attach
+            # the target model's Full block caches or in-place SWA state ring:
+            # speculative rejection cannot restore overwritten ring slots.
+            return ModelConfig(
+                hidden_size=hf_config.hidden_size,
+                num_layers=num_mtp_layers,
+                num_attention_heads=hf_config.swa_num_attention_heads,
+                num_key_value_heads=num_key_value_heads,
+                bos_token_id=getattr(hf_config, 'bos_token_id', None),
+                eos_token_id=getattr(hf_config, 'eos_token_id', None),
+                head_dim=hf_config.swa_head_dim,
+                k_head_dim=hf_config.swa_head_dim,
+                v_head_dim=hf_config.swa_v_head_dim,
+                sliding_window=window_size,
+                vocab_size=hf_config.vocab_size,
+                model_paradigm='ar_spec',
+                use_standard_kv_cache=True,
+            )
+
+        if getattr(hf_config, 'routed_scaling_factor', None) is None:
+            # The official eager implementation interprets null as 1.0;
+            # LMDeploy's fused noaux_tc router expects a numeric multiplier.
+            hf_config.routed_scaling_factor = 1.0
+        # Target verification writes tentative candidates and may reject a
+        # suffix.  A fixed in-place ring cannot restore history slots that a
+        # candidate overwrote across the modulo boundary, whereas paged KV is
+        # reclaimed by the normal speculative rollback path.
+        hf_config._lmdeploy_use_paged_swa = spec_method in supported_spec_methods
+        num_key_value_heads = _update_kv_heads_for_tp(
+            hf_config,
+            heads_attr='num_key_value_heads',
+            replicate_attr='num_replicate_key_value_heads',
+            tp=tp,
+            attention_type='full-attention',
+        )
+        _update_kv_heads_for_tp(
+            hf_config,
+            heads_attr='swa_num_key_value_heads',
+            replicate_attr='swa_num_replicate_key_value_heads',
+            tp=tp,
+            attention_type='SWA',
+        )
+
+        config = ModelConfig(
+            hidden_size=hf_config.hidden_size,
+            num_layers=hf_config.num_hidden_layers,
+            num_attention_heads=hf_config.num_attention_heads,
+            num_key_value_heads=num_key_value_heads,
+            bos_token_id=getattr(hf_config, 'bos_token_id', None),
+            eos_token_id=getattr(hf_config, 'eos_token_id', None),
+            head_dim=hf_config.head_dim,
+            k_head_dim=hf_config.head_dim,
+            v_head_dim=hf_config.v_head_dim,
+            sliding_window=-1,
+            vocab_size=hf_config.vocab_size,
+            model_paradigm='ar_spec' if spec_method is not None else 'ar',
+            use_standard_kv_cache=False,
+        )
+        if not hf_config._lmdeploy_use_paged_swa:
+            window_size = getattr(hf_config, 'sliding_window_size', getattr(hf_config, 'sliding_window', None))
+            swa_heads = _num_kv_heads_per_rank(hf_config.swa_num_key_value_heads, tp, 'SWA')
+            state_specs = [
+                StateCacheSpec(
+                    'mimo_swa_ring_k',
+                    (window_size, swa_heads, hf_config.swa_head_dim),
+                    torch.bfloat16,
+                    layer_ids=swa_layers,
+                ),
+                StateCacheSpec(
+                    'mimo_swa_ring_v',
+                    (window_size, swa_heads, hf_config.swa_v_head_dim),
+                    torch.bfloat16,
+                    layer_ids=swa_layers,
+                ),
+            ]
+            config.state_cache_specs = state_specs
+            # Keep scheduler state-slot accounting until it consumes named
+            # StateCacheSpec directly.
+            config.states_shapes = [(tuple(spec.shape), spec.dtype) for spec in state_specs]
+        config.update_cache_config_func = _update_mimo_cache_config
+        return config

--- a/lmdeploy/pytorch/distributed.py
+++ b/lmdeploy/pytorch/distributed.py
@@ -493,6 +493,6 @@ def reduce_scatter_by_tp_sizes(out: torch.Tensor, rank: int, tp_sizes: list[int]
     attn_tp = get_dist_manager().current_config().attn_tp
     outs = list(out.split(tp_sizes, -2))
     outs = [item for item in outs for _ in range(attn_tp)]
-    out = outs[rank]
-    dist.reduce_scatter(out, outs, group=group)
-    return out
+    output = torch.empty_like(outs[rank])
+    dist.reduce_scatter(output, outs, group=group)
+    return output

--- a/lmdeploy/pytorch/engine/config_builder.py
+++ b/lmdeploy/pytorch/engine/config_builder.py
@@ -218,7 +218,7 @@ class ConfigBuilder:
         """Build spec decode config."""
         def _build_draft_dist_ctx(dist_config, draft_arch):
             # TODO support tp > 1, ep > 1 for other methods
-            if speculative_config.method in ('deepseek_mtp', 'qwen3_5_mtp', 'hy3_mtp'):
+            if speculative_config.method in ('deepseek_mtp', 'hy3_mtp', 'mimo_mtp', 'qwen3_5_mtp'):
                 draft_dist_config = dist_config
             elif speculative_config.method == 'eagle3' and draft_arch == _EAGLE3_DEEPSEEK_ARCH:
                 draft_dist_config = dist_config
@@ -228,6 +228,14 @@ class ConfigBuilder:
 
         specdecode_config = None
         if speculative_config is not None:
+            if speculative_config.method == 'mimo_mtp':
+                target_hf_config = config_from_pretrained(target_model, trust_remote_code=trust_remote_code)
+                if target_hf_config.model_type != 'mimo_v2_flash':
+                    raise ValueError(
+                        f'mimo_mtp requires a MiMo-V2-Flash target, got {target_hf_config.model_type!r}.')
+                if not 1 <= speculative_config.num_speculative_tokens <= 3:
+                    raise ValueError('MiMo-V2-Flash mimo_mtp requires 1 to 3 draft tokens per step, '
+                                     f'got {speculative_config.num_speculative_tokens}.')
             draft_model = speculative_config.model
             if draft_model and not os.path.exists(speculative_config.model):
                 draft_model = get_model(draft_model, engine_config.download_dir, engine_config.revision)

--- a/lmdeploy/pytorch/kernels/cuda/flashattention.py
+++ b/lmdeploy/pytorch/kernels/cuda/flashattention.py
@@ -535,26 +535,33 @@ def flash_attn_varlen_func(
         assert sinks.numel() == num_heads
 
     BLOCK_DK, BLOCK_DK1, BLOCK_DV = _get_block_d(head_dim_k, head_dim_v)
+    # Kernel resource tuning must account for both Q/K tiles. For a
+    # non-power-of-two head such as MiMo's 192, computation is split into
+    # BLOCK_DK=128 and BLOCK_DK1=64. Tuning from BLOCK_DK alone incorrectly
+    # selects the aggressive 128-dim SM90 config and exceeds shared memory.
+    # Use the padded complete dimension for launch metadata while
+    # retaining the split tiles for the actual computation.
+    meta_block_dk = triton.next_power_of_2(head_dim_k)
 
     shared_kv = k.data_ptr() == v.data_ptr() and BLOCK_DK == BLOCK_DV
 
     num_warps = 4
     hip_mode = getattr(torch.version, 'hip', None) is not None
     if hip_mode:
-        BLOCK_M, BLOCK_N, num_warps, num_stages = _kernel_meta_rocm(BLOCK_DK, shared_kv)
+        BLOCK_M, BLOCK_N, num_warps, num_stages = _kernel_meta_rocm(meta_block_dk, shared_kv)
     else:
         nv_cap = get_device_props(q.device.index)['compute_capability']
         if nv_cap[0] < 8:
-            BLOCK_M, BLOCK_N, num_warps, num_stages = _kernel_meta_sm7x(BLOCK_DK)
+            BLOCK_M, BLOCK_N, num_warps, num_stages = _kernel_meta_sm7x(meta_block_dk)
         elif nv_cap[0] < 9:
             if nv_cap[1] in [6, 9]:
-                BLOCK_M, BLOCK_N, num_warps, num_stages = _kernel_meta_sm86(BLOCK_DK, shared_kv)
+                BLOCK_M, BLOCK_N, num_warps, num_stages = _kernel_meta_sm86(meta_block_dk, shared_kv)
             else:
-                BLOCK_M, BLOCK_N, num_warps, num_stages = _kernel_meta_sm8x(BLOCK_DK, shared_kv)
+                BLOCK_M, BLOCK_N, num_warps, num_stages = _kernel_meta_sm8x(meta_block_dk, shared_kv)
         elif nv_cap[0] < 10:
-            BLOCK_M, BLOCK_N, num_warps, num_stages = _kernel_meta_sm9x(BLOCK_DK, shared_kv)
+            BLOCK_M, BLOCK_N, num_warps, num_stages = _kernel_meta_sm9x(meta_block_dk, shared_kv)
         else:
-            BLOCK_M, BLOCK_N, num_warps, num_stages = _kernel_meta_sm12x(BLOCK_DK, shared_kv)
+            BLOCK_M, BLOCK_N, num_warps, num_stages = _kernel_meta_sm12x(meta_block_dk, shared_kv)
 
     BLOCK_M = min(128, BLOCK_M)
     _flash_prefill_fwd_kernel[grid](

--- a/lmdeploy/pytorch/kernels/cuda/pagedattention.py
+++ b/lmdeploy/pytorch/kernels/cuda/pagedattention.py
@@ -60,6 +60,7 @@ def _fwd_grouped_split_kernel(
     stride_boffb,
     kv_group_num: tl.constexpr,
     seq_len: tl.constexpr,
+    causal_multi_token: tl.constexpr,
     window_size: tl.constexpr,
     head_size: tl.constexpr,
     head_size_v: tl.constexpr,
@@ -91,11 +92,15 @@ def _fwd_grouped_split_kernel(
     mask_h = mask_h & (cur_token < cur_batch * seq_len + seq_len)
     mask_h = mask_h & (cur_head < num_heads_q)
 
-    q_seqlen = 1
     kv_seqlen = tl.load(cache_seqlens_ptr + cur_batch)
     if kv_seqlen <= 0:
         return
-    history_len = kv_seqlen - q_seqlen
+    if causal_multi_token:
+        history_len = kv_seqlen - seq_len
+        query_pos = history_len + cur_token - cur_batch * seq_len
+    else:
+        history_len = kv_seqlen - 1
+        query_pos = history_len
     if alibi_slopes_ptr is not None:
         alibi_slopes = tl.load(alibi_slopes_ptr + cur_head, mask=mask_h, other=1.0) * tl_log2(math.e)
     else:
@@ -134,18 +139,30 @@ def _fwd_grouped_split_kernel(
     l_i = tl.zeros([BLOCK_H], dtype=tl.float32)
     acc = tl.zeros([BLOCK_H, BLOCK_DV], dtype=tl.float32)
 
-    num_total_blocks = tl.cdiv(kv_seqlen, BLOCK_N)
+    first_range_block = 0
+    if causal_multi_token and window_size > 0:
+        # Partition only the union of keys visible to this q-token group.
+        # Splitting the complete context would leave almost every CTA empty
+        # for short sliding-attention windows.
+        first_range_block = tl.maximum(history_len - window_size, 0) // BLOCK_N
+    num_total_blocks = tl.cdiv(kv_seqlen, BLOCK_N) - first_range_block
     BLOCK_PER_CTA = tl.cdiv(num_total_blocks, SPLIT_K)
     kv_len_per_prog = BLOCK_PER_CTA * BLOCK_N
-    loop_start = kv_len_per_prog * split_k_id
+    loop_start = first_range_block * BLOCK_N + kv_len_per_prog * split_k_id
     loop_end = tl.minimum(loop_start + kv_len_per_prog, kv_seqlen)
 
     # load block offset
     # dirty
     start_block_id = loop_start // BLOCK_N
     if window_size > 0:
+        # Every query in a verification group has a different causal/window
+        # boundary. Start from the earliest query's window and apply the exact
+        # per-query lower bound below.
         start_block_id = tl.maximum(history_len - window_size, loop_start) // BLOCK_N
-        kv_min_loc = tl.maximum(history_len - window_size, 0)
+        if causal_multi_token:
+            kv_min_loc = tl.maximum(query_pos - window_size, 0)
+        else:
+            kv_min_loc = tl.maximum(history_len - window_size, 0)
 
     loop_start = start_block_id * BLOCK_N
     block_offset_ptrs += start_block_id
@@ -175,15 +192,16 @@ def _fwd_grouped_split_kernel(
             qk = qk * logit_softcapping
         qk = qk * tl_log2(math.e)
         # NOTE: inf - inf = nan, and nan will leads to error
-        if start_n + BLOCK_N > history_len or window_size > 0:
+        if causal_multi_token:
+            qk_mask = query_pos[:, None] >= (start_n + offs_n[None, :])
+            if window_size > 0:
+                qk_mask = qk_mask & ((start_n + offs_n[None, :]) >= kv_min_loc[:, None])
+            qk = tl.where(qk_mask, qk, -float('inf'))
+        elif start_n + BLOCK_N > history_len or window_size > 0:
             qk_mask = history_len >= (start_n + offs_n)
             if window_size > 0:
                 qk_mask = qk_mask & ((start_n + offs_n) >= kv_min_loc)
-            qk = tl.where(
-                qk_mask[None, :],
-                qk,
-                -float('inf'),
-            )
+            qk = tl.where(qk_mask[None, :], qk, -float('inf'))
 
         if alibi_slopes_ptr is not None:
             relative_pos = kv_seqlen - start_n - offs_n[None, :]
@@ -192,8 +210,11 @@ def _fwd_grouped_split_kernel(
 
         # -- compute p, m_i and l_i
         m_i_new = tl.maximum(m_i, tl.max(qk, 1))
-        p = tl_exp2(qk - m_i_new[:, None])
-        alpha = tl_exp2(m_i - m_i_new)
+        # A causal q>1 tile can be entirely to the right of an early query.
+        # Keep an empty row neutral instead of evaluating -inf - -inf.
+        has_valid_key = m_i_new != -float('inf')
+        p = tl.where(has_valid_key[:, None], tl_exp2(qk - m_i_new[:, None]), 0.0)
+        alpha = tl.where(has_valid_key, tl_exp2(m_i - m_i_new), 1.0)
         l_i_new = alpha * l_i + tl.sum(p, 1)
 
         # -- update output accumulator --
@@ -213,10 +234,11 @@ def _fwd_grouped_split_kernel(
         tl.extra.cuda.gdc_launch_dependents()
 
     # initialize pointers to output
-    if loop_end > loop_start:
-        off_acc = (cur_token[:, None] * stride_obs + split_k_id * stride_ok + cur_head[:, None] * stride_oh +
-                   offs_dv[None, :] * stride_od)
-        tl.store(acc_out_ptr + off_acc, acc, mask=mask_h[:, None] & mask_dv[None, :])
+    # Empty split-K partitions still participate in the reduction. Store the
+    # zero accumulator rather than leaving the workspace uninitialized.
+    off_acc = (cur_token[:, None] * stride_obs + split_k_id * stride_ok + cur_head[:, None] * stride_oh +
+               offs_dv[None, :] * stride_od)
+    tl.store(acc_out_ptr + off_acc, acc, mask=mask_h[:, None] & mask_dv[None, :])
 
     off_meta = (cur_token * stride_obs + split_k_id * stride_ok + cur_head * stride_oh + head_size_v)
     tl.store(acc_out_ptr + off_meta, m_i, mask=mask_h)
@@ -794,10 +816,13 @@ def flash_attn_with_kvcache(
     quant_policy: QuantPolicy = QuantPolicy.NONE,
     sinks: Tensor = None,
     kv_layout: str = 'bshd',
+    causal_multi_token: bool = False,
 ):
     """Paged Attention forward.
 
-    Note that this kernel is decoding-only
+    By default, multiple query tokens retain the historical block-decoding
+    mask. ``causal_multi_token`` opts into ordinary causal verification, where
+    token ``i`` attends through ``history_len + i``.
 
     Args:
         k_scales_zeros: Per-token scale/zero metadata for int KV cache, or
@@ -883,6 +908,11 @@ def flash_attn_with_kvcache(
     seq_len = num_tokens // batch
     if max_seqlen_q is not None:
         assert max_seqlen_q == seq_len, 'we only support decoding paged attention.'
+    if causal_multi_token and seq_len > 1:
+        if quant_policy != QuantPolicy.NONE:
+            raise NotImplementedError('Causal multi-token paged attention does not support quantized KV cache.')
+        if alibi_slopes is not None:
+            raise NotImplementedError('Causal multi-token paged attention does not support ALiBi.')
 
     BLOCK_DMODEL, BLOCK_DMODEL1, BLOCK_DV = _get_block_d(Lq, Lv)
     HEADS_PER_REQ = kv_group_num * seq_len
@@ -1014,6 +1044,7 @@ def flash_attn_with_kvcache(
                                         stride_boffb=page_table.stride(0),
                                         kv_group_num=kv_group_num,
                                         seq_len=seq_len,
+                                        causal_multi_token=causal_multi_token,
                                         window_size=window_size,
                                         head_size=Lk,
                                         head_size_v=Lv,

--- a/lmdeploy/pytorch/kernels/cuda/swa_state_ring.py
+++ b/lmdeploy/pytorch/kernels/cuda/swa_state_ring.py
@@ -1,0 +1,310 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+"""Triton flatten/scatter kernels for BF16 SWA state rings."""
+
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _scatter_swa_state_ring_kernel(
+    tokens_ptr,
+    ring_ptr,
+    state_slots_ptr,
+    start_positions_ptr,
+    q_seqlens_ptr,
+    cu_q_seqlens_ptr,
+    stride_tokens_token,
+    stride_tokens_head,
+    stride_tokens_dim,
+    stride_ring_slot,
+    stride_ring_pos,
+    stride_ring_head,
+    stride_ring_dim,
+    NUM_STATE_SLOTS: tl.constexpr,
+    WINDOW_SIZE: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    BLOCK_DIM: tl.constexpr,
+):
+    batch_id = tl.program_id(0)
+    write_idx = tl.program_id(1)
+    head_idx = tl.program_id(2)
+
+    state_slot = tl.load(state_slots_ptr + batch_id)
+    if state_slot < 0 or state_slot >= NUM_STATE_SLOTS:
+        return
+
+    start_position = tl.load(start_positions_ptr + batch_id)
+    if start_position < 0:
+        return
+
+    q_seqlen = tl.load(q_seqlens_ptr + batch_id)
+    write_len = tl.minimum(q_seqlen, WINDOW_SIZE)
+    if write_idx >= write_len:
+        return
+
+    # If a chunk exceeds the ring capacity, its early tokens cannot be part of
+    # the final state.  Starting at q_seqlen - write_len also prevents two
+    # programs from racing to write the same modulo slot.
+    local_position = q_seqlen - write_len + write_idx
+    token_idx = tl.load(cu_q_seqlens_ptr + batch_id) + local_position
+    absolute_position = start_position + local_position
+    ring_position = absolute_position % WINDOW_SIZE
+
+    dim_offsets = tl.arange(0, BLOCK_DIM)
+    dim_mask = dim_offsets < HEAD_DIM
+    token_offsets = (
+        token_idx.to(tl.int64) * stride_tokens_token
+        + head_idx * stride_tokens_head
+        + dim_offsets * stride_tokens_dim
+    )
+    ring_offsets = (
+        state_slot.to(tl.int64) * stride_ring_slot
+        + ring_position.to(tl.int64) * stride_ring_pos
+        + head_idx * stride_ring_head
+        + dim_offsets * stride_ring_dim
+    )
+    payload = tl.load(tokens_ptr + token_offsets, mask=dim_mask)
+    tl.store(ring_ptr + ring_offsets, payload, mask=dim_mask)
+
+
+@triton.jit
+def _flatten_swa_state_ring_kernel(
+    ring_ptr,
+    current_ptr,
+    output_ptr,
+    state_slots_ptr,
+    start_positions_ptr,
+    q_seqlens_ptr,
+    cu_q_seqlens_ptr,
+    history_lens_ptr,
+    cu_kv_seqlens_ptr,
+    stride_ring_slot,
+    stride_ring_pos,
+    stride_ring_head,
+    stride_ring_dim,
+    stride_current_token,
+    stride_current_head,
+    stride_current_dim,
+    stride_output_token,
+    stride_output_head,
+    stride_output_dim,
+    NUM_STATE_SLOTS: tl.constexpr,
+    WINDOW_SIZE: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    BLOCK_DIM: tl.constexpr,
+):
+    """Pack each sequence as chronological history followed by current KV."""
+    batch_id = tl.program_id(0)
+    sequence_token = tl.program_id(1)
+    head_idx = tl.program_id(2)
+
+    history_len = tl.load(history_lens_ptr + batch_id)
+    q_seqlen = tl.load(q_seqlens_ptr + batch_id)
+    if sequence_token >= history_len + q_seqlen:
+        return
+
+    output_token = tl.load(cu_kv_seqlens_ptr + batch_id) + sequence_token
+    dim_offsets = tl.arange(0, BLOCK_DIM)
+    dim_mask = dim_offsets < HEAD_DIM
+    output_offsets = (
+        output_token.to(tl.int64) * stride_output_token
+        + head_idx * stride_output_head
+        + dim_offsets * stride_output_dim
+    )
+
+    if sequence_token < history_len:
+        state_slot = tl.load(state_slots_ptr + batch_id)
+        start_position = tl.load(start_positions_ptr + batch_id)
+        absolute_position = start_position - history_len + sequence_token
+        ring_position = absolute_position % WINDOW_SIZE
+        source_offsets = (
+            state_slot.to(tl.int64) * stride_ring_slot
+            + ring_position.to(tl.int64) * stride_ring_pos
+            + head_idx * stride_ring_head
+            + dim_offsets * stride_ring_dim
+        )
+        payload = tl.load(ring_ptr + source_offsets, mask=dim_mask)
+    else:
+        current_token = tl.load(cu_q_seqlens_ptr + batch_id) + sequence_token - history_len
+        source_offsets = (
+            current_token.to(tl.int64) * stride_current_token
+            + head_idx * stride_current_head
+            + dim_offsets * stride_current_dim
+        )
+        payload = tl.load(current_ptr + source_offsets, mask=dim_mask)
+    tl.store(output_ptr + output_offsets, payload, mask=dim_mask)
+
+
+def _validate_ring(ring: torch.Tensor) -> None:
+    if ring.dim() != 4:
+        raise ValueError(f'SWA state ring must be [state_slots, window, heads, dim], got {tuple(ring.shape)}.')
+    if ring.dtype != torch.bfloat16:
+        raise TypeError(f'SWA state ring must use torch.bfloat16, got {ring.dtype}.')
+    if not ring.is_cuda:
+        raise ValueError('SWA state-ring kernels require CUDA tensors.')
+    if ring.size(1) <= 1:
+        raise ValueError(f'SWA state-ring window must be greater than one, got {ring.size(1)}.')
+
+
+def _validate_batch_vector(name: str, tensor: torch.Tensor, batch_size: int, device: torch.device) -> None:
+    if tensor.dim() != 1 or tensor.numel() != batch_size:
+        raise ValueError(f'{name} must have shape [{batch_size}], got {tuple(tensor.shape)}.')
+    if tensor.device != device:
+        raise ValueError(f'{name} must be on {device}, got {tensor.device}.')
+    if tensor.dtype not in (torch.int32, torch.int64):
+        raise TypeError(f'{name} must use int32 or int64, got {tensor.dtype}.')
+
+
+def flatten_swa_state_ring(
+    ring: torch.Tensor,
+    current: torch.Tensor,
+    state_slots: torch.Tensor,
+    start_positions: torch.Tensor,
+    q_seqlens: torch.Tensor,
+    cu_q_seqlens: torch.Tensor,
+    history_lens: torch.Tensor,
+    cu_kv_seqlens: torch.Tensor,
+    max_q_seqlen: int,
+) -> torch.Tensor:
+    """Pack chronological ring history and current tokens for varlen attention.
+
+    The output order is ``history_i + current_i`` for every sequence ``i``.
+    Its allocation uses a synchronization-free upper bound; only entries
+    addressed by ``cu_kv_seqlens`` are consumed by varlen attention.
+    """
+    _validate_ring(ring)
+    if current.dim() != 3:
+        raise ValueError(f'current must be [total_q, heads, dim], got {tuple(current.shape)}.')
+    if current.dtype != ring.dtype or current.device != ring.device:
+        raise ValueError('current and ring must have the same BF16 dtype and CUDA device.')
+    if current.shape[1:] != ring.shape[2:]:
+        raise ValueError(
+            f'current head shape {tuple(current.shape[1:])} does not match ring {tuple(ring.shape[2:])}.'
+        )
+    if not isinstance(max_q_seqlen, int) or max_q_seqlen < 0:
+        raise ValueError(f'max_q_seqlen must be a non-negative int, got {max_q_seqlen!r}.')
+
+    batch_size = state_slots.numel()
+    _validate_batch_vector('state_slots', state_slots, batch_size, ring.device)
+    _validate_batch_vector('start_positions', start_positions, batch_size, ring.device)
+    _validate_batch_vector('q_seqlens', q_seqlens, batch_size, ring.device)
+    _validate_batch_vector('history_lens', history_lens, batch_size, ring.device)
+    if cu_q_seqlens.dim() != 1 or cu_q_seqlens.numel() != batch_size + 1:
+        raise ValueError(f'cu_q_seqlens must have shape [{batch_size + 1}], got {tuple(cu_q_seqlens.shape)}.')
+    if cu_kv_seqlens.dim() != 1 or cu_kv_seqlens.numel() != batch_size + 1:
+        raise ValueError(f'cu_kv_seqlens must have shape [{batch_size + 1}], got {tuple(cu_kv_seqlens.shape)}.')
+    for name, cumulative in (('cu_q_seqlens', cu_q_seqlens), ('cu_kv_seqlens', cu_kv_seqlens)):
+        if cumulative.device != ring.device or cumulative.dtype not in (torch.int32, torch.int64):
+            raise ValueError(f'{name} must be an int32/int64 tensor on the ring device.')
+
+    history_limit = ring.size(1) - 1
+    output_capacity = current.size(0) + batch_size * history_limit
+    output = torch.empty(
+        (output_capacity, ring.size(2), ring.size(3)),
+        dtype=ring.dtype,
+        device=ring.device,
+    )
+    if batch_size == 0 or output_capacity == 0:
+        return output
+
+    block_dim = triton.next_power_of_2(ring.size(3))
+    grid = (batch_size, history_limit + max_q_seqlen, ring.size(2))
+    _flatten_swa_state_ring_kernel[grid](
+        ring,
+        current,
+        output,
+        state_slots,
+        start_positions,
+        q_seqlens,
+        cu_q_seqlens,
+        history_lens,
+        cu_kv_seqlens,
+        ring.stride(0),
+        ring.stride(1),
+        ring.stride(2),
+        ring.stride(3),
+        current.stride(0),
+        current.stride(1),
+        current.stride(2),
+        output.stride(0),
+        output.stride(1),
+        output.stride(2),
+        NUM_STATE_SLOTS=ring.size(0),
+        WINDOW_SIZE=ring.size(1),
+        HEAD_DIM=ring.size(3),
+        BLOCK_DIM=block_dim,
+    )
+    return output
+
+
+def scatter_swa_state_ring(
+    tokens: torch.Tensor,
+    ring: torch.Tensor,
+    state_slots: torch.Tensor,
+    start_positions: torch.Tensor,
+    q_seqlens: torch.Tensor,
+    cu_q_seqlens: torch.Tensor,
+    max_q_seqlen: int | None = None,
+) -> None:
+    """Write each chunk's newest tokens into one layer's SWA state ring.
+
+    ``tokens`` is packed by sequence.  Valid state slot IDs must be unique
+    within the batch.  At most the last ``window_size`` tokens of each chunk
+    are written; attention must gather the old state before this function is
+    called.
+    """
+    _validate_ring(ring)
+    if tokens.dim() != 3:
+        raise ValueError(f'tokens must be [total_q, heads, dim], got {tuple(tokens.shape)}.')
+    if tokens.dtype != ring.dtype or tokens.device != ring.device:
+        raise ValueError('tokens and ring must have the same BF16 dtype and CUDA device.')
+    if tokens.size(1) != ring.size(2) or tokens.size(2) != ring.size(3):
+        raise ValueError(
+            f'tokens head shape {tuple(tokens.shape[1:])} does not match ring {tuple(ring.shape[2:])}.'
+        )
+
+    batch_size = state_slots.numel()
+    _validate_batch_vector('state_slots', state_slots, batch_size, ring.device)
+    _validate_batch_vector('start_positions', start_positions, batch_size, ring.device)
+    _validate_batch_vector('q_seqlens', q_seqlens, batch_size, ring.device)
+    if cu_q_seqlens.dim() != 1 or cu_q_seqlens.numel() != batch_size + 1:
+        raise ValueError(
+            f'cu_q_seqlens must have shape [{batch_size + 1}], got {tuple(cu_q_seqlens.shape)}.'
+        )
+    if cu_q_seqlens.device != ring.device or cu_q_seqlens.dtype not in (torch.int32, torch.int64):
+        raise ValueError('cu_q_seqlens must be an int32/int64 tensor on the ring device.')
+    if max_q_seqlen is None:
+        max_q_seqlen = ring.size(1)
+    if not isinstance(max_q_seqlen, int) or max_q_seqlen < 0:
+        raise ValueError(f'max_q_seqlen must be a non-negative int, got {max_q_seqlen!r}.')
+    if batch_size == 0 or tokens.numel() == 0 or max_q_seqlen == 0:
+        return
+
+    window_size = ring.size(1)
+    num_heads = ring.size(2)
+    head_dim = ring.size(3)
+    block_dim = triton.next_power_of_2(head_dim)
+    # Each program with write_idx >= q_seqlen is a no-op.  The caller already
+    # has a synchronization-free q-length upper bound, so do not launch a
+    # full window of programs for the common q=1 decode case.
+    grid = (batch_size, min(window_size, max_q_seqlen), num_heads)
+    _scatter_swa_state_ring_kernel[grid](
+        tokens,
+        ring,
+        state_slots,
+        start_positions,
+        q_seqlens,
+        cu_q_seqlens,
+        tokens.stride(0),
+        tokens.stride(1),
+        tokens.stride(2),
+        ring.stride(0),
+        ring.stride(1),
+        ring.stride(2),
+        ring.stride(3),
+        NUM_STATE_SLOTS=ring.size(0),
+        WINDOW_SIZE=window_size,
+        HEAD_DIM=head_dim,
+        BLOCK_DIM=block_dim,
+    )

--- a/lmdeploy/pytorch/model_inputs.py
+++ b/lmdeploy/pytorch/model_inputs.py
@@ -233,6 +233,8 @@ class ModelInputs:
     logits_indices: torch.LongTensor | None = None
     # Number of compact logprob rows emitted for each sequence.
     seq_logit_length: torch.LongTensor | None = None
+    # Prediction-depth index for multi-layer MTP draft models.
+    spec_step_idx: int = 0
     is_chunk: bool = False
     is_first_chunk: bool = False
     is_last_chunk: bool = False
@@ -261,6 +263,7 @@ class ModelInputs:
             sum_kv_seqlen=self.sum_kv_seqlen + self.max_q_seqlen * self.seq_length.numel(),
             logits_indices=None,
             seq_logit_length=None,
+            spec_step_idx=self.spec_step_idx + 1,
             mrope_pos_ids=mrope_pos_ids,
         )
 
@@ -345,6 +348,7 @@ class StepContext:
     # for draft model
     target_hidden_states: torch.Tensor | None = None
     target_inputs_embeds: torch.Tensor | None = None
+    spec_step_idx: int = 0
 
     # states for ssm
     state_caches: list | None = None
@@ -432,6 +436,7 @@ class StepContext:
             state_offsets=inputs.state_offsets,
             target_hidden_states=inputs.target_hidden_states,
             target_inputs_embeds=inputs.target_inputs_embeds,
+            spec_step_idx=inputs.spec_step_idx,
             mrope_position_ids=inputs.mrope_pos_ids,
             is_chunk_multimodal=inputs.is_chunk_multimodal,
             is_dummy=inputs.is_dummy,

--- a/lmdeploy/pytorch/models/deepseek_mtp.py
+++ b/lmdeploy/pytorch/models/deepseek_mtp.py
@@ -287,6 +287,7 @@ class DeepseekMTPModel(nn.Module, CudaGraphMixin):
             attn_metadata=attn_metadata,
             inputs_embeds=inputs_embeds,
             target_hidden_states=target_hidden_states,
+            spec_step_idx=context.spec_step_idx,
         )
 
     def _load_weight_experts(self, name: str, loaded_weight: torch.Tensor, params_dict: dict[str, nn.Parameter],

--- a/lmdeploy/pytorch/models/mimo_v2_flash.py
+++ b/lmdeploy/pytorch/models/mimo_v2_flash.py
@@ -1,0 +1,930 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+import torch
+import torch.distributed as dist
+from torch import nn
+
+from lmdeploy.pytorch.distributed import get_dist_manager, get_ep_world_rank, get_tp_world_rank
+from lmdeploy.pytorch.engine.cache_engine.schema import BlockCacheBinding, BlockCacheRequest, BlockCacheRequestContext
+from lmdeploy.pytorch.model_inputs import StepContext, StepContextManager
+from lmdeploy.pytorch.nn import ApplyRotaryEmb, Attention, RMSNorm, SiluAndMul, build_rotary_embedding
+from lmdeploy.pytorch.nn.eplb import EPLBManager
+from lmdeploy.pytorch.nn.linear import build_down_linear, build_gateup_linear, build_o_proj, build_qkv_proj
+from lmdeploy.pytorch.weight_loader.model_weight_loader import default_weight_loader, load_weight
+
+from .deepseek_v2 import DeepseekV2MoE
+from .patch import add_prefix, get_build_model_context
+from .utils.cudagraph import CudaGraphMixin
+from .utils.model import DeployModelMixinV1, build_embedding
+
+if TYPE_CHECKING:
+    from lmdeploy.pytorch.backends.cuda.attention.swa_state_ring import SWAStateRingMetadata
+
+
+def _mimo_swa_kernel_window(total_window_size: int) -> tuple[int, int]:
+    """Translate MiMo's total causal window into kernel bounds."""
+    if not isinstance(total_window_size, int) or total_window_size <= 0:
+        raise ValueError(f'MiMo requires a positive total SWA window, got {total_window_size!r}.')
+    # Kernel bounds are inclusive of the current causal token.
+    return total_window_size - 1, 0
+
+
+def _get_norm_eps(config: Any) -> float:
+    """Read the native or remote-code MiMo RMSNorm epsilon field."""
+    norm_eps = getattr(config, 'rms_norm_eps', None)
+    if norm_eps is None:
+        norm_eps = config.layernorm_epsilon
+    return norm_eps
+
+
+def _reduce_tp_output(linear: nn.Module, output: torch.Tensor) -> torch.Tensor:
+    """Reduce one MiMo row-parallel output."""
+    if linear.tp > 1:
+        dist.all_reduce(output, group=linear.tp_group)
+    return output
+
+
+def _load_attention_sink(param: nn.Parameter, loaded_weight: torch.Tensor):
+    """Load this rank's Q-head slice of an attention sink vector."""
+    world_size, rank = get_tp_world_rank('attn')
+    if loaded_weight.size(0) % world_size != 0:
+        raise ValueError(f'Cannot shard {loaded_weight.size(0)} MiMo sink heads over TP={world_size}.')
+    loaded_weight = loaded_weight.chunk(world_size, dim=0)[rank]
+    default_weight_loader(param, loaded_weight)
+
+
+def _load_native_qkv_shard(
+    target_prefix: str,
+    tensor_kind: str,
+    loaded_weight: torch.Tensor,
+    params_dict: dict[str, nn.Parameter],
+    shard_id: str,
+) -> None:
+    """Load one official MiMo blocked-FP8 QKV tensor into a fused
+    projection."""
+    target_param = params_dict[f'{target_prefix}.weight']
+    target_scale = params_dict.get(f'{target_prefix}.weight_scale_inv')
+    fp8_dtypes = (torch.float8_e4m3fn, torch.float8_e5m2)
+    if target_scale is None or target_param.dtype not in fp8_dtypes:
+        raise TypeError(f'MiMo QKV target {target_prefix!r} must use native blocked-FP8 parameters.')
+    if tensor_kind == 'weight':
+        if loaded_weight.dtype not in fp8_dtypes:
+            raise TypeError(f'MiMo QKV checkpoint weight must use FP8, got {loaded_weight.dtype}.')
+        target = target_param
+    elif tensor_kind == 'scale':
+        target = target_scale
+    else:
+        raise ValueError(f'Unsupported MiMo QKV tensor kind: {tensor_kind!r}.')
+    load_weight(target, loaded_weight, shard_id=shard_id)
+
+
+@dataclass
+class MiMoV2Caches:
+    """Named Full-Attention block caches and SWA state rings."""
+
+    block_caches: Any
+    state_caches: Any
+
+    def state_cache(self, cache_name: str, layer_idx: int) -> torch.Tensor:
+        """Resolve a compact named-state row by global layer index."""
+        return self.state_caches.layer(cache_name, layer_idx)
+
+
+class MiMoV2Attention(nn.Module):
+    """Common MiMo-V2 QKV projection, partial RoPE and output projection."""
+
+    def __init__(
+        self,
+        config: Any,
+        is_swa: bool,
+        block_cache_prefix: str | None = None,
+        enable_paged_verification: bool = False,
+        quantize_o_proj: bool = True,
+        dtype: torch.dtype | None = None,
+        device: torch.device | None = None,
+        prefix: str = '',
+    ):
+        super().__init__()
+        self._block_cache_prefix = block_cache_prefix
+        self._block_cache_bindings: dict[str, BlockCacheBinding] = {}
+        self._cache_dtype = dtype
+        quantization_config = getattr(config, 'quantization_config', None)
+        if is_swa:
+            self.head_dim = config.swa_head_dim
+            self.v_head_dim = config.swa_v_head_dim
+            num_heads = config.swa_num_attention_heads
+            num_kv_heads = config.swa_num_key_value_heads
+            num_replicate_kv_heads = getattr(config, 'swa_num_replicate_key_value_heads', 1)
+            total_window_size = getattr(config, 'sliding_window_size', getattr(config, 'sliding_window', None))
+            sliding_window = _mimo_swa_kernel_window(total_window_size)
+            has_sink = getattr(config, 'add_swa_attention_sink_bias', False)
+        else:
+            self.head_dim = config.head_dim
+            self.v_head_dim = config.v_head_dim
+            num_heads = config.num_attention_heads
+            num_kv_heads = config.num_key_value_heads
+            num_replicate_kv_heads = getattr(config, 'num_replicate_key_value_heads', 1)
+            sliding_window = None
+            has_sink = getattr(config, 'add_full_attention_sink_bias', False)
+
+        self.v_scale = getattr(config, 'attention_value_scale', None)
+        self.rotary_dim = int(self.head_dim * config.partial_rotary_factor)
+        if self.rotary_dim <= 0 or self.rotary_dim > self.head_dim or self.rotary_dim % 2 != 0:
+            raise ValueError(f'Invalid MiMo-V2 rotary dimension: {self.rotary_dim}.')
+
+        # MiMo resets its blocked-FP8 output grid at four equal checkpoint
+        # sections. Inside each Full-Attention section, Q/K/V are quantized as one
+        # fused output: K's final scale block covers K[128:192] and V[0:64].
+        # SWA projection boundaries are block aligned and retain the ordinary
+        # per-projection planner (including TP8 sub-shard alignment).
+        checkpoint_quantization_sections = 4
+        if num_replicate_kv_heads < 1 or num_kv_heads % num_replicate_kv_heads:
+            raise ValueError(
+                'MiMo runtime KV heads must be divisible by their replication factor, '
+                f'got heads={num_kv_heads} and replicas={num_replicate_kv_heads}.'
+            )
+        checkpoint_num_kv_heads = num_kv_heads // num_replicate_kv_heads
+        checkpoint_output_shard_sizes = (
+            num_heads * self.head_dim // checkpoint_quantization_sections,
+            checkpoint_num_kv_heads * self.head_dim // checkpoint_quantization_sections,
+            checkpoint_num_kv_heads * self.v_head_dim // checkpoint_quantization_sections,
+        )
+        self.qkv_proj = build_qkv_proj(
+            config.hidden_size,
+            num_q_heads=num_heads,
+            num_kv_heads=num_kv_heads,
+            head_size=self.head_dim,
+            head_size_v=self.v_head_dim,
+            bias=config.attention_bias,
+            quant_config=quantization_config,
+            dtype=dtype,
+            device=device,
+            num_replicate_kv_heads=num_replicate_kv_heads,
+            checkpoint_output_shard_sizes=checkpoint_output_shard_sizes,
+            continuous_qkv_scale_layout=not is_swa,
+            prefix=add_prefix('qkv_proj', prefix),
+        )
+        self.apply_rotary_pos_emb = ApplyRotaryEmb()
+        enable_paged_multi_token_decode = bool(
+            enable_paged_verification or getattr(config, '_lmdeploy_use_paged_swa', False)
+        )
+        self.attn_fwd = Attention(
+            num_heads,
+            self.head_dim,
+            num_kv_heads=num_kv_heads,
+            v_head_size=self.v_head_dim,
+            sliding_window=sliding_window,
+            learnable_sink=has_sink,
+            # Full Attention can use FA3 when its wheel contains the asymmetric
+            # Q/K=192, V=128 instantiation. SWA remains on the MiMo-specific
+            # Triton/ring path because it also implements attention sinks.
+            enable_fa3=not is_swa,
+            enable_paged_multi_token_decode=enable_paged_multi_token_decode,
+        )
+        # MiMo verification reads the page table directly for both Full and
+        # SWA attention. This avoids a logical-KV-sized flatten workspace and
+        # remains valid when prefix caching shares physical cache blocks.
+        self.use_native_paged_verification = bool(
+            getattr(self.attn_fwd.impl, 'supports_paged_multi_token_decode', False)
+        )
+        self.attention_sink_bias = None
+        if has_sink:
+            self.attention_sink_bias = nn.Parameter(
+                torch.empty(self.qkv_proj.num_q_heads, dtype=dtype, device=device),
+                requires_grad=False,
+            )
+            self.attention_sink_bias.weight_loader = _load_attention_sink
+        self.o_proj = build_o_proj(
+            num_heads * self.v_head_dim,
+            config.hidden_size,
+            bias=False,
+            # MTP o_proj is serialized in BF16 and is not covered by the
+            # target model's ignored-layer names in quantization_config.
+            # Let the MTP wrapper explicitly request the BF16 module while
+            # preserving the target model's existing construction.
+            quant_config=quantization_config if quantize_o_proj else None,
+            dtype=dtype,
+            device=device,
+            is_tp=True,
+            # Keep reduction outside the linear so MiMo uses the same explicit
+            # tensor-parallel group for attention, dense FFN and MoE outputs.
+            all_reduce=False,
+            prefix=add_prefix('o_proj', prefix),
+        )
+
+    def get_block_cache_requests(self, context: BlockCacheRequestContext) -> tuple[BlockCacheRequest, ...]:
+        """Declare this attention layer's pageable K/V payloads."""
+        if self._block_cache_prefix is None:
+            return ()
+        if not isinstance(self._cache_dtype, torch.dtype):
+            raise TypeError(f'MiMo block caches require a concrete torch dtype, got {self._cache_dtype!r}.')
+        block_size = context.geometry.kernel_block_size
+        num_kv_heads = self.qkv_proj.num_kv_heads
+        return (
+            BlockCacheRequest(
+                name=f'{self._block_cache_prefix}_k',
+                shape=(block_size, num_kv_heads, self.head_dim),
+                dtype=self._cache_dtype,
+            ),
+            BlockCacheRequest(
+                name=f'{self._block_cache_prefix}_v',
+                shape=(block_size, num_kv_heads, self.v_head_dim),
+                dtype=self._cache_dtype,
+            ),
+        )
+
+    def bind_block_cache(self, binding: BlockCacheBinding) -> None:
+        """Bind one cache name to the collector-assigned consumer row."""
+        prefix = self._block_cache_prefix
+        expected = {f'{prefix}_k', f'{prefix}_v'} if prefix is not None else set()
+        if binding.cache_name not in expected:
+            raise ValueError(f'Unexpected MiMo block cache binding: {binding.cache_name!r}.')
+        if binding.cache_name in self._block_cache_bindings:
+            raise RuntimeError(f'MiMo block cache {binding.cache_name!r} was bound more than once.')
+        self._block_cache_bindings[binding.cache_name] = binding
+
+    def get_block_cache(self, block_caches) -> tuple[torch.Tensor, torch.Tensor]:
+        """Resolve the K/V rows bound to this attention layer."""
+        prefix = self._block_cache_prefix
+        if prefix is None:
+            raise RuntimeError('This MiMo attention layer does not own a pageable block cache.')
+        rows = []
+        for suffix in ('k', 'v'):
+            cache_name = f'{prefix}_{suffix}'
+            try:
+                binding = self._block_cache_bindings[cache_name]
+            except KeyError as e:
+                raise RuntimeError(f'MiMo block cache {cache_name!r} has not been bound.') from e
+            rows.append(block_caches.row(binding.cache_name, binding.consumer_row))
+        return rows[0], rows[1]
+
+    def _project_output(self, attn_output: torch.Tensor) -> torch.Tensor:
+        """Apply o_proj and its tensor-parallel reduction."""
+        output = self.o_proj(attn_output)
+        return _reduce_tp_output(self.o_proj, output)
+
+    def _project_qkv(
+        self,
+        hidden_states: torch.Tensor,
+        rotary_pos_emb: tuple[torch.Tensor, torch.Tensor],
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Project QKV, apply partial RoPE and scale V before caching."""
+        qkv_states = self.qkv_proj(hidden_states).flatten(0, -2)
+        query_states, key_states, value_states = self.qkv_proj.split_qkv(qkv_states)
+
+        # MiMo rotates only the leading rotary_dim features. Passing the views
+        # explicitly also keeps the default backend valid; broadcasting a
+        # rotary_dim-wide cos/sin table over the complete 192 features would
+        # be incorrect.
+        query_rope = query_states[..., : self.rotary_dim]
+        key_rope = key_states[..., : self.rotary_dim]
+        cos, sin = rotary_pos_emb
+        self.apply_rotary_pos_emb(query_rope, key_rope, cos, sin, inplace=True)
+        if self.v_scale is not None:
+            # Scale before either block/ring cache writes so current attention,
+            # decode and prefix restore share one V representation.
+            value_states = value_states * self.v_scale
+        return query_states, key_states, value_states
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        rotary_pos_emb: tuple[torch.Tensor, torch.Tensor],
+        past_key_value: tuple[torch.Tensor, torch.Tensor],
+        attn_metadata: Any,
+    ) -> torch.Tensor:
+        """Run attention over a pageable KV cache."""
+        query_states, key_states, value_states = self._project_qkv(hidden_states, rotary_pos_emb)
+
+        # ar_spec target verification sends multiple causal queries while
+        # retaining the scheduler's decoding flag. MiMo reads them directly
+        # from paged KV; flattening would duplicate shared-prefix blocks and
+        # make CUDA Graph workspace capacity depend on logical KV volume.
+        batch_size = attn_metadata.block_offsets.size(0)
+        is_verification = attn_metadata.is_decoding and query_states.size(0) > batch_size
+        if is_verification and not self.use_native_paged_verification:
+            raise RuntimeError('MiMo verification requires native paged multi-token attention.')
+
+        attn_output = self.attn_fwd(
+            query_states,
+            key_states,
+            value_states,
+            past_key_value[0],
+            past_key_value[1],
+            attn_metadata,
+            s_aux=self.attention_sink_bias,
+            inplace=True,
+        )
+        attn_output = attn_output.reshape(*hidden_states.shape[:-1], -1)
+        return self._project_output(attn_output)
+
+
+class MiMoV2FullAttention(MiMoV2Attention):
+    """MiMo-V2 full attention backed by the named paged KV cache."""
+
+    def __init__(self, config: Any, **kwargs):
+        super().__init__(config, is_swa=False, **kwargs)
+
+
+class MiMoV2SWAAttention(MiMoV2Attention):
+    """SWA attention backed by a sequence-scoped BF16 state ring."""
+
+    def __init__(self, config: Any, **kwargs):
+        super().__init__(config, is_swa=True, **kwargs)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        rotary_pos_emb: tuple[torch.Tensor, torch.Tensor],
+        state_cache: tuple[torch.Tensor, torch.Tensor],
+        swa_metadata: SWAStateRingMetadata,
+    ) -> torch.Tensor:
+        """Run varlen attention over chronological ring history and current
+        KV."""
+        from lmdeploy.pytorch.backends.cuda.attention.swa_state_ring import swa_state_ring_attention
+
+        query_states, key_states, value_states = self._project_qkv(hidden_states, rotary_pos_emb)
+        attn_output = swa_state_ring_attention(
+            self.attn_fwd,
+            query_states,
+            key_states,
+            value_states,
+            state_cache[0],
+            state_cache[1],
+            swa_metadata,
+            sink=self.attention_sink_bias,
+        )
+        attn_output = attn_output.reshape(*hidden_states.shape[:-1], -1)
+        return self._project_output(attn_output)
+
+
+class MiMoV2MLP(nn.Module):
+    """Dense SwiGLU block used by MiMo-V2-Flash."""
+
+    def __init__(
+        self,
+        config: Any,
+        intermediate_size: int | None = None,
+        dtype: torch.dtype | None = None,
+        device: torch.device | None = None,
+        prefix: str = '',
+    ):
+        super().__init__()
+        if intermediate_size is None:
+            intermediate_size = config.intermediate_size
+        quantization_config = getattr(config, 'quantization_config', None)
+
+        # The official checkpoint stores gate_proj and up_proj separately.
+        # LMDeploy packs them into one column-parallel projection; SiluAndMul
+        # consumes the packed [gate, up] output without changing the math.
+        self.gate_up_proj = build_gateup_linear(
+            config.hidden_size,
+            [intermediate_size, intermediate_size],
+            bias=False,
+            dtype=dtype,
+            device=device,
+            quant_config=quantization_config,
+            is_tp=True,
+            prefix=add_prefix('gate_up_proj', prefix),
+        )
+        self.act_fn = SiluAndMul(inplace=True)
+        self.down_proj = build_down_linear(
+            intermediate_size,
+            config.hidden_size,
+            bias=False,
+            dtype=dtype,
+            device=device,
+            quant_config=quantization_config,
+            is_tp=True,
+            # Keep the framework reduction enabled.  In DP+TP mode this is a
+            # reduce-scatter that restores each DP rank's local token layout;
+            # replacing it with a plain all-reduce leaves gathered tokens in
+            # the output and breaks the residual shape in the next layer.
+            all_reduce=True,
+            prefix=add_prefix('down_proj', prefix),
+        )
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        """Apply down_proj(silu(gate_proj(x)) * up_proj(x))."""
+        gate_up = self.gate_up_proj(hidden_states)
+        return self.down_proj(self.act_fn(gate_up))
+
+
+class MiMoV2MoE(DeepseekV2MoE):
+    """MiMo-V2 MoE using LMDeploy's fused DeepSeek-style execution path."""
+
+    def forward(self, hidden_states: torch.Tensor, all_routed_experts: torch.Tensor = None):
+        """Run fused experts and reduce their output over MiMo TP."""
+        batch_size, sequence_length, hidden_dim = hidden_states.shape
+        hidden_states = hidden_states.view(-1, hidden_dim)
+        routed_experts = None
+        if all_routed_experts is not None:
+            routed_experts = all_routed_experts[:, self.layer_idx, :]
+        topk_weights, topk_ids = self.gate(hidden_states, routed_experts=routed_experts)
+
+        out_states = self.experts(hidden_states, topk_weights, topk_ids)
+        if self.shared_experts is not None:
+            out_states += self.shared_experts(hidden_states)
+        out_states = out_states.reshape(batch_size, sequence_length, -1)
+
+        # DeepEP combine already returns the complete routed-expert output.
+        # With EP enabled ``moe_tp`` is one and its placeholder process group
+        # is None; reducing it would therefore use WORLD and sum an already
+        # complete tensor once per EP rank.
+        if self._all_reduce and self.experts.tp > 1:
+            dist.all_reduce(out_states, group=self.experts.tp_group)
+        return out_states
+
+
+class MiMoV2DecoderLayer(nn.Module):
+    """MiMo-V2 decoder layer with per-layer attention and FFN selection."""
+
+    def __init__(
+        self,
+        config: Any,
+        layer_idx: int,
+        dtype: torch.dtype | None = None,
+        device: torch.device | None = None,
+        prefix: str = '',
+    ):
+        super().__init__()
+        self.layer_idx = layer_idx
+        self.is_swa = config.hybrid_layer_pattern[layer_idx] == 1
+        self.is_moe = getattr(config, 'n_routed_experts', None) is not None and bool(config.moe_layer_freq[layer_idx])
+        quantization_config = getattr(config, 'quantization_config', None)
+
+        self.use_paged_swa = self.is_swa and getattr(config, '_lmdeploy_use_paged_swa', False)
+        if self.use_paged_swa:
+            self.self_attn = MiMoV2Attention(
+                config,
+                is_swa=True,
+                block_cache_prefix='mimo_swa_paged',
+                dtype=dtype,
+                device=device,
+                prefix=add_prefix('self_attn', prefix),
+            )
+        else:
+            attention_cls = MiMoV2SWAAttention if self.is_swa else MiMoV2FullAttention
+            self.self_attn = attention_cls(
+                config,
+                block_cache_prefix=None if self.is_swa else 'mimo_full',
+                dtype=dtype,
+                device=device,
+                prefix=add_prefix('self_attn', prefix),
+            )
+        if self.is_moe:
+            self.mlp = MiMoV2MoE(config, layer_idx, dtype=dtype, device=device)
+        else:
+            self.mlp = MiMoV2MLP(
+                config,
+                dtype=dtype,
+                device=device,
+                prefix=add_prefix('mlp', prefix),
+            )
+
+        norm_eps = _get_norm_eps(config)
+        self.input_layernorm = RMSNorm(
+            config.hidden_size,
+            norm_eps,
+            quant_config=quantization_config,
+            dtype=dtype,
+            device=device,
+            prefix=add_prefix('input_layernorm', prefix),
+        )
+        self.post_attention_layernorm = RMSNorm(
+            config.hidden_size,
+            norm_eps,
+            quant_config=quantization_config,
+            dtype=dtype,
+            device=device,
+            prefix=add_prefix('post_attention_layernorm', prefix),
+        )
+
+        if self.is_swa and not self.use_paged_swa:
+            self.k_cache_name = 'mimo_swa_ring_k'
+            self.v_cache_name = 'mimo_swa_ring_v'
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        rotary_pos_emb: tuple[torch.Tensor, torch.Tensor],
+        caches: MiMoV2Caches,
+        residual: torch.Tensor | None = None,
+        attn_metadata: Any = None,
+        swa_metadata: SWAStateRingMetadata | None = None,
+        all_routed_experts: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Run pre-norm attention and FFN while carrying fused residual."""
+        if residual is None:
+            residual = hidden_states
+            hidden_states = self.input_layernorm(hidden_states)
+        else:
+            hidden_states, residual = self.input_layernorm(hidden_states, residual)
+        if self.is_swa and not self.use_paged_swa:
+            if swa_metadata is None:
+                raise RuntimeError('MiMo SWA layer requires state-ring attention metadata.')
+            state_cache = (
+                caches.state_cache(self.k_cache_name, self.layer_idx),
+                caches.state_cache(self.v_cache_name, self.layer_idx),
+            )
+            hidden_states = self.self_attn(
+                hidden_states=hidden_states,
+                rotary_pos_emb=rotary_pos_emb,
+                state_cache=state_cache,
+                swa_metadata=swa_metadata,
+            )
+        else:
+            past_key_value = self.self_attn.get_block_cache(caches.block_caches)
+            hidden_states = self.self_attn(
+                hidden_states=hidden_states,
+                rotary_pos_emb=rotary_pos_emb,
+                past_key_value=past_key_value,
+                attn_metadata=attn_metadata,
+            )
+        hidden_states, residual = self.post_attention_layernorm(hidden_states, residual)
+        if self.is_moe:
+            hidden_states = self.mlp(hidden_states, all_routed_experts=all_routed_experts)
+        else:
+            hidden_states = self.mlp(hidden_states)
+        return hidden_states, residual
+
+
+class MiMoV2Model(nn.Module):
+    """MiMo-V2 transformer body using heterogeneous named caches."""
+
+    def __init__(
+        self,
+        config: Any,
+        dtype: torch.dtype | None = None,
+        device: torch.device | None = None,
+        prefix: str = '',
+    ):
+        super().__init__()
+        if dtype is not torch.bfloat16:
+            raise ValueError(f'MiMo-V2-Flash only supports torch.bfloat16, but got {dtype}.')
+        self.config = config
+        self.padding_idx = getattr(config, 'pad_token_id', None)
+        self.vocab_size = config.vocab_size
+
+        if len(config.hybrid_layer_pattern) != config.num_hidden_layers:
+            raise ValueError('MiMo-V2 hybrid_layer_pattern must contain one entry per decoder layer.')
+        if len(config.moe_layer_freq) != config.num_hidden_layers:
+            raise ValueError('MiMo-V2 moe_layer_freq must contain one entry per decoder layer.')
+
+        self.embed_tokens = build_embedding(
+            config.vocab_size,
+            config.hidden_size,
+            self.padding_idx,
+            dtype=dtype,
+            device=device,
+            is_tp=True,
+        )
+
+        if get_dist_manager().current_context().dist_config.enable_eplb:
+            ep_size, _ = get_ep_world_rank()
+            EPLBManager.init_global_eplb_metadata(
+                ep_size=ep_size,
+                num_routed_experts=config.n_routed_experts,
+                num_hidden_layers=config.num_hidden_layers,
+            )
+
+        self.layers = nn.ModuleList(
+            [
+                MiMoV2DecoderLayer(
+                    config,
+                    layer_idx,
+                    dtype=dtype,
+                    device=device,
+                    prefix=add_prefix(f'layers.{layer_idx}', prefix),
+                )
+                for layer_idx in range(config.num_hidden_layers)
+            ]
+        )
+        norm_eps = _get_norm_eps(config)
+        self.norm = RMSNorm(
+            config.hidden_size,
+            norm_eps,
+            dtype=dtype,
+            device=device,
+            prefix=add_prefix('norm', prefix),
+        )
+
+        rotary_kwargs = dict(
+            max_position_embeddings=config.max_position_embeddings,
+            partial_rotary_factor=config.partial_rotary_factor,
+            device=device,
+        )
+        self.rotary_emb = build_rotary_embedding(
+            dim=config.head_dim,
+            base=config.rope_theta,
+            **rotary_kwargs,
+        )
+        self.swa_rotary_emb = build_rotary_embedding(
+            dim=config.swa_head_dim,
+            base=config.swa_rope_theta,
+            **rotary_kwargs,
+        )
+
+    def forward(
+        self,
+        input_ids: torch.LongTensor | None,
+        position_ids: torch.LongTensor,
+        caches: MiMoV2Caches,
+        attn_metadata: Any = None,
+        swa_metadata: SWAStateRingMetadata | None = None,
+        inputs_embeds: torch.Tensor | None = None,
+        all_routed_experts: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        """Run all decoder layers with layer-appropriate RoPE and caches."""
+        if inputs_embeds is None:
+            inputs_embeds = self.embed_tokens(input_ids)
+        hidden_states = inputs_embeds
+
+        full_cos, full_sin = self.rotary_emb(hidden_states, position_ids)
+        swa_cos, swa_sin = self.swa_rotary_emb(hidden_states, position_ids)
+        full_rotary_pos_emb = (full_cos[0], full_sin[0])
+        swa_rotary_pos_emb = (swa_cos[0], swa_sin[0])
+
+        residual = None
+        for decoder_layer in self.layers:
+            rotary_pos_emb = swa_rotary_pos_emb if decoder_layer.is_swa else full_rotary_pos_emb
+            hidden_states, residual = decoder_layer(
+                hidden_states,
+                rotary_pos_emb=rotary_pos_emb,
+                caches=caches,
+                residual=residual,
+                attn_metadata=attn_metadata,
+                swa_metadata=swa_metadata,
+                all_routed_experts=all_routed_experts,
+            )
+        hidden_states, _ = self.norm(hidden_states, residual)
+        return hidden_states
+
+    def get_input_embeddings(self):
+        """Return the token embedding module."""
+        return self.embed_tokens
+
+
+class MiMoV2FlashForCausalLM(nn.Module, DeployModelMixinV1, CudaGraphMixin):
+    """MiMo-V2-Flash causal LM with named caches and FP8 checkpoint loading."""
+
+    packed_modules_mapping = {
+        'qkv_proj': ['q_proj', 'k_proj', 'v_proj'],
+        'gate_up_proj': ['gate_proj', 'up_proj'],
+    }
+
+    def supports_non_fa3_speculative_graph(self) -> bool:
+        """Allow MiMo verification to use native Triton paged attention."""
+        return True
+
+    def _prefix_cache_graph_is_safe(self) -> bool:
+        """Return whether this MiMo step can safely replay with shared blocks.
+
+        The speculative target reads both Full and SWA KV through page tables, so shared physical blocks do not expand a
+        Graph workspace. Target-only SWA rings still need prefix state checkpoint/restore; keep only that distinct
+        stateful combination eager.
+        """
+        context = self.ctx_mgr.current_context()
+        if not context.cache_config.enable_prefix_caching:
+            return True
+        return bool(getattr(self.config, '_lmdeploy_use_paged_swa', False))
+
+    def support_cuda_graph(
+        self,
+        input_ids: torch.Tensor,
+        position_ids: torch.Tensor,
+        past_key_values: list[list[torch.Tensor]],
+        attn_metadata: Any = None,
+        inputs_embeds: torch.Tensor | None = None,
+        **kwargs,
+    ) -> bool:
+        """Use verification graphs only with the MiMo metadata contract."""
+        batch_size = attn_metadata.block_offsets.size(0)
+        if not self._prefix_cache_graph_is_safe():
+            return False
+        step_meta_plan = getattr(self.ctx_mgr, 'backend_step_meta_plan', None)
+        if input_ids.numel() > batch_size and not getattr(step_meta_plan, 'is_supported', False):
+            return False
+        return super().support_cuda_graph(
+            input_ids,
+            position_ids,
+            past_key_values,
+            attn_metadata=attn_metadata,
+            inputs_embeds=inputs_embeds,
+            **kwargs,
+        )
+
+    def get_cudagraph_capture_cache(self,
+                                    past_key_values: list[list[torch.Tensor]],
+                                    **kwargs) -> list[torch.Tensor] | None:
+        """Return MiMo's paged target-cache rows for capture rollback.
+
+        MiMo keeps heterogeneous Full/SWA caches on ``StepContext`` instead
+        of ``past_key_values``. Returning per-layer views keeps the generic
+        graph runner's block dimension at axis zero while covering every
+        cache row touched by target verification.
+        """
+        del past_key_values, kwargs
+        if not getattr(self.config, '_lmdeploy_use_paged_swa', False):
+            return None
+        context = self.ctx_mgr.current_context()
+        if context.block_caches is None:
+            raise RuntimeError('MiMo CUDA Graph capture requires named block caches.')
+        capture_caches = []
+        for layer in self.model.layers:
+            capture_caches.extend(layer.self_attn.get_block_cache(context.block_caches))
+        return capture_caches
+
+    def __init__(
+        self,
+        config: Any,
+        ctx_mgr: StepContextManager,
+        dtype: torch.dtype | None = None,
+        device: torch.device | None = None,
+        prefix: str = '',
+    ):
+        super().__init__()
+        self.config = config
+        self.ctx_mgr = ctx_mgr
+        self.model = MiMoV2Model(
+            config,
+            dtype=dtype,
+            device=device,
+            prefix=add_prefix('model', prefix),
+        )
+        self.lm_head = self.build_lm_head(
+            config.hidden_size,
+            config.vocab_size,
+            bias=False,
+            dtype=dtype,
+            device=device,
+        )
+        self.enable_return_routed_experts = get_build_model_context().enable_return_routed_experts
+        self._first_swa_layer = next(
+            (layer_id for layer_id, layer_type in enumerate(config.hybrid_layer_pattern) if layer_type == 1),
+            None,
+        )
+        if self._first_swa_layer is None:
+            raise ValueError('MiMo-V2 requires at least one SWA layer.')
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        position_ids: torch.Tensor,
+        past_key_values: list[list[torch.Tensor]] | None = None,
+        attn_metadata: Any = None,
+        inputs_embeds: torch.Tensor | None = None,
+        state_ids: torch.Tensor | None = None,
+        **kwargs,
+    ):
+        """Resolve named caches once, then execute the transformer body."""
+        context = self.ctx_mgr.current_context()
+        if context.block_caches is None:
+            raise RuntimeError('MiMo-V2 requires named block caches in the current StepContext.')
+        use_paged_swa = getattr(self.config, '_lmdeploy_use_paged_swa', False)
+        if not use_paged_swa:
+            if context.named_state_caches is None:
+                raise RuntimeError('MiMo-V2 requires named SWA state caches in the current StepContext.')
+            if state_ids is None:
+                raise RuntimeError('MiMo-V2 requires state_ids to provide stable SWA ring slots.')
+        caches = MiMoV2Caches(
+            block_caches=context.block_caches,
+            state_caches=context.named_state_caches,
+        )
+        swa_metadata = None
+        if not use_paged_swa:
+            from lmdeploy.pytorch.backends.cuda.attention.swa_state_ring import SWAStateRingMetadata
+
+            first_swa_ring = context.named_state_caches.layer('mimo_swa_ring_k', self._first_swa_layer)
+            swa_metadata = SWAStateRingMetadata.from_step_context(
+                attn_metadata,
+                context,
+                state_ids,
+                num_state_slots=first_swa_ring.size(0),
+                window_size=first_swa_ring.size(1),
+            )
+
+        all_routed_experts = None
+        if self.enable_return_routed_experts:
+            num_tokens = inputs_embeds.size(1) if inputs_embeds is not None else input_ids.size(1)
+            all_routed_experts = position_ids.new_full(
+                (num_tokens, self.config.num_hidden_layers, self.config.num_experts_per_tok),
+                torch.iinfo(torch.uint16).max,
+                dtype=torch.uint16,
+            )
+
+        hidden_states = self.model(
+            input_ids=input_ids,
+            position_ids=position_ids,
+            caches=caches,
+            attn_metadata=attn_metadata,
+            inputs_embeds=inputs_embeds,
+            swa_metadata=swa_metadata,
+            all_routed_experts=all_routed_experts,
+        )
+        if all_routed_experts is None:
+            return hidden_states
+        return dict(hidden_states=hidden_states, all_routed_experts=all_routed_experts)
+
+    def get_input_embeddings(self):
+        """Return the model token embedding module."""
+        return self.model.get_input_embeddings()
+
+    def prepare_inputs_for_generation(
+        self,
+        past_key_values: list[list[torch.Tensor]],
+        inputs_embeds: torch.Tensor | None = None,
+        context: StepContext | None = None,
+    ):
+        """Prepare the standard engine inputs; named caches live on context."""
+        return dict(
+            input_ids=context.input_ids,
+            position_ids=context.position_ids,
+            past_key_values=past_key_values,
+            attn_metadata=context.attn_metadata,
+            inputs_embeds=inputs_embeds,
+            state_ids=context.state_offsets,
+        )
+
+    def _load_qkv_weight(
+        self,
+        name: str,
+        loaded_weight: torch.Tensor,
+        params_dict: dict[str, nn.Parameter],
+        shard_id: str,
+    ):
+        """Load one native blocked-FP8 Q/K/V weight or scale shard."""
+        if name.endswith('.weight_scale_inv'):
+            source_prefix = name.removesuffix('.weight_scale_inv')
+            tensor_kind = 'scale'
+        elif name.endswith('.weight'):
+            source_prefix = name.removesuffix('.weight')
+            tensor_kind = 'weight'
+        else:
+            raise KeyError(f'Unexpected MiMo QKV tensor name: {name}')
+
+        target_prefix = re.sub(r'\.(q|k|v)_proj$', '.qkv_proj', source_prefix)
+        _load_native_qkv_shard(target_prefix, tensor_kind, loaded_weight, params_dict, shard_id)
+
+    @staticmethod
+    def _load_expert_weight(name: str, loaded_weight: torch.Tensor, params_dict: dict[str, nn.Parameter]):
+        """Map one checkpoint expert tensor to the fused MoE parameter."""
+        match = re.match(
+            r'^(.*\.experts)\.(\d+)\.(gate_proj|up_proj|down_proj)\.(weight|weight_scale_inv)$',
+            name,
+        )
+        if match is None:
+            raise KeyError(f'Unexpected MiMo expert tensor name: {name}')
+        experts_prefix, expert_id, projection, suffix = match.groups()
+        if projection == 'gate_proj':
+            target_projection, shard_id = 'gate_up', 'gate'
+        elif projection == 'up_proj':
+            target_projection, shard_id = 'gate_up', 'up'
+        else:
+            target_projection, shard_id = 'down', 'down'
+        param = params_dict[f'{experts_prefix}.{target_projection}.{suffix}']
+        load_weight(param, loaded_weight, expert_id=int(expert_id), shard_id=shard_id)
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]):
+        """Load main-model weights and deliberately isolate MTP tensors."""
+        stacked_params_mapping = [
+            ('.qkv_proj', '.q_proj', 'q'),
+            ('.qkv_proj', '.k_proj', 'k'),
+            ('.qkv_proj', '.v_proj', 'v'),
+            ('.gate_up_proj', '.gate_proj', 0),
+            ('.gate_up_proj', '.up_proj', 1),
+        ]
+        params_dict = dict(self.named_parameters())
+        for name, loaded_weight in weights:
+            if name.startswith('model.mtp.'):
+                # MTP has an independent model/cache lifecycle and loader.
+                continue
+            if 'rotary_emb.inv_freq' in name or 'rotary_emb.cos_cached' in name or 'rotary_emb.sin_cached' in name:
+                continue
+            if self.config.tie_word_embeddings and name == 'lm_head.weight':
+                continue
+            if '.experts.' in name:
+                self._load_expert_weight(name, loaded_weight, params_dict)
+                continue
+
+            for param_name, weight_name, shard_id in stacked_params_mapping:
+                if weight_name not in name:
+                    continue
+                if weight_name in ('.q_proj', '.k_proj', '.v_proj'):
+                    self._load_qkv_weight(name, loaded_weight, params_dict, shard_id)
+                else:
+                    target_name = name.replace(weight_name, param_name)
+                    load_weight(params_dict[target_name], loaded_weight, shard_id=shard_id)
+                break
+            else:
+                try:
+                    param = params_dict[name]
+                except KeyError as error:
+                    raise KeyError(f'Unexpected MiMo-V2-Flash weight: {name}') from error
+                load_weight(param, loaded_weight)

--- a/lmdeploy/pytorch/models/mimo_v2_flash_mtp.py
+++ b/lmdeploy/pytorch/models/mimo_v2_flash_mtp.py
@@ -1,0 +1,483 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+import re
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Any
+
+import torch
+from torch import nn
+
+from lmdeploy.pytorch.model_inputs import StepContext, StepContextManager
+from lmdeploy.pytorch.nn import RMSNorm, build_rotary_embedding
+from lmdeploy.pytorch.nn.linear import build_colwise_linear
+from lmdeploy.pytorch.weight_loader.model_weight_loader import load_weight
+
+from .mimo_v2_flash import MiMoV2Attention, MiMoV2MLP, _get_norm_eps, _load_native_qkv_shard
+from .patch import add_prefix
+from .utils.cudagraph import CudaGraphMeta, CudaGraphMixin
+
+
+class MiMoV2FlashMTPLayer(nn.Module):
+    """One MiMo prediction-depth layer backed by paged SWA KV."""
+
+    def __init__(
+        self,
+        config: Any,
+        layer_idx: int,
+        dtype: torch.dtype | None = None,
+        device: torch.device | None = None,
+        prefix: str = '',
+    ):
+        super().__init__()
+        self.layer_idx = layer_idx
+        quantization_config = getattr(config, 'quantization_config', None)
+        norm_eps = _get_norm_eps(config)
+
+        self.enorm = RMSNorm(
+            config.hidden_size,
+            norm_eps,
+            dtype=dtype,
+            device=device,
+            prefix=add_prefix('enorm', prefix),
+        )
+        self.hnorm = RMSNorm(
+            config.hidden_size,
+            norm_eps,
+            dtype=dtype,
+            device=device,
+            prefix=add_prefix('hnorm', prefix),
+        )
+        # Checkpoint eh_proj is BF16 even though the dense MLP is FP8.
+        self.eh_proj = build_colwise_linear(
+            config.hidden_size * 2,
+            config.hidden_size,
+            bias=False,
+            dtype=dtype,
+            device=device,
+            is_tp=False,
+            quant_config=None,
+            dp_disable_tp=True,
+            prefix=add_prefix('eh_proj', prefix),
+        )
+
+        block_prefix = add_prefix('mtp_block', prefix)
+        self.self_attn = MiMoV2Attention(
+            config,
+            is_swa=True,
+            enable_paged_verification=True,
+            quantize_o_proj=False,
+            dtype=dtype,
+            device=device,
+            prefix=add_prefix('self_attn', block_prefix),
+        )
+        self.mlp = MiMoV2MLP(
+            config,
+            dtype=dtype,
+            device=device,
+            prefix=add_prefix('mlp', block_prefix),
+        )
+        self.input_layernorm = RMSNorm(
+            config.hidden_size,
+            norm_eps,
+            quant_config=quantization_config,
+            dtype=dtype,
+            device=device,
+            prefix=add_prefix('input_layernorm', block_prefix),
+        )
+        self.post_attention_layernorm = RMSNorm(
+            config.hidden_size,
+            norm_eps,
+            quant_config=quantization_config,
+            dtype=dtype,
+            device=device,
+            prefix=add_prefix('post_attention_layernorm', block_prefix),
+        )
+        self.final_layernorm = RMSNorm(
+            config.hidden_size,
+            norm_eps,
+            dtype=dtype,
+            device=device,
+            prefix=add_prefix('final_layernorm', prefix),
+        )
+
+        self.rotary_emb = build_rotary_embedding(
+            dim=config.swa_head_dim,
+            max_position_embeddings=config.max_position_embeddings,
+            base=config.swa_rope_theta,
+            partial_rotary_factor=config.partial_rotary_factor,
+            device=device,
+        )
+
+    def forward(
+        self,
+        position_ids: torch.Tensor,
+        previous_hidden_states: torch.Tensor,
+        past_key_value: list[torch.Tensor],
+        inputs_embeds: torch.Tensor,
+        attn_metadata: Any = None,
+    ) -> torch.Tensor:
+        """Fuse target state and run one dense SWA decoder layer."""
+        hidden_states = self.eh_proj(
+            torch.cat(
+                [self.enorm(inputs_embeds), self.hnorm(previous_hidden_states)],
+                dim=-1,
+            )
+        )
+        residual = hidden_states
+        hidden_states = self.input_layernorm(hidden_states)
+
+        cos, sin = self.rotary_emb(hidden_states, position_ids)
+        hidden_states = self.self_attn(
+            hidden_states,
+            rotary_pos_emb=(cos[0], sin[0]),
+            past_key_value=past_key_value,
+            attn_metadata=attn_metadata,
+        )
+        hidden_states, residual = self.post_attention_layernorm(hidden_states, residual)
+        hidden_states = self.mlp(hidden_states)
+        return hidden_states + residual
+
+
+class MiMoV2FlashMultiTokenPredictor(nn.Module):
+    """Three checkpoint prediction depths sharing target embed/head."""
+
+    def __init__(
+        self,
+        config: Any,
+        dtype: torch.dtype | None = None,
+        device: torch.device | None = None,
+        prefix: str = '',
+    ):
+        super().__init__()
+        self.num_mtp_layers = config.num_nextn_predict_layers
+        if self.num_mtp_layers != 3:
+            raise ValueError(f'MiMo-V2-Flash requires 3 MTP layers, got {self.num_mtp_layers}.')
+        self.embed_tokens = None
+        self.layers = nn.ModuleDict(
+            {
+                str(layer_idx): MiMoV2FlashMTPLayer(
+                    config,
+                    layer_idx,
+                    dtype=dtype,
+                    device=device,
+                    prefix=add_prefix(f'layers.{layer_idx}', prefix),
+                )
+                for layer_idx in range(self.num_mtp_layers)
+            }
+        )
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        position_ids: torch.Tensor,
+        previous_hidden_states: torch.Tensor,
+        past_key_values: list[list[torch.Tensor]],
+        inputs_embeds: torch.Tensor | None = None,
+        attn_metadata: Any = None,
+        spec_step_idx: int = 0,
+    ) -> torch.Tensor:
+        """Run the prediction layer and cache selected by ``spec_step_idx``."""
+        current_step_idx = spec_step_idx % self.num_mtp_layers
+        if inputs_embeds is None:
+            if self.embed_tokens is None:
+                raise RuntimeError('MiMo MTP input embedding has not been bound to the target model.')
+            inputs_embeds = self.embed_tokens(input_ids)
+        return self.layers[str(current_step_idx)](
+            position_ids,
+            previous_hidden_states,
+            past_key_values[current_step_idx],
+            inputs_embeds,
+            attn_metadata=attn_metadata,
+        )
+
+    def prepare_hidden_states_for_logits(
+        self,
+        hidden_states: torch.Tensor,
+        spec_step_idx: int = 0,
+    ) -> torch.Tensor:
+        """Apply the final norm belonging to the active prediction depth."""
+        current_step_idx = spec_step_idx % self.num_mtp_layers
+        return self.layers[str(current_step_idx)].final_layernorm(hidden_states)
+
+    def set_input_embeddings(self, embed_tokens: nn.Module):
+        """Bind the target model's shared token embedding."""
+        self.embed_tokens = embed_tokens
+
+    def get_input_embeddings(self):
+        """Return the target-owned shared token embedding."""
+        return self.embed_tokens
+
+
+class MiMoV2FlashMTPModel(nn.Module, CudaGraphMixin):
+    """MiMo-V2-Flash draft model for multi-token speculative decoding."""
+
+    packed_modules_mapping = {
+        'qkv_proj': ['q_proj', 'k_proj', 'v_proj'],
+        'gate_up_proj': ['gate_proj', 'up_proj'],
+    }
+
+    def supports_non_fa3_speculative_graph(self) -> bool:
+        """Allow MiMo draft graphs to use native Triton paged attention."""
+        return True
+
+    def get_cudagraph_capture_cache(self,
+                                    past_key_values: list[list[torch.Tensor]],
+                                    spec_step_idx: int = 0) -> list[torch.Tensor]:
+        """Return the active depth cache that Graph capture must preserve."""
+        depth = spec_step_idx % self.model.num_mtp_layers
+        return past_key_values[depth]
+
+    def get_cudagraph_extra_key(
+        self,
+        spec_step_idx: int = 0,
+        input_ids: torch.Tensor | None = None,
+        attn_metadata: Any = None,
+        **kwargs,
+    ) -> tuple[int]:
+        """Select a stable Graph for each MiMo prediction depth.
+
+        ``spec_step_idx`` selects both a decoder module and its KV-cache
+        entry.  As a Python scalar it cannot be changed by copying tensor
+        inputs before graph replay, so it must participate in the graph key.
+
+        Query length already participates in the generic Graph key. Keeping
+        this key independent of rank-local KV length prevents one DP rank from
+        inserting capture-time TP collectives while another rank replays.
+        """
+        del input_ids, attn_metadata, kwargs
+        return (spec_step_idx % self.model.num_mtp_layers, )
+
+    def get_cudagraph_warmup_specs(self, max_query_len: int) -> tuple[tuple[int, int], ...]:
+        """Return every query-length and prediction-depth graph used at
+        runtime."""
+        return tuple(
+            (query_len, depth)
+            for query_len in range(1, max_query_len + 1)
+            for depth in range(self.model.num_mtp_layers)
+        )
+
+    @staticmethod
+    def select_weight_paths(model_path: str, default_paths: Iterable[str]) -> tuple[str, ...]:
+        """Select the standalone MiMo MTP checkpoint instead of target
+        shards."""
+        del default_paths
+        mtp_path = Path(model_path) / 'model_mtp.safetensors'
+        if not mtp_path.is_file():
+            raise FileNotFoundError(f'MiMo MTP checkpoint was not found: {mtp_path}')
+        return (str(mtp_path),)
+
+    _MTP_TENSOR_SUFFIXES = frozenset(
+        {
+            'enorm.weight',
+            'hnorm.weight',
+            'eh_proj.weight',
+            'input_layernorm.weight',
+            'pre_mlp_layernorm.weight',
+            'final_layernorm.weight',
+            'self_attn.q_proj.weight',
+            'self_attn.q_proj.weight_scale_inv',
+            'self_attn.k_proj.weight',
+            'self_attn.k_proj.weight_scale_inv',
+            'self_attn.v_proj.weight',
+            'self_attn.v_proj.weight_scale_inv',
+            'self_attn.o_proj.weight',
+            'self_attn.attention_sink_bias',
+            'mlp.gate_proj.weight',
+            'mlp.gate_proj.weight_scale_inv',
+            'mlp.up_proj.weight',
+            'mlp.up_proj.weight_scale_inv',
+            'mlp.down_proj.weight',
+            'mlp.down_proj.weight_scale_inv',
+        }
+    )
+
+    def __init__(
+        self,
+        config: Any,
+        ctx_mgr: StepContextManager,
+        dtype: torch.dtype | None = None,
+        device: torch.device | None = None,
+    ):
+        super().__init__()
+        if dtype is not torch.bfloat16:
+            raise ValueError(f'MiMo-V2-Flash MTP only supports torch.bfloat16, but got {dtype}.')
+        self.config = config
+        self.dtype = dtype
+        self.ctx_mgr = ctx_mgr
+        self.model = MiMoV2FlashMultiTokenPredictor(
+            config,
+            dtype=dtype,
+            device=device,
+            prefix='model',
+        )
+
+    def set_input_embeddings(self, embed_tokens: nn.Module):
+        """Bind the target model's shared token embedding."""
+        self.model.set_input_embeddings(embed_tokens)
+
+    def get_input_embeddings(self):
+        """Return the target-owned shared token embedding."""
+        return self.model.get_input_embeddings()
+
+    def prepare_inputs_for_generation(
+        self,
+        past_key_values: list[list[torch.Tensor]],
+        inputs_embeds: torch.Tensor | None = None,
+        context: StepContext | None = None,
+    ):
+        """Prepare the active MTP depth's inputs from the step context."""
+        if context is None:
+            raise ValueError('MiMo MTP requires a StepContext.')
+        if context.target_inputs_embeds is not None:
+            inputs_embeds = context.target_inputs_embeds
+        return {
+            'input_ids': context.input_ids,
+            'position_ids': context.position_ids,
+            'past_key_values': past_key_values,
+            'attn_metadata': context.attn_metadata,
+            'inputs_embeds': inputs_embeds,
+            'target_hidden_states': context.target_hidden_states,
+            'spec_step_idx': context.spec_step_idx,
+        }
+
+    def make_buffers_cudagraph(self, graph_meta: CudaGraphMeta, **kwargs):
+        """Allocate stable storage for target hidden states during capture."""
+        input_buffers = super().make_buffers_cudagraph(graph_meta=graph_meta, **kwargs)
+        input_buffers['target_hidden_states'] = input_buffers['input_ids'].new_zeros(
+            1,
+            graph_meta.max_tokens,
+            self.config.hidden_size,
+            dtype=self.dtype,
+        )
+        return input_buffers
+
+    def fill_buffers_cudagraph(self, graph_meta: CudaGraphMeta, input_ids: torch.Tensor, **kwargs):
+        """Copy target hidden states into their CUDA Graph input buffer."""
+        new_inputs = super().fill_buffers_cudagraph(
+            graph_meta=graph_meta,
+            input_ids=input_ids,
+            **kwargs,
+        )
+        target_hidden_states = kwargs.get('target_hidden_states')
+        if target_hidden_states is None:
+            raise ValueError('target_hidden_states is required for MiMo MTP.')
+        num_tokens = input_ids.size(-1)
+        target_buffer = graph_meta.input_buffers['target_hidden_states']
+        target_buffer[:, :num_tokens] = target_hidden_states
+        new_inputs['target_hidden_states'] = target_buffer
+        return new_inputs
+
+    def prepare_hidden_states_for_logits(
+        self,
+        hidden_states: torch.Tensor,
+        spec_step_idx: int = 0,
+    ) -> torch.Tensor:
+        """Apply the active prediction depth's final norm before lm_head."""
+        return self.model.prepare_hidden_states_for_logits(hidden_states, spec_step_idx=spec_step_idx)
+
+    @staticmethod
+    def prepare_hidden_states_for_next_step(
+        hidden_states: torch.Tensor,
+        logits_hidden_states: torch.Tensor,
+    ) -> torch.Tensor:
+        """Carry MiMo's decoder output before final norm to the next depth."""
+        del logits_hidden_states
+        return hidden_states
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        position_ids: torch.Tensor,
+        target_hidden_states: torch.Tensor,
+        past_key_values: list[list[torch.Tensor]],
+        attn_metadata: Any = None,
+        inputs_embeds: torch.Tensor | None = None,
+        spec_step_idx: int = 0,
+    ) -> torch.Tensor:
+        """Run one same-position MiMo MTP prediction depth."""
+        return self.model(
+            input_ids,
+            position_ids,
+            target_hidden_states,
+            past_key_values,
+            inputs_embeds=inputs_embeds,
+            attn_metadata=attn_metadata,
+            spec_step_idx=spec_step_idx,
+        )
+
+    @classmethod
+    def _parse_mtp_name(cls, name: str) -> tuple[int, str] | None:
+        match = re.fullmatch(r'model\.mtp\.layers\.(\d+)\.(.+)', name)
+        if match is None:
+            return None
+        layer_idx = int(match.group(1))
+        suffix = match.group(2)
+        if layer_idx not in range(3):
+            raise KeyError(f'Unexpected MiMo MTP layer index in {name!r}.')
+        if suffix not in cls._MTP_TENSOR_SUFFIXES:
+            raise KeyError(f'Unknown MiMo MTP tensor {name!r}.')
+        return layer_idx, suffix
+
+    @staticmethod
+    def _target_name(layer_idx: int, suffix: str) -> str:
+        prefix = f'model.layers.{layer_idx}'
+        if suffix in {'enorm.weight', 'hnorm.weight', 'eh_proj.weight', 'final_layernorm.weight'}:
+            return f'{prefix}.{suffix}'
+        if suffix == 'pre_mlp_layernorm.weight':
+            suffix = 'post_attention_layernorm.weight'
+        return f'{prefix}.{suffix}'
+
+    def _load_qkv_weight(
+        self,
+        target_name: str,
+        source_name: str,
+        loaded_weight: torch.Tensor,
+        params_dict: dict[str, nn.Parameter],
+        shard_id: str,
+    ):
+        tensor_kind = 'scale' if source_name.endswith('.weight_scale_inv') else 'weight'
+        target_prefix = re.sub(r'\.(q|k|v)_proj$', '.qkv_proj', target_name.rsplit('.', 1)[0])
+        _load_native_qkv_shard(target_prefix, tensor_kind, loaded_weight, params_dict, shard_id)
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]):
+        """Load exactly the three MTP depths and reject incomplete payloads."""
+        params_dict = dict(self.named_parameters())
+        seen = set()
+        for name, loaded_weight in weights:
+            parsed = self._parse_mtp_name(name)
+            if parsed is None:
+                continue
+            if name in seen:
+                raise KeyError(f'Duplicate MiMo MTP tensor {name!r}.')
+            seen.add(name)
+            layer_idx, suffix = parsed
+            target_name = self._target_name(layer_idx, suffix)
+
+            qkv_match = re.search(r'self_attn\.(q|k|v)_proj\.', suffix)
+            if qkv_match is not None:
+                self._load_qkv_weight(
+                    target_name,
+                    name,
+                    loaded_weight,
+                    params_dict,
+                    qkv_match.group(1),
+                )
+                continue
+
+            for source_projection, target_projection, shard_id in (
+                ('gate_proj', 'gate_up_proj', 0),
+                ('up_proj', 'gate_up_proj', 1),
+            ):
+                if f'mlp.{source_projection}.' in suffix:
+                    target_name = target_name.replace(source_projection, target_projection)
+                    load_weight(params_dict[target_name], loaded_weight, shard_id=shard_id)
+                    break
+            else:
+                load_weight(params_dict[target_name], loaded_weight)
+
+        expected = {
+            f'model.mtp.layers.{layer_idx}.{suffix}' for layer_idx in range(3) for suffix in self._MTP_TENSOR_SUFFIXES
+        }
+        missing = sorted(expected - seen)
+        if missing:
+            raise KeyError(f'Missing {len(missing)} MiMo MTP tensors; first missing tensor: {missing[0]!r}.')

--- a/lmdeploy/pytorch/models/module_map.py
+++ b/lmdeploy/pytorch/models/module_map.py
@@ -132,6 +132,12 @@ MODULE_MAP.update({
     'DeepseekV4ForCausalLM': f'{LMDEPLOY_PYTORCH_MODEL_PATH}.deepseek_v4.DeepseekV4ForCausalLM',
 })
 
+# mimo-v2-flash
+MODULE_MAP.update({
+    'MiMoV2FlashForCausalLM': f'{LMDEPLOY_PYTORCH_MODEL_PATH}.mimo_v2_flash.MiMoV2FlashForCausalLM',
+    'MiMoV2FlashMTPModel': f'{LMDEPLOY_PYTORCH_MODEL_PATH}.mimo_v2_flash_mtp.MiMoV2FlashMTPModel',
+})
+
 # deepseek-vl2
 MODULE_MAP.update({
     'DeepseekVLV2ForCausalLM': f'{LMDEPLOY_PYTORCH_MODEL_PATH}.deepseek_vl2.DeepseekVLV2ForCausalLM',

--- a/lmdeploy/pytorch/models/utils/cudagraph.py
+++ b/lmdeploy/pytorch/models/utils/cudagraph.py
@@ -1,4 +1,5 @@
 # Copyright (c) OpenMMLab. All rights reserved.
+import copy
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
@@ -53,9 +54,32 @@ class CudaGraphMeta:
 class CudaGraphMixin:
     """Mixin class to support cudagraph."""
 
+    def get_cudagraph_warmup_specs(self, max_query_len: int) -> tuple[tuple[int, int], ...]:
+        """Return query-length and speculative-depth pairs to pre-capture.
+
+        Recurrent draft models use one graph for multi-token verification and one graph for single-token drafting.
+        Models with depth-specific graph state may override this method to enumerate every runtime pair.
+        """
+        return ((max_query_len, 0), (1, 0))
+
+    def supports_non_fa3_speculative_graph(self) -> bool:
+        """Return whether speculative CUDA Graph can use a non-FA3 backend."""
+        return False
+
     def get_cudagraph_extra_key(self, **kwargs) -> tuple:
         """Get model-specific CUDA graph keys."""
         return ()
+
+    def get_cudagraph_capture_cache(self,
+                                    past_key_values: list[list[torch.Tensor]],
+                                    **kwargs) -> list[torch.Tensor] | None:
+        """Return mutable cache tensors that capture must preserve.
+
+        Stateful models may opt in by returning the cache tensors touched by Graph warmup and capture. The runner
+        snapshots only request-visible blocks and restores them before the first semantic replay.
+        """
+        del past_key_values, kwargs
+        return None
 
     def support_cuda_graph(
         self,
@@ -176,6 +200,11 @@ class CudaGraphMixin:
         q_start_loc: Tensor = attn_metadata.q_start_loc
         q_seqlens: Tensor = attn_metadata.q_seqlens
         kv_seqlens: Tensor = attn_metadata.kv_seqlens
+        # Redirect only the metadata view passed to the captured model.  A
+        # graph is replayed once immediately after capture; mutating the
+        # caller-owned object here would make that replay read graph buffers
+        # as its source, then erase them with the zero_ calls below.
+        attn_metadata = copy.copy(attn_metadata)
         input_buffers: BuffType = graph_meta.input_buffers
 
         num_tokens = input_ids.size(-1)

--- a/lmdeploy/pytorch/nn/linear/__init__.py
+++ b/lmdeploy/pytorch/nn/linear/__init__.py
@@ -304,8 +304,10 @@ def build_qkv_proj(in_features: int,
                    device: torch.device | None = None,
                    is_tp: bool = True,
                    num_replicate_kv_heads: int = 1,
+                   checkpoint_output_shard_sizes: tuple[int, int, int] | None = None,
+                   continuous_qkv_scale_layout: bool = False,
                    prefix: str = ''):
-    """Build qkv proj."""
+    """Build a QKV projection, optionally preserving checkpoint FP8 grids."""
     dist_config = get_dist_manager().current_config()
     is_tp = is_tp if dist_config.attn_tp > 1 else False
     quant_method = None
@@ -379,7 +381,9 @@ def build_qkv_proj(in_features: int,
                                   device=device,
                                   is_tp=is_tp,
                                   dp_gather=False,
-                                  num_replicate_kv_heads=num_replicate_kv_heads)
+                                  num_replicate_kv_heads=num_replicate_kv_heads,
+                                  checkpoint_output_shard_sizes=checkpoint_output_shard_sizes,
+                                  continuous_qkv_scale_layout=continuous_qkv_scale_layout)
     else:
         raise RuntimeError(f'Unsupported quant method: {quant_method}')
 

--- a/lmdeploy/pytorch/nn/linear/blocked_fp8.py
+++ b/lmdeploy/pytorch/nn/linear/blocked_fp8.py
@@ -1,5 +1,5 @@
 # Copyright (c) OpenMMLab. All rights reserved.
-from typing import Any
+from typing import Any, NamedTuple
 
 import torch
 
@@ -271,8 +271,28 @@ class MergedBlockedF8Linear(BlockedF8Linear):
         return loaded_weight.split(self.split_section, dim=0)
 
 
+class _QKVShardPlan(NamedTuple):
+    """Physical FP8 shard and its logical output view."""
+
+    shard_idx: int
+    weight_start: int
+    weight_load_rows: int
+    physical_rows: int
+    valid_start: int
+    logical_rows: int
+    scale_start: int
+    scale_rows: int
+
+
 class QKVBlockedF8Linear(MergedBlockedF8Linear, QKVMixin):
-    """Qkv blockedf8 linear."""
+    """Blocked-FP8 QKV projection with checkpoint-aware output sharding.
+
+    ``checkpoint_output_shard_sizes`` gives the Q/K/V row counts in one
+    native checkpoint TP partition. Runtime TP shards are selected inside
+    those partitions so weight rows and scale rows stay paired.
+    ``continuous_qkv_scale_layout`` preserves checkpoints whose FP8 block
+    coordinate continues across the Q/K/V boundaries within each partition.
+    """
 
     def __init__(self,
                  in_features: int,
@@ -287,7 +307,9 @@ class QKVBlockedF8Linear(MergedBlockedF8Linear, QKVMixin):
                  device: torch.device | None = None,
                  is_tp: bool = True,
                  dp_gather: bool = False,
-                 num_replicate_kv_heads: int = 1):
+                 num_replicate_kv_heads: int = 1,
+                 checkpoint_output_shard_sizes: tuple[int, int, int] | None = None,
+                 continuous_qkv_scale_layout: bool = False):
         self.block_size = 128
         self.init_tp_args(is_tp, all_reduce=False, colwise=True, layer_type='attn')
         QKVMixin.__init__(self,
@@ -300,7 +322,12 @@ class QKVBlockedF8Linear(MergedBlockedF8Linear, QKVMixin):
                           tp=self.tp,
                           tp_rank=self.tp_rank)
 
-        all_out_features = self.get_qkv_out_feautures()
+        logical_out_features = self.get_qkv_out_feautures()
+        self.logical_out_features = logical_out_features
+        self.checkpoint_output_shard_sizes = checkpoint_output_shard_sizes
+        self.continuous_qkv_scale_layout = continuous_qkv_scale_layout
+        self._output_shard_plans = self._build_output_shard_plans(logical_out_features)
+        all_out_features = tuple(plan.physical_rows for plan in self._output_shard_plans)
         out_names = ('q', 'k', 'v')
         super().__init__(in_features,
                          all_out_features,
@@ -313,48 +340,134 @@ class QKVBlockedF8Linear(MergedBlockedF8Linear, QKVMixin):
                          out_names=out_names,
                          dp_gather=dp_gather,
                          layer_type='attn')
+        self.scale_split_section = [plan.scale_rows for plan in self._output_shard_plans]
 
     def _update_all_out_features(self, all_out_features: list[int], replicate: list[bool] | None):
         """Update all out features."""
         return all_out_features
 
+    def _build_output_shard_plans(self, logical_sections: tuple[int, int, int]):
+        """Align TP-local Q/K/V inside their checkpoint quant shards."""
+        _, rank = self.get_tp_world_rank()
+        quant_shards = getattr(self, 'checkpoint_output_shard_sizes', None) or self.qkv_split_section
+        continuous_qkv_scales = getattr(self, 'continuous_qkv_scale_layout', False)
+        if len(logical_sections) != 3 or len(quant_shards) != 3:
+            raise ValueError('Blocked-FP8 QKV sharding requires exactly three Q/K/V sections.')
+        trailing_padding = 0
+        if continuous_qkv_scales:
+            trailing_padding = div_up(sum(logical_sections), self.block_size) * self.block_size \
+                - sum(logical_sections)
+        plans = []
+        for shard_idx, (shard_id, logical_rows, source_rows, quant_shard_rows) in enumerate(
+                zip(('q', 'k', 'v'), logical_sections, self.qkv_split_section, quant_shards)):
+            rank_idx = rank if shard_id == 'q' else rank // self.num_replicate_kv_heads
+            logical_start = rank_idx * logical_rows
+            logical_end = logical_start + logical_rows
+            if logical_end > source_rows:
+                raise ValueError(
+                    f'QKV {shard_id} TP shard [{logical_start}:{logical_end}] exceeds {source_rows} source rows.')
+            if quant_shard_rows <= 0 or source_rows % quant_shard_rows:
+                raise ValueError(
+                    f'QKV {shard_id} source rows {source_rows} must be divisible by checkpoint '
+                    f'quantization shard size {quant_shard_rows}.')
+            quant_shard_idx = logical_start // quant_shard_rows
+            quant_shard_start = quant_shard_idx * quant_shard_rows
+            quant_shard_end = quant_shard_start + quant_shard_rows
+            if logical_end > quant_shard_end:
+                raise ValueError(
+                    f'QKV {shard_id} TP shard [{logical_start}:{logical_end}] crosses checkpoint '
+                    f'quantization shard [{quant_shard_start}:{quant_shard_end}].')
+            relative_start = logical_start - quant_shard_start
+            relative_end = logical_end - quant_shard_start
+            if continuous_qkv_scales:
+                if relative_start % self.block_size:
+                    raise ValueError(
+                        f'Fused QKV {shard_id} TP shard starts at unaligned checkpoint row '
+                        f'{relative_start}; its scale blocks cannot be repacked without requantization.')
+                physical_rows = logical_rows + (trailing_padding if shard_idx == 2 else 0)
+                scales_per_quant_shard = div_up(quant_shard_rows, self.block_size)
+                scale_start = quant_shard_idx * scales_per_quant_shard + relative_start // self.block_size
+                scale_rows = div_up(logical_rows, self.block_size)
+                plans.append(
+                    _QKVShardPlan(shard_idx, logical_start, logical_rows, physical_rows, 0,
+                                  logical_rows, scale_start, scale_rows))
+                continue
+            physical_relative_start = relative_start // self.block_size * self.block_size
+            physical_relative_end = div_up(relative_end, self.block_size) * self.block_size
+            physical_rows = physical_relative_end - physical_relative_start
+            weight_start = quant_shard_start + physical_relative_start
+            weight_end = min(quant_shard_start + physical_relative_end, quant_shard_end)
+            weight_load_rows = weight_end - weight_start
+            valid_start = relative_start - physical_relative_start
+            scales_per_quant_shard = div_up(quant_shard_rows, self.block_size)
+            scale_start = quant_shard_idx * scales_per_quant_shard + physical_relative_start // self.block_size
+            scale_rows = physical_rows // self.block_size
+            plans.append(
+                _QKVShardPlan(shard_idx, weight_start, weight_load_rows, physical_rows, valid_start,
+                              logical_rows, scale_start, scale_rows))
+        if continuous_qkv_scales:
+            physical_scale_rows = div_up(sum(plan.physical_rows for plan in plans), self.block_size)
+            source_scale_rows = sum(plan.scale_rows for plan in plans)
+            if physical_scale_rows != source_scale_rows:
+                raise ValueError(
+                    'Fused QKV checkpoint scale rows do not match the packed runtime output: '
+                    f'{source_scale_rows} != {physical_scale_rows}.')
+        return tuple(plans)
+
+    def _get_output_shard(self, shard_id: Any) -> _QKVShardPlan:
+        """Return checkpoint weight/scale rows for a TP-local shard."""
+        return self._output_shard_plans[self.out_names_map[shard_id]]
+
     def weight_loader(self, param: torch.nn.Parameter, loaded_weight: torch.Tensor, shard_id: Any):
         """Weight loader."""
-        _, rank = self.get_tp_world_rank()
-        shard_idx = self.out_names_map[shard_id]
-
-        num_head = self.num_q_heads if shard_id == 'q' \
-            else self.num_kv_heads
-        head_dim = self.head_size if shard_id in ['q', 'k'] \
-            else self.head_size_v
-        # update to duplicate k/v for tp_size > num_kv_heads
-        rank_idx = rank if shard_id == 'q' \
-            else rank // self.num_replicate_kv_heads
-        sec_len = num_head * head_dim
+        plan = self._get_output_shard(shard_id)
         all_out_features = self.all_out_features
         if param._weight_type == 'scales':
             loaded_weight = loaded_weight.to(torch.float32)
-            all_out_features = [sec // self.block_size for sec in all_out_features]
-            sec_len = sec_len // self.block_size
-
-        sec_start = rank_idx * sec_len
+            all_out_features = self.scale_split_section
+            sec_start, sec_len = plan.scale_start, plan.scale_rows
+        else:
+            sec_start, sec_len = plan.weight_start, plan.weight_load_rows
 
         loaded_weight = loaded_weight.narrow(dim=0, start=sec_start, length=sec_len)
-        param_w = param.data.split(all_out_features, 0)[shard_idx]
-        param_w.copy_(loaded_weight)
+        param_w = param.data.split(all_out_features, 0)[plan.shard_idx]
+        if param._weight_type == 'scales':
+            param_w.copy_(loaded_weight)
+        else:
+            param_w.zero_()
+            param_w.narrow(0, 0, sec_len).copy_(loaded_weight)
 
     def weight_loader_with_quant(self, param: torch.nn.Parameter, loaded_weight: torch.Tensor, shard_id: Any):
         """Weight loader with weight quant."""
         if loaded_weight.dtype != param.dtype:
-            # quant loaded weight
-            quanted_weight, scaling = quant_blocked_fp8(loaded_weight.to(param.device),
+            if self.continuous_qkv_scale_layout:
+                raise ValueError('Fused QKV output quantization requires native blocked-FP8 checkpoint weights.')
+            plan = self._get_output_shard(shard_id)
+            physical_weight = torch.zeros((plan.physical_rows, loaded_weight.shape[1]),
+                                          dtype=loaded_weight.dtype,
+                                          device=param.device)
+            physical_weight[:plan.weight_load_rows].copy_(
+                loaded_weight.narrow(0, plan.weight_start, plan.weight_load_rows))
+            quanted_weight, scaling = quant_blocked_fp8(physical_weight,
                                                         param.dtype,
                                                         self.block_size,
                                                         scale_fmt=self.scale_fmt)
-            self.weight_loader(self.weight, quanted_weight, shard_id)
-            self.weight_loader(self.weight_scale_inv, scaling, shard_id)
+            self.weight.data.split(self.all_out_features, 0)[plan.shard_idx].copy_(quanted_weight)
+            self.weight_scale_inv.data.split(self.scale_split_section, 0)[plan.shard_idx].copy_(scaling)
         else:
             return self.weight_loader(param, loaded_weight, shard_id)
+
+    def split_qkv(self, x: torch.Tensor):
+        """Crop physical alignment rows and restore logical Q/K/V heads."""
+        physical = x.split(self.all_out_features, dim=-1)
+        q, k, v = (
+            value.narrow(-1, plan.valid_start, plan.logical_rows)
+            for value, plan in zip(physical, self._output_shard_plans)
+        )
+        q = q.unflatten(-1, (self.num_q_heads, self.head_size))
+        k = k.unflatten(-1, (self.num_kv_heads, self.head_size))
+        v = v.unflatten(-1, (self.num_kv_heads, self.head_size_v))
+        return q, k, v
 
     def weight_spliter(self, loaded_weight: torch.Tensor, layout: str = 'default'):
         """Weight spliter."""
@@ -362,5 +475,5 @@ class QKVBlockedF8Linear(MergedBlockedF8Linear, QKVMixin):
         assert layout == 'default'
         qkv_split_section = self.qkv_split_section
         if loaded_weight.dim() == 2 and loaded_weight.dtype != self.fp8_dtype:
-            qkv_split_section = [sec // self.block_size for sec in qkv_split_section]
+            qkv_split_section = [div_up(sec, self.block_size) for sec in qkv_split_section]
         return loaded_weight.split(qkv_split_section, dim=0)

--- a/lmdeploy/pytorch/spec_decode/proposers/__init__.py
+++ b/lmdeploy/pytorch/spec_decode/proposers/__init__.py
@@ -1,8 +1,8 @@
 # Copyright (c) OpenMMLab. All rights reserved.
-# Copyright (c) OpenMMLab. All rights reserved.
 
 from .deepseek_mtp import DeepseekMTP  # noqa F401
 from .eagle import Eagle  # noqa F401
 from .eagle3 import Eagle3  # noqa F401
 from .hy3_mtp import Hy3MTP  # noqa F401
+from .mimo_mtp import MiMoMTP  # noqa F401
 from .qwen3_5_mtp import Qwen3_5MTP  # noqa F401

--- a/lmdeploy/pytorch/spec_decode/proposers/base.py
+++ b/lmdeploy/pytorch/spec_decode/proposers/base.py
@@ -135,7 +135,47 @@ class BaseSpecProposer:
             mrope_pos_ids=mrope_pos_ids,
             target_hidden_states=target_hidden_states,
             model_metas=model_metas,
+            spec_step_idx=model_inputs.spec_step_idx + 1,
         )
+
+    def advance_draft_depth(self,
+                            model_inputs: ModelInputs,
+                            extra_inputs: ExtraInputs | None,
+                            next_input_ids: torch.Tensor,
+                            target_hidden_states: torch.Tensor,
+                            model_metas: list[Any],
+                            *,
+                            first_depth: bool) -> tuple[ModelInputs, ExtraInputs | None]:
+        """Advance recurrent draft state to the next speculative depth.
+
+        The first transition converts target-model inputs into compact draft decoding inputs. Later transitions advance
+        those decoding inputs by one token. Subclasses may override this transition for architectures whose draft depths
+        do not follow autoregressive time.
+        """
+        if first_depth:
+            if extra_inputs is None:
+                raise ValueError('The first draft-depth transition requires extra inputs.')
+            model_inputs = self.update_inputs_decoding(model_inputs, extra_inputs, next_input_ids.transpose(0, 1),
+                                                       target_hidden_states, model_metas)
+            # Compact recurrent inputs contain one row per request, so later
+            # draft outputs no longer require last-token selection.
+            extra_inputs.last_token_indices = None
+        else:
+            step_seqlens = model_inputs.seq_length.new_ones(model_inputs.seq_length.size(0))
+            model_inputs = model_inputs.step(next_input_ids.transpose(0, 1), step_seqlens)
+            model_inputs.model_metas = model_metas
+            model_inputs.target_hidden_states = target_hidden_states
+            if model_inputs.target_position_ids is not None:
+                model_inputs.target_position_ids += 1
+        return model_inputs, None
+
+    def get_draft_depth_token_counts(self, dp_meta) -> list[int]:
+        """Return per-rank token counts after advancing a draft depth.
+
+        Recurrent draft models compact the next depth to one token per active request, so the DP batch counts are also
+        the token counts. Draft architectures that retain a varlen sequence across depths may override this contract.
+        """
+        return dp_meta.dp_batches
 
     def embed_input_ids(self, input_ids: torch.Tensor):
         """embed_input_ids."""

--- a/lmdeploy/pytorch/spec_decode/proposers/mimo_mtp.py
+++ b/lmdeploy/pytorch/spec_decode/proposers/mimo_mtp.py
@@ -1,0 +1,89 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+
+import torch
+
+from ...model_inputs import ModelInputs
+from ...strategies.ar_spec.model_agent import ARSpecExtraInputs
+from .base import SPEC_PROPOSERS, BaseSpecProposer
+
+
+@SPEC_PROPOSERS.register_module(name='mimo_mtp')
+class MiMoMTP(BaseSpecProposer):
+    """MiMo same-position, multi-depth MTP proposer."""
+
+    def build_model(self, empty_init: bool, target_model: torch.nn.Module = None, build_model_ctx=None):
+        """Build the MiMo draft and bind its target-owned TP embedding."""
+        if target_model is None:
+            raise ValueError('MiMo MTP requires the target model for its shared token embedding.')
+        # MiMo always shares the target vocab-parallel embedding; unlike the
+        # DeepSeek DSA optimization this is part of the model architecture.
+        super().build_model(empty_init, target_model=target_model, build_model_ctx=build_model_ctx)
+        draft_model = self.model
+        if not hasattr(draft_model, 'set_input_embeddings'):
+            raise TypeError(f'{type(draft_model).__name__} cannot bind MiMo shared token embeddings.')
+        draft_model.set_input_embeddings(target_model.get_input_embeddings())
+
+    def advance_draft_depth(self,
+                            model_inputs: ModelInputs,
+                            extra_inputs: ARSpecExtraInputs | None,
+                            next_input_ids: torch.Tensor,
+                            target_hidden_states: torch.Tensor,
+                            model_metas: list,
+                            *,
+                            first_depth: bool) -> tuple[ModelInputs, ARSpecExtraInputs]:
+        """Advance one same-position MiMo depth without advancing time."""
+        # Every depth conditions on the same target-model state; only the
+        # candidate token/embedding stream and prediction depth change.
+        del target_hidden_states, first_depth
+        if extra_inputs is None:
+            raise ValueError('MiMo MTP depth transitions require AR speculative inputs.')
+        last_token_indices = extra_inputs.last_token_indices
+        input_ids = model_inputs.input_ids.clone()
+        input_ids[:, :-1] = model_inputs.input_ids[:, 1:]
+        input_ids[:, last_token_indices] = next_input_ids.flatten()
+
+        target_inputs_embeds = model_inputs.target_inputs_embeds
+        if target_inputs_embeds is not None:
+            target_inputs_embeds = target_inputs_embeds.clone()
+            target_inputs_embeds[:, :-1] = model_inputs.target_inputs_embeds[:, 1:]
+            target_inputs_embeds[:, last_token_indices] = self.embed_input_ids(next_input_ids.flatten())
+
+        model_inputs = model_inputs.clone(
+            input_ids=input_ids,
+            target_inputs_embeds=target_inputs_embeds,
+            target_hidden_states=model_inputs.target_hidden_states,
+            model_metas=model_metas,
+            spec_step_idx=model_inputs.spec_step_idx + 1,
+        )
+        return model_inputs, extra_inputs
+
+    def get_draft_depth_token_counts(self, dp_meta) -> list[int]:
+        """Preserve varlen prompt sizes across same-position MTP depths."""
+        num_tokens = dp_meta.dp_draft_num_tokens
+        if num_tokens is None:
+            raise RuntimeError('MiMo MTP requires per-rank draft token counts for DP depth transitions.')
+        return num_tokens
+
+    async def get_outputs(self,
+                          model_outputs: dict[str, torch.Tensor],
+                          model_inputs: ModelInputs,
+                          extra_inputs: ARSpecExtraInputs = None,
+                          guided_processors: dict | None = None):
+        """Select the active MiMo depth's norm/head and produce its draft."""
+        raw_hidden_states = model_outputs['hidden_states']
+        model_metas = model_outputs['model_metas']
+        if extra_inputs is not None:
+            raw_hidden_states = raw_hidden_states[:, extra_inputs.last_token_indices]
+
+        draft_model = self.model.get_model() if hasattr(self.model, 'get_model') else self.model
+        logits_hidden_states = draft_model.prepare_hidden_states_for_logits(
+            raw_hidden_states, spec_step_idx=model_inputs.spec_step_idx)
+        logits = self.target_model.get_logits(logits_hidden_states)[0]
+
+        guided_bitmask = await self.guided_helper.prepare_bitmask(logits, guided_processors)
+        if guided_bitmask is not None:
+            self.guided_helper.apply_bitmask(logits, guided_bitmask)
+        draft_token_ids = logits.argmax(dim=-1, keepdim=True)
+
+        await self.guided_helper.accept_draft_tokens(draft_token_ids, guided_processors)
+        return draft_token_ids, model_metas, raw_hidden_states

--- a/lmdeploy/pytorch/spec_decode/spec_agent.py
+++ b/lmdeploy/pytorch/spec_decode/spec_agent.py
@@ -238,6 +238,7 @@ class SpecModelAgent(BaseSpecModelAgent):
             draft_dp_meta = DPMeta.build(input_ids.numel(), all_num_tokens)
         draft_dp_meta.dp_batches = dp_meta.dp_batches
         draft_dp_meta.dp_is_decoding = dp_meta.dp_is_decoding
+        draft_dp_meta.dp_draft_num_tokens = all_num_tokens
         return draft_dp_meta
 
     def _prepare_inputs_from_main(self, model_inputs: ModelInputs, extra_inputs: ExtraInputs):
@@ -592,8 +593,11 @@ class SpecModelAgent(BaseSpecModelAgent):
                 return dp_meta, None
 
             padding_batch_size = max(dp_meta.dp_batches)
-            new_dpmeta = DPMeta.build(inputs.input_ids.numel(), dp_meta.dp_batches)
+            num_tokens = self.proposer.get_draft_depth_token_counts(dp_meta)
+            new_dpmeta = DPMeta.build(inputs.input_ids.numel(), num_tokens)
+            new_dpmeta.dp_batches = dp_meta.dp_batches
             new_dpmeta.dp_is_decoding = dp_meta.dp_is_decoding
+            new_dpmeta.dp_draft_num_tokens = dp_meta.dp_draft_num_tokens
             return new_dpmeta, padding_batch_size
 
         def _update_dp_model_inputs(inputs: ModelInputs, dp_meta: DPMeta, padding_batch_size: int | None):
@@ -630,10 +634,13 @@ class SpecModelAgent(BaseSpecModelAgent):
                 guided_processors=draft_guided_processors)
             draft_tokens_li = [draft_token_ids]
             if loop_count > 0:
-                inputs = self.proposer.update_inputs_decoding(inputs, extra_inputs, draft_token_ids.transpose(0, 1),
-                                                              target_hidden_states, model_metas)
-                # set last_token_indices to None for decoding
-                extra_inputs.last_token_indices = None
+                inputs, draft_extra_inputs = self.proposer.advance_draft_depth(
+                    inputs,
+                    extra_inputs,
+                    draft_token_ids,
+                    target_hidden_states,
+                    model_metas,
+                    first_depth=True)
                 # for dp > 1, need to update dp_meta and model inputs for next loop
                 dp_meta, padding_batch_size = __build_dp_meta(inputs)
                 # pad block_offsets for non-last chunks dummy run when dp>1
@@ -643,16 +650,17 @@ class SpecModelAgent(BaseSpecModelAgent):
                     inputs = _update_dp_model_inputs(inputs, dp_meta, padding_batch_size)
                     outputs = self._forward_impl(inputs)
                     draft_token_ids, model_metas, target_hidden_states = await self.proposer.get_outputs(
-                        outputs, inputs,
+                        outputs, inputs, draft_extra_inputs,
                         guided_processors=draft_guided_processors)
                     draft_tokens_li.append(draft_token_ids)
                     if loop_idx < loop_count - 1:
-                        step_seqlens = inputs.seq_length.new_ones(inputs.seq_length.size(0))
-                        inputs = inputs.step(draft_token_ids.transpose(0, 1), step_seqlens)
-                        inputs.model_metas = model_metas
-                        inputs.target_hidden_states = target_hidden_states
-                        if inputs.target_position_ids is not None:
-                            inputs.target_position_ids += 1
+                        inputs, draft_extra_inputs = self.proposer.advance_draft_depth(
+                            inputs,
+                            draft_extra_inputs,
+                            draft_token_ids,
+                            target_hidden_states,
+                            model_metas,
+                            first_depth=False)
 
             output_draft_ids = torch.cat(draft_tokens_li, dim=-1)
 
@@ -717,33 +725,26 @@ class SpecModelAgent(BaseSpecModelAgent):
 
             capture_batch_sizes = self.proposer.model.get_capture_batch_sizes()
             capture_batch_sizes = sorted(capture_batch_sizes, reverse=True)
-
             # warmup decode
             for batch_size in capture_batch_sizes:
-                # decode with num_spec_tokens + 1 per seq
-                inputs = self.inputs_strategy.make_dummy(batch_size,
-                                                         is_decoding=True,
-                                                         device='cuda',
-                                                         vocab_size=self.model_config.vocab_size,
-                                                         max_q_seqlen=self.num_spec_tokens + 1,
-                                                         target_hidden_size=target_hidden_size,
-                                                         target_dtype=self.model_config.dtype,
-                                                         meta=self.make_dummy_meta)
-                self._build_warmup_dp_meta(inputs)
-                self._forward_impl(inputs)
-                torch.cuda.synchronize()
-                # decode 1 tokens per sequence
-                inputs = self.inputs_strategy.make_dummy(batch_size,
-                                                         is_decoding=True,
-                                                         device='cuda',
-                                                         vocab_size=self.model_config.vocab_size,
-                                                         max_q_seqlen=1,
-                                                         target_hidden_size=self.model_config.hidden_size,
-                                                         target_dtype=self.model_config.dtype,
-                                                         meta=self.make_dummy_meta)
-                self._build_warmup_dp_meta(inputs)
-                self._forward_impl(inputs)
-                torch.cuda.synchronize()
+                max_query_len = self.num_spec_tokens + 1
+                protocol_model = self.proposer.model.get_model()
+                specs = protocol_model.get_cudagraph_warmup_specs(max_query_len)
+                for query_len, spec_step_idx in specs:
+                    inputs = self.inputs_strategy.make_dummy(
+                        batch_size,
+                        is_decoding=True,
+                        device='cuda',
+                        vocab_size=self.model_config.vocab_size,
+                        max_q_seqlen=query_len,
+                        target_hidden_size=(target_hidden_size
+                                            if query_len > 1 else self.model_config.hidden_size),
+                        target_dtype=self.model_config.dtype,
+                        meta=self.make_dummy_meta)
+                    inputs.spec_step_idx = spec_step_idx
+                    self._build_warmup_dp_meta(inputs)
+                    self._forward_impl(inputs)
+                    torch.cuda.synchronize()
 
     def reset_graph_runner(self):
         """Reset graph runner."""

--- a/lmdeploy/pytorch/strategies/ar_spec/cudagraph.py
+++ b/lmdeploy/pytorch/strategies/ar_spec/cudagraph.py
@@ -14,4 +14,10 @@ class ARSpecCudagraphStrategy(CudagraphStrategy):
         if num_tokens == origin_batch_size:
             return batch_size
 
+        if self.method == 'mimo_mtp':
+            if num_tokens % origin_batch_size != 0:
+                raise ValueError('MiMo MTP CUDA Graph requires a uniform query length per batch.')
+            query_len = num_tokens // origin_batch_size
+            return batch_size * query_len
+
         return batch_size * (self.num_spec_tokens + 1)

--- a/lmdeploy/pytorch/weight_loader/model_weight_loader.py
+++ b/lmdeploy/pytorch/weight_loader/model_weight_loader.py
@@ -167,6 +167,13 @@ class ModelWeightLoader:
         """Load model weights implementation."""
         assert hasattr(model, 'load_weights')
         paths = self._shard_paths
+        select_paths = getattr(model, 'select_weight_paths', None)
+        if select_paths is not None:
+            if not callable(select_paths):
+                raise TypeError(f'{type(model).__name__}.select_weight_paths must be callable.')
+            paths = tuple(select_paths(self.model_path, paths))
+            if not paths:
+                raise RuntimeError(f'{type(model).__name__}.select_weight_paths returned no checkpoint files.')
         _, rank = get_world_rank()
         disable_tqdm = rank != 0
 

--- a/lmdeploy/serve/parsers/tool_parser/__init__.py
+++ b/lmdeploy/serve/parsers/tool_parser/__init__.py
@@ -6,6 +6,7 @@ from .internlm2_tool_parser import Internlm2ToolParser
 from .interns2preview_tool_parser import InternS2PreviewToolParser
 from .kimi_k2_tool_parser import KimiK2ToolParser
 from .llama3_tool_parser import Llama3JsonToolParser
+from .mimo_tool_parser import MiMoToolParser
 from .qwen2d5_tool_parser import Qwen2d5ToolParser
 from .qwen3_tool_parser import Qwen3ToolParser
 from .qwen3coder_tool_parser import Qwen3CoderToolParser
@@ -21,6 +22,7 @@ __all__ = [
     'Glm47ToolParser',
     'Internlm2ToolParser',
     'Llama3JsonToolParser',
+    'MiMoToolParser',
     'Qwen2d5ToolParser',
     'Qwen3ToolParser',
     'Qwen3CoderToolParser',

--- a/lmdeploy/serve/parsers/tool_parser/mimo_tool_parser.py
+++ b/lmdeploy/serve/parsers/tool_parser/mimo_tool_parser.py
@@ -1,0 +1,32 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+from __future__ import annotations
+
+import html
+from typing import Any
+
+from .qwen3coder_tool_parser import Qwen3CoderToolParser
+from .tool_parser import ToolParserManager
+from .xml_tool_parser import XmlToolParser
+
+
+@ToolParserManager.register_module('mimo')
+class MiMoToolParser(Qwen3CoderToolParser):
+    """Parse MiMo XML tool calls.
+
+    MiMo uses the same function/parameter tags as Qwen3-Coder, but its prompt contract preserves parameter whitespace.
+    HTML entities are decoded before values are converted according to the request's JSON schema.
+    """
+
+    validate_tool_names = True
+
+    @staticmethod
+    def _parse_param_value(param_val_str: str) -> str:
+        """Preserve MiMo parameter text while decoding HTML entities."""
+        return html.unescape(param_val_str)
+
+    @staticmethod
+    def _coerce_value(raw_value: str, schema_type: str | None) -> Any:
+        """Keep string whitespace and coerce non-string schema values."""
+        if schema_type is None or schema_type == 'string':
+            return raw_value
+        return XmlToolParser._coerce_value(raw_value, schema_type)

--- a/lmdeploy/serve/parsers/tool_parser/qwen3coder_tool_parser.py
+++ b/lmdeploy/serve/parsers/tool_parser/qwen3coder_tool_parser.py
@@ -103,7 +103,7 @@ class Qwen3CoderToolParser(XmlToolParser):
         if val_end == -1:
             self._in_progress_value = True
             return False
-        param_val_str = content[self._value_start:val_end].strip()
+        param_val_str = content[self._value_start:val_end]
         self._args[self._open_param_name] = self._parse_param_value(param_val_str)
         self._open_param_name = None
         self._value_start = -1
@@ -156,13 +156,14 @@ class Qwen3CoderToolParser(XmlToolParser):
                 self._scan_pos = next_pos
                 continue
 
-            param_val_str = content[val_start:val_end].strip()
+            param_val_str = content[val_start:val_end]
             self._args[param_name] = self._parse_param_value(param_val_str)
             self._scan_pos = next_pos
             self._in_progress_value = False
 
     @staticmethod
     def _parse_param_value(param_val_str: str) -> Any:
+        param_val_str = param_val_str.strip()
         try:
             parsed_val = json.loads(param_val_str)
             return parsed_val if isinstance(parsed_val, str) else param_val_str
@@ -211,7 +212,7 @@ class Qwen3CoderToolParser(XmlToolParser):
             if val_end == -1:
                 break
 
-            param_val_str = content[val_start:val_end].strip()
+            param_val_str = content[val_start:val_end]
             args_dict[param_name] = self._parse_param_value(param_val_str)
             search_idx = val_end + len(self.param_suffix)
 

--- a/tests/pytorch/kernel/test_fa3_attention.py
+++ b/tests/pytorch/kernel/test_fa3_attention.py
@@ -5,11 +5,31 @@ from types import SimpleNamespace
 import torch
 
 from lmdeploy.messages import QuantPolicy
-from lmdeploy.pytorch.backends.cuda.attention.default import TritonAttentionMetadata
+from lmdeploy.pytorch.backends.cuda.attention import TritonAttentionBuilder
+from lmdeploy.pytorch.backends.cuda.attention.default import TritonAttentionImpl, TritonAttentionMetadata
 from lmdeploy.pytorch.backends.cuda.attention.fa3 import FA3Impl
 
 _BLOCK_SIZE = 16
 _PREFILL_SEQLENS = (29, 18)
+
+
+def test_attention_builder_falls_back_when_fa3_lacks_asymmetric_head_shape(monkeypatch):
+    """Avoid dispatching a head shape omitted from the installed FA3 wheel."""
+    import lmdeploy.pytorch.backends.cuda.attention as attention_mod
+
+    flags = {
+        'FLASHATTENTION_DISABLE_HDIM192': False,
+        'FLASH_ATTENTION_DISABLE_HDIMDIFF192': True,
+    }
+    monkeypatch.setitem(sys.modules, 'flash_attn_config', SimpleNamespace(CONFIG={'build_flags': flags}))
+    monkeypatch.setattr(attention_mod, 'use_fa3_warning', lambda: True)
+    attention_mod._enable_fa3.cache_clear()
+    try:
+        impl = TritonAttentionBuilder.build(num_heads=8, head_size=192, num_kv_heads=2, v_head_size=128)
+    finally:
+        attention_mod._enable_fa3.cache_clear()
+
+    assert type(impl) is TritonAttentionImpl
 
 
 def _make_prefill_metadata(q_seqlens, block_offsets):

--- a/tests/pytorch/kernel/test_flash_attention.py
+++ b/tests/pytorch/kernel/test_flash_attention.py
@@ -146,6 +146,46 @@ def _naive_window_attention(q, k, v, seqlens_q, seqlens_k, window_size):
     return output
 
 
+def test_flash_attention_asymmetric_head_matches_reference():
+    """Run the split-D head shape that previously exceeded SM90 resources."""
+    from lmdeploy.pytorch.kernels.cuda.flashattention import flash_attn_varlen_func
+
+    head_dim_k, head_dim_v = 192, 128
+    torch.manual_seed(123)
+    dtype = torch.float16
+    device = 'cuda'
+    num_heads_q = 4
+    num_heads_kv = 2
+    q_seqlens = torch.tensor([7, 11], dtype=torch.int32, device=device)
+    history_lens = torch.tensor([5, 3], dtype=torch.int32, device=device)
+    kv_seqlens = q_seqlens + history_lens
+
+    q = torch.rand(2, 11, num_heads_q, head_dim_k, dtype=dtype, device=device)
+    k = torch.rand(2, 14, num_heads_kv, head_dim_k, dtype=dtype, device=device)
+    v = torch.rand(2, 14, num_heads_kv, head_dim_v, dtype=dtype, device=device)
+    bias = _make_bias(q_seqlens, history_lens, -1e30, causal=True)
+    expected = _conti_input(_naive_attention(q, (k, v), bias), q_seqlens)
+
+    packed_q = _conti_input(q, q_seqlens)
+    packed_k = _conti_input(k, kv_seqlens).transpose(0, 1).contiguous()
+    packed_v = _conti_input(v, kv_seqlens).transpose(0, 1).contiguous()
+    cu_seqlens_q = torch.nn.functional.pad(q_seqlens.cumsum(0), (1, 0))
+    cu_seqlens_k = torch.nn.functional.pad(kv_seqlens.cumsum(0), (1, 0))
+
+    actual = flash_attn_varlen_func(
+        packed_q,
+        packed_k,
+        packed_v,
+        cu_seqlens_q=cu_seqlens_q,
+        cu_seqlens_k=cu_seqlens_k,
+        max_seqlen_q=int(q_seqlens.max().item()),
+        max_seqlen_k=int(kv_seqlens.max().item()),
+        causal=True,
+    )
+
+    torch.testing.assert_close(actual, expected, atol=2e-3, rtol=2e-3)
+
+
 class TestFlashAttention:
 
     @pytest.fixture

--- a/tests/pytorch/kernel/test_paged_attention.py
+++ b/tests/pytorch/kernel/test_paged_attention.py
@@ -294,6 +294,20 @@ class TestPagedAttentionBase:
     def conti_gt(self, gt, seq_lens):
         yield _conti_input(gt, seq_lens)
 
+    @pytest.fixture
+    def win_size(self, request):
+        yield request.param
+
+    @pytest.fixture
+    def window_gt(self, conti_q, conti_kv, seq_lens, history_lens, win_size):
+        kv_lens = seq_lens + history_lens
+        yield _naive_window_attention(conti_q,
+                                      conti_kv[0],
+                                      conti_kv[1],
+                                      seq_lens,
+                                      kv_lens,
+                                      window_size=(win_size, win_size))
+
 
 class TestPagedAttention(TestPagedAttentionBase):
 
@@ -315,19 +329,161 @@ class TestPagedAttention(TestPagedAttentionBase):
                                       kv_layout=layout)
         torch.testing.assert_close(out, conti_gt, atol=1e-3, rtol=1e-5)
 
-    @pytest.fixture
-    def win_size(self, request):
-        yield request.param
+    @pytest.mark.parametrize(
+        ('window_size', 'use_sinks'),
+        [(None, False), ((127, 0), True)],
+    )
+    def test_causal_multi_token_with_shared_prefix(self, window_size, use_sinks):
+        """Multi-token attention reads causal full/windowed KV from shared
+        pages."""
+        from lmdeploy.pytorch.backends.cuda.attention.default import (
+            TritonAttentionImpl,
+            TritonAttentionMetadata,
+        )
+        from lmdeploy.pytorch.kernels.cuda import flash_attn_with_kvcache
 
-    @pytest.fixture
-    def window_gt(self, conti_q, conti_kv, seq_lens, history_lens, win_size):
-        kv_lens = seq_lens + history_lens
-        yield _naive_window_attention(conti_q,
-                                      conti_kv[0],
-                                      conti_kv[1],
-                                      seq_lens,
-                                      kv_lens,
-                                      window_size=(win_size, win_size))
+        torch.manual_seed(123)
+        device = 'cuda'
+        dtype = torch.bfloat16
+        batch_size, query_len = 2, 4
+        num_q_heads, num_kv_heads = 8, 1
+        head_size, value_head_size, block_size = 192, 128, 16
+        history_lens = torch.tensor([141, 155], device=device)
+        kv_seqlens = history_lens + query_len
+        max_blocks = int((kv_seqlens.max().item() + block_size - 1) // block_size)
+
+        queries = torch.randn(
+            batch_size, query_len, num_q_heads, head_size, device=device, dtype=dtype
+        )
+        keys = [
+            torch.randn(int(length), num_kv_heads, head_size, device=device, dtype=dtype)
+            for length in kv_seqlens
+        ]
+        values = [
+            torch.randn(int(length), num_kv_heads, value_head_size, device=device, dtype=dtype)
+            for length in kv_seqlens
+        ]
+        # Model a real prefix-cache hit: both requests reference the same first
+        # physical page and therefore have identical KV for that prefix.
+        keys[1][:block_size].copy_(keys[0][:block_size])
+        values[1][:block_size].copy_(values[0][:block_size])
+
+        page_table = torch.zeros(batch_size, max_blocks, dtype=torch.long, device=device)
+        page_table[:, 0] = 0
+        next_page = 1
+        for batch_id, length in enumerate(kv_seqlens.tolist()):
+            num_blocks = (length + block_size - 1) // block_size
+            page_table[batch_id, 1:num_blocks] = torch.arange(
+                next_page, next_page + num_blocks - 1, device=device
+            )
+            next_page += num_blocks - 1
+
+        k_cache = torch.zeros(next_page, block_size, num_kv_heads, head_size, device=device, dtype=dtype)
+        v_cache = torch.zeros(
+            next_page, block_size, num_kv_heads, value_head_size, device=device, dtype=dtype
+        )
+        for batch_id, length in enumerate(kv_seqlens.tolist()):
+            for logical_block in range((length + block_size - 1) // block_size):
+                physical_block = int(page_table[batch_id, logical_block])
+                start = logical_block * block_size
+                end = min(start + block_size, length)
+                k_cache[physical_block, :end - start].copy_(keys[batch_id][start:end])
+                v_cache[physical_block, :end - start].copy_(values[batch_id][start:end])
+
+        sinks = (
+            torch.randn(num_q_heads, device=device, dtype=dtype)
+            if use_sinks
+            else None
+        )
+        cu_seqlens_q = torch.arange(
+            0, (batch_size + 1) * query_len, query_len,
+            dtype=torch.int32, device=device)
+        kernel_metadata = TritonAttentionMetadata(
+            is_decoding=True,
+            block_offsets=page_table,
+            q_start_loc=cu_seqlens_q[:-1],
+            q_seqlens=torch.full(
+                (batch_size, ), query_len, dtype=torch.int32, device=device),
+            kv_seqlens=kv_seqlens,
+            cu_seqlens_q=cu_seqlens_q,
+        )
+        # The outer metadata intentionally describes a different route. The
+        # bound group metadata must be authoritative for this implementation.
+        metadata = TritonAttentionMetadata(
+            is_decoding=False,
+            block_offsets=torch.zeros_like(page_table),
+            kernel_metadata=(None, kernel_metadata),
+        )
+        impl = TritonAttentionImpl(
+            num_heads=num_q_heads,
+            head_size=head_size,
+            num_kv_heads=num_kv_heads,
+            v_head_size=value_head_size,
+            sliding_window=window_size,
+            enable_paged_multi_token_decode=True,
+        )
+        impl.bind_step_meta_group(1)
+        output = impl.forward(
+            queries.flatten(0, 1), None, None, k_cache, v_cache, metadata,
+            learnable_sink=sinks).unflatten(0, (batch_size, query_len))
+
+        reference = torch.empty_like(output)
+        scale = head_size**-0.5
+        for batch_id in range(batch_size):
+            for query_id in range(query_len):
+                query_pos = int(history_lens[batch_id]) + query_id
+                start = 0 if window_size is None else max(query_pos - window_size[0], 0)
+                key = keys[batch_id][start:query_pos + 1, 0].float()
+                value = values[batch_id][start:query_pos + 1, 0].float()
+                logits = queries[batch_id, query_id].float() @ key.T * scale
+                if sinks is not None:
+                    logits = torch.cat((logits, sinks[:, None].float()), dim=-1)
+                probs = logits.softmax(dim=-1)
+                if sinks is not None:
+                    probs = probs[:, :-1]
+                reference[batch_id, query_id] = (probs @ value).to(dtype)
+
+        torch.testing.assert_close(output, reference, atol=2e-2, rtol=2e-2)
+
+        if use_sinks:
+            graph = torch.cuda.CUDAGraph()
+            with torch.cuda.graph(graph):
+                graph_output = impl.forward(
+                    queries.flatten(0, 1), None, None, k_cache, v_cache,
+                    metadata, learnable_sink=sinks)
+            queries.add_(0.125)
+            kv_seqlens.sub_(3)
+            graph.replay()
+            replay_reference = flash_attn_with_kvcache(
+                queries.flatten(0, 1), k_cache, v_cache,
+                cache_seqlens=kv_seqlens, page_table=page_table,
+                max_seqlen_q=query_len, window_size=window_size,
+                sinks=sinks, causal_multi_token=True)
+            torch.testing.assert_close(graph_output, replay_reference, atol=2e-2, rtol=2e-2)
+
+    @pytest.mark.parametrize('feat_dim', [192], indirect=True)
+    @pytest.mark.parametrize('feat_dim_v', [128], indirect=True)
+    @pytest.mark.parametrize(['num_heads_q', 'num_heads_k'], [(16, 1)], indirect=True)
+    @pytest.mark.parametrize('history_lens', [(1370, )], indirect=True)
+    @pytest.mark.parametrize('block_size', [64], indirect=True)
+    @pytest.mark.parametrize('layout', ['bshd'], indirect=True)
+    def test_empty_split_k_partitions_are_neutral(self, monkeypatch, conti_q,
+                                                  blocked_kv, block_offsets,
+                                                  kv_seqlens, layout, conti_gt):
+        """Empty split-K partitions must not contribute stale values."""
+        from lmdeploy.pytorch.kernels.cuda import pagedattention
+
+        monkeypatch.setattr(pagedattention, '_get_split_k', lambda *args: 128)
+        blocked_k, blocked_v = blocked_kv
+        out = pagedattention.flash_attn_with_kvcache(
+            conti_q,
+            blocked_k,
+            blocked_v,
+            page_table=block_offsets,
+            cache_seqlens=kv_seqlens,
+            kv_layout=layout,
+        )
+        torch.testing.assert_close(out, conti_gt, atol=1e-3, rtol=1e-5)
 
     @pytest.mark.parametrize('feat_dim', [16], indirect=True)
     @pytest.mark.parametrize('feat_dim_v', [16], indirect=True)
@@ -519,7 +675,7 @@ def _make_blocked_cache_fp8_scalar(batched_k, batched_v, seq_lens, history_lens,
     return blocked_k, blocked_v, k_scale, v_scale, dequant_k, dequant_v
 
 
-class TestPagedAttentionInt8(TestPagedAttention):
+class TestPagedAttentionInt8(TestPagedAttentionBase):
 
     @pytest.fixture
     def nbits(self):

--- a/tests/pytorch/kernel/test_swa_state_ring.py
+++ b/tests/pytorch/kernel/test_swa_state_ring.py
@@ -1,0 +1,144 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+from types import SimpleNamespace
+
+import torch
+
+from lmdeploy.pytorch.backends.cuda.attention.swa_state_ring import (
+    SWAStateRingMetadata,
+    swa_state_ring_attention,
+)
+from lmdeploy.pytorch.kernels.cuda.swa_state_ring import flatten_swa_state_ring, scatter_swa_state_ring
+
+
+def test_swa_state_ring_flattens_history_then_updates_current_tokens():
+    ring = torch.zeros((1, 4, 1, 8), dtype=torch.bfloat16, device='cuda')
+    ring[0, 0].fill_(10)
+    ring[0, 1].fill_(20)
+    current = torch.stack((torch.full((1, 8), 30), torch.full((1, 8), 40))).to(
+        device='cuda', dtype=torch.bfloat16)
+    state_slots = torch.tensor([0], dtype=torch.int64, device='cuda')
+    start_positions = torch.tensor([2], dtype=torch.int64, device='cuda')
+    q_seqlens = torch.tensor([2], dtype=torch.int32, device='cuda')
+    cu_q_seqlens = torch.tensor([0, 2], dtype=torch.int32, device='cuda')
+    history_lens = torch.tensor([2], dtype=torch.int32, device='cuda')
+    cu_kv_seqlens = torch.tensor([0, 4], dtype=torch.int32, device='cuda')
+
+    flattened = flatten_swa_state_ring(
+        ring,
+        current,
+        state_slots,
+        start_positions,
+        q_seqlens,
+        cu_q_seqlens,
+        history_lens,
+        cu_kv_seqlens,
+        max_q_seqlen=2,
+    )
+    expected = torch.tensor([10, 20, 30, 40], dtype=torch.bfloat16, device='cuda')
+    torch.testing.assert_close(flattened[:4, 0, 0], expected)
+
+    scatter_swa_state_ring(
+        current,
+        ring,
+        state_slots,
+        start_positions,
+        q_seqlens,
+        cu_q_seqlens,
+        max_q_seqlen=2,
+    )
+    torch.testing.assert_close(ring[0, :, 0, 0], expected)
+
+
+def test_swa_state_ring_q1_paged_decode_matches_flatten():
+    """The q=1 ring-page fast path preserves pre-wrap and wrapped results."""
+
+    from lmdeploy.pytorch.kernels.cuda import flash_attn_varlen_func, flash_attn_with_kvcache
+
+    torch.manual_seed(7)
+    batch_size = 2
+    window_size = 128
+    num_q_heads = 8
+    num_kv_heads = 1
+    head_dim = 192
+    value_dim = 128
+    dtype = torch.bfloat16
+    device = 'cuda'
+
+    query = torch.randn(batch_size, num_q_heads, head_dim, dtype=dtype, device=device)
+    current_k = torch.randn(batch_size, num_kv_heads, head_dim, dtype=dtype, device=device)
+    current_v = torch.randn(batch_size, num_kv_heads, value_dim, dtype=dtype, device=device)
+    k_ring = torch.randn(batch_size, window_size, num_kv_heads, head_dim, dtype=dtype, device=device)
+    v_ring = torch.randn(batch_size, window_size, num_kv_heads, value_dim, dtype=dtype, device=device)
+    attn_metadata = SimpleNamespace(
+        q_seqlens=torch.ones(batch_size, dtype=torch.int64, device=device),
+        # The first sequence has not wrapped; the second has wrapped.
+        kv_seqlens=torch.tensor([6, 194], dtype=torch.int64, device=device),
+    )
+    metadata = SWAStateRingMetadata.from_step_context(
+        attn_metadata,
+        SimpleNamespace(max_q_seqlen=1),
+        state_slots=torch.arange(batch_size, dtype=torch.int64, device=device),
+        num_state_slots=batch_size,
+        window_size=window_size,
+    )
+    flat_k = flatten_swa_state_ring(
+        k_ring,
+        current_k,
+        metadata.state_slots,
+        metadata.start_positions,
+        metadata.q_seqlens,
+        metadata.cu_q_seqlens,
+        metadata.history_lens,
+        metadata.cu_kv_seqlens,
+        metadata.max_q_seqlen,
+    )
+    flat_v = flatten_swa_state_ring(
+        v_ring,
+        current_v,
+        metadata.state_slots,
+        metadata.start_positions,
+        metadata.q_seqlens,
+        metadata.cu_q_seqlens,
+        metadata.history_lens,
+        metadata.cu_kv_seqlens,
+        metadata.max_q_seqlen,
+    )
+    scale = head_dim**-0.5
+    sinks = torch.randn(num_q_heads, dtype=dtype, device=device)
+    expected = flash_attn_varlen_func(
+        query,
+        flat_k,
+        flat_v,
+        metadata.cu_q_seqlens,
+        metadata.cu_kv_seqlens,
+        max_seqlen_q=1,
+        max_seqlen_k=window_size,
+        window_size=window_size - 1,
+        softmax_scale=scale,
+        causal=True,
+        sinks=sinks,
+        kv_layout='shd',
+    )
+
+    impl = SimpleNamespace(
+        flash_attention_fwd=flash_attn_varlen_func,
+        paged_attention_fwd=flash_attn_with_kvcache,
+        alibi=False,
+        scale=scale,
+        logit_softcapping=None,
+    )
+    attention = SimpleNamespace(impl=impl, _lazy_init=lambda device: None)
+    actual = swa_state_ring_attention(
+        attention,
+        query,
+        current_k,
+        current_v,
+        k_ring,
+        v_ring,
+        metadata,
+        sink=sinks,
+    )
+
+    torch.testing.assert_close(actual, expected, atol=3e-3, rtol=3e-3)
+    torch.testing.assert_close(k_ring[0, 5], current_k[0])
+    torch.testing.assert_close(k_ring[1, 65], current_k[1])

--- a/tests/pytorch/nn/test_linear_blocked_fp8.py
+++ b/tests/pytorch/nn/test_linear_blocked_fp8.py
@@ -1,0 +1,163 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+import lmdeploy.pytorch.nn.linear.blocked_fp8 as blocked_fp8
+from lmdeploy.pytorch.config import TPMode
+from lmdeploy.pytorch.nn.linear.blocked_fp8 import QKVBlockedF8Linear
+
+
+class _ReferenceBlockedF8Impl:
+
+    def set_scale_fmt(self, scale_fmt):
+        del scale_fmt
+
+    def forward(self, x, weight, weight_scale_inv, *args, **kwargs):
+        del args, kwargs
+        row_scales = weight_scale_inv.repeat_interleave(128, dim=0)
+        col_scales = row_scales.repeat_interleave(128, dim=1)
+        dequantized = weight.float() * col_scales[:weight.size(0), :weight.size(1)]
+        return (x.float() @ dequantized.T).to(x.dtype)
+
+
+def _build_qkv(monkeypatch, *, tp, rank, num_kv_heads, num_replicas,
+               checkpoint_sections, continuous):
+
+    def _init_tp_args(self, *args, **kwargs):
+        del args, kwargs
+        self.is_tp = True
+        self.all_reduce = False
+        self.tp = tp
+        self.tp_rank = rank
+        self.tp_mode = TPMode.DEFAULT
+        self.tp_group = None
+        self.gather_group = None
+        self._tp_args_initialized = True
+
+    backend = SimpleNamespace(
+        get_layer_impl_builder=lambda op: SimpleNamespace(
+            build=lambda *args, **kwargs: _ReferenceBlockedF8Impl()))
+    monkeypatch.setattr(QKVBlockedF8Linear, 'init_tp_args', _init_tp_args)
+    monkeypatch.setattr(blocked_fp8, 'get_backend', lambda: backend)
+    return QKVBlockedF8Linear(
+        in_features=128,
+        num_q_heads=64,
+        num_kv_heads=num_kv_heads,
+        head_size=192,
+        head_size_v=128,
+        dtype=torch.bfloat16,
+        device=torch.device('cpu'),
+        num_replicate_kv_heads=num_replicas,
+        checkpoint_output_shard_sizes=checkpoint_sections,
+        continuous_qkv_scale_layout=continuous,
+    )
+
+
+def _source_weight(rows, offset):
+    values = (torch.arange(rows, dtype=torch.float32) + offset).remainder(13) - 6
+    return values[:, None].expand(rows, 128).to(torch.float8_e4m3fn)
+
+
+def _load_qkv(linear, weights, scales):
+    for shard_id in ('q', 'k', 'v'):
+        linear.weight.weight_loader(linear.weight, weights[shard_id], shard_id)
+        linear.weight_scale_inv.weight_loader(
+            linear.weight_scale_inv, scales[shard_id], shard_id)
+
+
+def _project(x, weight, row_scales):
+    dequantized = weight.float() * row_scales[:, None]
+    return (x.float() @ dequantized.T).to(x.dtype)
+
+
+@pytest.mark.parametrize(
+    ('tp', 'rank', 'num_kv_heads', 'num_replicas'),
+    [(4, 3, 4, 1), (8, 7, 8, 2)],
+)
+def test_full_qkv_loader_matches_checkpoint_quantization(monkeypatch, tp, rank,
+                                                         num_kv_heads,
+                                                         num_replicas):
+    """Full QKV preserves its TP4 K/V boundary under TP4 and TP8."""
+    linear = _build_qkv(
+        monkeypatch,
+        tp=tp,
+        rank=rank,
+        num_kv_heads=num_kv_heads,
+        num_replicas=num_replicas,
+        checkpoint_sections=(3072, 192, 128),
+        continuous=True,
+    )
+    weights = {
+        'q': _source_weight(12288, 0),
+        'k': _source_weight(768, 3),
+        'v': _source_weight(512, 7),
+    }
+    scales = {
+        'q': (1 + torch.arange(96, dtype=torch.float32) / 32)[:, None],
+        'k': (5 + torch.arange(8, dtype=torch.float32) / 16)[:, None],
+        'v': (9 + torch.arange(4, dtype=torch.float32) / 8)[:, None],
+    }
+    _load_qkv(linear, weights, scales)
+
+    x = torch.linspace(-1, 1, 128, dtype=torch.bfloat16).view(1, 128)
+    query, key, value = linear.split_qkv(linear(x))
+
+    q_rows = 12288 // tp
+    q_start = rank * q_rows
+    kv_rank = rank // num_replicas
+    k_start = kv_rank * 192
+    v_start = kv_rank * 128
+    q_scale = scales['q'].flatten().repeat_interleave(128)[q_start:q_start + q_rows]
+    k_scale = scales['k'][kv_rank * 2:kv_rank * 2 + 2].flatten().repeat_interleave(128)[:192]
+    # The checkpoint block crossing K/V uses K's final scale for V[0:64].
+    v_scale = torch.cat((
+        scales['k'][kv_rank * 2 + 1].expand(64),
+        scales['v'][kv_rank].expand(64),
+    ))
+
+    expected_q = _project(x, weights['q'][q_start:q_start + q_rows], q_scale)
+    expected_k = _project(x, weights['k'][k_start:k_start + 192], k_scale)
+    expected_v = _project(x, weights['v'][v_start:v_start + 128], v_scale)
+    torch.testing.assert_close(query.flatten(1), expected_q)
+    torch.testing.assert_close(key.flatten(1), expected_k)
+    torch.testing.assert_close(value.flatten(1), expected_v)
+
+
+def test_swa_qkv_loader_matches_unaligned_tp8_shard(monkeypatch):
+    """SWA TP8 crops an unaligned K shard without changing its scale grid."""
+    linear = _build_qkv(
+        monkeypatch,
+        tp=8,
+        rank=7,
+        num_kv_heads=8,
+        num_replicas=1,
+        checkpoint_sections=(3072, 384, 256),
+        continuous=False,
+    )
+    weights = {
+        'q': _source_weight(12288, 0),
+        'k': _source_weight(1536, 3),
+        'v': _source_weight(1024, 7),
+    }
+    scales = {
+        'q': (1 + torch.arange(96, dtype=torch.float32) / 32)[:, None],
+        'k': (5 + torch.arange(12, dtype=torch.float32) / 16)[:, None],
+        'v': (9 + torch.arange(8, dtype=torch.float32) / 8)[:, None],
+    }
+    _load_qkv(linear, weights, scales)
+
+    x = torch.linspace(-1, 1, 128, dtype=torch.bfloat16).view(1, 128)
+    query, key, value = linear.split_qkv(linear(x))
+    q_start, k_start, v_start = 7 * 1536, 7 * 192, 7 * 128
+    q_scale = scales['q'].flatten().repeat_interleave(128)[q_start:q_start + 1536]
+    k_scale = scales['k'].flatten().repeat_interleave(128)[k_start:k_start + 192]
+    v_scale = scales['v'].flatten().repeat_interleave(128)[v_start:v_start + 128]
+
+    expected_q = _project(x, weights['q'][q_start:q_start + 1536], q_scale)
+    expected_k = _project(x, weights['k'][k_start:k_start + 192], k_scale)
+    expected_v = _project(x, weights['v'][v_start:v_start + 128], v_scale)
+    torch.testing.assert_close(query.flatten(1), expected_q)
+    torch.testing.assert_close(key.flatten(1), expected_k)
+    torch.testing.assert_close(value.flatten(1), expected_v)

--- a/tests/pytorch/spec_decode/test_cudagraph_strategy.py
+++ b/tests/pytorch/spec_decode/test_cudagraph_strategy.py
@@ -76,6 +76,134 @@ def test_cudagraph_fa3_metadata_uses_single_query_len_for_single_token_capture()
     assert model.max_seqlen_q_calls == [1, 1]
 
 
+def test_cudagraph_fill_preserves_runtime_attention_metadata():
+    from types import SimpleNamespace
+
+    import torch
+
+    from lmdeploy.pytorch.models.utils.cudagraph import CudaGraphMeta, CudaGraphMixin
+
+    model = CudaGraphMixin()
+    graph_meta = CudaGraphMeta(
+        max_batchs=2,
+        max_tokens=4,
+        num_blocks=2,
+        is_decoding=True,
+        device=torch.device('cpu'),
+        input_buffers={},
+        output_buffers={},
+        decode_query_len=2,
+    )
+    input_ids = torch.arange(4).view(1, 4)
+    position_ids = input_ids.clone()
+    attn_metadata = SimpleNamespace(
+        q_seqlens=torch.tensor([2, 2]),
+        block_offsets=torch.tensor([[3, 4], [5, 6]]),
+        q_start_loc=torch.tensor([0, 2]),
+        kv_seqlens=torch.tensor([7, 11]),
+    )
+    original_fields = {
+        name: getattr(attn_metadata, name).clone()
+        for name in ('q_seqlens', 'block_offsets', 'q_start_loc', 'kv_seqlens')
+    }
+    graph_meta.input_buffers = model.make_buffers_cudagraph(
+        graph_meta,
+        input_ids=input_ids,
+        position_ids=position_ids,
+        past_key_values=[],
+        attn_metadata=attn_metadata,
+    )
+
+    for _ in range(2):
+        graph_inputs = model.fill_buffers_cudagraph(
+            graph_meta,
+            input_ids=input_ids,
+            position_ids=position_ids,
+            past_key_values=[],
+            attn_metadata=attn_metadata,
+            inputs_embeds=None,
+        )
+        for name, expected in original_fields.items():
+            assert torch.equal(getattr(attn_metadata, name), expected)
+        assert torch.equal(graph_inputs['attn_metadata'].q_seqlens[:2], original_fields['q_seqlens'])
+        assert torch.equal(graph_inputs['attn_metadata'].kv_seqlens[:2], original_fields['kv_seqlens'])
+        assert torch.equal(graph_inputs['attn_metadata'].block_offsets[:2], original_fields['block_offsets'])
+
+
+def test_cudagraph_capture_rolls_back_state_before_semantic_forward(monkeypatch):
+    from types import SimpleNamespace
+
+    import torch
+
+    from lmdeploy.pytorch.backends.cuda import graph_runner as graph_runner_mod
+
+    cache = [torch.arange(24).view(6, 4), torch.arange(24, 48).view(6, 4)]
+    original = [tensor.clone() for tensor in cache]
+    block_offsets = torch.tensor([[1, 3], [3, 4]])
+    block_ids = torch.tensor([1, 3, 4])
+
+    class FakeSingleGraphRunner:
+
+        def __init__(self, *args, **kwargs):
+            del args, kwargs
+
+        def capture(self, **kwargs):
+            del kwargs
+            for tensor in cache:
+                tensor[block_ids] += 10
+            return 'capture-output'
+
+        def forward(self, **kwargs):
+            del kwargs
+            for tensor, expected in zip(cache, original):
+                torch.testing.assert_close(tensor, expected)
+                tensor[block_ids] += 1
+            return 'semantic-output'
+
+    monkeypatch.setattr(graph_runner_mod, 'CUDASingleGraphRunner', FakeSingleGraphRunner)
+    monkeypatch.setattr(
+        graph_runner_mod,
+        'get_deepep_state',
+        lambda: SimpleNamespace(enabled=lambda: False),
+    )
+
+    model = SimpleNamespace(
+        get_cudagraph_capture_cache=lambda past_key_values, spec_step_idx: cache,
+        get_cudagraph_extra_key=lambda **kwargs: (),
+    )
+    runner = graph_runner_mod.CUDAGraphRunner.__new__(graph_runner_mod.CUDAGraphRunner)
+    runner.model = model
+    runner.ctx_mgr = SimpleNamespace(
+        current_context=lambda: SimpleNamespace(global_is_decoding=lambda: True))
+    runner.enable_graph = lambda **kwargs: True
+    runner.get_graph_key = lambda **kwargs: (2, True, False, 2)
+    runner._get_max_tokens = lambda *args: 4
+    runner._get_decode_model_forward = lambda: model
+    runner._runner_map = {}
+    runner.num_blocks = 8
+    runner.graph_pool_handle = None
+    runner.model_config = SimpleNamespace()
+    runner.device = torch.device('cpu')
+
+    output = runner(
+        input_ids=torch.zeros((1, 4), dtype=torch.long),
+        position_ids=torch.zeros((1, 4), dtype=torch.long),
+        past_key_values=[],
+        attn_metadata=SimpleNamespace(
+            q_seqlens=torch.tensor([2, 2]),
+            block_offsets=block_offsets.to(torch.int32),
+        ),
+        inputs_embeds=None,
+        spec_step_idx=0,
+    )
+
+    assert output == 'semantic-output'
+    assert (2, True, False, 2) in runner._runner_map
+    for actual, expected in zip(cache, original):
+        expected[block_ids] += 1
+        torch.testing.assert_close(actual, expected)
+
+
 def test_cuda_graph_key_separates_query_len_without_target_hidden_size(monkeypatch):
     from types import SimpleNamespace
 

--- a/tests/pytorch/spec_decode/test_spec_agent.py
+++ b/tests/pytorch/spec_decode/test_spec_agent.py
@@ -165,6 +165,10 @@ class _DummyProposer:
     def __init__(self):
         self.get_outputs_calls = 0
         self.update_inputs_decoding_calls = 0
+        self.advance_draft_depth_calls = 0
+        self.advance_extra_inputs = []
+        self.next_extra_inputs = object()
+        self.next_depth_dp_num_tokens = None
         self.model = _DummyDraftModel()
 
     async def get_outputs(self, outputs, inputs, extra_inputs=None, guided_processors=None):
@@ -187,6 +191,34 @@ class _DummyProposer:
             target_hidden_states=target_hidden_states,
             model_metas=model_metas,
         )
+
+    def advance_draft_depth(self,
+                            inputs,
+                            extra_inputs,
+                            draft_token_ids,
+                            target_hidden_states,
+                            model_metas,
+                            *,
+                            first_depth):
+        """Mirror the default recurrent draft transition for agent tests."""
+        self.advance_draft_depth_calls += 1
+        self.advance_extra_inputs.append(extra_inputs)
+        if first_depth:
+            inputs = self.update_inputs_decoding(inputs, extra_inputs, draft_token_ids.transpose(0, 1),
+                                                 target_hidden_states, model_metas)
+            extra_inputs.last_token_indices = None
+        else:
+            step_seqlens = inputs.seq_length.new_ones(inputs.seq_length.size(0))
+            inputs = inputs.step(draft_token_ids.transpose(0, 1), step_seqlens)
+            inputs.model_metas = model_metas
+            inputs.target_hidden_states = target_hidden_states
+        return inputs, self.next_extra_inputs
+
+    def get_draft_depth_token_counts(self, dp_meta):
+        """Return the configured depth layout or the recurrent default."""
+        if self.next_depth_dp_num_tokens is not None:
+            return self.next_depth_dp_num_tokens
+        return dp_meta.dp_batches
 
 
 def test_guided_serial_bitmask_updates_inference_tensor():
@@ -536,6 +568,7 @@ def test_async_model_forward_dp1_non_last_chunk_skips_remaining_spec_forwards():
     assert forward_calls == 1
     assert agent.proposer.get_outputs_calls == 0
     assert agent.proposer.update_inputs_decoding_calls == 0
+    assert agent.proposer.advance_draft_depth_calls == 0
 
 
 def test_async_model_forward_dp_non_last_chunk_pads_block_offsets(monkeypatch):
@@ -571,6 +604,8 @@ def test_async_model_forward_dp_non_last_chunk_pads_block_offsets(monkeypatch):
     assert forward_calls == agent.num_spec_tokens
     assert agent.proposer.get_outputs_calls == agent.num_spec_tokens
     assert agent.proposer.update_inputs_decoding_calls == 1
+    assert agent.proposer.advance_draft_depth_calls == agent.num_spec_tokens - 1
+    assert agent.proposer.advance_extra_inputs == [extra_inputs, agent.proposer.next_extra_inputs]
     assert agent.proposer.model.update_inputs_calls == agent.num_spec_tokens - 1
     assert forwarded_inputs[0] is inputs
     assert [inp.block_offsets.size(1) for inp in forwarded_inputs] == [1, 2, 2]
@@ -607,6 +642,40 @@ def test_async_model_forward_preserves_dp_global_decoding_in_draft_loop(monkeypa
     asyncio.run(agent._async_model_forward(inputs, extra_inputs, sampling_inputs=None))
 
     assert agent.proposer.model.update_inputs_dp_is_decoding == [True, True]
+
+
+def test_async_model_forward_uses_proposer_dp_token_layout(monkeypatch):
+    """Draft architectures may preserve varlen tokens across MTP depths."""
+    import lmdeploy.pytorch.spec_decode.spec_agent as spec_agent_mod
+    from lmdeploy.pytorch.model_inputs import DPMeta
+    from lmdeploy.pytorch.spec_decode.spec_agent import SpecModelAgent
+
+    build_num_tokens = []
+
+    def _build(seqlen, num_tokens):
+        build_num_tokens.append(list(num_tokens))
+        return DPMeta()
+
+    monkeypatch.setattr(spec_agent_mod.DPMeta, 'build', staticmethod(_build))
+    dp_meta = DPMeta(
+        dp_batches=[1, 1],
+        dp_is_decoding=False,
+        dp_draft_num_tokens=[5, 9],
+    )
+    inputs, extra_inputs = _make_non_last_chunk_inputs(dp_meta=dp_meta)
+    inputs.is_chunk = False
+
+    agent = object.__new__(SpecModelAgent)
+    agent.num_spec_tokens = 3
+    agent.rank = 0
+    agent.proposer = _DummyProposer()
+    agent.proposer.next_depth_dp_num_tokens = [5, 9]
+    agent.guided_helper = GuidedSpecHelper()
+    agent._forward_impl = lambda _inputs: {}
+
+    asyncio.run(agent._async_model_forward(inputs, extra_inputs, sampling_inputs=None))
+
+    assert build_num_tokens == [[5, 9]]
 
 
 def test_spec_model_agent_warmup_adds_dp_meta_for_draft_capture(monkeypatch):
@@ -648,6 +717,12 @@ def test_spec_model_agent_warmup_adds_dp_meta_for_draft_capture(monkeypatch):
 
         def get_capture_batch_sizes(self):
             return [2]
+
+        def get_model(self):
+            return self
+
+        def get_cudagraph_warmup_specs(self, max_query_len):
+            return ((max_query_len, 0), (1, 0))
 
     class DummyProposer:
 

--- a/tests/pytorch/test_distributed.py
+++ b/tests/pytorch/test_distributed.py
@@ -1,0 +1,31 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+from types import SimpleNamespace
+
+import torch
+
+import lmdeploy.pytorch.distributed as distributed
+
+
+def test_reduce_scatter_by_tp_sizes_uses_disjoint_output(monkeypatch):
+    """The collective output must not alias any reduce-scatter input view."""
+    manager = SimpleNamespace(current_config=lambda: SimpleNamespace(attn_tp=2))
+    monkeypatch.setattr(distributed, 'get_dist_manager', lambda: manager)
+
+    seen = {}
+
+    def _reduce_scatter(output, inputs, group):
+        seen['group'] = group
+        seen['inputs'] = inputs
+        output_storage = output.untyped_storage().data_ptr()
+        assert all(output_storage != item.untyped_storage().data_ptr() for item in inputs)
+        output.copy_(inputs[0])
+
+    monkeypatch.setattr(distributed.dist, 'reduce_scatter', _reduce_scatter)
+
+    source = torch.arange(12, dtype=torch.float32).reshape(3, 4)
+    result = distributed.reduce_scatter_by_tp_sizes(source, rank=0, tp_sizes=[2, 1], group='test-group')
+
+    assert seen['group'] == 'test-group'
+    assert len(seen['inputs']) == 4
+    torch.testing.assert_close(result, source[:2])
+    assert result.untyped_storage().data_ptr() != source.untyped_storage().data_ptr()

--- a/tests/test_lmdeploy/serve/parsers/test_mimo_parser.py
+++ b/tests/test_lmdeploy/serve/parsers/test_mimo_parser.py
@@ -1,0 +1,124 @@
+import json
+
+from lmdeploy.serve.openai.protocol import ChatCompletionRequest
+from lmdeploy.serve.parsers import ResponseParserManager
+from lmdeploy.serve.parsers.reasoning_parser import ReasoningParserManager
+from lmdeploy.serve.parsers.tool_parser import MiMoToolParser, ToolParserManager
+
+from .helpers import first_stream_delta
+
+MODEL_ID = 'XiaomiMiMo/MiMo-V2-Flash'
+
+
+def _make_request(*, stream: bool = False):
+    return ChatCompletionRequest(
+        model=MODEL_ID,
+        messages=[],
+        stream=stream,
+        tools=[{
+            'type': 'function',
+            'function': {
+                'name': 'run_command',
+                'description': 'Run a command.',
+                'parameters': {
+                    'type': 'object',
+                    'properties': {
+                        'command': {
+                            'type': 'string'
+                        },
+                        'timeout': {
+                            'type': 'integer'
+                        },
+                        'options': {
+                            'type': 'object'
+                        },
+                    },
+                },
+            },
+        }],
+        tool_choice='auto',
+        chat_template_kwargs={'enable_thinking': True},
+    )
+
+
+def _make_response_parser(*, stream: bool = False):
+    cls = ResponseParserManager.get('default')
+    cls.reasoning_parser_cls = ReasoningParserManager.get('default')
+    cls.tool_parser_cls = ToolParserManager.get('mimo')
+    return cls(request=_make_request(stream=stream))
+
+
+def test_mimo_complete_preserves_string_and_coerces_typed_values():
+    parser = MiMoToolParser()
+    parser.adjust_request(_make_request())
+    payload = (
+        '<function=run_command>'
+        '<parameter=command>  printf &quot;a&amp;b&quot;\nnext  </parameter>'
+        '<parameter=timeout>30</parameter>'
+        '<parameter=options>{"check":true}</parameter>'
+        '</function>'
+    )
+
+    call = parser.parse_tool_call_complete(payload)
+
+    assert call is not None
+    assert call.function.name == 'run_command'
+    assert json.loads(call.function.arguments) == {
+        'command': '  printf "a&b"\nnext  ',
+        'timeout': 30,
+        'options': {
+            'check': True
+        },
+    }
+
+def test_mimo_streaming_handles_split_tags_and_multiline_value():
+    parser = _make_response_parser(stream=True)
+    chunks = [
+        '<think>Need a tool.</think>',
+        '<tool_',
+        'call><function=run_',
+        'command><parameter=command>line 1\n',
+        '  line 2</parameter><parameter=timeout>',
+        '10</parameter></function></tool_call>',
+    ]
+    reasoning_parts = []
+    name = None
+    arguments = ''
+
+    for chunk in chunks:
+        for delta, emitted in parser.stream_chunk(delta_text=chunk, delta_token_ids=[]):
+            if delta.reasoning_content:
+                reasoning_parts.append(delta.reasoning_content)
+            if not emitted or not delta.tool_calls:
+                continue
+            for call in delta.tool_calls:
+                if call.function and call.function.name:
+                    name = call.function.name
+                if call.function and call.function.arguments:
+                    arguments += call.function.arguments
+
+    for _ in range(3):
+        delta, emitted = first_stream_delta(parser.stream_chunk(delta_text='', delta_token_ids=[]))
+        if emitted and delta and delta.tool_calls:
+            for call in delta.tool_calls:
+                if call.function and call.function.name:
+                    name = call.function.name
+                if call.function and call.function.arguments:
+                    arguments += call.function.arguments
+
+    assert ''.join(reasoning_parts) == 'Need a tool.'
+    assert name == 'run_command'
+    assert json.loads(arguments) == {
+        'command': 'line 1\n  line 2',
+        'timeout': 10,
+    }
+    assert parser.validate_complete() is True
+
+
+def test_mimo_filters_unknown_tool_names():
+    parser = MiMoToolParser()
+    parser.adjust_request(_make_request())
+
+    unknown = parser.parse_tool_call_complete('<function=unknown></function>')
+    assert unknown is not None
+    assert parser.filter_tool_calls([unknown]) == []


### PR DESCRIPTION
## Motivation

This PR adds support for Xiaomi MiMo-V2-Flash in LMDeploy's PyTorch backend. MiMo-V2-Flash uses hybrid full-attention and sliding-window-attention (SWA) layers and provides a three-layer MTP module for speculative decoding. This PR adds the required model implementation, attention and KV-cache support,
MTP integration, and tool-call parsing.

## Modification

 - Add the MiMo-V2-Flash model configuration and target model implementation.
 - Add the three-layer MiMo MTP draft model.
 - Add support for the model's hybrid full-attention/SWA layer pattern.
 - Add SWA state-ring cache and related CUDA attention kernels.
 - Add tensor-parallel KV-head replication for full-attention and SWA layers.
 - Add paged SWA KV-cache handling for speculative decoding.
 - Integrate MiMo MTP with LMDeploy speculative decoding and CUDA-graph paths.
 - Add the MiMo tool-call parser and register it with the parser manager.
 - Add the FP8 linear and attention paths required by the model.
 - Update model registration, supported-model lists, and English/Chinese documentation.

LMDeploy and Hugging Face were evaluated with aligned settings. The LMDeploy values are averages over repeated runs.

| Benchmark | LMDeploy | Hugging Face | Difference |
| --- | ---: | ---: | ---: |
| GPQA-Diamond | 84.47% (8-run average) | 83.70% | +0.77 pp |
| AIME 2025 | 95.10% (32-run average) | 94.10% | +1.00 pp |


## Acceptance of MTP

The following results use TP8 + DP2 + EP8, attention TP4 per DP group, fixed 128-request ShareGPT workload, 2048 generated tokens, temperature 0, `ignore_eos=true`, three MTP draft positions, and three repeated runs.

### Aggregate results

| Engine | Mean accept length | Acceptance rate |
| --- | ---: | ---: |
| LMDeploy | 3.115 | 70.49% (native draft-token definition) |
| SGLang | 3.076 | 76.91% (including bonus-token normalization) |

### Per-position results

| Engine | Position 1 | Position 2 | Position 3 | Strict 3/3 acceptance |
| --- | ---: | ---: | ---: | ---: |
| LMDeploy | 85.89% | 69.38% | 56.20% | 56.20% |
| SGLang | 84.86% | 67.99% | 54.78% | 54.78% |

LMDeploy's native acceptance rate is `accepted_draft_tokens / drafted_tokens` and excludes the bonus token. Mean accept length includes the bonus token. Position values are prefix acceptance probabilities; they must not be multiplied together. The strict 3/3 rate is the probability that all three draft positions are accepted.

## Performance

The fixed-output benchmark uses the same ShareGPT inputs, TP8 + DP2 + EP8 topology, attention TP4 per DP group, concurrency 128, and three repetitions per point.

### MTP throughput and TTFT

| Engine | Output | Duration (s) | Request throughput (req/s) | Output throughput (tok/s) | TTFT Mean (ms) | TTFT P50 (ms) | TTFT P99 (ms) |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| LMDeploy MTP | 2048 | 36.46 | 3.51 | 7195.01 | 934.35 | 909.23 | 1029.04 |
| SGLang MTP | 2048 | 35.18 | 3.64 | 7457.21 | 469.01 | 463.74 | 535.28 |
| LMDeploy MTP | 4096 | 66.54 | 1.93 | 7896.77 | 689.53 | 676.68 | 797.08 |
| SGLang MTP | 4096 | 63.66 | 2.01 | 8239.97 | 366.37 | 367.62 | 389.05 |
| LMDeploy MTP | 8192 | 121.75 | 1.06 | 8677.01 | 733.45 | 731.26 | 798.63 |
| SGLang MTP | 8192 | 119.26 | 1.08 | 8806.60 | 692.20 | 701.28 | 739.12 |

### MTP TPOT and ITL

| Engine | Output | TPOT Mean (ms) | TPOT P50 (ms) | TPOT P99 (ms) | ITL Mean (ms) | ITL P50 (ms) | ITL P99 (ms) |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| LMDeploy MTP | 2048 | 13.21 | 12.93 | 16.96 | 41.75 | 38.39 | 180.02 |
| SGLang MTP | 2048 | 13.44 | 13.42 | 16.83 | 41.20 | 38.49 | 126.80 |
| LMDeploy MTP | 4096 | 12.08 | 11.84 | 15.74 | 41.19 | 38.62 | 118.37 |
| SGLang MTP | 4096 | 12.27 | 12.15 | 15.26 | 40.28 | 38.60 | 58.35 |
| LMDeploy MTP | 8192 | 11.32 | 11.20 | 13.57 | 41.12 | 38.96 | 75.59 |
| SGLang MTP | 8192 | 11.61 | 11.44 | 13.95 | 40.72 | 39.08 | 49.32 |

LMDeploy MTP output throughput is 96.5%, 95.8%, and 98.5% of SGLang MTP for 2048, 4096, and 8192 output tokens, respectively. MTP TPOT remains within 3% of SGLang in these tests.

## Runtime validation

- TP4 and TP8 target inference and CUDA Graph serving.
- TP8 + DP2 + EP8 + DeepEP + DeepGEMM + MTP3 production topology.
- Prefix caching with MTP and high-concurrency replay.
- SWA boundary and speculative accept/reject/rollback cases.
- MiMo tool-call API round trips.

## Compatibility

No intentional backward-incompatible changes are introduced. MiMo-V2-Flash support targets the PyTorch backend. MTP requires the three-layer draft weights included in the checkpoint. FA3 is optional; unsupported asymmetric head-dimension builds automatically use Triton.

## Validation

- Ruff and `git diff --check` pass.
- Focused model, attention, cache, MTP, FP8, distributed, CUDA Graph, and parser tests pass.
- Real-checkpoint TP4/TP8 and production-topology runtime validation pass.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward-compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.
