### PR TITLE
feat(pytorch): add mimo-v2-flash support

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ LMDeploy is a toolkit for compressing, deploying, and serving LLM, developed by 
   <li>DeepSeek-V3 (685B)</li>
   <li>DeepSeek-V3.2 (685B)</li>
   <li>DeepSeek-V4 (284B, 1.6T)</li>
+  <li>MiMo-V2-Flash (309B-A15B)</li>
   <li>Hy3 (295B-A21B)</li>
   <li>Mixtral (8x7B, 8x22B)</li>
   <li>Gemma (2B - 7B)</li>

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -153,6 +153,7 @@ LMDeploy TurboMind 引擎拥有卓越的推理能力，在各种规模的模型�
   <li>DeepSeek-V3 (685B)</li>
   <li>DeepSeek-V3.2 (685B)</li>
   <li>DeepSeek-V4 (284B, 1.6T)</li>
+  <li>MiMo-V2-Flash (309B-A15B)</li>
   <li>Hy3 (295B-A21B)</li>
   <li>Mixtral (8x7B, 8x22B)</li>
   <li>Gemma (2B - 7B)</li>

--- a/docs/en/advance/spec_decoding.md
+++ b/docs/en/advance/spec_decoding.md
@@ -104,6 +104,29 @@ deepseek-ai/DeepSeek-V3 \
 --max-batch-size 128
 ```
 
+### MiMo-V2-Flash MTP
+
+MiMo-V2-Flash stores three MTP prediction layers in the target checkpoint, so no separate draft model is required. The following TP 4 configuration is a directly runnable example:
+
+```shell
+lmdeploy serve api_server \
+XiaomiMiMo/MiMo-V2-Flash \
+--backend pytorch \
+--trust-remote-code \
+--tp 4 \
+--session-len 262144 \
+--cache-max-entry-count 0.6 \
+--max-batch-size 128 \
+--speculative-algorithm mimo_mtp \
+--speculative-num-draft-tokens 3
+```
+
+MiMo MTP supports one to three draft tokens per step. TP 4 and TP 8 have been validated. CUDA Graph is enabled by default; prefix caching can be enabled with `--enable-prefix-caching` and uses paged verification without flattening the logical KV sequence.
+
+The full-attention path uses FlashAttention 3 only when the installed implementation supports MiMo's asymmetric Q/K and V head dimensions (192 and 128). Otherwise, LMDeploy selects its Triton implementation before execution.
+
+For an eight-GPU production deployment that combines data-parallel attention and expert parallelism, use `--tp 8 --dp 2 --ep 8 --distributed-executor-backend ray` together with an LMDeploy proxy. This topology has two attention groups of TP 4 while the MoE layers use EP 8.
+
 ## Guided Decoding with Speculative Decoding
 
 Speculative decoding (MTP) can be combined with [structured output](./structed_output.md) so that the draft tokens proposed by the spec model also respect the grammar constraints (e.g. JSON schema, regex). This significantly improves the acceptance rate compared to running spec decoding without grammar masks.

--- a/docs/en/llm/api_server_tools.md
+++ b/docs/en/llm/api_server_tools.md
@@ -1,11 +1,26 @@
 # Tools Calling
 
-LMDeploy supports tools for InternLM2, InternLM2.5, llama3.1 and Qwen2.5 models. Please use `--tool-call-parser` to specify
-which parser to use when launching the api_server. Supported names are:
+LMDeploy supports tool calling for multiple model families. Use `--tool-call-parser` to select the parser that matches the model when launching `api_server`. Common parser names include:
 
 1. internlm
 2. qwen
 3. llama3
+4. mimo
+
+## MiMo-V2-Flash
+
+Start MiMo-V2-Flash with its dedicated parser. The parser converts the model's `<tool_call>` output into the OpenAI-compatible `tool_calls` field and supports complete, streaming and multi-round responses.
+
+```shell
+lmdeploy serve api_server XiaomiMiMo/MiMo-V2-Flash \
+  --backend pytorch \
+  --trust-remote-code \
+  --tp 4 \
+  --reasoning-parser default \
+  --tool-call-parser mimo
+```
+
+The parser is also compatible with `mimo_mtp`; add `--speculative-algorithm mimo_mtp --speculative-num-draft-tokens 3` to enable MTP.
 
 ## Single Round Invocation
 

--- a/docs/en/supported_models/supported_models.md
+++ b/docs/en/supported_models/supported_models.md
@@ -92,6 +92,7 @@ The following tables detail the models supported by LMDeploy's TurboMind engine 
 |          DeepSeek-V3           |      685B       | LLM  |    Yes    |   No    |   No    |  No  |  No   |
 |         DeepSeek-V3.2          |      685B       | LLM  |    Yes    |   No    |   No    |  No  |  No   |
 |          DeepSeek-V4           |   284B, 1.6T    | LLM  |    Yes    |   No    |   No    |  No  |  No   |
+| MiMo-V2-Flash<sup>\[2\]</sup>  |    309B-A15B    | LLM  |   BF16    |   No    |   No    | Yes  |  No   |
 |              Hy3               |    295B-A21B    | LLM  |    Yes    |   No    |   No    | Yes  |  No   |
 |          DeepSeek-VL2          |    3B - 27B     | MLLM |    Yes    |   No    |   No    |  No  |  No   |
 |            MiniCPM3            |       4B        | LLM  |    Yes    |   Yes   |   Yes   |  No  |  No   |
@@ -128,6 +129,7 @@ The following tables detail the models supported by LMDeploy's TurboMind engine 
 
 ```{note}
 * [1] PyTorch engine removes the support of original llava models after v0.6.4. Please use their corresponding transformers models instead, which can be found in https://huggingface.co/llava-hf
+* [2] MiMo-V2-Flash is supported with attention TP 4 and TP 8. The checkpoint uses FP8 weights; runtime activations and KV caches require BF16 and the PyTorch CUDA backend.
 Starting from version 0.11.1, PytorchEngine no longer provides support for mllama.
 ```
 

--- a/docs/zh_cn/advance/spec_decoding.md
+++ b/docs/zh_cn/advance/spec_decoding.md
@@ -103,6 +103,29 @@ deepseek-ai/DeepSeek-V3 \
 --max-batch-size 128
 ```
 
+### MiMo-V2-Flash MTP
+
+MiMo-V2-Flash 的 target checkpoint 内含三层 MTP 预测层，因此不需要单独的 draft model。下面是可直接运行的 TP 4 配置：
+
+```shell
+lmdeploy serve api_server \
+XiaomiMiMo/MiMo-V2-Flash \
+--backend pytorch \
+--trust-remote-code \
+--tp 4 \
+--session-len 262144 \
+--cache-max-entry-count 0.6 \
+--max-batch-size 128 \
+--speculative-algorithm mimo_mtp \
+--speculative-num-draft-tokens 3
+```
+
+MiMo MTP 每步支持 1 至 3 个 draft token，TP 4 和 TP 8 均已验证。CUDA Graph 默认启用；可通过 `--enable-prefix-caching` 开启 prefix cache，此组合使用 paged verification，不会展开复制完整的逻辑 KV 序列。
+
+只有已安装的 FlashAttention 3 实现支持 MiMo 非对称的 Q/K 和 V head dimension（分别为 192 和 128）时，Full Attention 才会选择 FA3；否则 LMDeploy 会在执行前选择 Triton 实现。
+
+八卡生产部署如需同时使用 data-parallel attention 和 expert parallelism，请在 LMDeploy proxy 下配置 `--tp 8 --dp 2 --ep 8 --distributed-executor-backend ray`。此拓扑包含两个 attention TP 4 group，MoE 层使用 EP 8。
+
 ## 投机解码与结构化输出
 
 投机解码（MTP）可以与[结构化输出](./structed_output.md)结合使用，使草稿模型提出的 token 也遵循语法约束（如 JSON Schema、正则表达式），从而显著提高接受率。

--- a/docs/zh_cn/llm/api_server_tools.md
+++ b/docs/zh_cn/llm/api_server_tools.md
@@ -1,11 +1,26 @@
 # Tools
 
-LMDeploy 支持 InternLM2, InternLM2.5, Llama3.1 和 Qwen2.5模型的工具调用。请在启动 api_server 的时候使用 `--tool-call-parser` 指定
-parser 名字。以下是支持的名字:
+LMDeploy 支持多个模型系列的工具调用。启动 `api_server` 时，请使用 `--tool-call-parser` 选择与模型匹配的解析器。常用名称包括：
 
 1. internlm
 2. qwen
 3. llama3
+4. mimo
+
+## MiMo-V2-Flash
+
+请使用 MiMo-V2-Flash 专用解析器启动服务。解析器会将模型输出的 `<tool_call>` 转换为 OpenAI 兼容的 `tool_calls` 字段，并支持非流式、流式和多轮响应。
+
+```shell
+lmdeploy serve api_server XiaomiMiMo/MiMo-V2-Flash \
+  --backend pytorch \
+  --trust-remote-code \
+  --tp 4 \
+  --reasoning-parser default \
+  --tool-call-parser mimo
+```
+
+该解析器同样兼容 `mimo_mtp`；添加 `--speculative-algorithm mimo_mtp --speculative-num-draft-tokens 3` 即可开启 MTP。
 
 ## 单轮调用
 

--- a/docs/zh_cn/supported_models/supported_models.md
+++ b/docs/zh_cn/supported_models/supported_models.md
@@ -93,6 +93,7 @@
 |          DeepSeek-V3           |      685B       | LLM  |    Yes    |   No    |   No    |  No  |  No   |
 |         DeepSeek-V3.2          |      685B       | LLM  |    Yes    |   No    |   No    |  No  |  No   |
 |          DeepSeek-V4           |   284B, 1.6T    | LLM  |    Yes    |   No    |   No    |  No  |  No   |
+| MiMo-V2-Flash<sup>\[2\]</sup>  |    309B-A15B    | LLM  |   BF16    |   No    |   No    | Yes  |  No   |
 |              Hy3               |    295B-A21B    | LLM  |    Yes    |   No    |   No    | Yes  |  No   |
 |          DeepSeek-VL2          |    3B - 27B     | MLLM |    Yes    |   No    |   No    |  No  |  No   |
 |            MiniCPM3            |       4B        | LLM  |    Yes    |   Yes   |   Yes   |  No  |  No   |
@@ -129,6 +130,7 @@
 
 ```{note}
 * [1] 自 0.6.4 之后，PyTorch 引擎移除了对 llava 模型原始格式的支持。我们建议使用它们对应的 transformers 格式的模型。这些模型可以在 https://huggingface.co/llava-hf 中找到
+* [2] MiMo-V2-Flash 已验证支持 attention TP 4 和 TP 8。该 checkpoint 使用 FP8 权重；运行时激活和 KV cache 必须使用 BF16，且仅支持 PyTorch CUDA 后端。
 自 0.11.1 起，PytorchEngine 移除了 mllama 的支持
 ```
 

--- a/lmdeploy/cli/utils.py
+++ b/lmdeploy/cli/utils.py
@@ -821,7 +821,7 @@ class ArgumentHelper:
         spec_group.add_argument('--speculative-algorithm',
                                 type=str,
                                 default=None,
-                                choices=['eagle', 'eagle3', 'deepseek_mtp', 'hy3_mtp', 'qwen3_5_mtp'],
+                                choices=['eagle', 'eagle3', 'deepseek_mtp', 'hy3_mtp', 'mimo_mtp', 'qwen3_5_mtp'],
                                 help='The speculative algorithm to use. `None` means speculative decoding is disabled')
 
         spec_group.add_argument('--speculative-draft-model',

--- a/lmdeploy/pytorch/backends/attention.py
+++ b/lmdeploy/pytorch/backends/attention.py
@@ -227,18 +227,6 @@ class PagedAttentionBuildSpec(BuildSpec[AttentionImpl[AttentionMetadata]]):
     learnable_sink: bool
     block_sparse_size: int
 
-    @property
-    def requires_multi_token_decode(self) -> bool:
-        """Whether speculative decode needs a native multi-token backend."""
-        from lmdeploy.pytorch.model_inputs import get_step_ctx_manager
-
-        ctx_manager = get_step_ctx_manager()
-        if ctx_manager is None:
-            return False
-        build_ctx = ctx_manager.build_ctx
-        return (build_ctx.model_paradigm == 'ar_spec' and not build_ctx.use_flash_mla
-                and build_ctx.num_spec_tokens > 0)
-
 
 @dataclass(frozen=True)
 class SWAStateRingAttentionBuildSpec(BuildSpec[AttentionImpl[AttentionMetadata]]):

--- a/lmdeploy/pytorch/backends/attention.py
+++ b/lmdeploy/pytorch/backends/attention.py
@@ -2,13 +2,32 @@
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from functools import lru_cache
-from typing import Generic, TypeVar
+from typing import Generic, Literal, TypeVar, cast
 
 import torch
 
 from lmdeploy.messages import QuantPolicy
 
 from .base import BuildSpec
+
+DecodeMode = Literal['block', 'speculative']
+_VALID_DECODE_MODES = frozenset(('block', 'speculative'))
+
+
+def normalize_decode_mode(decode_mode: str | None, *, default: DecodeMode = 'block') -> DecodeMode:
+    """Validate and normalize an attention decode semantic."""
+    if decode_mode is None:
+        decode_mode = default
+    if decode_mode not in _VALID_DECODE_MODES:
+        raise ValueError(
+            f'Unsupported attention decode mode {decode_mode!r}; '
+            f'expected one of {sorted(_VALID_DECODE_MODES)}.')
+    return cast(DecodeMode, decode_mode)
+
+
+def decode_mode_uses_causal_mask(decode_mode: str | None) -> bool:
+    """Return whether multi-token decoding requires a causal mask."""
+    return normalize_decode_mode(decode_mode) == 'speculative'
 
 
 @dataclass
@@ -204,7 +223,7 @@ class AttentionImpl(ABC, Generic[T]):
         learnable_sink: torch.Tensor = None,
         nsa_indices: torch.Tensor = None,
         inplace: bool = False,
-        decode_mode: str = 'block',
+        decode_mode: DecodeMode = 'block',
     ) -> torch.Tensor:
         """forward."""
         raise NotImplementedError
@@ -227,6 +246,7 @@ class PagedAttentionBuildSpec(BuildSpec[AttentionImpl[AttentionMetadata]]):
     mla_index_topk: int | None
     learnable_sink: bool
     block_sparse_size: int
+    dtype: torch.dtype | None = None
 
 
 @dataclass(frozen=True)

--- a/lmdeploy/pytorch/backends/attention.py
+++ b/lmdeploy/pytorch/backends/attention.py
@@ -226,3 +226,5 @@ class PagedAttentionBuildSpec(BuildSpec[AttentionImpl[AttentionMetadata]]):
     mla_index_topk: int | None
     learnable_sink: bool
     block_sparse_size: int
+    allow_fa3: bool = True
+    enable_paged_multi_token_decode: bool = False

--- a/lmdeploy/pytorch/backends/attention.py
+++ b/lmdeploy/pytorch/backends/attention.py
@@ -226,5 +226,17 @@ class PagedAttentionBuildSpec(BuildSpec[AttentionImpl[AttentionMetadata]]):
     mla_index_topk: int | None
     learnable_sink: bool
     block_sparse_size: int
-    allow_fa3: bool = True
-    enable_paged_multi_token_decode: bool = False
+
+
+@dataclass(frozen=True)
+class SWAStateRingAttentionBuildSpec(BuildSpec[AttentionImpl[AttentionMetadata]]):
+    """Requirements for sequence-scoped sliding-window state-ring attention."""
+
+    num_heads: int
+    head_dim: int
+    scale: float | None
+    num_kv_heads: int
+    v_head_dim: int
+    sliding_window: tuple[int, int]
+    learnable_sink: bool
+    block_sparse_size: int = 1

--- a/lmdeploy/pytorch/backends/attention.py
+++ b/lmdeploy/pytorch/backends/attention.py
@@ -227,6 +227,18 @@ class PagedAttentionBuildSpec(BuildSpec[AttentionImpl[AttentionMetadata]]):
     learnable_sink: bool
     block_sparse_size: int
 
+    @property
+    def requires_multi_token_decode(self) -> bool:
+        """Whether speculative decode needs a native multi-token backend."""
+        from lmdeploy.pytorch.model_inputs import get_step_ctx_manager
+
+        ctx_manager = get_step_ctx_manager()
+        if ctx_manager is None:
+            return False
+        build_ctx = ctx_manager.build_ctx
+        return (build_ctx.model_paradigm == 'ar_spec' and not build_ctx.use_flash_mla
+                and build_ctx.num_spec_tokens > 0)
+
 
 @dataclass(frozen=True)
 class SWAStateRingAttentionBuildSpec(BuildSpec[AttentionImpl[AttentionMetadata]]):

--- a/lmdeploy/pytorch/backends/attention.py
+++ b/lmdeploy/pytorch/backends/attention.py
@@ -204,6 +204,7 @@ class AttentionImpl(ABC, Generic[T]):
         learnable_sink: torch.Tensor = None,
         nsa_indices: torch.Tensor = None,
         inplace: bool = False,
+        decode_mode: str = 'block',
     ) -> torch.Tensor:
         """forward."""
         raise NotImplementedError

--- a/lmdeploy/pytorch/backends/cuda/attention/__init__.py
+++ b/lmdeploy/pytorch/backends/cuda/attention/__init__.py
@@ -7,16 +7,9 @@ from lmdeploy.pytorch import envs as _envs
 from lmdeploy.pytorch.backends.attention import PagedAttentionBuildSpec
 from lmdeploy.utils import get_logger
 
-<<<<<<< HEAD
 from .default import TritonAttentionImpl
 from .default import TritonAttentionMetadata as TritonAttentionMetadata
 from .fa3_capabilities import fa3_build_supports_head_dims
-from .v4 import TritonV4AttentionBuilder  # noqa: F401
-=======
-from .default import TritonAttentionImpl, TritonAttentionMetadata
-from .fa3_capabilities import fa3_build_supports_head_dims
-from .v4 import TritonV4AttentionBuilder  # noqa: F401
->>>>>>> b9d967e0 (feat(pytorch): support MiMo-V2-Flash inference)
 
 logger = get_logger('lmdeploy')
 
@@ -102,7 +95,7 @@ def _build_paged_attention(spec: PagedAttentionBuildSpec) -> TritonAttentionImpl
 
     Selection order:
     1. use_flash_mla: Use dense or sparse FlashMLA for MLA models
-    2. enable_fa3: Use FA3Impl if FA3 is available and supported
+    2. allow_fa3: Enable FA3Impl if FA3 is available and supported
     3. Default: Use TritonAttentionImpl as fallback
     """
     sliding_window = _normalize_sliding_window(spec.sliding_window)
@@ -116,10 +109,20 @@ def _build_paged_attention(spec: PagedAttentionBuildSpec) -> TritonAttentionImpl
         sliding_window=sliding_window,
         logit_softcapping=spec.logit_softcapping,
         causal=spec.causal,
+        enable_paged_multi_token_decode=spec.enable_paged_multi_token_decode,
     )
-    enable_fa3 = spec.enable_fa3 and _enable_fa3(spec.alibi, spec.learnable_sink, spec.block_sparse_size, spec.head_dim, spec.v_head_dim)
+    enable_fa3 = spec.allow_fa3 and _enable_fa3(
+        spec.alibi,
+        spec.learnable_sink,
+        spec.block_sparse_size,
+        spec.head_dim,
+        spec.v_head_dim,
+    )
+    # FlashMLA's FA3 prefill path uses its own split dimensions (rope/nope),
+    # so the paged-attention head-shape capability check above does not apply.
+    # ``allow_fa3`` still provides the model-level opt-out used by MiMo SWA.
+    use_fa3_for_mla = spec.allow_fa3 and use_fa3
 
-<<<<<<< HEAD
     if spec.use_flash_mla is True:
         if spec.mla_index_topk is not None:
             if _envs.sparse_mla_backend == 'tilelang':
@@ -127,19 +130,19 @@ def _build_paged_attention(spec: PagedAttentionBuildSpec) -> TritonAttentionImpl
                 from .sparse_mla import TileLangSparseMLAImpl
                 return TileLangSparseMLAImpl(
                     mla_index_topk=spec.mla_index_topk,
-                    use_fa3=use_fa3,
+                    use_fa3=use_fa3_for_mla,
                     **common_args,
                 )
             logger.debug('Build FlashMLASparseImpl Attention')
             from .sparse_mla import FlashMLASparseImpl
             return FlashMLASparseImpl(
                 mla_index_topk=spec.mla_index_topk,
-                use_fa3=use_fa3,
+                use_fa3=use_fa3_for_mla,
                 **common_args,
             )
         logger.debug('Build FlashMLAImpl Attention')
         from .mla import FlashMLAImpl
-        return FlashMLAImpl(use_fa3=use_fa3, **common_args)
+        return FlashMLAImpl(use_fa3=use_fa3_for_mla, **common_args)
     elif enable_fa3:
         logger.debug('Build FA3Impl Attention')
         from .fa3 import FA3Impl
@@ -147,81 +150,3 @@ def _build_paged_attention(spec: PagedAttentionBuildSpec) -> TritonAttentionImpl
     else:
         logger.debug('Build TritonAttentionImpl Attention')
         return TritonAttentionImpl(block_sparse_size=spec.block_sparse_size, **common_args)
-=======
-    @staticmethod
-    def build(
-        num_heads: int,
-        head_size: int,
-        scale: float = None,
-        num_kv_heads: int = None,
-        v_head_size: int = None,
-        alibi: bool = False,
-        sliding_window: int = None,
-        logit_softcapping: float = 0.0,
-        causal: bool = True,
-        use_flash_mla: bool = False,
-        mla_index_topk: int | None = None,
-        learnable_sink: bool = False,
-        block_sparse_size: int = 1,
-        enable_fa3: bool = True,
-        **kwargs,
-    ) -> TritonAttentionImpl:
-        """Build appropriate attention implementation.
-
-        Args:
-            num_heads: Number of attention heads.
-            head_size: Size of each attention head.
-            scale: Scaling factor for attention scores.
-            num_kv_heads: Number of key-value heads (for GQA).
-            v_head_size: Size of value head (for MLA).
-            alibi: Whether to use ALiBi positional encoding.
-            sliding_window: Sliding window size for local attention.
-            logit_softcapping: Logit softcapping value (for Gemma 2).
-            causal: Whether to use causal attention.
-            use_flash_mla: Whether to use Flash MLA implementation.
-            mla_index_topk: Sparse MLA top-k width, or ``None`` for dense MLA.
-            learnable_sink: Whether to use learnable sink tokens.
-            block_sparse_size: Block sparse attention size.
-            enable_fa3: Whether this attention configuration may use FA3.
-            **kwargs: Additional arguments.
-
-        Returns:
-            Appropriate AttentionImpl instance.
-        """
-        # Normalize sliding window format
-        sliding_window = _normalize_sliding_window(sliding_window)
-
-        # Common arguments for all implementations
-        common_args = dict(
-            num_heads=num_heads,
-            head_size=head_size,
-            scale=scale,
-            num_kv_heads=num_kv_heads,
-            v_head_size=v_head_size,
-            alibi=alibi,
-            sliding_window=sliding_window,
-            logit_softcapping=logit_softcapping,
-            causal=causal,
-            **kwargs,
-        )
-        enable_fa3 = enable_fa3 and _enable_fa3(
-            alibi, learnable_sink, block_sparse_size, head_size, v_head_size)
-
-        if use_flash_mla is True:
-            if mla_index_topk is not None:
-                logger.debug('Build FlashMLASparseImpl Attention')
-                from .sparse_mla import FlashMLASparseImpl
-                return FlashMLASparseImpl(mla_index_topk=mla_index_topk,
-                                          use_fa3=use_fa3,
-                                          **common_args)
-            logger.debug('Build FlashMLAImpl Attention')
-            from .mla import FlashMLAImpl
-            return FlashMLAImpl(use_fa3=use_fa3, **common_args)
-        elif enable_fa3:
-            logger.debug('Build FA3Impl Attention')
-            from .fa3 import FA3Impl
-            return FA3Impl(**common_args)
-        else:
-            logger.debug('Build TritonAttentionImpl Attention')
-            return TritonAttentionImpl(block_sparse_size=block_sparse_size, **common_args)
->>>>>>> b9d967e0 (feat(pytorch): support MiMo-V2-Flash inference)

--- a/lmdeploy/pytorch/backends/cuda/attention/__init__.py
+++ b/lmdeploy/pytorch/backends/cuda/attention/__init__.py
@@ -95,7 +95,7 @@ def _build_paged_attention(spec: PagedAttentionBuildSpec) -> TritonAttentionImpl
 
     Selection order:
     1. use_flash_mla: Use dense or sparse FlashMLA for MLA models
-    2. allow_fa3: Enable FA3Impl if FA3 is available and supported
+    2. enable_fa3: Select FA3Impl if FA3 is available and supported
     3. Default: Use TritonAttentionImpl as fallback
     """
     sliding_window = _normalize_sliding_window(spec.sliding_window)
@@ -109,9 +109,8 @@ def _build_paged_attention(spec: PagedAttentionBuildSpec) -> TritonAttentionImpl
         sliding_window=sliding_window,
         logit_softcapping=spec.logit_softcapping,
         causal=spec.causal,
-        enable_paged_multi_token_decode=spec.enable_paged_multi_token_decode,
     )
-    enable_fa3 = spec.allow_fa3 and _enable_fa3(
+    enable_fa3 = _enable_fa3(
         spec.alibi,
         spec.learnable_sink,
         spec.block_sparse_size,
@@ -120,8 +119,7 @@ def _build_paged_attention(spec: PagedAttentionBuildSpec) -> TritonAttentionImpl
     )
     # FlashMLA's FA3 prefill path uses its own split dimensions (rope/nope),
     # so the paged-attention head-shape capability check above does not apply.
-    # ``allow_fa3`` still provides the model-level opt-out used by MiMo SWA.
-    use_fa3_for_mla = spec.allow_fa3 and use_fa3
+    use_fa3_for_mla = use_fa3
 
     if spec.use_flash_mla is True:
         if spec.mla_index_topk is not None:

--- a/lmdeploy/pytorch/backends/cuda/attention/__init__.py
+++ b/lmdeploy/pytorch/backends/cuda/attention/__init__.py
@@ -7,8 +7,16 @@ from lmdeploy.pytorch import envs as _envs
 from lmdeploy.pytorch.backends.attention import PagedAttentionBuildSpec
 from lmdeploy.utils import get_logger
 
+<<<<<<< HEAD
 from .default import TritonAttentionImpl
 from .default import TritonAttentionMetadata as TritonAttentionMetadata
+from .fa3_capabilities import fa3_build_supports_head_dims
+from .v4 import TritonV4AttentionBuilder  # noqa: F401
+=======
+from .default import TritonAttentionImpl, TritonAttentionMetadata
+from .fa3_capabilities import fa3_build_supports_head_dims
+from .v4 import TritonV4AttentionBuilder  # noqa: F401
+>>>>>>> b9d967e0 (feat(pytorch): support MiMo-V2-Flash inference)
 
 logger = get_logger('lmdeploy')
 
@@ -50,7 +58,11 @@ def use_fa3_warning():
 
 
 @functools.lru_cache
-def _enable_fa3(alibi: bool, learnable_sink: bool, block_sparse_size: int, head_size: int) -> bool:
+def _enable_fa3(alibi: bool,
+                learnable_sink: bool,
+                block_sparse_size: int,
+                head_size: int,
+                v_head_size: int | None = None) -> bool:
     """Check if FA3 should be enabled.
 
     FA3 is enabled when:
@@ -62,7 +74,8 @@ def _enable_fa3(alibi: bool, learnable_sink: bool, block_sparse_size: int, head_
     Returns:
         True if FA3 should be enabled, False otherwise.
     """
-    enable = not alibi and not learnable_sink and block_sparse_size == 1 and head_size <= 256
+    enable = (not alibi and not learnable_sink and block_sparse_size == 1
+              and fa3_build_supports_head_dims(head_size, v_head_size))
     if enable and not use_fa3_warning():
         enable = False
     return enable
@@ -104,8 +117,9 @@ def _build_paged_attention(spec: PagedAttentionBuildSpec) -> TritonAttentionImpl
         logit_softcapping=spec.logit_softcapping,
         causal=spec.causal,
     )
-    enable_fa3 = _enable_fa3(spec.alibi, spec.learnable_sink, spec.block_sparse_size, spec.head_dim)
+    enable_fa3 = spec.enable_fa3 and _enable_fa3(spec.alibi, spec.learnable_sink, spec.block_sparse_size, spec.head_dim, spec.v_head_dim)
 
+<<<<<<< HEAD
     if spec.use_flash_mla is True:
         if spec.mla_index_topk is not None:
             if _envs.sparse_mla_backend == 'tilelang':
@@ -133,3 +147,81 @@ def _build_paged_attention(spec: PagedAttentionBuildSpec) -> TritonAttentionImpl
     else:
         logger.debug('Build TritonAttentionImpl Attention')
         return TritonAttentionImpl(block_sparse_size=spec.block_sparse_size, **common_args)
+=======
+    @staticmethod
+    def build(
+        num_heads: int,
+        head_size: int,
+        scale: float = None,
+        num_kv_heads: int = None,
+        v_head_size: int = None,
+        alibi: bool = False,
+        sliding_window: int = None,
+        logit_softcapping: float = 0.0,
+        causal: bool = True,
+        use_flash_mla: bool = False,
+        mla_index_topk: int | None = None,
+        learnable_sink: bool = False,
+        block_sparse_size: int = 1,
+        enable_fa3: bool = True,
+        **kwargs,
+    ) -> TritonAttentionImpl:
+        """Build appropriate attention implementation.
+
+        Args:
+            num_heads: Number of attention heads.
+            head_size: Size of each attention head.
+            scale: Scaling factor for attention scores.
+            num_kv_heads: Number of key-value heads (for GQA).
+            v_head_size: Size of value head (for MLA).
+            alibi: Whether to use ALiBi positional encoding.
+            sliding_window: Sliding window size for local attention.
+            logit_softcapping: Logit softcapping value (for Gemma 2).
+            causal: Whether to use causal attention.
+            use_flash_mla: Whether to use Flash MLA implementation.
+            mla_index_topk: Sparse MLA top-k width, or ``None`` for dense MLA.
+            learnable_sink: Whether to use learnable sink tokens.
+            block_sparse_size: Block sparse attention size.
+            enable_fa3: Whether this attention configuration may use FA3.
+            **kwargs: Additional arguments.
+
+        Returns:
+            Appropriate AttentionImpl instance.
+        """
+        # Normalize sliding window format
+        sliding_window = _normalize_sliding_window(sliding_window)
+
+        # Common arguments for all implementations
+        common_args = dict(
+            num_heads=num_heads,
+            head_size=head_size,
+            scale=scale,
+            num_kv_heads=num_kv_heads,
+            v_head_size=v_head_size,
+            alibi=alibi,
+            sliding_window=sliding_window,
+            logit_softcapping=logit_softcapping,
+            causal=causal,
+            **kwargs,
+        )
+        enable_fa3 = enable_fa3 and _enable_fa3(
+            alibi, learnable_sink, block_sparse_size, head_size, v_head_size)
+
+        if use_flash_mla is True:
+            if mla_index_topk is not None:
+                logger.debug('Build FlashMLASparseImpl Attention')
+                from .sparse_mla import FlashMLASparseImpl
+                return FlashMLASparseImpl(mla_index_topk=mla_index_topk,
+                                          use_fa3=use_fa3,
+                                          **common_args)
+            logger.debug('Build FlashMLAImpl Attention')
+            from .mla import FlashMLAImpl
+            return FlashMLAImpl(use_fa3=use_fa3, **common_args)
+        elif enable_fa3:
+            logger.debug('Build FA3Impl Attention')
+            from .fa3 import FA3Impl
+            return FA3Impl(**common_args)
+        else:
+            logger.debug('Build TritonAttentionImpl Attention')
+            return TritonAttentionImpl(block_sparse_size=block_sparse_size, **common_args)
+>>>>>>> b9d967e0 (feat(pytorch): support MiMo-V2-Flash inference)

--- a/lmdeploy/pytorch/backends/cuda/attention/__init__.py
+++ b/lmdeploy/pytorch/backends/cuda/attention/__init__.py
@@ -9,7 +9,7 @@ from lmdeploy.utils import get_logger
 
 from .default import TritonAttentionImpl
 from .default import TritonAttentionMetadata as TritonAttentionMetadata
-from .fa3_capabilities import fa3_build_supports_head_dims
+from .fa3_capabilities import fa3_build_supports_operation
 
 logger = get_logger('lmdeploy')
 
@@ -50,28 +50,45 @@ def use_fa3_warning():
     return False
 
 
-@functools.lru_cache
 def _enable_fa3(alibi: bool,
                 learnable_sink: bool,
                 block_sparse_size: int,
                 head_size: int,
-                v_head_size: int | None = None) -> bool:
+                v_head_size: int | None = None,
+                sliding_window: tuple[int, int] | None = None,
+                logit_softcapping: float = 0.0,
+                dtype: torch.dtype | None = None) -> bool:
     """Check if FA3 should be enabled.
 
-    FA3 is enabled when:
-    - No alibi
-    - No learnable sink
-    - block_sparse_size == 1
-    - FA3 is available (checked by use_fa3_warning)
+    FA3 is enabled when the attention features, current GPU architecture,
+    and installed wheel build flags all support the complete implementation.
+    Do not cache this decision: one process may construct models on devices
+    with different compute capabilities.
 
     Returns:
         True if FA3 should be enabled, False otherwise.
     """
-    enable = (not alibi and not learnable_sink and block_sparse_size == 1
-              and fa3_build_supports_head_dims(head_size, v_head_size))
-    if enable and not use_fa3_warning():
-        enable = False
-    return enable
+    if alibi or learnable_sink or block_sparse_size != 1:
+        return False
+    try:
+        device_capability = torch.cuda.get_device_capability()
+    except Exception:
+        return False
+
+    sliding_window = _normalize_sliding_window(sliding_window)
+    supported = fa3_build_supports_operation(
+        head_size,
+        v_head_size,
+        device_capability=device_capability,
+        dtype=dtype,
+        # FA3Impl serves varlen prefill and paged-KV decoding, so a selected
+        # wheel must contain both operation families.
+        paged_kv=True,
+        varlen=True,
+        local=sliding_window != (-1, -1),
+        softcap=logit_softcapping > 0.0,
+    )
+    return supported and use_fa3_warning()
 
 
 def _normalize_sliding_window(sliding_window):
@@ -116,6 +133,9 @@ def _build_paged_attention(spec: PagedAttentionBuildSpec) -> TritonAttentionImpl
         spec.block_sparse_size,
         spec.head_dim,
         spec.v_head_dim,
+        sliding_window,
+        spec.logit_softcapping,
+        spec.dtype,
     )
     # FlashMLA's FA3 prefill path uses its own split dimensions (rope/nope),
     # so the paged-attention head-shape capability check above does not apply.

--- a/lmdeploy/pytorch/backends/cuda/attention/default.py
+++ b/lmdeploy/pytorch/backends/cuda/attention/default.py
@@ -115,6 +115,8 @@ class TritonAttentionMetaBuilder(CudaAttentionMetaBuilder[None, None]):
 class TritonAttentionImpl(AttentionImpl[TritonAttentionMetadata]):
     """Triton attention implementation."""
 
+    supports_multi_token_decode = True
+
     def __init__(
         self,
         num_heads: int,
@@ -127,7 +129,6 @@ class TritonAttentionImpl(AttentionImpl[TritonAttentionMetadata]):
         logit_softcapping: float = 0.0,
         causal: bool = True,
         block_sparse_size: int = 1,
-        enable_paged_multi_token_decode: bool = False,
         **kwargs,
     ):
         super().__init__(
@@ -158,10 +159,6 @@ class TritonAttentionImpl(AttentionImpl[TritonAttentionMetadata]):
         self.flash_attention_fwd = flash_attn_varlen_func
 
         self.block_sparse_size = block_sparse_size
-        self.supports_paged_multi_token_decode = (
-            enable_paged_multi_token_decode
-            or getattr(type(self), 'supports_paged_multi_token_decode', False)
-        )
         self._step_meta_group: int | None = None
         self._piecewise_forward: Callable[..., torch.Tensor] | None = None
 
@@ -244,7 +241,7 @@ class TritonAttentionImpl(AttentionImpl[TritonAttentionMetadata]):
     ) -> int:
         """Get max q seqlen."""
         if attn_metadata.is_decoding:
-            if self.supports_paged_multi_token_decode:
+            if self.supports_multi_token_decode:
                 batch_size = attn_metadata.block_offsets.size(0)
                 return query.size(0) // batch_size
             max_q_seqlen = self.block_sparse_size
@@ -352,7 +349,7 @@ class TritonAttentionImpl(AttentionImpl[TritonAttentionMetadata]):
             quant_policy=quant_policy,
             k_scales_zeros=k_scales_zeros,
             v_scales_zeros=v_scales_zeros,
-            causal_multi_token=self.supports_paged_multi_token_decode and max_q_seqlen > 1,
+            causal_multi_token=self.supports_multi_token_decode and max_q_seqlen > 1,
         )
         return attn_output
 

--- a/lmdeploy/pytorch/backends/cuda/attention/default.py
+++ b/lmdeploy/pytorch/backends/cuda/attention/default.py
@@ -56,6 +56,9 @@ class TritonAttentionMetadata(AttentionMetadata):
     max_kv_seqlen: int = None
     max_q_seqlen: int = None
     kernel_metadata: tuple[Any, ...] = ()
+    # Semantic mode is selected by the step context, while MiMo may override
+    # it at the individual attention call for mixed target/draft paths.
+    decode_mode: str = 'block'
 
 
 def build_triton_attention_metadata(attn_meta_cls, step_context,
@@ -74,6 +77,7 @@ def build_triton_attention_metadata(attn_meta_cls, step_context,
         cu_seqlens_k=sequence_metadata.cu_seqlens_k,
         max_kv_seqlen=sequence_metadata.max_kv_seqlen,
         max_q_seqlen=step_context.max_q_seqlen,
+        decode_mode=('speculative' if step_context.model_config.model_paradigm == 'ar_spec' else 'block'),
     )
 
 

--- a/lmdeploy/pytorch/backends/cuda/attention/default.py
+++ b/lmdeploy/pytorch/backends/cuda/attention/default.py
@@ -6,7 +6,13 @@ from typing import Any
 import torch
 
 from lmdeploy.messages import QuantPolicy
-from lmdeploy.pytorch.backends.attention import AttentionImpl, AttentionMetadata
+from lmdeploy.pytorch.backends.attention import (
+    AttentionImpl,
+    AttentionMetadata,
+    DecodeMode,
+    decode_mode_uses_causal_mask,
+    normalize_decode_mode,
+)
 from lmdeploy.utils import get_logger
 
 from ..step_metadata import CudaAttentionMetaBuilder, CudaSequenceMetadata, register_step_metadata_impl
@@ -56,9 +62,9 @@ class TritonAttentionMetadata(AttentionMetadata):
     max_kv_seqlen: int = None
     max_q_seqlen: int = None
     kernel_metadata: tuple[Any, ...] = ()
-    # Semantic mode is selected by the step context, while MiMo may override
-    # it at the individual attention call for mixed target/draft paths.
-    decode_mode: str = 'block'
+    # Semantic mode is selected once by the step context. Attention calls must
+    # agree with it so scheduler metadata and kernel masking cannot diverge.
+    decode_mode: DecodeMode = 'block'
 
 
 def build_triton_attention_metadata(attn_meta_cls, step_context,
@@ -77,7 +83,7 @@ def build_triton_attention_metadata(attn_meta_cls, step_context,
         cu_seqlens_k=sequence_metadata.cu_seqlens_k,
         max_kv_seqlen=sequence_metadata.max_kv_seqlen,
         max_q_seqlen=step_context.max_q_seqlen,
-        decode_mode=getattr(step_context, 'decode_mode', 'block'),
+        decode_mode=normalize_decode_mode(getattr(step_context, 'decode_mode', 'block')),
     )
 
 
@@ -317,7 +323,7 @@ class TritonAttentionImpl(AttentionImpl[TritonAttentionMetadata]):
         k_scales_zeros: torch.Tensor = None,
         v_scales_zeros: torch.Tensor = None,
         learnable_sink: torch.Tensor = None,
-        decode_mode: str = 'block',
+        decode_mode: DecodeMode = 'block',
     ) -> torch.Tensor:
         """Forward pass for decoding stage.
 
@@ -354,13 +360,14 @@ class TritonAttentionImpl(AttentionImpl[TritonAttentionMetadata]):
             quant_policy=quant_policy,
             k_scales_zeros=k_scales_zeros,
             v_scales_zeros=v_scales_zeros,
-            causal_multi_token=decode_mode == 'speculative' and max_q_seqlen > 1,
+            causal_multi_token=(decode_mode_uses_causal_mask(decode_mode) and max_q_seqlen > 1),
         )
         return attn_output
 
-    def decode_mode_uses_causal_mask(self, decode_mode: str) -> bool:
-        """Whether a semantic decode mode requires causal multi-token masking."""
-        return decode_mode == 'speculative'
+    def decode_mode_uses_causal_mask(self, decode_mode: DecodeMode) -> bool:
+        """Whether a semantic decode mode requires causal multi-token
+        masking."""
+        return decode_mode_uses_causal_mask(decode_mode)
 
     def _forward_prefill(
         self,
@@ -460,7 +467,7 @@ class TritonAttentionImpl(AttentionImpl[TritonAttentionMetadata]):
         v_scales_zeros: torch.Tensor = None,
         learnable_sink: torch.Tensor = None,
         inplace: bool = True,
-        decode_mode: str = 'block',
+        decode_mode: DecodeMode = 'block',
         **kwargs,
     ) -> torch.Tensor:
         """Forward pass for attention computation.
@@ -485,6 +492,7 @@ class TritonAttentionImpl(AttentionImpl[TritonAttentionMetadata]):
         Returns:
             Attention output tensor.
         """
+        decode_mode = normalize_decode_mode(decode_mode)
         kernel_metadata = self.get_step_kernel_metadata(attn_metadata)
         if kernel_metadata is not None:
             attn_metadata = kernel_metadata

--- a/lmdeploy/pytorch/backends/cuda/attention/default.py
+++ b/lmdeploy/pytorch/backends/cuda/attention/default.py
@@ -313,6 +313,7 @@ class TritonAttentionImpl(AttentionImpl[TritonAttentionMetadata]):
         k_scales_zeros: torch.Tensor = None,
         v_scales_zeros: torch.Tensor = None,
         learnable_sink: torch.Tensor = None,
+        decode_mode: str = 'block',
     ) -> torch.Tensor:
         """Forward pass for decoding stage.
 
@@ -349,9 +350,13 @@ class TritonAttentionImpl(AttentionImpl[TritonAttentionMetadata]):
             quant_policy=quant_policy,
             k_scales_zeros=k_scales_zeros,
             v_scales_zeros=v_scales_zeros,
-            causal_multi_token=self.supports_multi_token_decode and max_q_seqlen > 1,
+            causal_multi_token=decode_mode == 'speculative' and max_q_seqlen > 1,
         )
         return attn_output
+
+    def decode_mode_uses_causal_mask(self, decode_mode: str) -> bool:
+        """Whether a semantic decode mode requires causal multi-token masking."""
+        return decode_mode == 'speculative'
 
     def _forward_prefill(
         self,
@@ -451,6 +456,7 @@ class TritonAttentionImpl(AttentionImpl[TritonAttentionMetadata]):
         v_scales_zeros: torch.Tensor = None,
         learnable_sink: torch.Tensor = None,
         inplace: bool = True,
+        decode_mode: str = 'block',
         **kwargs,
     ) -> torch.Tensor:
         """Forward pass for attention computation.
@@ -510,6 +516,7 @@ class TritonAttentionImpl(AttentionImpl[TritonAttentionMetadata]):
                 k_scales_zeros=k_scales_zeros,
                 v_scales_zeros=v_scales_zeros,
                 learnable_sink=learnable_sink,
+                decode_mode=decode_mode,
             )
         else:
             return self._forward_prefill(

--- a/lmdeploy/pytorch/backends/cuda/attention/default.py
+++ b/lmdeploy/pytorch/backends/cuda/attention/default.py
@@ -127,6 +127,7 @@ class TritonAttentionImpl(AttentionImpl[TritonAttentionMetadata]):
         logit_softcapping: float = 0.0,
         causal: bool = True,
         block_sparse_size: int = 1,
+        enable_paged_multi_token_decode: bool = False,
         **kwargs,
     ):
         super().__init__(
@@ -157,6 +158,10 @@ class TritonAttentionImpl(AttentionImpl[TritonAttentionMetadata]):
         self.flash_attention_fwd = flash_attn_varlen_func
 
         self.block_sparse_size = block_sparse_size
+        self.supports_paged_multi_token_decode = (
+            enable_paged_multi_token_decode
+            or getattr(type(self), 'supports_paged_multi_token_decode', False)
+        )
         self._step_meta_group: int | None = None
         self._piecewise_forward: Callable[..., torch.Tensor] | None = None
 
@@ -239,6 +244,9 @@ class TritonAttentionImpl(AttentionImpl[TritonAttentionMetadata]):
     ) -> int:
         """Get max q seqlen."""
         if attn_metadata.is_decoding:
+            if self.supports_paged_multi_token_decode:
+                batch_size = attn_metadata.block_offsets.size(0)
+                return query.size(0) // batch_size
             max_q_seqlen = self.block_sparse_size
         else:
             if attn_metadata.max_q_seqlen is not None:
@@ -344,6 +352,7 @@ class TritonAttentionImpl(AttentionImpl[TritonAttentionMetadata]):
             quant_policy=quant_policy,
             k_scales_zeros=k_scales_zeros,
             v_scales_zeros=v_scales_zeros,
+            causal_multi_token=self.supports_paged_multi_token_decode and max_q_seqlen > 1,
         )
         return attn_output
 
@@ -469,6 +478,10 @@ class TritonAttentionImpl(AttentionImpl[TritonAttentionMetadata]):
         Returns:
             Attention output tensor.
         """
+        kernel_metadata = self.get_step_kernel_metadata(attn_metadata)
+        if kernel_metadata is not None:
+            attn_metadata = kernel_metadata
+
         # Shared preparation
         max_q_seqlen = self._get_max_q_seqlen(query, attn_metadata)
 

--- a/lmdeploy/pytorch/backends/cuda/attention/default.py
+++ b/lmdeploy/pytorch/backends/cuda/attention/default.py
@@ -77,7 +77,7 @@ def build_triton_attention_metadata(attn_meta_cls, step_context,
         cu_seqlens_k=sequence_metadata.cu_seqlens_k,
         max_kv_seqlen=sequence_metadata.max_kv_seqlen,
         max_q_seqlen=step_context.max_q_seqlen,
-        decode_mode=('speculative' if step_context.model_config.model_paradigm == 'ar_spec' else 'block'),
+        decode_mode=getattr(step_context, 'decode_mode', 'block'),
     )
 
 

--- a/lmdeploy/pytorch/backends/cuda/attention/fa3.py
+++ b/lmdeploy/pytorch/backends/cuda/attention/fa3.py
@@ -263,7 +263,7 @@ class FA3Impl(TritonAttentionImpl):
     - Standard single-token decoding with paged attention
     """
 
-    supports_paged_multi_token_decode = True
+    supports_multi_token_decode = True
 
     def __init__(
         self,

--- a/lmdeploy/pytorch/backends/cuda/attention/fa3.py
+++ b/lmdeploy/pytorch/backends/cuda/attention/fa3.py
@@ -5,6 +5,11 @@ from dataclasses import dataclass
 import torch
 
 from lmdeploy.messages import QuantPolicy
+from lmdeploy.pytorch.backends.attention import (
+    DecodeMode,
+    decode_mode_uses_causal_mask,
+    normalize_decode_mode,
+)
 from lmdeploy.utils import get_logger
 
 from ..step_metadata import CudaAttentionMetaBuilder
@@ -95,6 +100,7 @@ def _build_fa3_metadata(batch_size: int,
         assert block_offsets is not None
         max_seqlen_k = block_offsets.size(1) * block_size
 
+    decode_mode = normalize_decode_mode(getattr(step_context, 'decode_mode', 'block'))
     scheduler_metadata = _get_meta_flashattn(
         batch_size=batch_size,
         max_seqlen_q=max_seqlen_q,
@@ -106,7 +112,7 @@ def _build_fa3_metadata(batch_size: int,
         cache_seqlens=kv_seqlens.to(torch.int32),
         qkv_dtype=step_context.model_config.dtype,
         page_size=block_size,
-        causal=causal,
+        causal=causal and decode_mode_uses_causal_mask(decode_mode),
         window_size=_normalize_sliding_window(sliding_window),
         has_softcap=has_softcap,
     )
@@ -355,6 +361,7 @@ class FA3Impl(TritonAttentionImpl):
         v_cache: torch.Tensor,
         attn_metadata: TritonAttentionMetadata,
         max_q_seqlen: int,
+        decode_mode: DecodeMode = 'speculative',
     ) -> torch.Tensor:
         """Speculative decoding with multi-token queries.
 
@@ -400,7 +407,7 @@ class FA3Impl(TritonAttentionImpl):
             scheduler_metadata=self._get_scheduler_metadata(attn_metadata),
             page_table=block_offsets,
             softmax_scale=self.scale,
-            causal=self.causal,
+            causal=self.causal and decode_mode_uses_causal_mask(decode_mode),
             window_size=sliding_window,
             softcap=self.logit_softcapping,
         )
@@ -465,6 +472,7 @@ class FA3Impl(TritonAttentionImpl):
         max_q_seqlen: int,
         k_scales_zeros: torch.Tensor = None,
         v_scales_zeros: torch.Tensor = None,
+        decode_mode: DecodeMode = 'block',
     ) -> torch.Tensor:
         """Forward pass for decoding stage.
 
@@ -485,7 +493,14 @@ class FA3Impl(TritonAttentionImpl):
             Attention output tensor.
         """
         if max_q_seqlen > 1:
-            return self._decoding_speculative(query, k_cache, v_cache, attn_metadata, max_q_seqlen)
+            return self._decoding_speculative(
+                query,
+                k_cache,
+                v_cache,
+                attn_metadata,
+                max_q_seqlen,
+                decode_mode=decode_mode,
+            )
         return self._decoding_standard(
             query,
             k_cache,
@@ -589,7 +604,7 @@ class FA3Impl(TritonAttentionImpl):
         v_scales_zeros: torch.Tensor = None,
         learnable_sink: torch.Tensor = None,
         inplace: bool = True,
-        decode_mode: str = 'block',
+        decode_mode: DecodeMode = 'block',
     ) -> torch.Tensor:
         """Forward pass for FA3 attention computation.
 
@@ -617,6 +632,8 @@ class FA3Impl(TritonAttentionImpl):
         Returns:
             Attention output tensor.
         """
+        decode_mode = normalize_decode_mode(decode_mode)
+
         # Shared preparation
         max_q_seqlen = self._get_max_q_seqlen(query, attn_metadata)
 
@@ -643,6 +660,7 @@ class FA3Impl(TritonAttentionImpl):
                 max_q_seqlen,
                 k_scales_zeros,
                 v_scales_zeros,
+                decode_mode,
             )
         else:
             return self._forward_prefill(

--- a/lmdeploy/pytorch/backends/cuda/attention/fa3.py
+++ b/lmdeploy/pytorch/backends/cuda/attention/fa3.py
@@ -589,6 +589,7 @@ class FA3Impl(TritonAttentionImpl):
         v_scales_zeros: torch.Tensor = None,
         learnable_sink: torch.Tensor = None,
         inplace: bool = True,
+        decode_mode: str = 'block',
     ) -> torch.Tensor:
         """Forward pass for FA3 attention computation.
 

--- a/lmdeploy/pytorch/backends/cuda/attention/fa3.py
+++ b/lmdeploy/pytorch/backends/cuda/attention/fa3.py
@@ -263,6 +263,8 @@ class FA3Impl(TritonAttentionImpl):
     - Standard single-token decoding with paged attention
     """
 
+    supports_paged_multi_token_decode = True
+
     def __init__(
         self,
         num_heads: int,

--- a/lmdeploy/pytorch/backends/cuda/attention/fa3_capabilities.py
+++ b/lmdeploy/pytorch/backends/cuda/attention/fa3_capabilities.py
@@ -1,6 +1,8 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 """FlashAttention-3 build capability detection."""
 
+import torch
+
 
 def _get_build_flags() -> dict | None:
     """Read build flags exported by recent FlashAttention-3 wheels."""
@@ -51,3 +53,59 @@ def fa3_build_supports_head_dims(head_size: int, v_head_size: int | None = None)
     if head_size <= 256:
         return v_head_size <= 256 and not _disabled('FLASHATTENTION_DISABLE_HDIM256')
     return False
+
+
+def fa3_build_supports_operation(
+    head_size: int,
+    v_head_size: int | None = None,
+    *,
+    device_capability: tuple[int, int],
+    dtype: torch.dtype | None = None,
+    paged_kv: bool = False,
+    varlen: bool = False,
+    local: bool = False,
+    softcap: bool = False,
+) -> bool:
+    """Return whether the installed FA3 build can run an operation.
+
+    Shape templates alone are insufficient: FA3 wheels can independently
+    omit paged-KV, varlen, local-attention, softcap, FP16, and SM8x kernels.
+    FA3 also rejects asymmetric QK/V head dimensions on non-Hopper devices
+    before template dispatch.
+    """
+    if v_head_size is None:
+        v_head_size = head_size
+
+    major, _ = device_capability
+    if major < 8:
+        return False
+    if head_size != v_head_size and major != 9:
+        return False
+    if dtype is not None and dtype not in (torch.float16, torch.bfloat16):
+        return False
+    if not fa3_build_supports_head_dims(head_size, v_head_size):
+        return False
+
+    flags = _get_build_flags()
+    if flags is None:
+        # Older wheels do not expose feature-level build metadata. Preserve
+        # their established symmetric-shape behavior; asymmetric shapes were
+        # already rejected by fa3_build_supports_head_dims above.
+        return True
+
+    def _disabled(name: str) -> bool:
+        return bool(flags.get(name, False))
+
+    if major == 8 and _disabled('FLASHATTENTION_DISABLE_SM8x'):
+        return False
+    if dtype == torch.float16 and _disabled('FLASHATTENTION_DISABLE_FP16'):
+        return False
+    if paged_kv and _disabled('FLASHATTENTION_DISABLE_PAGEDKV'):
+        return False
+    if varlen and _disabled('FLASHATTENTION_DISABLE_VARLEN'):
+        return False
+    if local and _disabled('FLASHATTENTION_DISABLE_LOCAL'):
+        return False
+    if softcap and _disabled('FLASHATTENTION_DISABLE_SOFTCAP'):
+        return False
+    return True

--- a/lmdeploy/pytorch/backends/cuda/attention/fa3_capabilities.py
+++ b/lmdeploy/pytorch/backends/cuda/attention/fa3_capabilities.py
@@ -1,0 +1,53 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+"""FlashAttention-3 build capability detection."""
+
+
+def _get_build_flags() -> dict | None:
+    """Read build flags exported by recent FlashAttention-3 wheels."""
+    try:
+        from flash_attn_config import CONFIG
+        flags = CONFIG['build_flags']
+    except (ImportError, KeyError, TypeError):
+        return None
+    return flags if isinstance(flags, dict) else None
+
+
+def fa3_build_supports_head_dims(head_size: int, v_head_size: int | None = None) -> bool:
+    """Return whether the installed FA3 wheel contains a head shape.
+
+    FA3 wheels may omit template instantiations to reduce build time and binary size. Wheels without exported build
+    metadata are accepted only for symmetric head shapes, preserving compatibility with older packages while avoiding
+    unsafe asymmetric dispatch.
+    """
+    if v_head_size is None:
+        v_head_size = head_size
+
+    flags = _get_build_flags()
+    if flags is None:
+        return head_size == v_head_size and head_size <= 256
+
+    def _disabled(name: str) -> bool:
+        # Older generated configs used FLASH_ATTENTION for HDIMDIFF while the
+        # other flags use FLASHATTENTION. Accept both spellings.
+        aliases = (name, name.replace('FLASHATTENTION_DISABLE_HDIMDIFF',
+                                      'FLASH_ATTENTION_DISABLE_HDIMDIFF'))
+        return any(bool(flags.get(alias, False)) for alias in aliases)
+
+    if head_size <= 64:
+        if _disabled('FLASHATTENTION_DISABLE_HDIM64'):
+            return False
+        return v_head_size <= 64 or (
+            v_head_size <= 512 and not _disabled('FLASHATTENTION_DISABLE_HDIMDIFF64'))
+    if head_size <= 96:
+        return v_head_size <= 96 and not _disabled('FLASHATTENTION_DISABLE_HDIM96')
+    if head_size <= 128:
+        return v_head_size <= 128 and not _disabled('FLASHATTENTION_DISABLE_HDIM128')
+    if head_size <= 192:
+        if _disabled('FLASHATTENTION_DISABLE_HDIM192'):
+            return False
+        if v_head_size <= 128:
+            return not _disabled('FLASHATTENTION_DISABLE_HDIMDIFF192')
+        return v_head_size <= 192
+    if head_size <= 256:
+        return v_head_size <= 256 and not _disabled('FLASHATTENTION_DISABLE_HDIM256')
+    return False

--- a/lmdeploy/pytorch/backends/cuda/attention/swa_state_ring.py
+++ b/lmdeploy/pytorch/backends/cuda/attention/swa_state_ring.py
@@ -1,0 +1,252 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+"""Sliding-window attention backed by a sequence-scoped BF16 state ring."""
+
+from dataclasses import dataclass
+from typing import Any
+
+import torch
+
+
+@dataclass
+class SWAStateRingMetadata:
+    """Layer-invariant sequence layout for an SWA state ring."""
+
+    state_slots: torch.Tensor
+    start_positions: torch.Tensor
+    q_seqlens: torch.Tensor
+    cu_q_seqlens: torch.Tensor
+    history_lens: torch.Tensor
+    kv_seqlens: torch.Tensor
+    cu_kv_seqlens: torch.Tensor
+    max_q_seqlen: int
+    max_kv_seqlen: int
+    window_size: int
+    block_offsets: torch.Tensor
+
+    @classmethod
+    def from_step_context(
+        cls,
+        attn_metadata: Any,
+        step_context: Any,
+        state_slots: torch.Tensor,
+        num_state_slots: int,
+        window_size: int,
+    ) -> 'SWAStateRingMetadata':
+        """Build once per model step, then reuse for all SWA layers."""
+        if attn_metadata is None:
+            raise RuntimeError('SWA state-ring attention requires attention metadata.')
+        if not isinstance(window_size, int) or window_size <= 1:
+            raise ValueError(f'SWA state-ring window_size must be greater than one, got {window_size!r}.')
+
+        q_seqlens = getattr(attn_metadata, 'q_seqlens', None)
+        kv_seqlens = getattr(attn_metadata, 'kv_seqlens', None)
+        if q_seqlens is None or kv_seqlens is None:
+            raise RuntimeError('SWA state-ring attention requires q_seqlens and kv_seqlens.')
+        q_seqlens = q_seqlens.to(dtype=torch.int32)
+        kv_seqlens = kv_seqlens.to(device=q_seqlens.device, dtype=torch.int64)
+        state_slots = state_slots.to(device=q_seqlens.device, dtype=torch.int64)
+        if state_slots.dim() != 1 or state_slots.numel() != q_seqlens.numel():
+            raise ValueError(
+                f'SWA state_slots must have shape [{q_seqlens.numel()}], got {tuple(state_slots.shape)}.'
+            )
+
+        start_positions = kv_seqlens - q_seqlens.to(torch.int64)
+        history_limit = window_size - 1
+        valid_slots = (state_slots >= 0) & (state_slots < num_state_slots) & (start_positions >= 0)
+        history_lens = start_positions.clamp(min=0, max=history_limit).to(torch.int32)
+        history_lens = torch.where(valid_slots, history_lens, 0)
+
+        cu_q_seqlens = torch.zeros(q_seqlens.numel() + 1, dtype=torch.int32, device=q_seqlens.device)
+        torch.cumsum(q_seqlens, dim=0, out=cu_q_seqlens[1:])
+        ring_kv_seqlens = history_lens + q_seqlens
+        cu_kv_seqlens = torch.zeros_like(cu_q_seqlens)
+        torch.cumsum(ring_kv_seqlens, dim=0, out=cu_kv_seqlens[1:])
+
+        max_q_seqlen = getattr(step_context, 'max_q_seqlen', None)
+        if max_q_seqlen is None:
+            max_q_seqlen = getattr(attn_metadata, 'max_q_seqlen', None)
+        if max_q_seqlen is None:
+            # A synchronization-free upper bound.  It is exact for batch=1
+            # and only affects launch metadata for ragged batches.
+            max_q_seqlen = int(step_context.input_ids.numel())
+        max_q_seqlen = int(max_q_seqlen)
+
+        return cls(
+            state_slots=state_slots,
+            start_positions=start_positions,
+            q_seqlens=q_seqlens,
+            cu_q_seqlens=cu_q_seqlens,
+            history_lens=history_lens,
+            kv_seqlens=ring_kv_seqlens,
+            cu_kv_seqlens=cu_kv_seqlens,
+            max_q_seqlen=max_q_seqlen,
+            max_kv_seqlen=max_q_seqlen + history_limit,
+            window_size=window_size,
+            # A ring is one physical page per sequence slot.  Invalid graph
+            # padding slots use page zero; their outputs are discarded and
+            # scatter_swa_state_ring continues to mask their writes.
+            block_offsets=state_slots.clamp(min=0, max=num_state_slots - 1).unsqueeze(1),
+        )
+
+
+def _decode_swa_state_ring(
+    attention,
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    k_ring: torch.Tensor,
+    v_ring: torch.Tensor,
+    metadata: SWAStateRingMetadata,
+    sink: torch.Tensor | None,
+) -> torch.Tensor:
+    """Run single-token decode directly over one ring page per sequence."""
+    from lmdeploy.pytorch.kernels.cuda.swa_state_ring import scatter_swa_state_ring
+
+    # For q=1, overwriting the current modulo slot removes only the token just
+    # outside the causal window.  The remaining ring order is immaterial:
+    # attention has no ALiBi and softmax over one query is permutation
+    # invariant in K/V.  Multi-token chunks still require chronological
+    # flattening for their causal mask and are handled by the fallback below.
+    scatter_swa_state_ring(
+        key,
+        k_ring,
+        metadata.state_slots,
+        metadata.start_positions,
+        metadata.q_seqlens,
+        metadata.cu_q_seqlens,
+        max_q_seqlen=1,
+    )
+    scatter_swa_state_ring(
+        value,
+        v_ring,
+        metadata.state_slots,
+        metadata.start_positions,
+        metadata.q_seqlens,
+        metadata.cu_q_seqlens,
+        max_q_seqlen=1,
+    )
+
+    impl = attention.impl
+    attention._lazy_init(query.device)
+    return impl.paged_attention_fwd(
+        query,
+        k_ring,
+        v_ring,
+        cache_seqlens=metadata.kv_seqlens,
+        page_table=metadata.block_offsets,
+        cu_seqlens_q=metadata.cu_q_seqlens,
+        max_seqlen_q=1,
+        softmax_scale=impl.scale,
+        softcap=impl.logit_softcapping,
+        window_size=metadata.window_size - 1,
+        sinks=sink,
+    )
+
+
+def swa_state_ring_attention(
+    attention,
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    k_ring: torch.Tensor,
+    v_ring: torch.Tensor,
+    metadata: SWAStateRingMetadata,
+    sink: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Attend to chronological ring history plus current K/V, then update
+    it."""
+    if k_ring.size(0) != v_ring.size(0) or k_ring.size(1) != v_ring.size(1):
+        raise ValueError('SWA K/V state rings must have identical state-slot and window dimensions.')
+    if k_ring.size(1) != metadata.window_size:
+        raise ValueError(
+            f'SWA metadata window {metadata.window_size} does not match ring window {k_ring.size(1)}.'
+        )
+
+    impl = attention.impl
+    if not hasattr(impl, 'flash_attention_fwd'):
+        raise RuntimeError(f'SWA state ring requires Triton varlen attention, got {type(impl).__name__}.')
+    if getattr(impl, 'alibi', False):
+        raise RuntimeError('SWA state ring does not support ALiBi.')
+
+    if metadata.max_q_seqlen == 1:
+        return _decode_swa_state_ring(
+            attention,
+            query,
+            key,
+            value,
+            k_ring,
+            v_ring,
+            metadata,
+            sink,
+        )
+
+    # Delay CUDA/Triton kernel imports until a real SWA forward.  Model/config
+    # inspection on a CPU-only host must not initialize the Triton driver.
+    from lmdeploy.pytorch.kernels.cuda.swa_state_ring import (
+        flatten_swa_state_ring,
+        scatter_swa_state_ring,
+    )
+
+    flat_key = flatten_swa_state_ring(
+        k_ring,
+        key,
+        metadata.state_slots,
+        metadata.start_positions,
+        metadata.q_seqlens,
+        metadata.cu_q_seqlens,
+        metadata.history_lens,
+        metadata.cu_kv_seqlens,
+        metadata.max_q_seqlen,
+    )
+    flat_value = flatten_swa_state_ring(
+        v_ring,
+        value,
+        metadata.state_slots,
+        metadata.start_positions,
+        metadata.q_seqlens,
+        metadata.cu_q_seqlens,
+        metadata.history_lens,
+        metadata.cu_kv_seqlens,
+        metadata.max_q_seqlen,
+    )
+
+    attention._lazy_init(query.device)
+    output = impl.flash_attention_fwd(
+        query,
+        flat_key,
+        flat_value,
+        cu_seqlens_q=metadata.cu_q_seqlens,
+        cu_seqlens_k=metadata.cu_kv_seqlens,
+        max_seqlen_q=metadata.max_q_seqlen,
+        max_seqlen_k=metadata.max_kv_seqlen,
+        window_size=metadata.window_size - 1,
+        softmax_scale=impl.scale,
+        softcap=impl.logit_softcapping,
+        causal=True,
+        sinks=sink,
+        alibi_slopes=None,
+        block_sparse_size=impl.block_sparse_size,
+        kv_layout='shd',
+    )
+
+    # Preserve the old ring until the attention kernel has consumed it.  CUDA
+    # stream ordering then makes these writes visible to the next model step.
+    scatter_swa_state_ring(
+        key,
+        k_ring,
+        metadata.state_slots,
+        metadata.start_positions,
+        metadata.q_seqlens,
+        metadata.cu_q_seqlens,
+        max_q_seqlen=metadata.max_q_seqlen,
+    )
+    scatter_swa_state_ring(
+        value,
+        v_ring,
+        metadata.state_slots,
+        metadata.start_positions,
+        metadata.q_seqlens,
+        metadata.cu_q_seqlens,
+        max_q_seqlen=metadata.max_q_seqlen,
+    )
+    return output

--- a/lmdeploy/pytorch/backends/cuda/attention/swa_state_ring.py
+++ b/lmdeploy/pytorch/backends/cuda/attention/swa_state_ring.py
@@ -6,6 +6,8 @@ from typing import Any
 
 import torch
 
+from lmdeploy.pytorch.backends.attention import AttentionImpl, SWAStateRingAttentionBuildSpec
+
 
 @dataclass
 class SWAStateRingMetadata:
@@ -90,7 +92,7 @@ class SWAStateRingMetadata:
 
 
 def _decode_swa_state_ring(
-    attention,
+    impl: 'SWAStateRingAttentionImpl',
     query: torch.Tensor,
     key: torch.Tensor,
     value: torch.Tensor,
@@ -126,8 +128,6 @@ def _decode_swa_state_ring(
         max_q_seqlen=1,
     )
 
-    impl = attention.impl
-    attention._lazy_init(query.device)
     return impl.paged_attention_fwd(
         query,
         k_ring,
@@ -144,7 +144,7 @@ def _decode_swa_state_ring(
 
 
 def swa_state_ring_attention(
-    attention,
+    impl: 'SWAStateRingAttentionImpl',
     query: torch.Tensor,
     key: torch.Tensor,
     value: torch.Tensor,
@@ -162,7 +162,6 @@ def swa_state_ring_attention(
             f'SWA metadata window {metadata.window_size} does not match ring window {k_ring.size(1)}.'
         )
 
-    impl = attention.impl
     if not hasattr(impl, 'flash_attention_fwd'):
         raise RuntimeError(f'SWA state ring requires Triton varlen attention, got {type(impl).__name__}.')
     if getattr(impl, 'alibi', False):
@@ -170,7 +169,7 @@ def swa_state_ring_attention(
 
     if metadata.max_q_seqlen == 1:
         return _decode_swa_state_ring(
-            attention,
+            impl,
             query,
             key,
             value,
@@ -210,7 +209,6 @@ def swa_state_ring_attention(
         metadata.max_q_seqlen,
     )
 
-    attention._lazy_init(query.device)
     output = impl.flash_attention_fwd(
         query,
         flat_key,
@@ -250,3 +248,62 @@ def swa_state_ring_attention(
         max_q_seqlen=metadata.max_q_seqlen,
     )
     return output
+
+
+class SWAStateRingAttentionImpl(AttentionImpl):
+    """Own the kernel configuration for CUDA sliding-window state rings."""
+
+    supports_multi_token_decode = True
+
+    def __init__(self, spec: SWAStateRingAttentionBuildSpec):
+        super().__init__(
+            num_heads=spec.num_heads,
+            head_size=spec.head_dim,
+            scale=spec.scale,
+            num_kv_heads=spec.num_kv_heads,
+            v_head_size=spec.v_head_dim,
+            alibi=False,
+            sliding_window=spec.sliding_window,
+            logit_softcapping=0.0,
+            causal=True,
+        )
+        self.block_sparse_size = spec.block_sparse_size
+
+        self.flash_attention_fwd = None
+        self.paged_attention_fwd = None
+
+    def _lazy_init(self):
+        if self.flash_attention_fwd is None or self.paged_attention_fwd is None:
+            from lmdeploy.pytorch.kernels.cuda import (
+                flash_attn_varlen_func,
+                flash_attn_with_kvcache,
+            )
+            self.flash_attention_fwd = flash_attn_varlen_func
+            self.paged_attention_fwd = flash_attn_with_kvcache
+
+    def forward(
+        self,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        k_cache: torch.Tensor,
+        v_cache: torch.Tensor,
+        metadata: SWAStateRingMetadata,
+        k_scales_zeros: torch.Tensor = None,
+        v_scales_zeros: torch.Tensor = None,
+        learnable_sink: torch.Tensor = None,
+        nsa_indices: torch.Tensor = None,
+        inplace: bool = False,
+    ) -> torch.Tensor:
+        del k_scales_zeros, v_scales_zeros, nsa_indices, inplace
+        self._lazy_init()
+        return swa_state_ring_attention(
+            self,
+            query,
+            key,
+            value,
+            k_cache,
+            v_cache,
+            metadata,
+            sink=learnable_sink,
+        )

--- a/lmdeploy/pytorch/backends/cuda/graph_runner/full_graph.py
+++ b/lmdeploy/pytorch/backends/cuda/graph_runner/full_graph.py
@@ -88,7 +88,7 @@ def _make_graph_meta(
     is_decoding: bool,
     decode_query_len: int,
     device: torch.device,
-    supports_non_fa3_speculative_graph: bool = False,
+    supports_multi_token_decode: bool = False,
 ) -> CudaGraphMeta:
     """Build the fixed metadata owned by one full CUDA graph."""
     step_meta_plan = ctx_mgr.backend_step_meta_plan
@@ -109,7 +109,7 @@ def _make_graph_meta(
         mla_index_topk=model_config.mla_index_topk,
         use_fa3_decoding=(model_config.model_paradigm == 'ar_spec'
                           and not model_config.use_flash_mla
-                          and not supports_non_fa3_speculative_graph),
+                          and not supports_multi_token_decode),
         is_ssm=bool(model_config.states_shapes),
         use_mrope=model_config.use_mrope,
         block_size=model_config.block_size,
@@ -133,7 +133,7 @@ class CUDASingleGraphRunner:
         model_config: ModelConfig,
         device: torch.device,
         model_forward: Callable[..., Any] | None = None,
-        supports_non_fa3_speculative_graph: bool = False,
+        supports_multi_token_decode: bool = False,
     ):
         self.model = model
         self._model_forward = model if model_forward is None else model_forward
@@ -146,7 +146,7 @@ class CUDASingleGraphRunner:
             num_blocks=num_blocks,
             is_decoding=is_decoding,
             decode_query_len=decode_query_len,
-            supports_non_fa3_speculative_graph=supports_non_fa3_speculative_graph,
+            supports_multi_token_decode=supports_multi_token_decode,
             device=device,
         )
         self._pool = pool

--- a/lmdeploy/pytorch/backends/cuda/graph_runner/full_graph.py
+++ b/lmdeploy/pytorch/backends/cuda/graph_runner/full_graph.py
@@ -88,6 +88,7 @@ def _make_graph_meta(
     is_decoding: bool,
     decode_query_len: int,
     device: torch.device,
+    supports_non_fa3_speculative_graph: bool = False,
 ) -> CudaGraphMeta:
     """Build the fixed metadata owned by one full CUDA graph."""
     step_meta_plan = ctx_mgr.backend_step_meta_plan
@@ -106,7 +107,9 @@ def _make_graph_meta(
         use_mla_fp8_cache=model_config.use_mla_fp8_cache,
         use_flash_mla=model_config.use_flash_mla,
         mla_index_topk=model_config.mla_index_topk,
-        use_fa3_decoding=(model_config.model_paradigm == 'ar_spec' and not model_config.use_flash_mla),
+        use_fa3_decoding=(model_config.model_paradigm == 'ar_spec'
+                          and not model_config.use_flash_mla
+                          and not supports_non_fa3_speculative_graph),
         is_ssm=bool(model_config.states_shapes),
         use_mrope=model_config.use_mrope,
         block_size=model_config.block_size,
@@ -130,6 +133,7 @@ class CUDASingleGraphRunner:
         model_config: ModelConfig,
         device: torch.device,
         model_forward: Callable[..., Any] | None = None,
+        supports_non_fa3_speculative_graph: bool = False,
     ):
         self.model = model
         self._model_forward = model if model_forward is None else model_forward
@@ -142,6 +146,7 @@ class CUDASingleGraphRunner:
             num_blocks=num_blocks,
             is_decoding=is_decoding,
             decode_query_len=decode_query_len,
+            supports_non_fa3_speculative_graph=supports_non_fa3_speculative_graph,
             device=device,
         )
         self._pool = pool

--- a/lmdeploy/pytorch/backends/cuda/graph_runner/full_graph.py
+++ b/lmdeploy/pytorch/backends/cuda/graph_runner/full_graph.py
@@ -88,7 +88,6 @@ def _make_graph_meta(
     is_decoding: bool,
     decode_query_len: int,
     device: torch.device,
-    supports_multi_token_decode: bool = False,
 ) -> CudaGraphMeta:
     """Build the fixed metadata owned by one full CUDA graph."""
     step_meta_plan = ctx_mgr.backend_step_meta_plan
@@ -107,9 +106,7 @@ def _make_graph_meta(
         use_mla_fp8_cache=model_config.use_mla_fp8_cache,
         use_flash_mla=model_config.use_flash_mla,
         mla_index_topk=model_config.mla_index_topk,
-        use_fa3_decoding=(model_config.model_paradigm == 'ar_spec'
-                          and not model_config.use_flash_mla
-                          and not supports_multi_token_decode),
+        use_fa3_decoding=True,
         is_ssm=bool(model_config.states_shapes),
         use_mrope=model_config.use_mrope,
         block_size=model_config.block_size,
@@ -133,7 +130,6 @@ class CUDASingleGraphRunner:
         model_config: ModelConfig,
         device: torch.device,
         model_forward: Callable[..., Any] | None = None,
-        supports_multi_token_decode: bool = False,
     ):
         self.model = model
         self._model_forward = model if model_forward is None else model_forward
@@ -146,7 +142,6 @@ class CUDASingleGraphRunner:
             num_blocks=num_blocks,
             is_decoding=is_decoding,
             decode_query_len=decode_query_len,
-            supports_multi_token_decode=supports_multi_token_decode,
             device=device,
         )
         self._pool = pool

--- a/lmdeploy/pytorch/backends/cuda/graph_runner/full_graph.py
+++ b/lmdeploy/pytorch/backends/cuda/graph_runner/full_graph.py
@@ -88,6 +88,7 @@ def _make_graph_meta(
     is_decoding: bool,
     decode_query_len: int,
     device: torch.device,
+    supports_multi_token_decode: bool = False,
 ) -> CudaGraphMeta:
     """Build the fixed metadata owned by one full CUDA graph."""
     step_meta_plan = ctx_mgr.backend_step_meta_plan
@@ -106,7 +107,9 @@ def _make_graph_meta(
         use_mla_fp8_cache=model_config.use_mla_fp8_cache,
         use_flash_mla=model_config.use_flash_mla,
         mla_index_topk=model_config.mla_index_topk,
-        use_fa3_decoding=True,
+        use_fa3_decoding=(model_config.model_paradigm == 'ar_spec'
+                          and not model_config.use_flash_mla
+                          and not supports_multi_token_decode),
         is_ssm=bool(model_config.states_shapes),
         use_mrope=model_config.use_mrope,
         block_size=model_config.block_size,
@@ -130,6 +133,7 @@ class CUDASingleGraphRunner:
         model_config: ModelConfig,
         device: torch.device,
         model_forward: Callable[..., Any] | None = None,
+        supports_multi_token_decode: bool = False,
     ):
         self.model = model
         self._model_forward = model if model_forward is None else model_forward
@@ -142,6 +146,7 @@ class CUDASingleGraphRunner:
             num_blocks=num_blocks,
             is_decoding=is_decoding,
             decode_query_len=decode_query_len,
+            supports_multi_token_decode=supports_multi_token_decode,
             device=device,
         )
         self._pool = pool

--- a/lmdeploy/pytorch/backends/cuda/graph_runner/runner.py
+++ b/lmdeploy/pytorch/backends/cuda/graph_runner/runner.py
@@ -17,6 +17,7 @@ from lmdeploy.pytorch.config import (
     normalize_cudagraph_capture_batch_sizes,
 )
 from lmdeploy.pytorch.model_inputs import StepContext, get_step_ctx_manager
+from lmdeploy.pytorch.models.utils.cudagraph import GraphCaptureContext
 from lmdeploy.pytorch.strategies.base import StrategyFactoryBase
 
 from ...graph_runner import GraphRunner, is_preparing_prefill
@@ -253,11 +254,13 @@ class CUDAGraphRunner(GraphRunner):
             supports_multi_token_decode=self._supports_multi_token_decode,
             device=self.device,
         )
-        capture_state = self.model.get_cudagraph_capture_state(
-            kwargs['past_key_values'],
+        capture_context = GraphCaptureContext(
+            past_key_values=kwargs['past_key_values'],
             attn_metadata=kwargs['attn_metadata'],
             num_blocks=self.num_blocks,
-            spec_step_idx=int(kwargs.get('spec_step_idx', 0)))
+            spec_step_idx=int(kwargs.get('spec_step_idx', 0)),
+        )
+        capture_state = self.model.get_cudagraph_capture_state(capture_context)
         if capture_state is not None:
             capture_state.snapshot()
 

--- a/lmdeploy/pytorch/backends/cuda/graph_runner/runner.py
+++ b/lmdeploy/pytorch/backends/cuda/graph_runner/runner.py
@@ -51,6 +51,14 @@ def _false(*args, **kwargs):
     return False
 
 
+def _supports_multi_token_decode(model: torch.nn.Module) -> bool:
+    """Whether the selected model paths support multi-token decode."""
+    handler = getattr(model, 'supports_multi_token_decode', None)
+    if not callable(handler):
+        return False
+    return bool(handler())
+
+
 def _make_piecewise_graph_manager(model: torch.nn.Module, model_config: ModelConfig, cache_config: CacheConfig,
                                   backend_config: BackendConfig) -> PiecewiseGraphManager | None:
     """Build the optional PCG runtime only for an eligible CUDA model."""
@@ -113,6 +121,7 @@ class CUDAGraphRunner(GraphRunner):
                  backend_config: BackendConfig, device: torch.device):
         super().__init__(model, model_config, cache_config, backend_config, device)
         self.num_blocks = cache_config.num_gpu_blocks
+        self._supports_multi_token_decode = _supports_multi_token_decode(self.model)
         self.enable_graph = self.check_enable_graph()
         self._decode_model_forward: Callable[..., Any] | None = None
 
@@ -241,6 +250,7 @@ class CUDAGraphRunner(GraphRunner):
             decode_query_len=graph_key[3],
             pool=self._full_graph_pool_handle,
             model_config=self.model_config,
+            supports_multi_token_decode=self._supports_multi_token_decode,
             device=self.device,
         )
         capture_state = self.model.get_cudagraph_capture_state(

--- a/lmdeploy/pytorch/backends/cuda/graph_runner/runner.py
+++ b/lmdeploy/pytorch/backends/cuda/graph_runner/runner.py
@@ -51,27 +51,6 @@ def _false(*args, **kwargs):
     return False
 
 
-def _validate_speculative_decoding(model: torch.nn.Module, model_config: ModelConfig) -> None:
-    """Validate the attention capability required by speculative decode."""
-    if model_config.model_paradigm != 'ar_spec' or model_config.use_flash_mla:
-        return
-
-    supports_multi_token = getattr(model, 'supports_multi_token_decode', lambda: False)
-    if callable(supports_multi_token) and supports_multi_token():
-        return
-
-    from ..attention import require_fa3_for_speculative_decoding
-    require_fa3_for_speculative_decoding()
-
-
-def _supports_multi_token_decode(model: torch.nn.Module) -> bool:
-    """Whether the selected attention implementations support speculative queries."""
-    handler = getattr(model, 'supports_multi_token_decode', None)
-    if not callable(handler):
-        return False
-    return bool(handler())
-
-
 def _make_piecewise_graph_manager(model: torch.nn.Module, model_config: ModelConfig, cache_config: CacheConfig,
                                   backend_config: BackendConfig) -> PiecewiseGraphManager | None:
     """Build the optional PCG runtime only for an eligible CUDA model."""
@@ -134,9 +113,6 @@ class CUDAGraphRunner(GraphRunner):
                  backend_config: BackendConfig, device: torch.device):
         super().__init__(model, model_config, cache_config, backend_config, device)
         self.num_blocks = cache_config.num_gpu_blocks
-        self._supports_multi_token_decode = _supports_multi_token_decode(self.model)
-        _validate_speculative_decoding(model, model_config)
-
         self.enable_graph = self.check_enable_graph()
         self._decode_model_forward: Callable[..., Any] | None = None
 
@@ -265,7 +241,6 @@ class CUDAGraphRunner(GraphRunner):
             decode_query_len=graph_key[3],
             pool=self._full_graph_pool_handle,
             model_config=self.model_config,
-            supports_multi_token_decode=self._supports_multi_token_decode,
             device=self.device,
         )
         capture_state = self.model.get_cudagraph_capture_state(

--- a/lmdeploy/pytorch/backends/cuda/graph_runner/runner.py
+++ b/lmdeploy/pytorch/backends/cuda/graph_runner/runner.py
@@ -51,13 +51,25 @@ def _false(*args, **kwargs):
     return False
 
 
-def _validate_speculative_decoding(model_config: ModelConfig) -> None:
+def _validate_speculative_decoding(model: torch.nn.Module, model_config: ModelConfig) -> None:
     """Validate the CUDA attention backend required by speculative decode."""
     if model_config.model_paradigm != 'ar_spec' or model_config.use_flash_mla:
         return
 
+    supports_non_fa3 = getattr(model, 'supports_non_fa3_speculative_graph', lambda: False)
+    if callable(supports_non_fa3) and supports_non_fa3():
+        return
+
     from ..attention import require_fa3_for_speculative_decoding
     require_fa3_for_speculative_decoding()
+
+
+def _supports_non_fa3_speculative_graph(model: torch.nn.Module) -> bool:
+    """Whether model-level speculative decode can run without FA3."""
+    handler = getattr(model, 'supports_non_fa3_speculative_graph', None)
+    if not callable(handler):
+        return False
+    return bool(handler())
 
 
 def _make_piecewise_graph_manager(model: torch.nn.Module, model_config: ModelConfig, cache_config: CacheConfig,
@@ -122,7 +134,8 @@ class CUDAGraphRunner(GraphRunner):
                  backend_config: BackendConfig, device: torch.device):
         super().__init__(model, model_config, cache_config, backend_config, device)
         self.num_blocks = cache_config.num_gpu_blocks
-        _validate_speculative_decoding(model_config)
+        self._supports_non_fa3_speculative_graph = _supports_non_fa3_speculative_graph(self.model)
+        _validate_speculative_decoding(model, model_config)
 
         self.enable_graph = self.check_enable_graph()
         self._decode_model_forward: Callable[..., Any] | None = None
@@ -252,12 +265,40 @@ class CUDAGraphRunner(GraphRunner):
             decode_query_len=graph_key[3],
             pool=self._full_graph_pool_handle,
             model_config=self.model_config,
+            supports_non_fa3_speculative_graph=self._supports_non_fa3_speculative_graph,
             device=self.device,
         )
-        output = runner.capture(**kwargs)
+        capture_cache = self.model.get_cudagraph_capture_cache(
+            kwargs['past_key_values'], spec_step_idx=int(kwargs.get('spec_step_idx', 0)))
+        block_ids: torch.Tensor | None = None
+        snapshot: list[torch.Tensor] | None = None
+        if capture_cache is not None:
+            attn_metadata = kwargs['attn_metadata']
+            batch_size = attn_metadata.q_seqlens.numel()
+            block_ids = torch.unique(attn_metadata.block_offsets[:batch_size]).long()
+            snapshot = [tensor.index_select(0, block_ids).clone() for tensor in capture_cache]
+
+        try:
+            output = runner.capture(**kwargs)
+        finally:
+            if snapshot is not None:
+                if len(capture_cache) != len(snapshot):
+                    raise RuntimeError('CUDA Graph capture cache changed '
+                                       f'from {len(snapshot)} to {len(capture_cache)} tensors.')
+                for tensor, saved in zip(capture_cache, snapshot):
+                    tensor.index_copy_(0, block_ids, saved)
+
+        if snapshot is not None:
+            try:
+                output = runner.forward(**kwargs)
+            except Exception:
+                for tensor, saved in zip(capture_cache, snapshot):
+                    tensor.index_copy_(0, block_ids, saved)
+                raise
+
         self._full_graph_runners[graph_key] = runner
         # SSM capture warmup updates state, so the first call returns that
-        # warmup output instead of replaying and applying the update twice.
+        # warmup output unless a stateful cache snapshot restored it first.
         return output
 
     def __call__(self, **kwargs):

--- a/lmdeploy/pytorch/backends/cuda/graph_runner/runner.py
+++ b/lmdeploy/pytorch/backends/cuda/graph_runner/runner.py
@@ -52,21 +52,21 @@ def _false(*args, **kwargs):
 
 
 def _validate_speculative_decoding(model: torch.nn.Module, model_config: ModelConfig) -> None:
-    """Validate the CUDA attention backend required by speculative decode."""
+    """Validate the attention capability required by speculative decode."""
     if model_config.model_paradigm != 'ar_spec' or model_config.use_flash_mla:
         return
 
-    supports_non_fa3 = getattr(model, 'supports_non_fa3_speculative_graph', lambda: False)
-    if callable(supports_non_fa3) and supports_non_fa3():
+    supports_multi_token = getattr(model, 'supports_multi_token_decode', lambda: False)
+    if callable(supports_multi_token) and supports_multi_token():
         return
 
     from ..attention import require_fa3_for_speculative_decoding
     require_fa3_for_speculative_decoding()
 
 
-def _supports_non_fa3_speculative_graph(model: torch.nn.Module) -> bool:
-    """Whether model-level speculative decode can run without FA3."""
-    handler = getattr(model, 'supports_non_fa3_speculative_graph', None)
+def _supports_multi_token_decode(model: torch.nn.Module) -> bool:
+    """Whether the selected attention implementations support speculative queries."""
+    handler = getattr(model, 'supports_multi_token_decode', None)
     if not callable(handler):
         return False
     return bool(handler())
@@ -134,7 +134,7 @@ class CUDAGraphRunner(GraphRunner):
                  backend_config: BackendConfig, device: torch.device):
         super().__init__(model, model_config, cache_config, backend_config, device)
         self.num_blocks = cache_config.num_gpu_blocks
-        self._supports_non_fa3_speculative_graph = _supports_non_fa3_speculative_graph(self.model)
+        self._supports_multi_token_decode = _supports_multi_token_decode(self.model)
         _validate_speculative_decoding(model, model_config)
 
         self.enable_graph = self.check_enable_graph()
@@ -265,7 +265,7 @@ class CUDAGraphRunner(GraphRunner):
             decode_query_len=graph_key[3],
             pool=self._full_graph_pool_handle,
             model_config=self.model_config,
-            supports_non_fa3_speculative_graph=self._supports_non_fa3_speculative_graph,
+            supports_multi_token_decode=self._supports_multi_token_decode,
             device=self.device,
         )
         capture_cache = self.model.get_cudagraph_capture_cache(

--- a/lmdeploy/pytorch/backends/cuda/graph_runner/runner.py
+++ b/lmdeploy/pytorch/backends/cuda/graph_runner/runner.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any
 import torch
 from torch.profiler import record_function
 
+from lmdeploy.pytorch.backends.attention import normalize_decode_mode
 from lmdeploy.pytorch.backends.deepep_state import get_deepep_state
 from lmdeploy.pytorch.config import (
     BackendConfig,
@@ -176,7 +177,8 @@ class CUDAGraphRunner(GraphRunner):
             batch_size = self._get_capture_tokens(batch_size)
         else:
             batch_size = self._get_capture_tokens(meta.padding_batch_size)
-        graph_key = (batch_size, is_decoding, enable_microbatch, query_len)
+        decode_mode = normalize_decode_mode(getattr(context, 'decode_mode', 'block'))
+        graph_key = (batch_size, is_decoding, enable_microbatch, query_len, decode_mode)
         graph_key += self.model.get_cudagraph_extra_key(**kwargs)
         return graph_key
 

--- a/lmdeploy/pytorch/backends/cuda/graph_runner/runner.py
+++ b/lmdeploy/pytorch/backends/cuda/graph_runner/runner.py
@@ -275,8 +275,13 @@ class CUDAGraphRunner(GraphRunner):
         if capture_cache is not None:
             attn_metadata = kwargs['attn_metadata']
             batch_size = attn_metadata.q_seqlens.numel()
-            block_ids = torch.unique(attn_metadata.block_offsets[:batch_size]).long()
-            snapshot = [tensor.index_select(0, block_ids).clone() for tensor in capture_cache]
+            candidate_ids = attn_metadata.block_offsets[:batch_size].flatten().long()
+            valid_ids = candidate_ids[(candidate_ids >= 0) & (candidate_ids < self.num_blocks)]
+            block_ids = torch.unique(valid_ids)
+            if block_ids.numel() > 0:
+                snapshot = [tensor.index_select(0, block_ids).clone() for tensor in capture_cache]
+            else:
+                block_ids = None
 
         try:
             output = runner.capture(**kwargs)

--- a/lmdeploy/pytorch/backends/cuda/graph_runner/runner.py
+++ b/lmdeploy/pytorch/backends/cuda/graph_runner/runner.py
@@ -268,37 +268,25 @@ class CUDAGraphRunner(GraphRunner):
             supports_multi_token_decode=self._supports_multi_token_decode,
             device=self.device,
         )
-        capture_cache = self.model.get_cudagraph_capture_cache(
-            kwargs['past_key_values'], spec_step_idx=int(kwargs.get('spec_step_idx', 0)))
-        block_ids: torch.Tensor | None = None
-        snapshot: list[torch.Tensor] | None = None
-        if capture_cache is not None:
-            attn_metadata = kwargs['attn_metadata']
-            batch_size = attn_metadata.q_seqlens.numel()
-            candidate_ids = attn_metadata.block_offsets[:batch_size].flatten().long()
-            valid_ids = candidate_ids[(candidate_ids >= 0) & (candidate_ids < self.num_blocks)]
-            block_ids = torch.unique(valid_ids)
-            if block_ids.numel() > 0:
-                snapshot = [tensor.index_select(0, block_ids).clone() for tensor in capture_cache]
-            else:
-                block_ids = None
+        capture_state = self.model.get_cudagraph_capture_state(
+            kwargs['past_key_values'],
+            attn_metadata=kwargs['attn_metadata'],
+            num_blocks=self.num_blocks,
+            spec_step_idx=int(kwargs.get('spec_step_idx', 0)))
+        if capture_state is not None:
+            capture_state.snapshot()
 
         try:
             output = runner.capture(**kwargs)
         finally:
-            if snapshot is not None:
-                if len(capture_cache) != len(snapshot):
-                    raise RuntimeError('CUDA Graph capture cache changed '
-                                       f'from {len(snapshot)} to {len(capture_cache)} tensors.')
-                for tensor, saved in zip(capture_cache, snapshot):
-                    tensor.index_copy_(0, block_ids, saved)
+            if capture_state is not None:
+                capture_state.restore()
 
-        if snapshot is not None:
+        if capture_state is not None:
             try:
                 output = runner.forward(**kwargs)
             except Exception:
-                for tensor, saved in zip(capture_cache, snapshot):
-                    tensor.index_copy_(0, block_ids, saved)
+                capture_state.restore()
                 raise
 
         self._full_graph_runners[graph_key] = runner

--- a/lmdeploy/pytorch/backends/cuda/op_backend.py
+++ b/lmdeploy/pytorch/backends/cuda/op_backend.py
@@ -34,7 +34,7 @@ class CudaOpsBackend(DefaultOpsBackend):
         """Build a typed CUDA operator implementation."""
         from ..activation import SiluAndMulBuildSpec
         from ..apply_rotary_emb import ApplyRotaryEmbBuildSpec
-        from ..attention import PagedAttentionBuildSpec, V4AttentionBuildSpec
+        from ..attention import PagedAttentionBuildSpec, SWAStateRingAttentionBuildSpec, V4AttentionBuildSpec
         from ..awq_modules import LinearW4A16BuildSpec
         from ..blockedf8_modules import LinearBlockedF8BuildSpec
         from ..causal_conv1d import CausalConv1dBuildSpec
@@ -198,6 +198,9 @@ class CudaOpsBackend(DefaultOpsBackend):
         if isinstance(spec, PagedAttentionBuildSpec):
             from .attention import _build_paged_attention
             return cast(ImplT, _build_paged_attention(spec))
+        if isinstance(spec, SWAStateRingAttentionBuildSpec):
+            from .attention.swa_state_ring import SWAStateRingAttentionImpl
+            return cast(ImplT, SWAStateRingAttentionImpl(spec))
         if isinstance(spec, FlashAttentionBuildSpec):
             from .flash_attention import TritonFlashAttentionImpl
             return cast(

--- a/lmdeploy/pytorch/backends/cuda/op_backend.py
+++ b/lmdeploy/pytorch/backends/cuda/op_backend.py
@@ -197,9 +197,6 @@ class CudaOpsBackend(DefaultOpsBackend):
             return cast(ImplT, _build_fused_moe_v4_fp4(spec))
         if isinstance(spec, PagedAttentionBuildSpec):
             from .attention import _build_paged_attention
-            if spec.requires_multi_token_decode:
-                from .attention import require_fa3_for_speculative_decoding
-                require_fa3_for_speculative_decoding()
             return cast(ImplT, _build_paged_attention(spec))
         if isinstance(spec, SWAStateRingAttentionBuildSpec):
             from .attention.swa_state_ring import SWAStateRingAttentionImpl

--- a/lmdeploy/pytorch/backends/cuda/op_backend.py
+++ b/lmdeploy/pytorch/backends/cuda/op_backend.py
@@ -197,6 +197,9 @@ class CudaOpsBackend(DefaultOpsBackend):
             return cast(ImplT, _build_fused_moe_v4_fp4(spec))
         if isinstance(spec, PagedAttentionBuildSpec):
             from .attention import _build_paged_attention
+            if spec.requires_multi_token_decode:
+                from .attention import require_fa3_for_speculative_decoding
+                require_fa3_for_speculative_decoding()
             return cast(ImplT, _build_paged_attention(spec))
         if isinstance(spec, SWAStateRingAttentionBuildSpec):
             from .attention.swa_state_ring import SWAStateRingAttentionImpl

--- a/lmdeploy/pytorch/backends/cuda/op_backend.py
+++ b/lmdeploy/pytorch/backends/cuda/op_backend.py
@@ -331,10 +331,21 @@ class CudaOpsBackend(DefaultOpsBackend):
                 decode_query_len = step_context.input_ids.size(1) // q_seqlens.size(0)
                 cls.update_meta_flashmla(attn_metadata, model_config, decode_query_len)
             elif use_flash_attn3_decoding:
-                # Metadata preparation is backend agnostic.  The attention
-                # factory may select FA3 or Triton, so do not impose an FA3
-                # dependency from this shared context update path.
-                cls.update_meta_flashattn(attn_metadata, step_context)
+                # A supported implementation-derived plan owns metadata for
+                # both FA3 and Triton. The legacy path can only build FA3
+                # scheduler metadata when FA3 is actually available; Triton
+                # requires no extra scheduler metadata.
+                from .attention import _enable_fa3
+                model_config = step_context.model_config
+                if _enable_fa3(
+                        False,
+                        False,
+                        1,
+                        model_config.head_dim,
+                        getattr(model_config, 'v_head_dim', model_config.head_dim),
+                        getattr(model_config, 'sliding_window', None),
+                        dtype=getattr(model_config, 'dtype', None)):
+                    cls.update_meta_flashattn(attn_metadata, step_context)
 
         if step_context.model_config.is_gated_delta and not step_context.is_decoding:
             cls.update_chunked_gated_delta_rule_meta(attn_metadata)

--- a/lmdeploy/pytorch/backends/cuda/op_backend.py
+++ b/lmdeploy/pytorch/backends/cuda/op_backend.py
@@ -331,8 +331,9 @@ class CudaOpsBackend(DefaultOpsBackend):
                 decode_query_len = step_context.input_ids.size(1) // q_seqlens.size(0)
                 cls.update_meta_flashmla(attn_metadata, model_config, decode_query_len)
             elif use_flash_attn3_decoding:
-                from .attention import require_fa3_for_speculative_decoding
-                require_fa3_for_speculative_decoding()
+                # Metadata preparation is backend agnostic.  The attention
+                # factory may select FA3 or Triton, so do not impose an FA3
+                # dependency from this shared context update path.
                 cls.update_meta_flashattn(attn_metadata, step_context)
 
         if step_context.model_config.is_gated_delta and not step_context.is_decoding:

--- a/lmdeploy/pytorch/backends/dlinfer/attention.py
+++ b/lmdeploy/pytorch/backends/dlinfer/attention.py
@@ -73,8 +73,15 @@ class DlinferAttentionImpl(AttentionImpl[DlinferAttentionMetadata]):
         learnable_sink: Tensor = None,
         nsa_indices: Tensor = None,
         inplace: bool = True,
+        decode_mode: str = 'block',
     ) -> Tensor:
         """forward."""
+
+        # dlinfer owns its mask selection in attention metadata.  Accept the
+        # common protocol argument so the public Attention wrapper remains
+        # backend compatible; speculative mask semantics are represented by
+        # ``is_multi_token_decoding`` on DlinferAttentionMetadata.
+        del decode_mode
 
         block_offsets = attn_metadata.block_offsets
         q_start_loc = attn_metadata.q_start_loc

--- a/lmdeploy/pytorch/configurations/mimo_v2_flash.py
+++ b/lmdeploy/pytorch/configurations/mimo_v2_flash.py
@@ -1,0 +1,206 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+import torch
+
+from lmdeploy.pytorch.config import ModelConfig, StateCacheSpec
+
+from .builder import AutoModelConfigBuilder
+
+
+def _get_mimo_cache_layers(hf_config):
+    """Validate the hybrid pattern and return full/SWA layer partitions."""
+    num_layers = hf_config.num_hidden_layers
+    pattern = list(hf_config.hybrid_layer_pattern)
+    if len(pattern) != num_layers:
+        raise ValueError(
+            'MiMo-V2-Flash hybrid_layer_pattern must contain one entry per layer, '
+            f'but got {len(pattern)} entries for num_hidden_layers={num_layers}.'
+        )
+
+    invalid = sorted(set(pattern) - {0, 1})
+    if invalid:
+        raise ValueError(
+            f'MiMo-V2-Flash hybrid_layer_pattern only supports 0 (full attention) and 1 (SWA), but got {invalid}.'
+        )
+
+    full_layers = [i for i, layer_type in enumerate(pattern) if layer_type == 0]
+    swa_layers = [i for i, layer_type in enumerate(pattern) if layer_type == 1]
+    if not full_layers or not swa_layers:
+        raise ValueError('MiMo-V2-Flash requires both full-attention and SWA layers.')
+    return full_layers, swa_layers
+
+
+def _num_kv_heads_per_rank(num_heads: int, tp: int, attention_type: str) -> int:
+    """Return local KV heads, including replication when TP exceeds KV
+    heads."""
+    if num_heads >= tp:
+        if num_heads % tp != 0:
+            raise ValueError(f'MiMo-V2-Flash {attention_type} KV heads ({num_heads}) must be divisible by TP ({tp}).')
+        return num_heads // tp
+    if tp % num_heads != 0:
+        raise ValueError(f'MiMo-V2-Flash TP ({tp}) must be divisible by {attention_type} KV heads ({num_heads}).')
+    return 1
+
+
+def _update_kv_heads_for_tp(hf_config, *, heads_attr: str, replicate_attr: str, tp: int, attention_type: str) -> int:
+    """Expand KV heads for runtime replication while retaining idempotence."""
+    current_heads = getattr(hf_config, heads_attr)
+    current_replicas = getattr(hf_config, replicate_attr, 1)
+    if current_replicas < 1 or current_heads % current_replicas:
+        raise ValueError(
+            f'Invalid {attention_type} KV replication metadata: '
+            f'heads={current_heads}, replicas={current_replicas}.'
+        )
+    original_heads = current_heads // current_replicas
+    _num_kv_heads_per_rank(original_heads, tp, attention_type)
+    replicas = tp // original_heads if tp > original_heads else 1
+    runtime_heads = original_heads * replicas
+    # Always overwrite both runtime fields. This keeps repeated config builds
+    # idempotent if the same HF config object is reused with a different TP.
+    setattr(hf_config, heads_attr, runtime_heads)
+    setattr(hf_config, replicate_attr, replicas)
+    return runtime_heads
+
+
+def _update_mimo_cache_config(cache_config):
+    """Keep all logical blocks and align named-cache allocation granularity."""
+    # Operator cache requests use the finalized kernel-block granularity.
+    cache_config.kernel_block_size = cache_config.block_size
+    # SWA masking is handled by the model backend. Using DefaultBlockManager
+    # preserves the full-attention history and keeps BlockTrie available.
+    cache_config.window_size = -1
+
+
+class MiMoV2FlashModelConfigBuilder(AutoModelConfigBuilder):
+    """Build MiMo-V2-Flash target or MTP configuration and cache policy."""
+
+    @classmethod
+    def condition(cls, hf_config):
+        """Match MiMo-V2-Flash Hugging Face configurations."""
+        return hf_config.model_type == 'mimo_v2_flash'
+
+    @classmethod
+    def build(
+        cls,
+        hf_config,
+        model_path: str | None = None,
+        tp: int = 1,
+        is_draft_model: bool = False,
+        spec_method: str | None = None,
+        **kwargs,
+    ):
+        """Build the target or three-depth draft model configuration."""
+        _, swa_layers = _get_mimo_cache_layers(hf_config)
+        supported_spec_methods = {'mimo_mtp'}
+        if spec_method is not None and spec_method not in supported_spec_methods:
+            raise ValueError(
+                f'MiMo-V2-Flash only supports speculative method mimo_mtp, got {spec_method!r}.'
+            )
+
+        if is_draft_model:
+            # The official config does not declare the MTP depth, while the
+            # checkpoint index contains model.mtp.layers.{0,1,2}. Keep this
+            # explicit until depth discovery is moved into the weight-index
+            # loader; silently falling back to one layer would load an
+            # incomplete draft model.
+            num_mtp_layers = getattr(hf_config, 'num_nextn_predict_layers', 3)
+            if num_mtp_layers != 3:
+                raise ValueError(f'MiMo-V2-Flash requires 3 MTP prediction-depth layers, got {num_mtp_layers}.')
+            hf_config.num_nextn_predict_layers = num_mtp_layers
+            hf_config.architectures = ['MiMoV2FlashMTPModel']
+            # Remote-code AutoModelForCausalLM still points at the target
+            # model and takes precedence over architectures in the patcher.
+            if hasattr(hf_config, 'auto_map'):
+                del hf_config.auto_map
+
+            num_key_value_heads = _update_kv_heads_for_tp(
+                hf_config,
+                heads_attr='swa_num_key_value_heads',
+                replicate_attr='swa_num_replicate_key_value_heads',
+                tp=tp,
+                attention_type='MTP SWA',
+            )
+            window_size = getattr(hf_config, 'sliding_window_size', getattr(hf_config, 'sliding_window', None))
+            if not isinstance(window_size, int) or window_size <= 0:
+                raise ValueError(f'MiMo-V2-Flash MTP requires a positive integer SWA window size, got {window_size!r}.')
+
+            # MTP owns a separate, rollback-safe paged KV cache. Do not attach
+            # the target model's Full block caches or in-place SWA state ring:
+            # speculative rejection cannot restore overwritten ring slots.
+            return ModelConfig(
+                hidden_size=hf_config.hidden_size,
+                num_layers=num_mtp_layers,
+                num_attention_heads=hf_config.swa_num_attention_heads,
+                num_key_value_heads=num_key_value_heads,
+                bos_token_id=getattr(hf_config, 'bos_token_id', None),
+                eos_token_id=getattr(hf_config, 'eos_token_id', None),
+                head_dim=hf_config.swa_head_dim,
+                k_head_dim=hf_config.swa_head_dim,
+                v_head_dim=hf_config.swa_v_head_dim,
+                sliding_window=window_size,
+                vocab_size=hf_config.vocab_size,
+                model_paradigm='ar_spec',
+                use_standard_kv_cache=True,
+            )
+
+        if getattr(hf_config, 'routed_scaling_factor', None) is None:
+            # The official eager implementation interprets null as 1.0;
+            # LMDeploy's fused noaux_tc router expects a numeric multiplier.
+            hf_config.routed_scaling_factor = 1.0
+        # Target verification writes tentative candidates and may reject a
+        # suffix.  A fixed in-place ring cannot restore history slots that a
+        # candidate overwrote across the modulo boundary, whereas paged KV is
+        # reclaimed by the normal speculative rollback path.
+        hf_config._lmdeploy_use_paged_swa = spec_method in supported_spec_methods
+        num_key_value_heads = _update_kv_heads_for_tp(
+            hf_config,
+            heads_attr='num_key_value_heads',
+            replicate_attr='num_replicate_key_value_heads',
+            tp=tp,
+            attention_type='full-attention',
+        )
+        _update_kv_heads_for_tp(
+            hf_config,
+            heads_attr='swa_num_key_value_heads',
+            replicate_attr='swa_num_replicate_key_value_heads',
+            tp=tp,
+            attention_type='SWA',
+        )
+
+        config = ModelConfig(
+            hidden_size=hf_config.hidden_size,
+            num_layers=hf_config.num_hidden_layers,
+            num_attention_heads=hf_config.num_attention_heads,
+            num_key_value_heads=num_key_value_heads,
+            bos_token_id=getattr(hf_config, 'bos_token_id', None),
+            eos_token_id=getattr(hf_config, 'eos_token_id', None),
+            head_dim=hf_config.head_dim,
+            k_head_dim=hf_config.head_dim,
+            v_head_dim=hf_config.v_head_dim,
+            sliding_window=-1,
+            vocab_size=hf_config.vocab_size,
+            model_paradigm='ar_spec' if spec_method is not None else 'ar',
+            use_standard_kv_cache=False,
+        )
+        if not hf_config._lmdeploy_use_paged_swa:
+            window_size = getattr(hf_config, 'sliding_window_size', getattr(hf_config, 'sliding_window', None))
+            swa_heads = _num_kv_heads_per_rank(hf_config.swa_num_key_value_heads, tp, 'SWA')
+            state_specs = [
+                StateCacheSpec(
+                    'mimo_swa_ring_k',
+                    (window_size, swa_heads, hf_config.swa_head_dim),
+                    torch.bfloat16,
+                    layer_ids=swa_layers,
+                ),
+                StateCacheSpec(
+                    'mimo_swa_ring_v',
+                    (window_size, swa_heads, hf_config.swa_v_head_dim),
+                    torch.bfloat16,
+                    layer_ids=swa_layers,
+                ),
+            ]
+            config.state_cache_specs = state_specs
+            # Keep scheduler state-slot accounting until it consumes named
+            # StateCacheSpec directly.
+            config.states_shapes = [(tuple(spec.shape), spec.dtype) for spec in state_specs]
+        config.update_cache_config_func = _update_mimo_cache_config
+        return config

--- a/lmdeploy/pytorch/distributed.py
+++ b/lmdeploy/pytorch/distributed.py
@@ -493,6 +493,6 @@ def reduce_scatter_by_tp_sizes(out: torch.Tensor, rank: int, tp_sizes: list[int]
     attn_tp = get_dist_manager().current_config().attn_tp
     outs = list(out.split(tp_sizes, -2))
     outs = [item for item in outs for _ in range(attn_tp)]
-    out = outs[rank]
-    dist.reduce_scatter(out, outs, group=group)
-    return out
+    output = torch.empty_like(outs[rank])
+    dist.reduce_scatter(output, outs, group=group)
+    return output

--- a/lmdeploy/pytorch/engine/config_builder.py
+++ b/lmdeploy/pytorch/engine/config_builder.py
@@ -219,7 +219,7 @@ class ConfigBuilder:
         """Build spec decode config."""
         def _build_draft_dist_ctx(dist_config, draft_arch):
             # TODO support tp > 1, ep > 1 for other methods
-            if speculative_config.method in ('deepseek_mtp', 'qwen3_5_mtp', 'hy3_mtp'):
+            if speculative_config.method in ('deepseek_mtp', 'hy3_mtp', 'mimo_mtp', 'qwen3_5_mtp'):
                 draft_dist_config = dist_config
             elif speculative_config.method == 'eagle3' and draft_arch == _EAGLE3_DEEPSEEK_ARCH:
                 draft_dist_config = dist_config
@@ -229,6 +229,14 @@ class ConfigBuilder:
 
         specdecode_config = None
         if speculative_config is not None:
+            if speculative_config.method == 'mimo_mtp':
+                target_hf_config = config_from_pretrained(target_model, trust_remote_code=trust_remote_code)
+                if target_hf_config.model_type != 'mimo_v2_flash':
+                    raise ValueError(
+                        f'mimo_mtp requires a MiMo-V2-Flash target, got {target_hf_config.model_type!r}.')
+                if not 1 <= speculative_config.num_speculative_tokens <= 3:
+                    raise ValueError('MiMo-V2-Flash mimo_mtp requires 1 to 3 draft tokens per step, '
+                                     f'got {speculative_config.num_speculative_tokens}.')
             draft_model = speculative_config.model
             if draft_model and not os.path.exists(speculative_config.model):
                 draft_model = get_model(draft_model, engine_config.download_dir, engine_config.revision)

--- a/lmdeploy/pytorch/kernels/cuda/flashattention.py
+++ b/lmdeploy/pytorch/kernels/cuda/flashattention.py
@@ -535,26 +535,33 @@ def flash_attn_varlen_func(
         assert sinks.numel() == num_heads
 
     BLOCK_DK, BLOCK_DK1, BLOCK_DV = _get_block_d(head_dim_k, head_dim_v)
+    # Kernel resource tuning must account for both Q/K tiles. For a
+    # non-power-of-two head such as MiMo's 192, computation is split into
+    # BLOCK_DK=128 and BLOCK_DK1=64. Tuning from BLOCK_DK alone incorrectly
+    # selects the aggressive 128-dim SM90 config and exceeds shared memory.
+    # Use the padded complete dimension for launch metadata while
+    # retaining the split tiles for the actual computation.
+    meta_block_dk = triton.next_power_of_2(head_dim_k)
 
     shared_kv = k.data_ptr() == v.data_ptr() and BLOCK_DK == BLOCK_DV
 
     num_warps = 4
     hip_mode = getattr(torch.version, 'hip', None) is not None
     if hip_mode:
-        BLOCK_M, BLOCK_N, num_warps, num_stages = _kernel_meta_rocm(BLOCK_DK, shared_kv)
+        BLOCK_M, BLOCK_N, num_warps, num_stages = _kernel_meta_rocm(meta_block_dk, shared_kv)
     else:
         nv_cap = get_device_props(q.device.index)['compute_capability']
         if nv_cap[0] < 8:
-            BLOCK_M, BLOCK_N, num_warps, num_stages = _kernel_meta_sm7x(BLOCK_DK)
+            BLOCK_M, BLOCK_N, num_warps, num_stages = _kernel_meta_sm7x(meta_block_dk)
         elif nv_cap[0] < 9:
             if nv_cap[1] in [6, 9]:
-                BLOCK_M, BLOCK_N, num_warps, num_stages = _kernel_meta_sm86(BLOCK_DK, shared_kv)
+                BLOCK_M, BLOCK_N, num_warps, num_stages = _kernel_meta_sm86(meta_block_dk, shared_kv)
             else:
-                BLOCK_M, BLOCK_N, num_warps, num_stages = _kernel_meta_sm8x(BLOCK_DK, shared_kv)
+                BLOCK_M, BLOCK_N, num_warps, num_stages = _kernel_meta_sm8x(meta_block_dk, shared_kv)
         elif nv_cap[0] < 10:
-            BLOCK_M, BLOCK_N, num_warps, num_stages = _kernel_meta_sm9x(BLOCK_DK, shared_kv)
+            BLOCK_M, BLOCK_N, num_warps, num_stages = _kernel_meta_sm9x(meta_block_dk, shared_kv)
         else:
-            BLOCK_M, BLOCK_N, num_warps, num_stages = _kernel_meta_sm12x(BLOCK_DK, shared_kv)
+            BLOCK_M, BLOCK_N, num_warps, num_stages = _kernel_meta_sm12x(meta_block_dk, shared_kv)
 
     BLOCK_M = min(128, BLOCK_M)
     _flash_prefill_fwd_kernel[grid](

--- a/lmdeploy/pytorch/kernels/cuda/pagedattention.py
+++ b/lmdeploy/pytorch/kernels/cuda/pagedattention.py
@@ -60,6 +60,7 @@ def _fwd_grouped_split_kernel(
     stride_boffb,
     kv_group_num: tl.constexpr,
     seq_len: tl.constexpr,
+    causal_multi_token: tl.constexpr,
     window_size: tl.constexpr,
     head_size: tl.constexpr,
     head_size_v: tl.constexpr,
@@ -91,11 +92,15 @@ def _fwd_grouped_split_kernel(
     mask_h = mask_h & (cur_token < cur_batch * seq_len + seq_len)
     mask_h = mask_h & (cur_head < num_heads_q)
 
-    q_seqlen = 1
     kv_seqlen = tl.load(cache_seqlens_ptr + cur_batch)
     if kv_seqlen <= 0:
         return
-    history_len = kv_seqlen - q_seqlen
+    if causal_multi_token:
+        history_len = kv_seqlen - seq_len
+        query_pos = history_len + cur_token - cur_batch * seq_len
+    else:
+        history_len = kv_seqlen - 1
+        query_pos = history_len
     if alibi_slopes_ptr is not None:
         alibi_slopes = tl.load(alibi_slopes_ptr + cur_head, mask=mask_h, other=1.0) * tl_log2(math.e)
     else:
@@ -134,18 +139,30 @@ def _fwd_grouped_split_kernel(
     l_i = tl.zeros([BLOCK_H], dtype=tl.float32)
     acc = tl.zeros([BLOCK_H, BLOCK_DV], dtype=tl.float32)
 
-    num_total_blocks = tl.cdiv(kv_seqlen, BLOCK_N)
+    first_range_block = 0
+    if causal_multi_token and window_size > 0:
+        # Partition only the union of keys visible to this q-token group.
+        # Splitting the complete context would leave almost every CTA empty
+        # for short sliding-attention windows.
+        first_range_block = tl.maximum(history_len - window_size, 0) // BLOCK_N
+    num_total_blocks = tl.cdiv(kv_seqlen, BLOCK_N) - first_range_block
     BLOCK_PER_CTA = tl.cdiv(num_total_blocks, SPLIT_K)
     kv_len_per_prog = BLOCK_PER_CTA * BLOCK_N
-    loop_start = kv_len_per_prog * split_k_id
+    loop_start = first_range_block * BLOCK_N + kv_len_per_prog * split_k_id
     loop_end = tl.minimum(loop_start + kv_len_per_prog, kv_seqlen)
 
     # load block offset
     # dirty
     start_block_id = loop_start // BLOCK_N
     if window_size > 0:
+        # Every query in a verification group has a different causal/window
+        # boundary. Start from the earliest query's window and apply the exact
+        # per-query lower bound below.
         start_block_id = tl.maximum(history_len - window_size, loop_start) // BLOCK_N
-        kv_min_loc = tl.maximum(history_len - window_size, 0)
+        if causal_multi_token:
+            kv_min_loc = tl.maximum(query_pos - window_size, 0)
+        else:
+            kv_min_loc = tl.maximum(history_len - window_size, 0)
 
     loop_start = start_block_id * BLOCK_N
     block_offset_ptrs += start_block_id
@@ -175,15 +192,16 @@ def _fwd_grouped_split_kernel(
             qk = qk * logit_softcapping
         qk = qk * tl_log2(math.e)
         # NOTE: inf - inf = nan, and nan will leads to error
-        if start_n + BLOCK_N > history_len or window_size > 0:
+        if causal_multi_token:
+            qk_mask = query_pos[:, None] >= (start_n + offs_n[None, :])
+            if window_size > 0:
+                qk_mask = qk_mask & ((start_n + offs_n[None, :]) >= kv_min_loc[:, None])
+            qk = tl.where(qk_mask, qk, -float('inf'))
+        elif start_n + BLOCK_N > history_len or window_size > 0:
             qk_mask = history_len >= (start_n + offs_n)
             if window_size > 0:
                 qk_mask = qk_mask & ((start_n + offs_n) >= kv_min_loc)
-            qk = tl.where(
-                qk_mask[None, :],
-                qk,
-                -float('inf'),
-            )
+            qk = tl.where(qk_mask[None, :], qk, -float('inf'))
 
         if alibi_slopes_ptr is not None:
             relative_pos = kv_seqlen - start_n - offs_n[None, :]
@@ -192,8 +210,11 @@ def _fwd_grouped_split_kernel(
 
         # -- compute p, m_i and l_i
         m_i_new = tl.maximum(m_i, tl.max(qk, 1))
-        p = tl_exp2(qk - m_i_new[:, None])
-        alpha = tl_exp2(m_i - m_i_new)
+        # A causal q>1 tile can be entirely to the right of an early query.
+        # Keep an empty row neutral instead of evaluating -inf - -inf.
+        has_valid_key = m_i_new != -float('inf')
+        p = tl.where(has_valid_key[:, None], tl_exp2(qk - m_i_new[:, None]), 0.0)
+        alpha = tl.where(has_valid_key, tl_exp2(m_i - m_i_new), 1.0)
         l_i_new = alpha * l_i + tl.sum(p, 1)
 
         # -- update output accumulator --
@@ -213,10 +234,11 @@ def _fwd_grouped_split_kernel(
         tl.extra.cuda.gdc_launch_dependents()
 
     # initialize pointers to output
-    if loop_end > loop_start:
-        off_acc = (cur_token[:, None] * stride_obs + split_k_id * stride_ok + cur_head[:, None] * stride_oh +
-                   offs_dv[None, :] * stride_od)
-        tl.store(acc_out_ptr + off_acc, acc, mask=mask_h[:, None] & mask_dv[None, :])
+    # Empty split-K partitions still participate in the reduction. Store the
+    # zero accumulator rather than leaving the workspace uninitialized.
+    off_acc = (cur_token[:, None] * stride_obs + split_k_id * stride_ok + cur_head[:, None] * stride_oh +
+               offs_dv[None, :] * stride_od)
+    tl.store(acc_out_ptr + off_acc, acc, mask=mask_h[:, None] & mask_dv[None, :])
 
     off_meta = (cur_token * stride_obs + split_k_id * stride_ok + cur_head * stride_oh + head_size_v)
     tl.store(acc_out_ptr + off_meta, m_i, mask=mask_h)
@@ -794,10 +816,13 @@ def flash_attn_with_kvcache(
     quant_policy: QuantPolicy = QuantPolicy.NONE,
     sinks: Tensor = None,
     kv_layout: str = 'bshd',
+    causal_multi_token: bool = False,
 ):
     """Paged Attention forward.
 
-    Note that this kernel is decoding-only
+    By default, multiple query tokens retain the historical block-decoding
+    mask. ``causal_multi_token`` opts into ordinary causal verification, where
+    token ``i`` attends through ``history_len + i``.
 
     Args:
         k_scales_zeros: Per-token scale/zero metadata for int KV cache, or
@@ -883,6 +908,11 @@ def flash_attn_with_kvcache(
     seq_len = num_tokens // batch
     if max_seqlen_q is not None:
         assert max_seqlen_q == seq_len, 'we only support decoding paged attention.'
+    if causal_multi_token and seq_len > 1:
+        if quant_policy != QuantPolicy.NONE:
+            raise NotImplementedError('Causal multi-token paged attention does not support quantized KV cache.')
+        if alibi_slopes is not None:
+            raise NotImplementedError('Causal multi-token paged attention does not support ALiBi.')
 
     BLOCK_DMODEL, BLOCK_DMODEL1, BLOCK_DV = _get_block_d(Lq, Lv)
     HEADS_PER_REQ = kv_group_num * seq_len
@@ -1014,6 +1044,7 @@ def flash_attn_with_kvcache(
                                         stride_boffb=page_table.stride(0),
                                         kv_group_num=kv_group_num,
                                         seq_len=seq_len,
+                                        causal_multi_token=causal_multi_token,
                                         window_size=window_size,
                                         head_size=Lk,
                                         head_size_v=Lv,

--- a/lmdeploy/pytorch/kernels/cuda/swa_state_ring.py
+++ b/lmdeploy/pytorch/kernels/cuda/swa_state_ring.py
@@ -1,0 +1,310 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+"""Triton flatten/scatter kernels for BF16 SWA state rings."""
+
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _scatter_swa_state_ring_kernel(
+    tokens_ptr,
+    ring_ptr,
+    state_slots_ptr,
+    start_positions_ptr,
+    q_seqlens_ptr,
+    cu_q_seqlens_ptr,
+    stride_tokens_token,
+    stride_tokens_head,
+    stride_tokens_dim,
+    stride_ring_slot,
+    stride_ring_pos,
+    stride_ring_head,
+    stride_ring_dim,
+    NUM_STATE_SLOTS: tl.constexpr,
+    WINDOW_SIZE: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    BLOCK_DIM: tl.constexpr,
+):
+    batch_id = tl.program_id(0)
+    write_idx = tl.program_id(1)
+    head_idx = tl.program_id(2)
+
+    state_slot = tl.load(state_slots_ptr + batch_id)
+    if state_slot < 0 or state_slot >= NUM_STATE_SLOTS:
+        return
+
+    start_position = tl.load(start_positions_ptr + batch_id)
+    if start_position < 0:
+        return
+
+    q_seqlen = tl.load(q_seqlens_ptr + batch_id)
+    write_len = tl.minimum(q_seqlen, WINDOW_SIZE)
+    if write_idx >= write_len:
+        return
+
+    # If a chunk exceeds the ring capacity, its early tokens cannot be part of
+    # the final state.  Starting at q_seqlen - write_len also prevents two
+    # programs from racing to write the same modulo slot.
+    local_position = q_seqlen - write_len + write_idx
+    token_idx = tl.load(cu_q_seqlens_ptr + batch_id) + local_position
+    absolute_position = start_position + local_position
+    ring_position = absolute_position % WINDOW_SIZE
+
+    dim_offsets = tl.arange(0, BLOCK_DIM)
+    dim_mask = dim_offsets < HEAD_DIM
+    token_offsets = (
+        token_idx.to(tl.int64) * stride_tokens_token
+        + head_idx * stride_tokens_head
+        + dim_offsets * stride_tokens_dim
+    )
+    ring_offsets = (
+        state_slot.to(tl.int64) * stride_ring_slot
+        + ring_position.to(tl.int64) * stride_ring_pos
+        + head_idx * stride_ring_head
+        + dim_offsets * stride_ring_dim
+    )
+    payload = tl.load(tokens_ptr + token_offsets, mask=dim_mask)
+    tl.store(ring_ptr + ring_offsets, payload, mask=dim_mask)
+
+
+@triton.jit
+def _flatten_swa_state_ring_kernel(
+    ring_ptr,
+    current_ptr,
+    output_ptr,
+    state_slots_ptr,
+    start_positions_ptr,
+    q_seqlens_ptr,
+    cu_q_seqlens_ptr,
+    history_lens_ptr,
+    cu_kv_seqlens_ptr,
+    stride_ring_slot,
+    stride_ring_pos,
+    stride_ring_head,
+    stride_ring_dim,
+    stride_current_token,
+    stride_current_head,
+    stride_current_dim,
+    stride_output_token,
+    stride_output_head,
+    stride_output_dim,
+    NUM_STATE_SLOTS: tl.constexpr,
+    WINDOW_SIZE: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    BLOCK_DIM: tl.constexpr,
+):
+    """Pack each sequence as chronological history followed by current KV."""
+    batch_id = tl.program_id(0)
+    sequence_token = tl.program_id(1)
+    head_idx = tl.program_id(2)
+
+    history_len = tl.load(history_lens_ptr + batch_id)
+    q_seqlen = tl.load(q_seqlens_ptr + batch_id)
+    if sequence_token >= history_len + q_seqlen:
+        return
+
+    output_token = tl.load(cu_kv_seqlens_ptr + batch_id) + sequence_token
+    dim_offsets = tl.arange(0, BLOCK_DIM)
+    dim_mask = dim_offsets < HEAD_DIM
+    output_offsets = (
+        output_token.to(tl.int64) * stride_output_token
+        + head_idx * stride_output_head
+        + dim_offsets * stride_output_dim
+    )
+
+    if sequence_token < history_len:
+        state_slot = tl.load(state_slots_ptr + batch_id)
+        start_position = tl.load(start_positions_ptr + batch_id)
+        absolute_position = start_position - history_len + sequence_token
+        ring_position = absolute_position % WINDOW_SIZE
+        source_offsets = (
+            state_slot.to(tl.int64) * stride_ring_slot
+            + ring_position.to(tl.int64) * stride_ring_pos
+            + head_idx * stride_ring_head
+            + dim_offsets * stride_ring_dim
+        )
+        payload = tl.load(ring_ptr + source_offsets, mask=dim_mask)
+    else:
+        current_token = tl.load(cu_q_seqlens_ptr + batch_id) + sequence_token - history_len
+        source_offsets = (
+            current_token.to(tl.int64) * stride_current_token
+            + head_idx * stride_current_head
+            + dim_offsets * stride_current_dim
+        )
+        payload = tl.load(current_ptr + source_offsets, mask=dim_mask)
+    tl.store(output_ptr + output_offsets, payload, mask=dim_mask)
+
+
+def _validate_ring(ring: torch.Tensor) -> None:
+    if ring.dim() != 4:
+        raise ValueError(f'SWA state ring must be [state_slots, window, heads, dim], got {tuple(ring.shape)}.')
+    if ring.dtype != torch.bfloat16:
+        raise TypeError(f'SWA state ring must use torch.bfloat16, got {ring.dtype}.')
+    if not ring.is_cuda:
+        raise ValueError('SWA state-ring kernels require CUDA tensors.')
+    if ring.size(1) <= 1:
+        raise ValueError(f'SWA state-ring window must be greater than one, got {ring.size(1)}.')
+
+
+def _validate_batch_vector(name: str, tensor: torch.Tensor, batch_size: int, device: torch.device) -> None:
+    if tensor.dim() != 1 or tensor.numel() != batch_size:
+        raise ValueError(f'{name} must have shape [{batch_size}], got {tuple(tensor.shape)}.')
+    if tensor.device != device:
+        raise ValueError(f'{name} must be on {device}, got {tensor.device}.')
+    if tensor.dtype not in (torch.int32, torch.int64):
+        raise TypeError(f'{name} must use int32 or int64, got {tensor.dtype}.')
+
+
+def flatten_swa_state_ring(
+    ring: torch.Tensor,
+    current: torch.Tensor,
+    state_slots: torch.Tensor,
+    start_positions: torch.Tensor,
+    q_seqlens: torch.Tensor,
+    cu_q_seqlens: torch.Tensor,
+    history_lens: torch.Tensor,
+    cu_kv_seqlens: torch.Tensor,
+    max_q_seqlen: int,
+) -> torch.Tensor:
+    """Pack chronological ring history and current tokens for varlen attention.
+
+    The output order is ``history_i + current_i`` for every sequence ``i``.
+    Its allocation uses a synchronization-free upper bound; only entries
+    addressed by ``cu_kv_seqlens`` are consumed by varlen attention.
+    """
+    _validate_ring(ring)
+    if current.dim() != 3:
+        raise ValueError(f'current must be [total_q, heads, dim], got {tuple(current.shape)}.')
+    if current.dtype != ring.dtype or current.device != ring.device:
+        raise ValueError('current and ring must have the same BF16 dtype and CUDA device.')
+    if current.shape[1:] != ring.shape[2:]:
+        raise ValueError(
+            f'current head shape {tuple(current.shape[1:])} does not match ring {tuple(ring.shape[2:])}.'
+        )
+    if not isinstance(max_q_seqlen, int) or max_q_seqlen < 0:
+        raise ValueError(f'max_q_seqlen must be a non-negative int, got {max_q_seqlen!r}.')
+
+    batch_size = state_slots.numel()
+    _validate_batch_vector('state_slots', state_slots, batch_size, ring.device)
+    _validate_batch_vector('start_positions', start_positions, batch_size, ring.device)
+    _validate_batch_vector('q_seqlens', q_seqlens, batch_size, ring.device)
+    _validate_batch_vector('history_lens', history_lens, batch_size, ring.device)
+    if cu_q_seqlens.dim() != 1 or cu_q_seqlens.numel() != batch_size + 1:
+        raise ValueError(f'cu_q_seqlens must have shape [{batch_size + 1}], got {tuple(cu_q_seqlens.shape)}.')
+    if cu_kv_seqlens.dim() != 1 or cu_kv_seqlens.numel() != batch_size + 1:
+        raise ValueError(f'cu_kv_seqlens must have shape [{batch_size + 1}], got {tuple(cu_kv_seqlens.shape)}.')
+    for name, cumulative in (('cu_q_seqlens', cu_q_seqlens), ('cu_kv_seqlens', cu_kv_seqlens)):
+        if cumulative.device != ring.device or cumulative.dtype not in (torch.int32, torch.int64):
+            raise ValueError(f'{name} must be an int32/int64 tensor on the ring device.')
+
+    history_limit = ring.size(1) - 1
+    output_capacity = current.size(0) + batch_size * history_limit
+    output = torch.empty(
+        (output_capacity, ring.size(2), ring.size(3)),
+        dtype=ring.dtype,
+        device=ring.device,
+    )
+    if batch_size == 0 or output_capacity == 0:
+        return output
+
+    block_dim = triton.next_power_of_2(ring.size(3))
+    grid = (batch_size, history_limit + max_q_seqlen, ring.size(2))
+    _flatten_swa_state_ring_kernel[grid](
+        ring,
+        current,
+        output,
+        state_slots,
+        start_positions,
+        q_seqlens,
+        cu_q_seqlens,
+        history_lens,
+        cu_kv_seqlens,
+        ring.stride(0),
+        ring.stride(1),
+        ring.stride(2),
+        ring.stride(3),
+        current.stride(0),
+        current.stride(1),
+        current.stride(2),
+        output.stride(0),
+        output.stride(1),
+        output.stride(2),
+        NUM_STATE_SLOTS=ring.size(0),
+        WINDOW_SIZE=ring.size(1),
+        HEAD_DIM=ring.size(3),
+        BLOCK_DIM=block_dim,
+    )
+    return output
+
+
+def scatter_swa_state_ring(
+    tokens: torch.Tensor,
+    ring: torch.Tensor,
+    state_slots: torch.Tensor,
+    start_positions: torch.Tensor,
+    q_seqlens: torch.Tensor,
+    cu_q_seqlens: torch.Tensor,
+    max_q_seqlen: int | None = None,
+) -> None:
+    """Write each chunk's newest tokens into one layer's SWA state ring.
+
+    ``tokens`` is packed by sequence.  Valid state slot IDs must be unique
+    within the batch.  At most the last ``window_size`` tokens of each chunk
+    are written; attention must gather the old state before this function is
+    called.
+    """
+    _validate_ring(ring)
+    if tokens.dim() != 3:
+        raise ValueError(f'tokens must be [total_q, heads, dim], got {tuple(tokens.shape)}.')
+    if tokens.dtype != ring.dtype or tokens.device != ring.device:
+        raise ValueError('tokens and ring must have the same BF16 dtype and CUDA device.')
+    if tokens.size(1) != ring.size(2) or tokens.size(2) != ring.size(3):
+        raise ValueError(
+            f'tokens head shape {tuple(tokens.shape[1:])} does not match ring {tuple(ring.shape[2:])}.'
+        )
+
+    batch_size = state_slots.numel()
+    _validate_batch_vector('state_slots', state_slots, batch_size, ring.device)
+    _validate_batch_vector('start_positions', start_positions, batch_size, ring.device)
+    _validate_batch_vector('q_seqlens', q_seqlens, batch_size, ring.device)
+    if cu_q_seqlens.dim() != 1 or cu_q_seqlens.numel() != batch_size + 1:
+        raise ValueError(
+            f'cu_q_seqlens must have shape [{batch_size + 1}], got {tuple(cu_q_seqlens.shape)}.'
+        )
+    if cu_q_seqlens.device != ring.device or cu_q_seqlens.dtype not in (torch.int32, torch.int64):
+        raise ValueError('cu_q_seqlens must be an int32/int64 tensor on the ring device.')
+    if max_q_seqlen is None:
+        max_q_seqlen = ring.size(1)
+    if not isinstance(max_q_seqlen, int) or max_q_seqlen < 0:
+        raise ValueError(f'max_q_seqlen must be a non-negative int, got {max_q_seqlen!r}.')
+    if batch_size == 0 or tokens.numel() == 0 or max_q_seqlen == 0:
+        return
+
+    window_size = ring.size(1)
+    num_heads = ring.size(2)
+    head_dim = ring.size(3)
+    block_dim = triton.next_power_of_2(head_dim)
+    # Each program with write_idx >= q_seqlen is a no-op.  The caller already
+    # has a synchronization-free q-length upper bound, so do not launch a
+    # full window of programs for the common q=1 decode case.
+    grid = (batch_size, min(window_size, max_q_seqlen), num_heads)
+    _scatter_swa_state_ring_kernel[grid](
+        tokens,
+        ring,
+        state_slots,
+        start_positions,
+        q_seqlens,
+        cu_q_seqlens,
+        tokens.stride(0),
+        tokens.stride(1),
+        tokens.stride(2),
+        ring.stride(0),
+        ring.stride(1),
+        ring.stride(2),
+        ring.stride(3),
+        NUM_STATE_SLOTS=ring.size(0),
+        WINDOW_SIZE=window_size,
+        HEAD_DIM=head_dim,
+        BLOCK_DIM=block_dim,
+    )

--- a/lmdeploy/pytorch/model_inputs.py
+++ b/lmdeploy/pytorch/model_inputs.py
@@ -235,6 +235,10 @@ class ModelInputs:
     seq_logit_length: torch.LongTensor | None = None
     # Prediction-depth index for multi-layer MTP draft models.
     spec_step_idx: int = 0
+    # Attention decode semantic selected by the caller.  ``None`` keeps the
+    # legacy model-level default while allowing mixed block/speculative paths
+    # to override it explicitly.
+    decode_mode: str | None = None
     is_chunk: bool = False
     is_first_chunk: bool = False
     is_last_chunk: bool = False
@@ -349,6 +353,7 @@ class StepContext:
     target_hidden_states: torch.Tensor | None = None
     target_inputs_embeds: torch.Tensor | None = None
     spec_step_idx: int = 0
+    decode_mode: str = 'block'
 
     # states for ssm
     state_caches: list | None = None
@@ -406,6 +411,11 @@ class StepContext:
         if cache_config.window_size > 0:
             kv_seqlens -= inputs.num_ignored_history
 
+        decode_mode = inputs.decode_mode
+        if decode_mode is None:
+            decode_mode = ('speculative'
+                           if getattr(model_config, 'model_paradigm', None) == 'ar_spec' else 'block')
+
         ret = StepContext(
             input_ids=inputs.input_ids,
             model_config=model_config,
@@ -435,6 +445,7 @@ class StepContext:
             target_hidden_states=inputs.target_hidden_states,
             target_inputs_embeds=inputs.target_inputs_embeds,
             spec_step_idx=inputs.spec_step_idx,
+            decode_mode=decode_mode,
             mrope_position_ids=inputs.mrope_pos_ids,
             is_chunk_multimodal=inputs.is_chunk_multimodal,
             is_dummy=inputs.is_dummy,

--- a/lmdeploy/pytorch/model_inputs.py
+++ b/lmdeploy/pytorch/model_inputs.py
@@ -233,6 +233,8 @@ class ModelInputs:
     logits_indices: torch.LongTensor | None = None
     # Number of compact logprob rows emitted for each sequence.
     seq_logit_length: torch.LongTensor | None = None
+    # Prediction-depth index for multi-layer MTP draft models.
+    spec_step_idx: int = 0
     is_chunk: bool = False
     is_first_chunk: bool = False
     is_last_chunk: bool = False
@@ -261,6 +263,7 @@ class ModelInputs:
             sum_kv_seqlen=self.sum_kv_seqlen + self.max_q_seqlen * self.seq_length.numel(),
             logits_indices=None,
             seq_logit_length=None,
+            spec_step_idx=self.spec_step_idx + 1,
             mrope_pos_ids=mrope_pos_ids,
         )
 
@@ -345,6 +348,7 @@ class StepContext:
     # for draft model
     target_hidden_states: torch.Tensor | None = None
     target_inputs_embeds: torch.Tensor | None = None
+    spec_step_idx: int = 0
 
     # states for ssm
     state_caches: list | None = None
@@ -430,6 +434,7 @@ class StepContext:
             state_offsets=inputs.state_offsets,
             target_hidden_states=inputs.target_hidden_states,
             target_inputs_embeds=inputs.target_inputs_embeds,
+            spec_step_idx=inputs.spec_step_idx,
             mrope_position_ids=inputs.mrope_pos_ids,
             is_chunk_multimodal=inputs.is_chunk_multimodal,
             is_dummy=inputs.is_dummy,

--- a/lmdeploy/pytorch/model_inputs.py
+++ b/lmdeploy/pytorch/model_inputs.py
@@ -12,6 +12,7 @@ from torch.profiler import record_function
 import lmdeploy.pytorch.distributed as dist
 from lmdeploy.messages import QuantPolicy
 from lmdeploy.pytorch.backends import get_backend
+from lmdeploy.pytorch.backends.attention import DecodeMode, normalize_decode_mode
 from lmdeploy.pytorch.config import CacheConfig, DLLMConfig, ModelConfig, QuantizationConfig
 from lmdeploy.pytorch.multimodal.data_type import MultiModalData
 from lmdeploy.pytorch.utils import CtxMgrBase, singleton
@@ -238,7 +239,7 @@ class ModelInputs:
     # Attention decode semantic selected by the caller.  ``None`` keeps the
     # legacy model-level default while allowing mixed block/speculative paths
     # to override it explicitly.
-    decode_mode: str | None = None
+    decode_mode: DecodeMode | None = None
     is_chunk: bool = False
     is_first_chunk: bool = False
     is_last_chunk: bool = False
@@ -353,7 +354,7 @@ class StepContext:
     target_hidden_states: torch.Tensor | None = None
     target_inputs_embeds: torch.Tensor | None = None
     spec_step_idx: int = 0
-    decode_mode: str = 'block'
+    decode_mode: DecodeMode = 'block'
 
     # states for ssm
     state_caches: list | None = None
@@ -411,10 +412,9 @@ class StepContext:
         if cache_config.window_size > 0:
             kv_seqlens -= inputs.num_ignored_history
 
-        decode_mode = inputs.decode_mode
-        if decode_mode is None:
-            decode_mode = ('speculative'
-                           if getattr(model_config, 'model_paradigm', None) == 'ar_spec' else 'block')
+        default_decode_mode: DecodeMode = (
+            'speculative' if getattr(model_config, 'model_paradigm', None) == 'ar_spec' else 'block')
+        decode_mode = normalize_decode_mode(inputs.decode_mode, default=default_decode_mode)
 
         ret = StepContext(
             input_ids=inputs.input_ids,

--- a/lmdeploy/pytorch/models/deepseek_mtp.py
+++ b/lmdeploy/pytorch/models/deepseek_mtp.py
@@ -284,6 +284,7 @@ class DeepseekMTPModel(nn.Module, CudaGraphMixin):
             attn_metadata=attn_metadata,
             inputs_embeds=inputs_embeds,
             target_hidden_states=target_hidden_states,
+            spec_step_idx=context.spec_step_idx,
         )
 
     def _load_weight_experts(self, name: str, loaded_weight: torch.Tensor, params_dict: dict[str, nn.Parameter],

--- a/lmdeploy/pytorch/models/deepseek_mtp.py
+++ b/lmdeploy/pytorch/models/deepseek_mtp.py
@@ -284,7 +284,6 @@ class DeepseekMTPModel(nn.Module, CudaGraphMixin):
             attn_metadata=attn_metadata,
             inputs_embeds=inputs_embeds,
             target_hidden_states=target_hidden_states,
-            spec_step_idx=context.spec_step_idx,
         )
 
     def _load_weight_experts(self, name: str, loaded_weight: torch.Tensor, params_dict: dict[str, nn.Parameter],

--- a/lmdeploy/pytorch/models/mimo_v2_flash.py
+++ b/lmdeploy/pytorch/models/mimo_v2_flash.py
@@ -27,7 +27,7 @@ from lmdeploy.pytorch.weight_loader.model_weight_loader import default_weight_lo
 
 from .deepseek_v2 import DeepseekV2MoE
 from .patch import add_prefix, get_build_model_context
-from .utils.cudagraph import CudaGraphMixin, GraphCaptureState
+from .utils.cudagraph import CudaGraphMixin, GraphCaptureContext, GraphCaptureState
 from .utils.model import DeployModelMixinV1, build_embedding
 
 if TYPE_CHECKING:
@@ -740,17 +740,13 @@ class MiMoV2FlashForCausalLM(nn.Module, DeployModelMixinV1, CudaGraphMixin):
         )
 
     def get_cudagraph_capture_state(self,
-                                    past_key_values: list[list[torch.Tensor]],
-                                    attn_metadata: Any = None,
-                                    num_blocks: int = 0,
-                                    **kwargs) -> GraphCaptureState | None:
+                                    capture_context: GraphCaptureContext) -> GraphCaptureState | None:
         """Return MiMo's paged target-cache state for capture rollback.
 
         MiMo keeps heterogeneous Full/SWA caches on ``StepContext`` instead
         of ``past_key_values``. The state adapter owns those paged-cache
         rows and their request-visible snapshot semantics.
         """
-        del past_key_values, kwargs
         if not getattr(self.config, '_lmdeploy_use_paged_swa', False):
             return None
         context = self.ctx_mgr.current_context()
@@ -761,9 +757,9 @@ class MiMoV2FlashForCausalLM(nn.Module, DeployModelMixinV1, CudaGraphMixin):
             capture_caches += tuple(layer.self_attn.get_block_cache(context.block_caches))
         return GraphCaptureState.from_paged_tensors(
             capture_caches,
-            block_offsets=attn_metadata.block_offsets,
-            num_blocks=num_blocks,
-            num_requests=attn_metadata.q_seqlens.numel(),
+            block_offsets=capture_context.attn_metadata.block_offsets,
+            num_blocks=capture_context.num_blocks,
+            num_requests=capture_context.attn_metadata.q_seqlens.numel(),
         )
 
     def __init__(

--- a/lmdeploy/pytorch/models/mimo_v2_flash.py
+++ b/lmdeploy/pytorch/models/mimo_v2_flash.py
@@ -184,7 +184,7 @@ class MiMoV2Attention(nn.Module):
             # Full Attention can use FA3 when its wheel contains the asymmetric
             # Q/K=192, V=128 instantiation. SWA remains on the MiMo-specific
             # Triton/ring path because it also implements attention sinks.
-            enable_fa3=not is_swa,
+            allow_fa3=not is_swa,
             enable_paged_multi_token_decode=enable_paged_multi_token_decode,
         )
         # MiMo verification reads the page table directly for both Full and

--- a/lmdeploy/pytorch/models/mimo_v2_flash.py
+++ b/lmdeploy/pytorch/models/mimo_v2_flash.py
@@ -27,7 +27,7 @@ from lmdeploy.pytorch.weight_loader.model_weight_loader import default_weight_lo
 
 from .deepseek_v2 import DeepseekV2MoE
 from .patch import add_prefix, get_build_model_context
-from .utils.cudagraph import CudaGraphMixin
+from .utils.cudagraph import CudaGraphMixin, GraphCaptureState
 from .utils.model import DeployModelMixinV1, build_embedding
 
 if TYPE_CHECKING:
@@ -738,15 +738,16 @@ class MiMoV2FlashForCausalLM(nn.Module, DeployModelMixinV1, CudaGraphMixin):
             **kwargs,
         )
 
-    def get_cudagraph_capture_cache(self,
+    def get_cudagraph_capture_state(self,
                                     past_key_values: list[list[torch.Tensor]],
-                                    **kwargs) -> list[torch.Tensor] | None:
-        """Return MiMo's paged target-cache rows for capture rollback.
+                                    attn_metadata: Any = None,
+                                    num_blocks: int = 0,
+                                    **kwargs) -> GraphCaptureState | None:
+        """Return MiMo's paged target-cache state for capture rollback.
 
         MiMo keeps heterogeneous Full/SWA caches on ``StepContext`` instead
-        of ``past_key_values``. Returning per-layer views keeps the generic
-        graph runner's block dimension at axis zero while covering every
-        cache row touched by target verification.
+        of ``past_key_values``. The state adapter owns those paged-cache
+        rows and their request-visible snapshot semantics.
         """
         del past_key_values, kwargs
         if not getattr(self.config, '_lmdeploy_use_paged_swa', False):
@@ -754,10 +755,15 @@ class MiMoV2FlashForCausalLM(nn.Module, DeployModelMixinV1, CudaGraphMixin):
         context = self.ctx_mgr.current_context()
         if context.block_caches is None:
             raise RuntimeError('MiMo CUDA Graph capture requires named block caches.')
-        capture_caches = []
+        capture_caches: tuple[torch.Tensor, ...] = ()
         for layer in self.model.layers:
-            capture_caches.extend(layer.self_attn.get_block_cache(context.block_caches))
-        return capture_caches
+            capture_caches += tuple(layer.self_attn.get_block_cache(context.block_caches))
+        return GraphCaptureState.from_paged_tensors(
+            capture_caches,
+            block_offsets=attn_metadata.block_offsets,
+            num_blocks=num_blocks,
+            num_requests=attn_metadata.q_seqlens.numel(),
+        )
 
     def __init__(
         self,

--- a/lmdeploy/pytorch/models/mimo_v2_flash.py
+++ b/lmdeploy/pytorch/models/mimo_v2_flash.py
@@ -10,6 +10,7 @@ import torch
 import torch.distributed as dist
 from torch import nn
 
+from lmdeploy.pytorch.backends.attention import normalize_decode_mode
 from lmdeploy.pytorch.distributed import get_dist_manager, get_ep_world_rank, get_tp_world_rank
 from lmdeploy.pytorch.engine.cache_engine.schema import BlockCacheBinding, BlockCacheRequest, BlockCacheRequestContext
 from lmdeploy.pytorch.model_inputs import StepContext, StepContextManager
@@ -187,6 +188,7 @@ class MiMoV2Attention(nn.Module):
                     v_head_size=self.v_head_dim,
                     sliding_window=sliding_window,
                     learnable_sink=has_sink,
+                    dtype=dtype,
                 )
                 # Paged SWA and Full attention both consume page tables.
                 self.use_native_paged_verification = True
@@ -208,6 +210,7 @@ class MiMoV2Attention(nn.Module):
                 num_kv_heads=num_kv_heads,
                 v_head_size=self.v_head_dim,
                 learnable_sink=has_sink,
+                dtype=dtype,
             )
             # MiMo verification reads the page table directly. This avoids a
             # logical-KV-sized flatten workspace and remains valid when prefix
@@ -327,7 +330,9 @@ class MiMoV2Attention(nn.Module):
         # from paged KV; flattening would duplicate shared-prefix blocks and
         # make CUDA Graph workspace capacity depend on logical KV volume.
         batch_size = attn_metadata.block_offsets.size(0)
-        is_verification = attn_metadata.is_decoding and query_states.size(0) > batch_size
+        decode_mode = normalize_decode_mode(getattr(attn_metadata, 'decode_mode', 'block'))
+        is_verification = (attn_metadata.is_decoding and decode_mode == 'speculative'
+                           and query_states.size(0) > batch_size)
         if is_verification and not self.use_native_paged_verification:
             raise RuntimeError('MiMo verification requires native paged multi-token attention.')
 
@@ -340,7 +345,7 @@ class MiMoV2Attention(nn.Module):
             attn_metadata,
             s_aux=self.attention_sink_bias,
             inplace=True,
-            decode_mode='speculative' if is_verification else 'block',
+            decode_mode=decode_mode,
         )
         attn_output = attn_output.reshape(*hidden_states.shape[:-1], -1)
         return self._project_output(attn_output)
@@ -699,7 +704,8 @@ class MiMoV2FlashForCausalLM(nn.Module, DeployModelMixinV1, CudaGraphMixin):
     }
 
     def supports_multi_token_decode(self) -> bool:
-        """Return whether every selected attention path supports spec queries."""
+        """Return whether every selected attention path supports spec
+        queries."""
         return all(layer.self_attn.attn_fwd.supports_multi_token_decode for layer in self.model.layers)
 
     def _prefix_cache_graph_is_safe(self) -> bool:

--- a/lmdeploy/pytorch/models/mimo_v2_flash.py
+++ b/lmdeploy/pytorch/models/mimo_v2_flash.py
@@ -697,6 +697,10 @@ class MiMoV2FlashForCausalLM(nn.Module, DeployModelMixinV1, CudaGraphMixin):
         'gate_up_proj': ['gate_proj', 'up_proj'],
     }
 
+    def supports_multi_token_decode(self) -> bool:
+        """Return whether every selected attention path supports spec queries."""
+        return all(layer.self_attn.attn_fwd.supports_multi_token_decode for layer in self.layers)
+
     def _prefix_cache_graph_is_safe(self) -> bool:
         """Return whether this MiMo step can safely replay with shared blocks.
 

--- a/lmdeploy/pytorch/models/mimo_v2_flash.py
+++ b/lmdeploy/pytorch/models/mimo_v2_flash.py
@@ -340,6 +340,7 @@ class MiMoV2Attention(nn.Module):
             attn_metadata,
             s_aux=self.attention_sink_bias,
             inplace=True,
+            decode_mode='speculative' if is_verification else 'block',
         )
         attn_output = attn_output.reshape(*hidden_states.shape[:-1], -1)
         return self._project_output(attn_output)

--- a/lmdeploy/pytorch/models/mimo_v2_flash.py
+++ b/lmdeploy/pytorch/models/mimo_v2_flash.py
@@ -13,7 +13,14 @@ from torch import nn
 from lmdeploy.pytorch.distributed import get_dist_manager, get_ep_world_rank, get_tp_world_rank
 from lmdeploy.pytorch.engine.cache_engine.schema import BlockCacheBinding, BlockCacheRequest, BlockCacheRequestContext
 from lmdeploy.pytorch.model_inputs import StepContext, StepContextManager
-from lmdeploy.pytorch.nn import ApplyRotaryEmb, Attention, RMSNorm, SiluAndMul, build_rotary_embedding
+from lmdeploy.pytorch.nn import (
+    ApplyRotaryEmb,
+    Attention,
+    RMSNorm,
+    SiluAndMul,
+    SWAStateRingAttention,
+    build_rotary_embedding,
+)
 from lmdeploy.pytorch.nn.eplb import EPLBManager
 from lmdeploy.pytorch.nn.linear import build_down_linear, build_gateup_linear, build_o_proj, build_qkv_proj
 from lmdeploy.pytorch.weight_loader.model_weight_loader import default_weight_loader, load_weight
@@ -104,7 +111,7 @@ class MiMoV2Attention(nn.Module):
         config: Any,
         is_swa: bool,
         block_cache_prefix: str | None = None,
-        enable_paged_verification: bool = False,
+        use_paged_cache: bool = False,
         quantize_o_proj: bool = True,
         dtype: torch.dtype | None = None,
         device: torch.device | None = None,
@@ -171,28 +178,41 @@ class MiMoV2Attention(nn.Module):
             prefix=add_prefix('qkv_proj', prefix),
         )
         self.apply_rotary_pos_emb = ApplyRotaryEmb()
-        enable_paged_multi_token_decode = bool(
-            enable_paged_verification or getattr(config, '_lmdeploy_use_paged_swa', False)
-        )
-        self.attn_fwd = Attention(
-            num_heads,
-            self.head_dim,
-            num_kv_heads=num_kv_heads,
-            v_head_size=self.v_head_dim,
-            sliding_window=sliding_window,
-            learnable_sink=has_sink,
-            # Full Attention can use FA3 when its wheel contains the asymmetric
-            # Q/K=192, V=128 instantiation. SWA remains on the MiMo-specific
-            # Triton/ring path because it also implements attention sinks.
-            allow_fa3=not is_swa,
-            enable_paged_multi_token_decode=enable_paged_multi_token_decode,
-        )
-        # MiMo verification reads the page table directly for both Full and
-        # SWA attention. This avoids a logical-KV-sized flatten workspace and
-        # remains valid when prefix caching shares physical cache blocks.
-        self.use_native_paged_verification = bool(
-            getattr(self.attn_fwd.impl, 'supports_paged_multi_token_decode', False)
-        )
+        if is_swa:
+            if use_paged_cache:
+                self.attn_fwd = Attention(
+                    num_heads,
+                    self.head_dim,
+                    num_kv_heads=num_kv_heads,
+                    v_head_size=self.v_head_dim,
+                    sliding_window=sliding_window,
+                    learnable_sink=has_sink,
+                )
+                # Paged SWA and Full attention both consume page tables.
+                self.use_native_paged_verification = True
+            else:
+                # State-ring SWA never uses paged speculative verification.
+                self.use_native_paged_verification = False
+                self.attn_fwd = SWAStateRingAttention(
+                    num_heads,
+                    self.head_dim,
+                    num_kv_heads=num_kv_heads,
+                    v_head_size=self.v_head_dim,
+                    sliding_window=sliding_window,
+                    learnable_sink=has_sink,
+                )
+        else:
+            self.attn_fwd = Attention(
+                num_heads,
+                self.head_dim,
+                num_kv_heads=num_kv_heads,
+                v_head_size=self.v_head_dim,
+                learnable_sink=has_sink,
+            )
+            # MiMo verification reads the page table directly. This avoids a
+            # logical-KV-sized flatten workspace and remains valid when prefix
+            # caching shares physical cache blocks.
+            self.use_native_paged_verification = True
         self.attention_sink_bias = None
         if has_sink:
             self.attention_sink_bias = nn.Parameter(
@@ -347,18 +367,15 @@ class MiMoV2SWAAttention(MiMoV2Attention):
     ) -> torch.Tensor:
         """Run varlen attention over chronological ring history and current
         KV."""
-        from lmdeploy.pytorch.backends.cuda.attention.swa_state_ring import swa_state_ring_attention
-
         query_states, key_states, value_states = self._project_qkv(hidden_states, rotary_pos_emb)
-        attn_output = swa_state_ring_attention(
-            self.attn_fwd,
+        attn_output = self.attn_fwd(
             query_states,
             key_states,
             value_states,
             state_cache[0],
             state_cache[1],
             swa_metadata,
-            sink=self.attention_sink_bias,
+            s_aux=self.attention_sink_bias,
         )
         attn_output = attn_output.reshape(*hidden_states.shape[:-1], -1)
         return self._project_output(attn_output)
@@ -465,6 +482,7 @@ class MiMoV2DecoderLayer(nn.Module):
                 config,
                 is_swa=True,
                 block_cache_prefix='mimo_swa_paged',
+                use_paged_cache=True,
                 dtype=dtype,
                 device=device,
                 prefix=add_prefix('self_attn', prefix),
@@ -679,9 +697,9 @@ class MiMoV2FlashForCausalLM(nn.Module, DeployModelMixinV1, CudaGraphMixin):
         'gate_up_proj': ['gate_proj', 'up_proj'],
     }
 
-    def supports_non_fa3_speculative_graph(self) -> bool:
-        """Allow MiMo verification to use native Triton paged attention."""
-        return True
+    def supports_multi_token_decode(self) -> bool:
+        """Return whether all selected attention paths support spec queries."""
+        return all(layer.self_attn.attn_fwd.supports_multi_token_decode for layer in self.layers)
 
     def _prefix_cache_graph_is_safe(self) -> bool:
         """Return whether this MiMo step can safely replay with shared blocks.

--- a/lmdeploy/pytorch/models/mimo_v2_flash.py
+++ b/lmdeploy/pytorch/models/mimo_v2_flash.py
@@ -699,7 +699,7 @@ class MiMoV2FlashForCausalLM(nn.Module, DeployModelMixinV1, CudaGraphMixin):
 
     def supports_multi_token_decode(self) -> bool:
         """Return whether every selected attention path supports spec queries."""
-        return all(layer.self_attn.attn_fwd.supports_multi_token_decode for layer in self.layers)
+        return all(layer.self_attn.attn_fwd.supports_multi_token_decode for layer in self.model.layers)
 
     def _prefix_cache_graph_is_safe(self) -> bool:
         """Return whether this MiMo step can safely replay with shared blocks.

--- a/lmdeploy/pytorch/models/mimo_v2_flash.py
+++ b/lmdeploy/pytorch/models/mimo_v2_flash.py
@@ -697,10 +697,6 @@ class MiMoV2FlashForCausalLM(nn.Module, DeployModelMixinV1, CudaGraphMixin):
         'gate_up_proj': ['gate_proj', 'up_proj'],
     }
 
-    def supports_multi_token_decode(self) -> bool:
-        """Return whether all selected attention paths support spec queries."""
-        return all(layer.self_attn.attn_fwd.supports_multi_token_decode for layer in self.layers)
-
     def _prefix_cache_graph_is_safe(self) -> bool:
         """Return whether this MiMo step can safely replay with shared blocks.
 

--- a/lmdeploy/pytorch/models/mimo_v2_flash.py
+++ b/lmdeploy/pytorch/models/mimo_v2_flash.py
@@ -1,0 +1,930 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+import torch
+import torch.distributed as dist
+from torch import nn
+
+from lmdeploy.pytorch.distributed import get_dist_manager, get_ep_world_rank, get_tp_world_rank
+from lmdeploy.pytorch.engine.cache_engine.schema import BlockCacheBinding, BlockCacheRequest, BlockCacheRequestContext
+from lmdeploy.pytorch.model_inputs import StepContext, StepContextManager
+from lmdeploy.pytorch.nn import ApplyRotaryEmb, Attention, RMSNorm, SiluAndMul, build_rotary_embedding
+from lmdeploy.pytorch.nn.eplb import EPLBManager
+from lmdeploy.pytorch.nn.linear import build_down_linear, build_gateup_linear, build_o_proj, build_qkv_proj
+from lmdeploy.pytorch.weight_loader.model_weight_loader import default_weight_loader, load_weight
+
+from .deepseek_v2 import DeepseekV2MoE
+from .patch import add_prefix, get_build_model_context
+from .utils.cudagraph import CudaGraphMixin
+from .utils.model import DeployModelMixinV1, build_embedding
+
+if TYPE_CHECKING:
+    from lmdeploy.pytorch.backends.cuda.attention.swa_state_ring import SWAStateRingMetadata
+
+
+def _mimo_swa_kernel_window(total_window_size: int) -> tuple[int, int]:
+    """Translate MiMo's total causal window into kernel bounds."""
+    if not isinstance(total_window_size, int) or total_window_size <= 0:
+        raise ValueError(f'MiMo requires a positive total SWA window, got {total_window_size!r}.')
+    # Kernel bounds are inclusive of the current causal token.
+    return total_window_size - 1, 0
+
+
+def _get_norm_eps(config: Any) -> float:
+    """Read the native or remote-code MiMo RMSNorm epsilon field."""
+    norm_eps = getattr(config, 'rms_norm_eps', None)
+    if norm_eps is None:
+        norm_eps = config.layernorm_epsilon
+    return norm_eps
+
+
+def _reduce_tp_output(linear: nn.Module, output: torch.Tensor) -> torch.Tensor:
+    """Reduce one MiMo row-parallel output."""
+    if linear.tp > 1:
+        dist.all_reduce(output, group=linear.tp_group)
+    return output
+
+
+def _load_attention_sink(param: nn.Parameter, loaded_weight: torch.Tensor):
+    """Load this rank's Q-head slice of an attention sink vector."""
+    world_size, rank = get_tp_world_rank('attn')
+    if loaded_weight.size(0) % world_size != 0:
+        raise ValueError(f'Cannot shard {loaded_weight.size(0)} MiMo sink heads over TP={world_size}.')
+    loaded_weight = loaded_weight.chunk(world_size, dim=0)[rank]
+    default_weight_loader(param, loaded_weight)
+
+
+def _load_native_qkv_shard(
+    target_prefix: str,
+    tensor_kind: str,
+    loaded_weight: torch.Tensor,
+    params_dict: dict[str, nn.Parameter],
+    shard_id: str,
+) -> None:
+    """Load one official MiMo blocked-FP8 QKV tensor into a fused
+    projection."""
+    target_param = params_dict[f'{target_prefix}.weight']
+    target_scale = params_dict.get(f'{target_prefix}.weight_scale_inv')
+    fp8_dtypes = (torch.float8_e4m3fn, torch.float8_e5m2)
+    if target_scale is None or target_param.dtype not in fp8_dtypes:
+        raise TypeError(f'MiMo QKV target {target_prefix!r} must use native blocked-FP8 parameters.')
+    if tensor_kind == 'weight':
+        if loaded_weight.dtype not in fp8_dtypes:
+            raise TypeError(f'MiMo QKV checkpoint weight must use FP8, got {loaded_weight.dtype}.')
+        target = target_param
+    elif tensor_kind == 'scale':
+        target = target_scale
+    else:
+        raise ValueError(f'Unsupported MiMo QKV tensor kind: {tensor_kind!r}.')
+    load_weight(target, loaded_weight, shard_id=shard_id)
+
+
+@dataclass
+class MiMoV2Caches:
+    """Named Full-Attention block caches and SWA state rings."""
+
+    block_caches: Any
+    state_caches: Any
+
+    def state_cache(self, cache_name: str, layer_idx: int) -> torch.Tensor:
+        """Resolve a compact named-state row by global layer index."""
+        return self.state_caches.layer(cache_name, layer_idx)
+
+
+class MiMoV2Attention(nn.Module):
+    """Common MiMo-V2 QKV projection, partial RoPE and output projection."""
+
+    def __init__(
+        self,
+        config: Any,
+        is_swa: bool,
+        block_cache_prefix: str | None = None,
+        enable_paged_verification: bool = False,
+        quantize_o_proj: bool = True,
+        dtype: torch.dtype | None = None,
+        device: torch.device | None = None,
+        prefix: str = '',
+    ):
+        super().__init__()
+        self._block_cache_prefix = block_cache_prefix
+        self._block_cache_bindings: dict[str, BlockCacheBinding] = {}
+        self._cache_dtype = dtype
+        quantization_config = getattr(config, 'quantization_config', None)
+        if is_swa:
+            self.head_dim = config.swa_head_dim
+            self.v_head_dim = config.swa_v_head_dim
+            num_heads = config.swa_num_attention_heads
+            num_kv_heads = config.swa_num_key_value_heads
+            num_replicate_kv_heads = getattr(config, 'swa_num_replicate_key_value_heads', 1)
+            total_window_size = getattr(config, 'sliding_window_size', getattr(config, 'sliding_window', None))
+            sliding_window = _mimo_swa_kernel_window(total_window_size)
+            has_sink = getattr(config, 'add_swa_attention_sink_bias', False)
+        else:
+            self.head_dim = config.head_dim
+            self.v_head_dim = config.v_head_dim
+            num_heads = config.num_attention_heads
+            num_kv_heads = config.num_key_value_heads
+            num_replicate_kv_heads = getattr(config, 'num_replicate_key_value_heads', 1)
+            sliding_window = None
+            has_sink = getattr(config, 'add_full_attention_sink_bias', False)
+
+        self.v_scale = getattr(config, 'attention_value_scale', None)
+        self.rotary_dim = int(self.head_dim * config.partial_rotary_factor)
+        if self.rotary_dim <= 0 or self.rotary_dim > self.head_dim or self.rotary_dim % 2 != 0:
+            raise ValueError(f'Invalid MiMo-V2 rotary dimension: {self.rotary_dim}.')
+
+        # MiMo resets its blocked-FP8 output grid at four equal checkpoint
+        # sections. Inside each Full-Attention section, Q/K/V are quantized as one
+        # fused output: K's final scale block covers K[128:192] and V[0:64].
+        # SWA projection boundaries are block aligned and retain the ordinary
+        # per-projection planner (including TP8 sub-shard alignment).
+        checkpoint_quantization_sections = 4
+        if num_replicate_kv_heads < 1 or num_kv_heads % num_replicate_kv_heads:
+            raise ValueError(
+                'MiMo runtime KV heads must be divisible by their replication factor, '
+                f'got heads={num_kv_heads} and replicas={num_replicate_kv_heads}.'
+            )
+        checkpoint_num_kv_heads = num_kv_heads // num_replicate_kv_heads
+        checkpoint_output_shard_sizes = (
+            num_heads * self.head_dim // checkpoint_quantization_sections,
+            checkpoint_num_kv_heads * self.head_dim // checkpoint_quantization_sections,
+            checkpoint_num_kv_heads * self.v_head_dim // checkpoint_quantization_sections,
+        )
+        self.qkv_proj = build_qkv_proj(
+            config.hidden_size,
+            num_q_heads=num_heads,
+            num_kv_heads=num_kv_heads,
+            head_size=self.head_dim,
+            head_size_v=self.v_head_dim,
+            bias=config.attention_bias,
+            quant_config=quantization_config,
+            dtype=dtype,
+            device=device,
+            num_replicate_kv_heads=num_replicate_kv_heads,
+            checkpoint_output_shard_sizes=checkpoint_output_shard_sizes,
+            continuous_qkv_scale_layout=not is_swa,
+            prefix=add_prefix('qkv_proj', prefix),
+        )
+        self.apply_rotary_pos_emb = ApplyRotaryEmb()
+        enable_paged_multi_token_decode = bool(
+            enable_paged_verification or getattr(config, '_lmdeploy_use_paged_swa', False)
+        )
+        self.attn_fwd = Attention(
+            num_heads,
+            self.head_dim,
+            num_kv_heads=num_kv_heads,
+            v_head_size=self.v_head_dim,
+            sliding_window=sliding_window,
+            learnable_sink=has_sink,
+            # Full Attention can use FA3 when its wheel contains the asymmetric
+            # Q/K=192, V=128 instantiation. SWA remains on the MiMo-specific
+            # Triton/ring path because it also implements attention sinks.
+            enable_fa3=not is_swa,
+            enable_paged_multi_token_decode=enable_paged_multi_token_decode,
+        )
+        # MiMo verification reads the page table directly for both Full and
+        # SWA attention. This avoids a logical-KV-sized flatten workspace and
+        # remains valid when prefix caching shares physical cache blocks.
+        self.use_native_paged_verification = bool(
+            getattr(self.attn_fwd.impl, 'supports_paged_multi_token_decode', False)
+        )
+        self.attention_sink_bias = None
+        if has_sink:
+            self.attention_sink_bias = nn.Parameter(
+                torch.empty(self.qkv_proj.num_q_heads, dtype=dtype, device=device),
+                requires_grad=False,
+            )
+            self.attention_sink_bias.weight_loader = _load_attention_sink
+        self.o_proj = build_o_proj(
+            num_heads * self.v_head_dim,
+            config.hidden_size,
+            bias=False,
+            # MTP o_proj is serialized in BF16 and is not covered by the
+            # target model's ignored-layer names in quantization_config.
+            # Let the MTP wrapper explicitly request the BF16 module while
+            # preserving the target model's existing construction.
+            quant_config=quantization_config if quantize_o_proj else None,
+            dtype=dtype,
+            device=device,
+            is_tp=True,
+            # Keep reduction outside the linear so MiMo uses the same explicit
+            # tensor-parallel group for attention, dense FFN and MoE outputs.
+            all_reduce=False,
+            prefix=add_prefix('o_proj', prefix),
+        )
+
+    def get_block_cache_requests(self, context: BlockCacheRequestContext) -> tuple[BlockCacheRequest, ...]:
+        """Declare this attention layer's pageable K/V payloads."""
+        if self._block_cache_prefix is None:
+            return ()
+        if not isinstance(self._cache_dtype, torch.dtype):
+            raise TypeError(f'MiMo block caches require a concrete torch dtype, got {self._cache_dtype!r}.')
+        block_size = context.geometry.kernel_block_size
+        num_kv_heads = self.qkv_proj.num_kv_heads
+        return (
+            BlockCacheRequest(
+                name=f'{self._block_cache_prefix}_k',
+                shape=(block_size, num_kv_heads, self.head_dim),
+                dtype=self._cache_dtype,
+            ),
+            BlockCacheRequest(
+                name=f'{self._block_cache_prefix}_v',
+                shape=(block_size, num_kv_heads, self.v_head_dim),
+                dtype=self._cache_dtype,
+            ),
+        )
+
+    def bind_block_cache(self, binding: BlockCacheBinding) -> None:
+        """Bind one cache name to the collector-assigned consumer row."""
+        prefix = self._block_cache_prefix
+        expected = {f'{prefix}_k', f'{prefix}_v'} if prefix is not None else set()
+        if binding.cache_name not in expected:
+            raise ValueError(f'Unexpected MiMo block cache binding: {binding.cache_name!r}.')
+        if binding.cache_name in self._block_cache_bindings:
+            raise RuntimeError(f'MiMo block cache {binding.cache_name!r} was bound more than once.')
+        self._block_cache_bindings[binding.cache_name] = binding
+
+    def get_block_cache(self, block_caches) -> tuple[torch.Tensor, torch.Tensor]:
+        """Resolve the K/V rows bound to this attention layer."""
+        prefix = self._block_cache_prefix
+        if prefix is None:
+            raise RuntimeError('This MiMo attention layer does not own a pageable block cache.')
+        rows = []
+        for suffix in ('k', 'v'):
+            cache_name = f'{prefix}_{suffix}'
+            try:
+                binding = self._block_cache_bindings[cache_name]
+            except KeyError as e:
+                raise RuntimeError(f'MiMo block cache {cache_name!r} has not been bound.') from e
+            rows.append(block_caches.row(binding.cache_name, binding.consumer_row))
+        return rows[0], rows[1]
+
+    def _project_output(self, attn_output: torch.Tensor) -> torch.Tensor:
+        """Apply o_proj and its tensor-parallel reduction."""
+        output = self.o_proj(attn_output)
+        return _reduce_tp_output(self.o_proj, output)
+
+    def _project_qkv(
+        self,
+        hidden_states: torch.Tensor,
+        rotary_pos_emb: tuple[torch.Tensor, torch.Tensor],
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Project QKV, apply partial RoPE and scale V before caching."""
+        qkv_states = self.qkv_proj(hidden_states).flatten(0, -2)
+        query_states, key_states, value_states = self.qkv_proj.split_qkv(qkv_states)
+
+        # MiMo rotates only the leading rotary_dim features. Passing the views
+        # explicitly also keeps the default backend valid; broadcasting a
+        # rotary_dim-wide cos/sin table over the complete 192 features would
+        # be incorrect.
+        query_rope = query_states[..., : self.rotary_dim]
+        key_rope = key_states[..., : self.rotary_dim]
+        cos, sin = rotary_pos_emb
+        self.apply_rotary_pos_emb(query_rope, key_rope, cos, sin, inplace=True)
+        if self.v_scale is not None:
+            # Scale before either block/ring cache writes so current attention,
+            # decode and prefix restore share one V representation.
+            value_states = value_states * self.v_scale
+        return query_states, key_states, value_states
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        rotary_pos_emb: tuple[torch.Tensor, torch.Tensor],
+        past_key_value: tuple[torch.Tensor, torch.Tensor],
+        attn_metadata: Any,
+    ) -> torch.Tensor:
+        """Run attention over a pageable KV cache."""
+        query_states, key_states, value_states = self._project_qkv(hidden_states, rotary_pos_emb)
+
+        # ar_spec target verification sends multiple causal queries while
+        # retaining the scheduler's decoding flag. MiMo reads them directly
+        # from paged KV; flattening would duplicate shared-prefix blocks and
+        # make CUDA Graph workspace capacity depend on logical KV volume.
+        batch_size = attn_metadata.block_offsets.size(0)
+        is_verification = attn_metadata.is_decoding and query_states.size(0) > batch_size
+        if is_verification and not self.use_native_paged_verification:
+            raise RuntimeError('MiMo verification requires native paged multi-token attention.')
+
+        attn_output = self.attn_fwd(
+            query_states,
+            key_states,
+            value_states,
+            past_key_value[0],
+            past_key_value[1],
+            attn_metadata,
+            s_aux=self.attention_sink_bias,
+            inplace=True,
+        )
+        attn_output = attn_output.reshape(*hidden_states.shape[:-1], -1)
+        return self._project_output(attn_output)
+
+
+class MiMoV2FullAttention(MiMoV2Attention):
+    """MiMo-V2 full attention backed by the named paged KV cache."""
+
+    def __init__(self, config: Any, **kwargs):
+        super().__init__(config, is_swa=False, **kwargs)
+
+
+class MiMoV2SWAAttention(MiMoV2Attention):
+    """SWA attention backed by a sequence-scoped BF16 state ring."""
+
+    def __init__(self, config: Any, **kwargs):
+        super().__init__(config, is_swa=True, **kwargs)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        rotary_pos_emb: tuple[torch.Tensor, torch.Tensor],
+        state_cache: tuple[torch.Tensor, torch.Tensor],
+        swa_metadata: SWAStateRingMetadata,
+    ) -> torch.Tensor:
+        """Run varlen attention over chronological ring history and current
+        KV."""
+        from lmdeploy.pytorch.backends.cuda.attention.swa_state_ring import swa_state_ring_attention
+
+        query_states, key_states, value_states = self._project_qkv(hidden_states, rotary_pos_emb)
+        attn_output = swa_state_ring_attention(
+            self.attn_fwd,
+            query_states,
+            key_states,
+            value_states,
+            state_cache[0],
+            state_cache[1],
+            swa_metadata,
+            sink=self.attention_sink_bias,
+        )
+        attn_output = attn_output.reshape(*hidden_states.shape[:-1], -1)
+        return self._project_output(attn_output)
+
+
+class MiMoV2MLP(nn.Module):
+    """Dense SwiGLU block used by MiMo-V2-Flash."""
+
+    def __init__(
+        self,
+        config: Any,
+        intermediate_size: int | None = None,
+        dtype: torch.dtype | None = None,
+        device: torch.device | None = None,
+        prefix: str = '',
+    ):
+        super().__init__()
+        if intermediate_size is None:
+            intermediate_size = config.intermediate_size
+        quantization_config = getattr(config, 'quantization_config', None)
+
+        # The official checkpoint stores gate_proj and up_proj separately.
+        # LMDeploy packs them into one column-parallel projection; SiluAndMul
+        # consumes the packed [gate, up] output without changing the math.
+        self.gate_up_proj = build_gateup_linear(
+            config.hidden_size,
+            [intermediate_size, intermediate_size],
+            bias=False,
+            dtype=dtype,
+            device=device,
+            quant_config=quantization_config,
+            is_tp=True,
+            prefix=add_prefix('gate_up_proj', prefix),
+        )
+        self.act_fn = SiluAndMul(inplace=True)
+        self.down_proj = build_down_linear(
+            intermediate_size,
+            config.hidden_size,
+            bias=False,
+            dtype=dtype,
+            device=device,
+            quant_config=quantization_config,
+            is_tp=True,
+            # Keep the framework reduction enabled.  In DP+TP mode this is a
+            # reduce-scatter that restores each DP rank's local token layout;
+            # replacing it with a plain all-reduce leaves gathered tokens in
+            # the output and breaks the residual shape in the next layer.
+            all_reduce=True,
+            prefix=add_prefix('down_proj', prefix),
+        )
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        """Apply down_proj(silu(gate_proj(x)) * up_proj(x))."""
+        gate_up = self.gate_up_proj(hidden_states)
+        return self.down_proj(self.act_fn(gate_up))
+
+
+class MiMoV2MoE(DeepseekV2MoE):
+    """MiMo-V2 MoE using LMDeploy's fused DeepSeek-style execution path."""
+
+    def forward(self, hidden_states: torch.Tensor, all_routed_experts: torch.Tensor = None):
+        """Run fused experts and reduce their output over MiMo TP."""
+        batch_size, sequence_length, hidden_dim = hidden_states.shape
+        hidden_states = hidden_states.view(-1, hidden_dim)
+        routed_experts = None
+        if all_routed_experts is not None:
+            routed_experts = all_routed_experts[:, self.layer_idx, :]
+        topk_weights, topk_ids = self.gate(hidden_states, routed_experts=routed_experts)
+
+        out_states = self.experts(hidden_states, topk_weights, topk_ids)
+        if self.shared_experts is not None:
+            out_states += self.shared_experts(hidden_states)
+        out_states = out_states.reshape(batch_size, sequence_length, -1)
+
+        # DeepEP combine already returns the complete routed-expert output.
+        # With EP enabled ``moe_tp`` is one and its placeholder process group
+        # is None; reducing it would therefore use WORLD and sum an already
+        # complete tensor once per EP rank.
+        if self._all_reduce and self.experts.tp > 1:
+            dist.all_reduce(out_states, group=self.experts.tp_group)
+        return out_states
+
+
+class MiMoV2DecoderLayer(nn.Module):
+    """MiMo-V2 decoder layer with per-layer attention and FFN selection."""
+
+    def __init__(
+        self,
+        config: Any,
+        layer_idx: int,
+        dtype: torch.dtype | None = None,
+        device: torch.device | None = None,
+        prefix: str = '',
+    ):
+        super().__init__()
+        self.layer_idx = layer_idx
+        self.is_swa = config.hybrid_layer_pattern[layer_idx] == 1
+        self.is_moe = getattr(config, 'n_routed_experts', None) is not None and bool(config.moe_layer_freq[layer_idx])
+        quantization_config = getattr(config, 'quantization_config', None)
+
+        self.use_paged_swa = self.is_swa and getattr(config, '_lmdeploy_use_paged_swa', False)
+        if self.use_paged_swa:
+            self.self_attn = MiMoV2Attention(
+                config,
+                is_swa=True,
+                block_cache_prefix='mimo_swa_paged',
+                dtype=dtype,
+                device=device,
+                prefix=add_prefix('self_attn', prefix),
+            )
+        else:
+            attention_cls = MiMoV2SWAAttention if self.is_swa else MiMoV2FullAttention
+            self.self_attn = attention_cls(
+                config,
+                block_cache_prefix=None if self.is_swa else 'mimo_full',
+                dtype=dtype,
+                device=device,
+                prefix=add_prefix('self_attn', prefix),
+            )
+        if self.is_moe:
+            self.mlp = MiMoV2MoE(config, layer_idx, dtype=dtype, device=device)
+        else:
+            self.mlp = MiMoV2MLP(
+                config,
+                dtype=dtype,
+                device=device,
+                prefix=add_prefix('mlp', prefix),
+            )
+
+        norm_eps = _get_norm_eps(config)
+        self.input_layernorm = RMSNorm(
+            config.hidden_size,
+            norm_eps,
+            quant_config=quantization_config,
+            dtype=dtype,
+            device=device,
+            prefix=add_prefix('input_layernorm', prefix),
+        )
+        self.post_attention_layernorm = RMSNorm(
+            config.hidden_size,
+            norm_eps,
+            quant_config=quantization_config,
+            dtype=dtype,
+            device=device,
+            prefix=add_prefix('post_attention_layernorm', prefix),
+        )
+
+        if self.is_swa and not self.use_paged_swa:
+            self.k_cache_name = 'mimo_swa_ring_k'
+            self.v_cache_name = 'mimo_swa_ring_v'
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        rotary_pos_emb: tuple[torch.Tensor, torch.Tensor],
+        caches: MiMoV2Caches,
+        residual: torch.Tensor | None = None,
+        attn_metadata: Any = None,
+        swa_metadata: SWAStateRingMetadata | None = None,
+        all_routed_experts: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Run pre-norm attention and FFN while carrying fused residual."""
+        if residual is None:
+            residual = hidden_states
+            hidden_states = self.input_layernorm(hidden_states)
+        else:
+            hidden_states, residual = self.input_layernorm(hidden_states, residual)
+        if self.is_swa and not self.use_paged_swa:
+            if swa_metadata is None:
+                raise RuntimeError('MiMo SWA layer requires state-ring attention metadata.')
+            state_cache = (
+                caches.state_cache(self.k_cache_name, self.layer_idx),
+                caches.state_cache(self.v_cache_name, self.layer_idx),
+            )
+            hidden_states = self.self_attn(
+                hidden_states=hidden_states,
+                rotary_pos_emb=rotary_pos_emb,
+                state_cache=state_cache,
+                swa_metadata=swa_metadata,
+            )
+        else:
+            past_key_value = self.self_attn.get_block_cache(caches.block_caches)
+            hidden_states = self.self_attn(
+                hidden_states=hidden_states,
+                rotary_pos_emb=rotary_pos_emb,
+                past_key_value=past_key_value,
+                attn_metadata=attn_metadata,
+            )
+        hidden_states, residual = self.post_attention_layernorm(hidden_states, residual)
+        if self.is_moe:
+            hidden_states = self.mlp(hidden_states, all_routed_experts=all_routed_experts)
+        else:
+            hidden_states = self.mlp(hidden_states)
+        return hidden_states, residual
+
+
+class MiMoV2Model(nn.Module):
+    """MiMo-V2 transformer body using heterogeneous named caches."""
+
+    def __init__(
+        self,
+        config: Any,
+        dtype: torch.dtype | None = None,
+        device: torch.device | None = None,
+        prefix: str = '',
+    ):
+        super().__init__()
+        if dtype is not torch.bfloat16:
+            raise ValueError(f'MiMo-V2-Flash only supports torch.bfloat16, but got {dtype}.')
+        self.config = config
+        self.padding_idx = getattr(config, 'pad_token_id', None)
+        self.vocab_size = config.vocab_size
+
+        if len(config.hybrid_layer_pattern) != config.num_hidden_layers:
+            raise ValueError('MiMo-V2 hybrid_layer_pattern must contain one entry per decoder layer.')
+        if len(config.moe_layer_freq) != config.num_hidden_layers:
+            raise ValueError('MiMo-V2 moe_layer_freq must contain one entry per decoder layer.')
+
+        self.embed_tokens = build_embedding(
+            config.vocab_size,
+            config.hidden_size,
+            self.padding_idx,
+            dtype=dtype,
+            device=device,
+            is_tp=True,
+        )
+
+        if get_dist_manager().current_context().dist_config.enable_eplb:
+            ep_size, _ = get_ep_world_rank()
+            EPLBManager.init_global_eplb_metadata(
+                ep_size=ep_size,
+                num_routed_experts=config.n_routed_experts,
+                num_hidden_layers=config.num_hidden_layers,
+            )
+
+        self.layers = nn.ModuleList(
+            [
+                MiMoV2DecoderLayer(
+                    config,
+                    layer_idx,
+                    dtype=dtype,
+                    device=device,
+                    prefix=add_prefix(f'layers.{layer_idx}', prefix),
+                )
+                for layer_idx in range(config.num_hidden_layers)
+            ]
+        )
+        norm_eps = _get_norm_eps(config)
+        self.norm = RMSNorm(
+            config.hidden_size,
+            norm_eps,
+            dtype=dtype,
+            device=device,
+            prefix=add_prefix('norm', prefix),
+        )
+
+        rotary_kwargs = dict(
+            max_position_embeddings=config.max_position_embeddings,
+            partial_rotary_factor=config.partial_rotary_factor,
+            device=device,
+        )
+        self.rotary_emb = build_rotary_embedding(
+            dim=config.head_dim,
+            base=config.rope_theta,
+            **rotary_kwargs,
+        )
+        self.swa_rotary_emb = build_rotary_embedding(
+            dim=config.swa_head_dim,
+            base=config.swa_rope_theta,
+            **rotary_kwargs,
+        )
+
+    def forward(
+        self,
+        input_ids: torch.LongTensor | None,
+        position_ids: torch.LongTensor,
+        caches: MiMoV2Caches,
+        attn_metadata: Any = None,
+        swa_metadata: SWAStateRingMetadata | None = None,
+        inputs_embeds: torch.Tensor | None = None,
+        all_routed_experts: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        """Run all decoder layers with layer-appropriate RoPE and caches."""
+        if inputs_embeds is None:
+            inputs_embeds = self.embed_tokens(input_ids)
+        hidden_states = inputs_embeds
+
+        full_cos, full_sin = self.rotary_emb(hidden_states, position_ids)
+        swa_cos, swa_sin = self.swa_rotary_emb(hidden_states, position_ids)
+        full_rotary_pos_emb = (full_cos[0], full_sin[0])
+        swa_rotary_pos_emb = (swa_cos[0], swa_sin[0])
+
+        residual = None
+        for decoder_layer in self.layers:
+            rotary_pos_emb = swa_rotary_pos_emb if decoder_layer.is_swa else full_rotary_pos_emb
+            hidden_states, residual = decoder_layer(
+                hidden_states,
+                rotary_pos_emb=rotary_pos_emb,
+                caches=caches,
+                residual=residual,
+                attn_metadata=attn_metadata,
+                swa_metadata=swa_metadata,
+                all_routed_experts=all_routed_experts,
+            )
+        hidden_states, _ = self.norm(hidden_states, residual)
+        return hidden_states
+
+    def get_input_embeddings(self):
+        """Return the token embedding module."""
+        return self.embed_tokens
+
+
+class MiMoV2FlashForCausalLM(nn.Module, DeployModelMixinV1, CudaGraphMixin):
+    """MiMo-V2-Flash causal LM with named caches and FP8 checkpoint loading."""
+
+    packed_modules_mapping = {
+        'qkv_proj': ['q_proj', 'k_proj', 'v_proj'],
+        'gate_up_proj': ['gate_proj', 'up_proj'],
+    }
+
+    def supports_non_fa3_speculative_graph(self) -> bool:
+        """Allow MiMo verification to use native Triton paged attention."""
+        return True
+
+    def _prefix_cache_graph_is_safe(self) -> bool:
+        """Return whether this MiMo step can safely replay with shared blocks.
+
+        The speculative target reads both Full and SWA KV through page tables, so shared physical blocks do not expand a
+        Graph workspace. Target-only SWA rings still need prefix state checkpoint/restore; keep only that distinct
+        stateful combination eager.
+        """
+        context = self.ctx_mgr.current_context()
+        if not context.cache_config.enable_prefix_caching:
+            return True
+        return bool(getattr(self.config, '_lmdeploy_use_paged_swa', False))
+
+    def support_cuda_graph(
+        self,
+        input_ids: torch.Tensor,
+        position_ids: torch.Tensor,
+        past_key_values: list[list[torch.Tensor]],
+        attn_metadata: Any = None,
+        inputs_embeds: torch.Tensor | None = None,
+        **kwargs,
+    ) -> bool:
+        """Use verification graphs only with the MiMo metadata contract."""
+        batch_size = attn_metadata.block_offsets.size(0)
+        if not self._prefix_cache_graph_is_safe():
+            return False
+        step_meta_plan = getattr(self.ctx_mgr, 'backend_step_meta_plan', None)
+        if input_ids.numel() > batch_size and not getattr(step_meta_plan, 'is_supported', False):
+            return False
+        return super().support_cuda_graph(
+            input_ids,
+            position_ids,
+            past_key_values,
+            attn_metadata=attn_metadata,
+            inputs_embeds=inputs_embeds,
+            **kwargs,
+        )
+
+    def get_cudagraph_capture_cache(self,
+                                    past_key_values: list[list[torch.Tensor]],
+                                    **kwargs) -> list[torch.Tensor] | None:
+        """Return MiMo's paged target-cache rows for capture rollback.
+
+        MiMo keeps heterogeneous Full/SWA caches on ``StepContext`` instead
+        of ``past_key_values``. Returning per-layer views keeps the generic
+        graph runner's block dimension at axis zero while covering every
+        cache row touched by target verification.
+        """
+        del past_key_values, kwargs
+        if not getattr(self.config, '_lmdeploy_use_paged_swa', False):
+            return None
+        context = self.ctx_mgr.current_context()
+        if context.block_caches is None:
+            raise RuntimeError('MiMo CUDA Graph capture requires named block caches.')
+        capture_caches = []
+        for layer in self.model.layers:
+            capture_caches.extend(layer.self_attn.get_block_cache(context.block_caches))
+        return capture_caches
+
+    def __init__(
+        self,
+        config: Any,
+        ctx_mgr: StepContextManager,
+        dtype: torch.dtype | None = None,
+        device: torch.device | None = None,
+        prefix: str = '',
+    ):
+        super().__init__()
+        self.config = config
+        self.ctx_mgr = ctx_mgr
+        self.model = MiMoV2Model(
+            config,
+            dtype=dtype,
+            device=device,
+            prefix=add_prefix('model', prefix),
+        )
+        self.lm_head = self.build_lm_head(
+            config.hidden_size,
+            config.vocab_size,
+            bias=False,
+            dtype=dtype,
+            device=device,
+        )
+        self.enable_return_routed_experts = get_build_model_context().enable_return_routed_experts
+        self._first_swa_layer = next(
+            (layer_id for layer_id, layer_type in enumerate(config.hybrid_layer_pattern) if layer_type == 1),
+            None,
+        )
+        if self._first_swa_layer is None:
+            raise ValueError('MiMo-V2 requires at least one SWA layer.')
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        position_ids: torch.Tensor,
+        past_key_values: list[list[torch.Tensor]] | None = None,
+        attn_metadata: Any = None,
+        inputs_embeds: torch.Tensor | None = None,
+        state_ids: torch.Tensor | None = None,
+        **kwargs,
+    ):
+        """Resolve named caches once, then execute the transformer body."""
+        context = self.ctx_mgr.current_context()
+        if context.block_caches is None:
+            raise RuntimeError('MiMo-V2 requires named block caches in the current StepContext.')
+        use_paged_swa = getattr(self.config, '_lmdeploy_use_paged_swa', False)
+        if not use_paged_swa:
+            if context.named_state_caches is None:
+                raise RuntimeError('MiMo-V2 requires named SWA state caches in the current StepContext.')
+            if state_ids is None:
+                raise RuntimeError('MiMo-V2 requires state_ids to provide stable SWA ring slots.')
+        caches = MiMoV2Caches(
+            block_caches=context.block_caches,
+            state_caches=context.named_state_caches,
+        )
+        swa_metadata = None
+        if not use_paged_swa:
+            from lmdeploy.pytorch.backends.cuda.attention.swa_state_ring import SWAStateRingMetadata
+
+            first_swa_ring = context.named_state_caches.layer('mimo_swa_ring_k', self._first_swa_layer)
+            swa_metadata = SWAStateRingMetadata.from_step_context(
+                attn_metadata,
+                context,
+                state_ids,
+                num_state_slots=first_swa_ring.size(0),
+                window_size=first_swa_ring.size(1),
+            )
+
+        all_routed_experts = None
+        if self.enable_return_routed_experts:
+            num_tokens = inputs_embeds.size(1) if inputs_embeds is not None else input_ids.size(1)
+            all_routed_experts = position_ids.new_full(
+                (num_tokens, self.config.num_hidden_layers, self.config.num_experts_per_tok),
+                torch.iinfo(torch.uint16).max,
+                dtype=torch.uint16,
+            )
+
+        hidden_states = self.model(
+            input_ids=input_ids,
+            position_ids=position_ids,
+            caches=caches,
+            attn_metadata=attn_metadata,
+            inputs_embeds=inputs_embeds,
+            swa_metadata=swa_metadata,
+            all_routed_experts=all_routed_experts,
+        )
+        if all_routed_experts is None:
+            return hidden_states
+        return dict(hidden_states=hidden_states, all_routed_experts=all_routed_experts)
+
+    def get_input_embeddings(self):
+        """Return the model token embedding module."""
+        return self.model.get_input_embeddings()
+
+    def prepare_inputs_for_generation(
+        self,
+        past_key_values: list[list[torch.Tensor]],
+        inputs_embeds: torch.Tensor | None = None,
+        context: StepContext | None = None,
+    ):
+        """Prepare the standard engine inputs; named caches live on context."""
+        return dict(
+            input_ids=context.input_ids,
+            position_ids=context.position_ids,
+            past_key_values=past_key_values,
+            attn_metadata=context.attn_metadata,
+            inputs_embeds=inputs_embeds,
+            state_ids=context.state_offsets,
+        )
+
+    def _load_qkv_weight(
+        self,
+        name: str,
+        loaded_weight: torch.Tensor,
+        params_dict: dict[str, nn.Parameter],
+        shard_id: str,
+    ):
+        """Load one native blocked-FP8 Q/K/V weight or scale shard."""
+        if name.endswith('.weight_scale_inv'):
+            source_prefix = name.removesuffix('.weight_scale_inv')
+            tensor_kind = 'scale'
+        elif name.endswith('.weight'):
+            source_prefix = name.removesuffix('.weight')
+            tensor_kind = 'weight'
+        else:
+            raise KeyError(f'Unexpected MiMo QKV tensor name: {name}')
+
+        target_prefix = re.sub(r'\.(q|k|v)_proj$', '.qkv_proj', source_prefix)
+        _load_native_qkv_shard(target_prefix, tensor_kind, loaded_weight, params_dict, shard_id)
+
+    @staticmethod
+    def _load_expert_weight(name: str, loaded_weight: torch.Tensor, params_dict: dict[str, nn.Parameter]):
+        """Map one checkpoint expert tensor to the fused MoE parameter."""
+        match = re.match(
+            r'^(.*\.experts)\.(\d+)\.(gate_proj|up_proj|down_proj)\.(weight|weight_scale_inv)$',
+            name,
+        )
+        if match is None:
+            raise KeyError(f'Unexpected MiMo expert tensor name: {name}')
+        experts_prefix, expert_id, projection, suffix = match.groups()
+        if projection == 'gate_proj':
+            target_projection, shard_id = 'gate_up', 'gate'
+        elif projection == 'up_proj':
+            target_projection, shard_id = 'gate_up', 'up'
+        else:
+            target_projection, shard_id = 'down', 'down'
+        param = params_dict[f'{experts_prefix}.{target_projection}.{suffix}']
+        load_weight(param, loaded_weight, expert_id=int(expert_id), shard_id=shard_id)
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]):
+        """Load main-model weights and deliberately isolate MTP tensors."""
+        stacked_params_mapping = [
+            ('.qkv_proj', '.q_proj', 'q'),
+            ('.qkv_proj', '.k_proj', 'k'),
+            ('.qkv_proj', '.v_proj', 'v'),
+            ('.gate_up_proj', '.gate_proj', 0),
+            ('.gate_up_proj', '.up_proj', 1),
+        ]
+        params_dict = dict(self.named_parameters())
+        for name, loaded_weight in weights:
+            if name.startswith('model.mtp.'):
+                # MTP has an independent model/cache lifecycle and loader.
+                continue
+            if 'rotary_emb.inv_freq' in name or 'rotary_emb.cos_cached' in name or 'rotary_emb.sin_cached' in name:
+                continue
+            if self.config.tie_word_embeddings and name == 'lm_head.weight':
+                continue
+            if '.experts.' in name:
+                self._load_expert_weight(name, loaded_weight, params_dict)
+                continue
+
+            for param_name, weight_name, shard_id in stacked_params_mapping:
+                if weight_name not in name:
+                    continue
+                if weight_name in ('.q_proj', '.k_proj', '.v_proj'):
+                    self._load_qkv_weight(name, loaded_weight, params_dict, shard_id)
+                else:
+                    target_name = name.replace(weight_name, param_name)
+                    load_weight(params_dict[target_name], loaded_weight, shard_id=shard_id)
+                break
+            else:
+                try:
+                    param = params_dict[name]
+                except KeyError as error:
+                    raise KeyError(f'Unexpected MiMo-V2-Flash weight: {name}') from error
+                load_weight(param, loaded_weight)

--- a/lmdeploy/pytorch/models/mimo_v2_flash_mtp.py
+++ b/lmdeploy/pytorch/models/mimo_v2_flash_mtp.py
@@ -216,9 +216,13 @@ class MiMoV2FlashMTPModel(nn.Module, CudaGraphMixin):
         'gate_up_proj': ['gate_proj', 'up_proj'],
     }
 
-    def get_cudagraph_capture_state(self, past_key_values: list[list[torch.Tensor]],
+    def get_cudagraph_capture_state(self,
+                                    past_key_values: list[list[torch.Tensor]],
+                                    attn_metadata: Any = None,
+                                    num_blocks: int = 0,
                                     spec_step_idx: int = 0) -> GraphCaptureState:
         """Return the active depth cache that Graph capture must preserve."""
+        del attn_metadata, num_blocks
         depth = spec_step_idx % self.model.num_mtp_layers
         return GraphCaptureState(tensors=tuple(past_key_values[depth]))
 

--- a/lmdeploy/pytorch/models/mimo_v2_flash_mtp.py
+++ b/lmdeploy/pytorch/models/mimo_v2_flash_mtp.py
@@ -1,0 +1,483 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+import re
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Any
+
+import torch
+from torch import nn
+
+from lmdeploy.pytorch.model_inputs import StepContext, StepContextManager
+from lmdeploy.pytorch.nn import RMSNorm, build_rotary_embedding
+from lmdeploy.pytorch.nn.linear import build_colwise_linear
+from lmdeploy.pytorch.weight_loader.model_weight_loader import load_weight
+
+from .mimo_v2_flash import MiMoV2Attention, MiMoV2MLP, _get_norm_eps, _load_native_qkv_shard
+from .patch import add_prefix
+from .utils.cudagraph import CudaGraphMeta, CudaGraphMixin
+
+
+class MiMoV2FlashMTPLayer(nn.Module):
+    """One MiMo prediction-depth layer backed by paged SWA KV."""
+
+    def __init__(
+        self,
+        config: Any,
+        layer_idx: int,
+        dtype: torch.dtype | None = None,
+        device: torch.device | None = None,
+        prefix: str = '',
+    ):
+        super().__init__()
+        self.layer_idx = layer_idx
+        quantization_config = getattr(config, 'quantization_config', None)
+        norm_eps = _get_norm_eps(config)
+
+        self.enorm = RMSNorm(
+            config.hidden_size,
+            norm_eps,
+            dtype=dtype,
+            device=device,
+            prefix=add_prefix('enorm', prefix),
+        )
+        self.hnorm = RMSNorm(
+            config.hidden_size,
+            norm_eps,
+            dtype=dtype,
+            device=device,
+            prefix=add_prefix('hnorm', prefix),
+        )
+        # Checkpoint eh_proj is BF16 even though the dense MLP is FP8.
+        self.eh_proj = build_colwise_linear(
+            config.hidden_size * 2,
+            config.hidden_size,
+            bias=False,
+            dtype=dtype,
+            device=device,
+            is_tp=False,
+            quant_config=None,
+            dp_disable_tp=True,
+            prefix=add_prefix('eh_proj', prefix),
+        )
+
+        block_prefix = add_prefix('mtp_block', prefix)
+        self.self_attn = MiMoV2Attention(
+            config,
+            is_swa=True,
+            enable_paged_verification=True,
+            quantize_o_proj=False,
+            dtype=dtype,
+            device=device,
+            prefix=add_prefix('self_attn', block_prefix),
+        )
+        self.mlp = MiMoV2MLP(
+            config,
+            dtype=dtype,
+            device=device,
+            prefix=add_prefix('mlp', block_prefix),
+        )
+        self.input_layernorm = RMSNorm(
+            config.hidden_size,
+            norm_eps,
+            quant_config=quantization_config,
+            dtype=dtype,
+            device=device,
+            prefix=add_prefix('input_layernorm', block_prefix),
+        )
+        self.post_attention_layernorm = RMSNorm(
+            config.hidden_size,
+            norm_eps,
+            quant_config=quantization_config,
+            dtype=dtype,
+            device=device,
+            prefix=add_prefix('post_attention_layernorm', block_prefix),
+        )
+        self.final_layernorm = RMSNorm(
+            config.hidden_size,
+            norm_eps,
+            dtype=dtype,
+            device=device,
+            prefix=add_prefix('final_layernorm', prefix),
+        )
+
+        self.rotary_emb = build_rotary_embedding(
+            dim=config.swa_head_dim,
+            max_position_embeddings=config.max_position_embeddings,
+            base=config.swa_rope_theta,
+            partial_rotary_factor=config.partial_rotary_factor,
+            device=device,
+        )
+
+    def forward(
+        self,
+        position_ids: torch.Tensor,
+        previous_hidden_states: torch.Tensor,
+        past_key_value: list[torch.Tensor],
+        inputs_embeds: torch.Tensor,
+        attn_metadata: Any = None,
+    ) -> torch.Tensor:
+        """Fuse target state and run one dense SWA decoder layer."""
+        hidden_states = self.eh_proj(
+            torch.cat(
+                [self.enorm(inputs_embeds), self.hnorm(previous_hidden_states)],
+                dim=-1,
+            )
+        )
+        residual = hidden_states
+        hidden_states = self.input_layernorm(hidden_states)
+
+        cos, sin = self.rotary_emb(hidden_states, position_ids)
+        hidden_states = self.self_attn(
+            hidden_states,
+            rotary_pos_emb=(cos[0], sin[0]),
+            past_key_value=past_key_value,
+            attn_metadata=attn_metadata,
+        )
+        hidden_states, residual = self.post_attention_layernorm(hidden_states, residual)
+        hidden_states = self.mlp(hidden_states)
+        return hidden_states + residual
+
+
+class MiMoV2FlashMultiTokenPredictor(nn.Module):
+    """Three checkpoint prediction depths sharing target embed/head."""
+
+    def __init__(
+        self,
+        config: Any,
+        dtype: torch.dtype | None = None,
+        device: torch.device | None = None,
+        prefix: str = '',
+    ):
+        super().__init__()
+        self.num_mtp_layers = config.num_nextn_predict_layers
+        if self.num_mtp_layers != 3:
+            raise ValueError(f'MiMo-V2-Flash requires 3 MTP layers, got {self.num_mtp_layers}.')
+        self.embed_tokens = None
+        self.layers = nn.ModuleDict(
+            {
+                str(layer_idx): MiMoV2FlashMTPLayer(
+                    config,
+                    layer_idx,
+                    dtype=dtype,
+                    device=device,
+                    prefix=add_prefix(f'layers.{layer_idx}', prefix),
+                )
+                for layer_idx in range(self.num_mtp_layers)
+            }
+        )
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        position_ids: torch.Tensor,
+        previous_hidden_states: torch.Tensor,
+        past_key_values: list[list[torch.Tensor]],
+        inputs_embeds: torch.Tensor | None = None,
+        attn_metadata: Any = None,
+        spec_step_idx: int = 0,
+    ) -> torch.Tensor:
+        """Run the prediction layer and cache selected by ``spec_step_idx``."""
+        current_step_idx = spec_step_idx % self.num_mtp_layers
+        if inputs_embeds is None:
+            if self.embed_tokens is None:
+                raise RuntimeError('MiMo MTP input embedding has not been bound to the target model.')
+            inputs_embeds = self.embed_tokens(input_ids)
+        return self.layers[str(current_step_idx)](
+            position_ids,
+            previous_hidden_states,
+            past_key_values[current_step_idx],
+            inputs_embeds,
+            attn_metadata=attn_metadata,
+        )
+
+    def prepare_hidden_states_for_logits(
+        self,
+        hidden_states: torch.Tensor,
+        spec_step_idx: int = 0,
+    ) -> torch.Tensor:
+        """Apply the final norm belonging to the active prediction depth."""
+        current_step_idx = spec_step_idx % self.num_mtp_layers
+        return self.layers[str(current_step_idx)].final_layernorm(hidden_states)
+
+    def set_input_embeddings(self, embed_tokens: nn.Module):
+        """Bind the target model's shared token embedding."""
+        self.embed_tokens = embed_tokens
+
+    def get_input_embeddings(self):
+        """Return the target-owned shared token embedding."""
+        return self.embed_tokens
+
+
+class MiMoV2FlashMTPModel(nn.Module, CudaGraphMixin):
+    """MiMo-V2-Flash draft model for multi-token speculative decoding."""
+
+    packed_modules_mapping = {
+        'qkv_proj': ['q_proj', 'k_proj', 'v_proj'],
+        'gate_up_proj': ['gate_proj', 'up_proj'],
+    }
+
+    def supports_non_fa3_speculative_graph(self) -> bool:
+        """Allow MiMo draft graphs to use native Triton paged attention."""
+        return True
+
+    def get_cudagraph_capture_cache(self,
+                                    past_key_values: list[list[torch.Tensor]],
+                                    spec_step_idx: int = 0) -> list[torch.Tensor]:
+        """Return the active depth cache that Graph capture must preserve."""
+        depth = spec_step_idx % self.model.num_mtp_layers
+        return past_key_values[depth]
+
+    def get_cudagraph_extra_key(
+        self,
+        spec_step_idx: int = 0,
+        input_ids: torch.Tensor | None = None,
+        attn_metadata: Any = None,
+        **kwargs,
+    ) -> tuple[int]:
+        """Select a stable Graph for each MiMo prediction depth.
+
+        ``spec_step_idx`` selects both a decoder module and its KV-cache
+        entry.  As a Python scalar it cannot be changed by copying tensor
+        inputs before graph replay, so it must participate in the graph key.
+
+        Query length already participates in the generic Graph key. Keeping
+        this key independent of rank-local KV length prevents one DP rank from
+        inserting capture-time TP collectives while another rank replays.
+        """
+        del input_ids, attn_metadata, kwargs
+        return (spec_step_idx % self.model.num_mtp_layers, )
+
+    def get_cudagraph_warmup_specs(self, max_query_len: int) -> tuple[tuple[int, int], ...]:
+        """Return every query-length and prediction-depth graph used at
+        runtime."""
+        return tuple(
+            (query_len, depth)
+            for query_len in range(1, max_query_len + 1)
+            for depth in range(self.model.num_mtp_layers)
+        )
+
+    @staticmethod
+    def select_weight_paths(model_path: str, default_paths: Iterable[str]) -> tuple[str, ...]:
+        """Select the standalone MiMo MTP checkpoint instead of target
+        shards."""
+        del default_paths
+        mtp_path = Path(model_path) / 'model_mtp.safetensors'
+        if not mtp_path.is_file():
+            raise FileNotFoundError(f'MiMo MTP checkpoint was not found: {mtp_path}')
+        return (str(mtp_path),)
+
+    _MTP_TENSOR_SUFFIXES = frozenset(
+        {
+            'enorm.weight',
+            'hnorm.weight',
+            'eh_proj.weight',
+            'input_layernorm.weight',
+            'pre_mlp_layernorm.weight',
+            'final_layernorm.weight',
+            'self_attn.q_proj.weight',
+            'self_attn.q_proj.weight_scale_inv',
+            'self_attn.k_proj.weight',
+            'self_attn.k_proj.weight_scale_inv',
+            'self_attn.v_proj.weight',
+            'self_attn.v_proj.weight_scale_inv',
+            'self_attn.o_proj.weight',
+            'self_attn.attention_sink_bias',
+            'mlp.gate_proj.weight',
+            'mlp.gate_proj.weight_scale_inv',
+            'mlp.up_proj.weight',
+            'mlp.up_proj.weight_scale_inv',
+            'mlp.down_proj.weight',
+            'mlp.down_proj.weight_scale_inv',
+        }
+    )
+
+    def __init__(
+        self,
+        config: Any,
+        ctx_mgr: StepContextManager,
+        dtype: torch.dtype | None = None,
+        device: torch.device | None = None,
+    ):
+        super().__init__()
+        if dtype is not torch.bfloat16:
+            raise ValueError(f'MiMo-V2-Flash MTP only supports torch.bfloat16, but got {dtype}.')
+        self.config = config
+        self.dtype = dtype
+        self.ctx_mgr = ctx_mgr
+        self.model = MiMoV2FlashMultiTokenPredictor(
+            config,
+            dtype=dtype,
+            device=device,
+            prefix='model',
+        )
+
+    def set_input_embeddings(self, embed_tokens: nn.Module):
+        """Bind the target model's shared token embedding."""
+        self.model.set_input_embeddings(embed_tokens)
+
+    def get_input_embeddings(self):
+        """Return the target-owned shared token embedding."""
+        return self.model.get_input_embeddings()
+
+    def prepare_inputs_for_generation(
+        self,
+        past_key_values: list[list[torch.Tensor]],
+        inputs_embeds: torch.Tensor | None = None,
+        context: StepContext | None = None,
+    ):
+        """Prepare the active MTP depth's inputs from the step context."""
+        if context is None:
+            raise ValueError('MiMo MTP requires a StepContext.')
+        if context.target_inputs_embeds is not None:
+            inputs_embeds = context.target_inputs_embeds
+        return {
+            'input_ids': context.input_ids,
+            'position_ids': context.position_ids,
+            'past_key_values': past_key_values,
+            'attn_metadata': context.attn_metadata,
+            'inputs_embeds': inputs_embeds,
+            'target_hidden_states': context.target_hidden_states,
+            'spec_step_idx': context.spec_step_idx,
+        }
+
+    def make_buffers_cudagraph(self, graph_meta: CudaGraphMeta, **kwargs):
+        """Allocate stable storage for target hidden states during capture."""
+        input_buffers = super().make_buffers_cudagraph(graph_meta=graph_meta, **kwargs)
+        input_buffers['target_hidden_states'] = input_buffers['input_ids'].new_zeros(
+            1,
+            graph_meta.max_tokens,
+            self.config.hidden_size,
+            dtype=self.dtype,
+        )
+        return input_buffers
+
+    def fill_buffers_cudagraph(self, graph_meta: CudaGraphMeta, input_ids: torch.Tensor, **kwargs):
+        """Copy target hidden states into their CUDA Graph input buffer."""
+        new_inputs = super().fill_buffers_cudagraph(
+            graph_meta=graph_meta,
+            input_ids=input_ids,
+            **kwargs,
+        )
+        target_hidden_states = kwargs.get('target_hidden_states')
+        if target_hidden_states is None:
+            raise ValueError('target_hidden_states is required for MiMo MTP.')
+        num_tokens = input_ids.size(-1)
+        target_buffer = graph_meta.input_buffers['target_hidden_states']
+        target_buffer[:, :num_tokens] = target_hidden_states
+        new_inputs['target_hidden_states'] = target_buffer
+        return new_inputs
+
+    def prepare_hidden_states_for_logits(
+        self,
+        hidden_states: torch.Tensor,
+        spec_step_idx: int = 0,
+    ) -> torch.Tensor:
+        """Apply the active prediction depth's final norm before lm_head."""
+        return self.model.prepare_hidden_states_for_logits(hidden_states, spec_step_idx=spec_step_idx)
+
+    @staticmethod
+    def prepare_hidden_states_for_next_step(
+        hidden_states: torch.Tensor,
+        logits_hidden_states: torch.Tensor,
+    ) -> torch.Tensor:
+        """Carry MiMo's decoder output before final norm to the next depth."""
+        del logits_hidden_states
+        return hidden_states
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        position_ids: torch.Tensor,
+        target_hidden_states: torch.Tensor,
+        past_key_values: list[list[torch.Tensor]],
+        attn_metadata: Any = None,
+        inputs_embeds: torch.Tensor | None = None,
+        spec_step_idx: int = 0,
+    ) -> torch.Tensor:
+        """Run one same-position MiMo MTP prediction depth."""
+        return self.model(
+            input_ids,
+            position_ids,
+            target_hidden_states,
+            past_key_values,
+            inputs_embeds=inputs_embeds,
+            attn_metadata=attn_metadata,
+            spec_step_idx=spec_step_idx,
+        )
+
+    @classmethod
+    def _parse_mtp_name(cls, name: str) -> tuple[int, str] | None:
+        match = re.fullmatch(r'model\.mtp\.layers\.(\d+)\.(.+)', name)
+        if match is None:
+            return None
+        layer_idx = int(match.group(1))
+        suffix = match.group(2)
+        if layer_idx not in range(3):
+            raise KeyError(f'Unexpected MiMo MTP layer index in {name!r}.')
+        if suffix not in cls._MTP_TENSOR_SUFFIXES:
+            raise KeyError(f'Unknown MiMo MTP tensor {name!r}.')
+        return layer_idx, suffix
+
+    @staticmethod
+    def _target_name(layer_idx: int, suffix: str) -> str:
+        prefix = f'model.layers.{layer_idx}'
+        if suffix in {'enorm.weight', 'hnorm.weight', 'eh_proj.weight', 'final_layernorm.weight'}:
+            return f'{prefix}.{suffix}'
+        if suffix == 'pre_mlp_layernorm.weight':
+            suffix = 'post_attention_layernorm.weight'
+        return f'{prefix}.{suffix}'
+
+    def _load_qkv_weight(
+        self,
+        target_name: str,
+        source_name: str,
+        loaded_weight: torch.Tensor,
+        params_dict: dict[str, nn.Parameter],
+        shard_id: str,
+    ):
+        tensor_kind = 'scale' if source_name.endswith('.weight_scale_inv') else 'weight'
+        target_prefix = re.sub(r'\.(q|k|v)_proj$', '.qkv_proj', target_name.rsplit('.', 1)[0])
+        _load_native_qkv_shard(target_prefix, tensor_kind, loaded_weight, params_dict, shard_id)
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]):
+        """Load exactly the three MTP depths and reject incomplete payloads."""
+        params_dict = dict(self.named_parameters())
+        seen = set()
+        for name, loaded_weight in weights:
+            parsed = self._parse_mtp_name(name)
+            if parsed is None:
+                continue
+            if name in seen:
+                raise KeyError(f'Duplicate MiMo MTP tensor {name!r}.')
+            seen.add(name)
+            layer_idx, suffix = parsed
+            target_name = self._target_name(layer_idx, suffix)
+
+            qkv_match = re.search(r'self_attn\.(q|k|v)_proj\.', suffix)
+            if qkv_match is not None:
+                self._load_qkv_weight(
+                    target_name,
+                    name,
+                    loaded_weight,
+                    params_dict,
+                    qkv_match.group(1),
+                )
+                continue
+
+            for source_projection, target_projection, shard_id in (
+                ('gate_proj', 'gate_up_proj', 0),
+                ('up_proj', 'gate_up_proj', 1),
+            ):
+                if f'mlp.{source_projection}.' in suffix:
+                    target_name = target_name.replace(source_projection, target_projection)
+                    load_weight(params_dict[target_name], loaded_weight, shard_id=shard_id)
+                    break
+            else:
+                load_weight(params_dict[target_name], loaded_weight)
+
+        expected = {
+            f'model.mtp.layers.{layer_idx}.{suffix}' for layer_idx in range(3) for suffix in self._MTP_TENSOR_SUFFIXES
+        }
+        missing = sorted(expected - seen)
+        if missing:
+            raise KeyError(f'Missing {len(missing)} MiMo MTP tensors; first missing tensor: {missing[0]!r}.')

--- a/lmdeploy/pytorch/models/mimo_v2_flash_mtp.py
+++ b/lmdeploy/pytorch/models/mimo_v2_flash_mtp.py
@@ -216,11 +216,45 @@ class MiMoV2FlashMTPModel(nn.Module, CudaGraphMixin):
         'gate_up_proj': ['gate_proj', 'up_proj'],
     }
 
+    def supports_multi_token_decode(self) -> bool:
+        """Return whether every prediction depth supports paged q>1."""
+        return all(
+            layer.self_attn.attn_fwd.supports_multi_token_decode
+            for layer in self.model.layers.values())
+
     def get_cudagraph_capture_state(self,
-                                    capture_context: GraphCaptureContext) -> GraphCaptureState:
+                                    capture_context: GraphCaptureContext) -> GraphCaptureState | None:
         """Return the active depth cache that Graph capture must preserve."""
         depth = capture_context.spec_step_idx % self.model.num_mtp_layers
-        return GraphCaptureState(tensors=tuple(capture_context.past_key_values[depth]))
+        return GraphCaptureState.from_paged_tensors(
+            tuple(capture_context.past_key_values[depth]),
+            block_offsets=capture_context.attn_metadata.block_offsets,
+            num_blocks=capture_context.num_blocks,
+            num_requests=capture_context.attn_metadata.q_seqlens.numel(),
+        )
+
+    def support_cuda_graph(
+        self,
+        input_ids: torch.Tensor,
+        position_ids: torch.Tensor,
+        past_key_values: list[list[torch.Tensor]],
+        attn_metadata: Any = None,
+        inputs_embeds: torch.Tensor | None = None,
+        **kwargs,
+    ) -> bool:
+        """Require implementation-owned metadata for multi-token graphs."""
+        batch_size = attn_metadata.block_offsets.size(0)
+        step_meta_plan = getattr(self.ctx_mgr, 'backend_step_meta_plan', None)
+        if input_ids.numel() > batch_size and not getattr(step_meta_plan, 'is_supported', False):
+            return False
+        return super().support_cuda_graph(
+            input_ids,
+            position_ids,
+            past_key_values,
+            attn_metadata=attn_metadata,
+            inputs_embeds=inputs_embeds,
+            **kwargs,
+        )
 
     def get_cudagraph_extra_key(
         self,

--- a/lmdeploy/pytorch/models/mimo_v2_flash_mtp.py
+++ b/lmdeploy/pytorch/models/mimo_v2_flash_mtp.py
@@ -14,7 +14,7 @@ from lmdeploy.pytorch.weight_loader.model_weight_loader import load_weight
 
 from .mimo_v2_flash import MiMoV2Attention, MiMoV2MLP, _get_norm_eps, _load_native_qkv_shard
 from .patch import add_prefix
-from .utils.cudagraph import CudaGraphMeta, CudaGraphMixin, GraphCaptureState
+from .utils.cudagraph import CudaGraphMeta, CudaGraphMixin, GraphCaptureContext, GraphCaptureState
 
 
 class MiMoV2FlashMTPLayer(nn.Module):
@@ -217,14 +217,10 @@ class MiMoV2FlashMTPModel(nn.Module, CudaGraphMixin):
     }
 
     def get_cudagraph_capture_state(self,
-                                    past_key_values: list[list[torch.Tensor]],
-                                    attn_metadata: Any = None,
-                                    num_blocks: int = 0,
-                                    spec_step_idx: int = 0) -> GraphCaptureState:
+                                    capture_context: GraphCaptureContext) -> GraphCaptureState:
         """Return the active depth cache that Graph capture must preserve."""
-        del attn_metadata, num_blocks
-        depth = spec_step_idx % self.model.num_mtp_layers
-        return GraphCaptureState(tensors=tuple(past_key_values[depth]))
+        depth = capture_context.spec_step_idx % self.model.num_mtp_layers
+        return GraphCaptureState(tensors=tuple(capture_context.past_key_values[depth]))
 
     def get_cudagraph_extra_key(
         self,

--- a/lmdeploy/pytorch/models/mimo_v2_flash_mtp.py
+++ b/lmdeploy/pytorch/models/mimo_v2_flash_mtp.py
@@ -14,7 +14,7 @@ from lmdeploy.pytorch.weight_loader.model_weight_loader import load_weight
 
 from .mimo_v2_flash import MiMoV2Attention, MiMoV2MLP, _get_norm_eps, _load_native_qkv_shard
 from .patch import add_prefix
-from .utils.cudagraph import CudaGraphMeta, CudaGraphMixin
+from .utils.cudagraph import CudaGraphMeta, CudaGraphMixin, GraphCaptureState
 
 
 class MiMoV2FlashMTPLayer(nn.Module):
@@ -216,12 +216,11 @@ class MiMoV2FlashMTPModel(nn.Module, CudaGraphMixin):
         'gate_up_proj': ['gate_proj', 'up_proj'],
     }
 
-    def get_cudagraph_capture_cache(self,
-                                    past_key_values: list[list[torch.Tensor]],
-                                    spec_step_idx: int = 0) -> list[torch.Tensor]:
+    def get_cudagraph_capture_state(self, past_key_values: list[list[torch.Tensor]],
+                                    spec_step_idx: int = 0) -> GraphCaptureState:
         """Return the active depth cache that Graph capture must preserve."""
         depth = spec_step_idx % self.model.num_mtp_layers
-        return past_key_values[depth]
+        return GraphCaptureState(tensors=tuple(past_key_values[depth]))
 
     def get_cudagraph_extra_key(
         self,

--- a/lmdeploy/pytorch/models/mimo_v2_flash_mtp.py
+++ b/lmdeploy/pytorch/models/mimo_v2_flash_mtp.py
@@ -64,7 +64,7 @@ class MiMoV2FlashMTPLayer(nn.Module):
         self.self_attn = MiMoV2Attention(
             config,
             is_swa=True,
-            enable_paged_verification=True,
+            use_paged_cache=True,
             quantize_o_proj=False,
             dtype=dtype,
             device=device,
@@ -215,10 +215,6 @@ class MiMoV2FlashMTPModel(nn.Module, CudaGraphMixin):
         'qkv_proj': ['q_proj', 'k_proj', 'v_proj'],
         'gate_up_proj': ['gate_proj', 'up_proj'],
     }
-
-    def supports_non_fa3_speculative_graph(self) -> bool:
-        """Allow MiMo draft graphs to use native Triton paged attention."""
-        return True
 
     def get_cudagraph_capture_cache(self,
                                     past_key_values: list[list[torch.Tensor]],

--- a/lmdeploy/pytorch/models/module_map.py
+++ b/lmdeploy/pytorch/models/module_map.py
@@ -132,6 +132,12 @@ MODULE_MAP.update({
     'DeepseekV4ForCausalLM': f'{LMDEPLOY_PYTORCH_MODEL_PATH}.deepseek_v4.DeepseekV4ForCausalLM',
 })
 
+# mimo-v2-flash
+MODULE_MAP.update({
+    'MiMoV2FlashForCausalLM': f'{LMDEPLOY_PYTORCH_MODEL_PATH}.mimo_v2_flash.MiMoV2FlashForCausalLM',
+    'MiMoV2FlashMTPModel': f'{LMDEPLOY_PYTORCH_MODEL_PATH}.mimo_v2_flash_mtp.MiMoV2FlashMTPModel',
+})
+
 # deepseek-vl2
 MODULE_MAP.update({
     'DeepseekVLV2ForCausalLM': f'{LMDEPLOY_PYTORCH_MODEL_PATH}.deepseek_vl2.DeepseekVLV2ForCausalLM',

--- a/lmdeploy/pytorch/models/utils/cudagraph.py
+++ b/lmdeploy/pytorch/models/utils/cudagraph.py
@@ -62,8 +62,8 @@ class CudaGraphMixin:
         """
         return ((max_query_len, 0), (1, 0))
 
-    def supports_non_fa3_speculative_graph(self) -> bool:
-        """Return whether speculative CUDA Graph can use a non-FA3 backend."""
+    def supports_multi_token_decode(self) -> bool:
+        """Return whether attention supports multi-token decode queries."""
         return False
 
     def get_cudagraph_extra_key(self, **kwargs) -> tuple:

--- a/lmdeploy/pytorch/models/utils/cudagraph.py
+++ b/lmdeploy/pytorch/models/utils/cudagraph.py
@@ -1,4 +1,5 @@
 # Copyright (c) OpenMMLab. All rights reserved.
+import copy
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
@@ -53,9 +54,32 @@ class CudaGraphMeta:
 class CudaGraphMixin:
     """Mixin class to support cudagraph."""
 
+    def get_cudagraph_warmup_specs(self, max_query_len: int) -> tuple[tuple[int, int], ...]:
+        """Return query-length and speculative-depth pairs to pre-capture.
+
+        Recurrent draft models use one graph for multi-token verification and one graph for single-token drafting.
+        Models with depth-specific graph state may override this method to enumerate every runtime pair.
+        """
+        return ((max_query_len, 0), (1, 0))
+
+    def supports_non_fa3_speculative_graph(self) -> bool:
+        """Return whether speculative CUDA Graph can use a non-FA3 backend."""
+        return False
+
     def get_cudagraph_extra_key(self, **kwargs) -> tuple:
         """Get model-specific CUDA graph keys."""
         return ()
+
+    def get_cudagraph_capture_cache(self,
+                                    past_key_values: list[list[torch.Tensor]],
+                                    **kwargs) -> list[torch.Tensor] | None:
+        """Return mutable cache tensors that capture must preserve.
+
+        Stateful models may opt in by returning the cache tensors touched by Graph warmup and capture. The runner
+        snapshots only request-visible blocks and restores them before the first semantic replay.
+        """
+        del past_key_values, kwargs
+        return None
 
     def support_cuda_graph(
         self,
@@ -176,6 +200,11 @@ class CudaGraphMixin:
         q_start_loc: Tensor = attn_metadata.q_start_loc
         q_seqlens: Tensor = attn_metadata.q_seqlens
         kv_seqlens: Tensor = attn_metadata.kv_seqlens
+        # Redirect only the metadata view passed to the captured model.  A
+        # graph is replayed once immediately after capture; mutating the
+        # caller-owned object here would make that replay read graph buffers
+        # as its source, then erase them with the zero_ calls below.
+        attn_metadata = copy.copy(attn_metadata)
         input_buffers: BuffType = graph_meta.input_buffers
 
         num_tokens = input_ids.size(-1)

--- a/lmdeploy/pytorch/models/utils/cudagraph.py
+++ b/lmdeploy/pytorch/models/utils/cudagraph.py
@@ -114,10 +114,6 @@ class CudaGraphMixin:
         """
         return ((max_query_len, 0), (1, 0))
 
-    def supports_multi_token_decode(self) -> bool:
-        """Return whether attention supports multi-token decode queries."""
-        return False
-
     def get_cudagraph_extra_key(self, **kwargs) -> tuple:
         """Get model-specific CUDA graph keys."""
         return ()

--- a/lmdeploy/pytorch/models/utils/cudagraph.py
+++ b/lmdeploy/pytorch/models/utils/cudagraph.py
@@ -15,6 +15,16 @@ if TYPE_CHECKING:
 BuffType = dict[str, Tensor]
 
 
+@dataclass(frozen=True)
+class GraphCaptureContext:
+    """Inputs and static metadata for one CUDA Graph capture."""
+
+    past_key_values: list[list[Tensor]]
+    attn_metadata: Any
+    num_blocks: int
+    spec_step_idx: int = 0
+
+
 @dataclass
 class GraphCaptureState:
     """Own snapshot and restore semantics for mutable model state."""
@@ -123,14 +133,13 @@ class CudaGraphMixin:
         return ()
 
     def get_cudagraph_capture_state(self,
-                                    past_key_values: list[list[torch.Tensor]],
-                                    **kwargs) -> GraphCaptureState | None:
+                                    capture_context: GraphCaptureContext) -> GraphCaptureState | None:
         """Return mutable state that capture must preserve.
 
         Stateful models may opt in by returning a snapshot/restore adapter for state touched by graph warmup and
         capture. The runner only owns the lifecycle; the adapter owns the storage layout.
         """
-        del past_key_values, kwargs
+        del capture_context
         return None
 
     def support_cuda_graph(

--- a/lmdeploy/pytorch/models/utils/cudagraph.py
+++ b/lmdeploy/pytorch/models/utils/cudagraph.py
@@ -15,6 +15,58 @@ if TYPE_CHECKING:
 BuffType = dict[str, Tensor]
 
 
+@dataclass
+class GraphCaptureState:
+    """Own snapshot and restore semantics for mutable model state."""
+
+    tensors: tuple[Tensor, ...] = ()
+    block_ids: Tensor | None = None
+    saved_tensors: tuple[Tensor, ...] | None = None
+
+    @classmethod
+    def from_paged_tensors(
+        cls,
+        tensors: tuple[Tensor, ...] | list[Tensor],
+        *,
+        block_offsets: Tensor,
+        num_blocks: int,
+        num_requests: int | None = None,
+    ) -> 'GraphCaptureState | None':
+        """Snapshot only the paged rows visible to this capture request."""
+        if not tensors:
+            return None
+
+        if num_requests is not None:
+            block_offsets = block_offsets[:num_requests]
+        block_ids = block_offsets.flatten().long()
+        block_ids = block_ids[(block_ids >= 0) & (block_ids < num_blocks)]
+        block_ids = torch.unique(block_ids)
+        if block_ids.numel() == 0:
+            return None
+        return cls(tensors=tuple(tensors), block_ids=block_ids)
+
+    def snapshot(self) -> None:
+        """Save mutable tensors before graph warmup and capture."""
+        if self.block_ids is None:
+            self.saved_tensors = tuple(tensor.clone() for tensor in self.tensors)
+            return
+        self.saved_tensors = tuple(
+            tensor.index_select(0, self.block_ids).clone() for tensor in self.tensors)
+
+    def restore(self) -> None:
+        """Restore the pre-capture contents of mutable tensors."""
+        if self.saved_tensors is None:
+            return
+        if len(self.saved_tensors) != len(self.tensors):
+            raise RuntimeError('CUDA Graph capture state changed '
+                               f'from {len(self.saved_tensors)} to {len(self.tensors)} tensors.')
+        for tensor, saved in zip(self.tensors, self.saved_tensors):
+            if self.block_ids is None:
+                tensor.copy_(saved)
+            else:
+                tensor.index_copy_(0, self.block_ids, saved)
+
+
 def next_power_of_2(n: int):
     """Return the smallest power of 2 greater than or equal to n."""
     n -= 1
@@ -70,13 +122,13 @@ class CudaGraphMixin:
         """Get model-specific CUDA graph keys."""
         return ()
 
-    def get_cudagraph_capture_cache(self,
+    def get_cudagraph_capture_state(self,
                                     past_key_values: list[list[torch.Tensor]],
-                                    **kwargs) -> list[torch.Tensor] | None:
-        """Return mutable cache tensors that capture must preserve.
+                                    **kwargs) -> GraphCaptureState | None:
+        """Return mutable state that capture must preserve.
 
-        Stateful models may opt in by returning the cache tensors touched by Graph warmup and capture. The runner
-        snapshots only request-visible blocks and restores them before the first semantic replay.
+        Stateful models may opt in by returning a snapshot/restore adapter for state touched by graph warmup and
+        capture. The runner only owns the lifecycle; the adapter owns the storage layout.
         """
         del past_key_values, kwargs
         return None

--- a/lmdeploy/pytorch/models/utils/cudagraph.py
+++ b/lmdeploy/pytorch/models/utils/cudagraph.py
@@ -114,6 +114,10 @@ class CudaGraphMixin:
         """
         return ((max_query_len, 0), (1, 0))
 
+    def supports_multi_token_decode(self) -> bool:
+        """Return whether all attention paths support multi-token decode."""
+        return False
+
     def get_cudagraph_extra_key(self, **kwargs) -> tuple:
         """Get model-specific CUDA graph keys."""
         return ()

--- a/lmdeploy/pytorch/nn/__init__.py
+++ b/lmdeploy/pytorch/nn/__init__.py
@@ -2,7 +2,7 @@
 # attention module is modified from:
 # https://github.com/vllm-project/vllm/blob/main/vllm/attention/
 from .activation import GeluAndMul, SiluAndMul  # noqa: F401
-from .attention import Attention, FlashAttention  # noqa: F401
+from .attention import Attention, FlashAttention, SWAStateRingAttention  # noqa: F401
 from .embedding import ParallelEmbedding, ParallelLMHead  # noqa: F401
 from .hc_prepost import HcPrePost  # noqa: F401
 from .norm import LayerNorm, RMSNorm, rms_scale  # noqa: F401

--- a/lmdeploy/pytorch/nn/attention.py
+++ b/lmdeploy/pytorch/nn/attention.py
@@ -114,6 +114,7 @@ class Attention(nn.Module):
         s_aux: torch.Tensor = None,
         nsa_indices: torch.Tensor = None,
         inplace: bool = True,
+        decode_mode: str = 'block',
     ) -> torch.Tensor:
         """forward."""
         self._lazy_init(query.device)
@@ -143,6 +144,7 @@ class Attention(nn.Module):
             k_scales_zeros=k_scales_zeros,
             v_scales_zeros=v_scales_zeros,
             inplace=inplace,
+            decode_mode=decode_mode,
             **kwargs,
         )
 

--- a/lmdeploy/pytorch/nn/attention.py
+++ b/lmdeploy/pytorch/nn/attention.py
@@ -11,8 +11,10 @@ from lmdeploy.pytorch.models.patch import get_build_model_context
 from ..backends import get_backend
 from ..backends.attention import (
     AttentionMetadata,
+    DecodeMode,
     PagedAttentionBuildSpec,
     SWAStateRingAttentionBuildSpec,
+    normalize_decode_mode,
 )
 from ..backends.flash_attention import FlashAttentionBuildSpec
 from .utils import get_distribute_size
@@ -70,6 +72,7 @@ class Attention(nn.Module):
                 mla_index_topk=mla_index_topk,
                 learnable_sink=learnable_sink,
                 block_sparse_size=block_sparse_size,
+                dtype=kwargs.get('dtype'),
             ),
             enable_deterministic=get_build_model_context().enable_deterministic,
         )
@@ -114,12 +117,19 @@ class Attention(nn.Module):
         s_aux: torch.Tensor = None,
         nsa_indices: torch.Tensor = None,
         inplace: bool = True,
-        decode_mode: str | None = None,
+        decode_mode: DecodeMode | None = None,
     ) -> torch.Tensor:
         """forward."""
         self._lazy_init(query.device)
+        metadata_decode_mode = normalize_decode_mode(getattr(attn_metadata, 'decode_mode', 'block'))
         if decode_mode is None:
-            decode_mode = getattr(attn_metadata, 'decode_mode', 'block')
+            decode_mode = metadata_decode_mode
+        else:
+            decode_mode = normalize_decode_mode(decode_mode)
+            if hasattr(attn_metadata, 'decode_mode') and decode_mode != metadata_decode_mode:
+                raise ValueError(
+                    f'Attention decode mode {decode_mode!r} does not match '
+                    f'metadata mode {metadata_decode_mode!r}.')
 
         quant_policy = attn_metadata.quant_policy
         if quant_policy in (QuantPolicy.FP8, QuantPolicy.FP8_E5M2):
@@ -149,6 +159,11 @@ class Attention(nn.Module):
             decode_mode=decode_mode,
             **kwargs,
         )
+
+    @staticmethod
+    def update_meta_flashmla(attn_metadata: AttentionMetadata, num_attention_heads):
+        """Update FlashMLA metadata through the active backend."""
+        get_backend().update_meta_flashmla(attn_metadata, num_attention_heads)
 
 
 class SWAStateRingAttention(nn.Module):

--- a/lmdeploy/pytorch/nn/attention.py
+++ b/lmdeploy/pytorch/nn/attention.py
@@ -114,10 +114,12 @@ class Attention(nn.Module):
         s_aux: torch.Tensor = None,
         nsa_indices: torch.Tensor = None,
         inplace: bool = True,
-        decode_mode: str = 'block',
+        decode_mode: str | None = None,
     ) -> torch.Tensor:
         """forward."""
         self._lazy_init(query.device)
+        if decode_mode is None:
+            decode_mode = getattr(attn_metadata, 'decode_mode', 'block')
 
         quant_policy = attn_metadata.quant_policy
         if quant_policy in (QuantPolicy.FP8, QuantPolicy.FP8_E5M2):

--- a/lmdeploy/pytorch/nn/attention.py
+++ b/lmdeploy/pytorch/nn/attention.py
@@ -38,6 +38,8 @@ class Attention(nn.Module):
         mla_index_topk: int | None = None,
         learnable_sink: bool = False,
         block_sparse_size: int = 1,
+        allow_fa3: bool = True,
+        enable_paged_multi_token_decode: bool = False,
         **kwargs,
     ):
         super().__init__()
@@ -64,6 +66,8 @@ class Attention(nn.Module):
                 mla_index_topk=mla_index_topk,
                 learnable_sink=learnable_sink,
                 block_sparse_size=block_sparse_size,
+                allow_fa3=allow_fa3,
+                enable_paged_multi_token_decode=enable_paged_multi_token_decode,
             ),
             enable_deterministic=get_build_model_context().enable_deterministic,
         )

--- a/lmdeploy/pytorch/nn/attention.py
+++ b/lmdeploy/pytorch/nn/attention.py
@@ -1,4 +1,6 @@
 # Copyright (c) OpenMMLab. All rights reserved.
+from typing import Any
+
 import torch
 from torch import nn
 
@@ -7,7 +9,11 @@ from lmdeploy.pytorch.distributed import get_tp_world_rank
 from lmdeploy.pytorch.models.patch import get_build_model_context
 
 from ..backends import get_backend
-from ..backends.attention import AttentionMetadata, PagedAttentionBuildSpec
+from ..backends.attention import (
+    AttentionMetadata,
+    PagedAttentionBuildSpec,
+    SWAStateRingAttentionBuildSpec,
+)
 from ..backends.flash_attention import FlashAttentionBuildSpec
 from .utils import get_distribute_size
 
@@ -38,8 +44,6 @@ class Attention(nn.Module):
         mla_index_topk: int | None = None,
         learnable_sink: bool = False,
         block_sparse_size: int = 1,
-        allow_fa3: bool = True,
-        enable_paged_multi_token_decode: bool = False,
         **kwargs,
     ):
         super().__init__()
@@ -66,11 +70,11 @@ class Attention(nn.Module):
                 mla_index_topk=mla_index_topk,
                 learnable_sink=learnable_sink,
                 block_sparse_size=block_sparse_size,
-                allow_fa3=allow_fa3,
-                enable_paged_multi_token_decode=enable_paged_multi_token_decode,
             ),
             enable_deterministic=get_build_model_context().enable_deterministic,
         )
+        self.supports_multi_token_decode = bool(
+            getattr(self.impl, 'supports_multi_token_decode', False))
 
         if alibi:
             self.alibi_ready = False
@@ -142,9 +146,67 @@ class Attention(nn.Module):
             **kwargs,
         )
 
-    @staticmethod
-    def update_meta_flashmla(attn_metadata: AttentionMetadata, num_attention_heads):
-        get_backend().update_meta_flashmla(attn_metadata, num_attention_heads)
+
+class SWAStateRingAttention(nn.Module):
+    """Sequence-scoped sliding-window attention backed by a state ring."""
+
+    def __init__(
+        self,
+        num_heads: int,
+        head_size: int,
+        scale: float = None,
+        num_kv_heads: int = None,
+        v_head_size: int = None,
+        sliding_window: tuple[int, int] = (-1, -1),
+        learnable_sink: bool = False,
+        block_sparse_size: int = 1,
+        **kwargs,
+    ):
+        super().__init__()
+        if num_kv_heads is None:
+            num_kv_heads = num_heads
+        if v_head_size is None:
+            v_head_size = head_size
+        num_heads, num_kv_heads = _update_num_heads(num_heads, num_kv_heads)
+
+        self.impl = get_backend().build_op(
+            SWAStateRingAttentionBuildSpec(
+                num_heads=num_heads,
+                head_dim=head_size,
+                scale=scale,
+                num_kv_heads=num_kv_heads,
+                v_head_dim=v_head_size,
+                sliding_window=sliding_window,
+                learnable_sink=learnable_sink,
+                block_sparse_size=block_sparse_size,
+            ),
+            enable_deterministic=get_build_model_context().enable_deterministic,
+        )
+        self.supports_multi_token_decode = bool(
+            getattr(self.impl, 'supports_multi_token_decode', False))
+
+    def forward(
+        self,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        k_cache: torch.Tensor,
+        v_cache: torch.Tensor,
+        attn_metadata: Any,
+        s_aux: torch.Tensor = None,
+        **kwargs,
+    ) -> torch.Tensor:
+        """Run state-ring sliding-window attention."""
+        del kwargs
+        return self.impl.forward(
+            query,
+            key,
+            value,
+            k_cache,
+            v_cache,
+            metadata=attn_metadata,
+            learnable_sink=s_aux,
+        )
 
 
 class FlashAttention(nn.Module):

--- a/lmdeploy/pytorch/nn/linear/__init__.py
+++ b/lmdeploy/pytorch/nn/linear/__init__.py
@@ -304,8 +304,10 @@ def build_qkv_proj(in_features: int,
                    device: torch.device | None = None,
                    is_tp: bool = True,
                    num_replicate_kv_heads: int = 1,
+                   checkpoint_output_shard_sizes: tuple[int, int, int] | None = None,
+                   continuous_qkv_scale_layout: bool = False,
                    prefix: str = ''):
-    """Build qkv proj."""
+    """Build a QKV projection, optionally preserving checkpoint FP8 grids."""
     dist_config = get_dist_manager().current_config()
     is_tp = is_tp if dist_config.attn_tp > 1 else False
     quant_method = None
@@ -379,7 +381,9 @@ def build_qkv_proj(in_features: int,
                                   device=device,
                                   is_tp=is_tp,
                                   dp_gather=False,
-                                  num_replicate_kv_heads=num_replicate_kv_heads)
+                                  num_replicate_kv_heads=num_replicate_kv_heads,
+                                  checkpoint_output_shard_sizes=checkpoint_output_shard_sizes,
+                                  continuous_qkv_scale_layout=continuous_qkv_scale_layout)
     else:
         raise RuntimeError(f'Unsupported quant method: {quant_method}')
 

--- a/lmdeploy/pytorch/nn/linear/__init__.py
+++ b/lmdeploy/pytorch/nn/linear/__init__.py
@@ -304,9 +304,9 @@ def build_qkv_proj(in_features: int,
                    device: torch.device | None = None,
                    is_tp: bool = True,
                    num_replicate_kv_heads: int = 1,
+                   prefix: str = '',
                    checkpoint_output_shard_sizes: tuple[int, int, int] | None = None,
-                   continuous_qkv_scale_layout: bool = False,
-                   prefix: str = ''):
+                   continuous_qkv_scale_layout: bool = False):
     """Build a QKV projection, optionally preserving checkpoint FP8 grids."""
     dist_config = get_dist_manager().current_config()
     is_tp = is_tp if dist_config.attn_tp > 1 else False

--- a/lmdeploy/pytorch/nn/linear/blocked_fp8.py
+++ b/lmdeploy/pytorch/nn/linear/blocked_fp8.py
@@ -1,5 +1,5 @@
 # Copyright (c) OpenMMLab. All rights reserved.
-from typing import Any
+from typing import Any, NamedTuple
 
 import torch
 
@@ -291,8 +291,28 @@ class MergedBlockedF8Linear(BlockedF8Linear):
         return loaded_weight.split(self.split_section, dim=0)
 
 
+class _QKVShardPlan(NamedTuple):
+    """Physical FP8 shard and its logical output view."""
+
+    shard_idx: int
+    weight_start: int
+    weight_load_rows: int
+    physical_rows: int
+    valid_start: int
+    logical_rows: int
+    scale_start: int
+    scale_rows: int
+
+
 class QKVBlockedF8Linear(MergedBlockedF8Linear, QKVMixin):
-    """Qkv blockedf8 linear."""
+    """Blocked-FP8 QKV projection with checkpoint-aware output sharding.
+
+    ``checkpoint_output_shard_sizes`` gives the Q/K/V row counts in one
+    native checkpoint TP partition. Runtime TP shards are selected inside
+    those partitions so weight rows and scale rows stay paired.
+    ``continuous_qkv_scale_layout`` preserves checkpoints whose FP8 block
+    coordinate continues across the Q/K/V boundaries within each partition.
+    """
 
     def __init__(self,
                  in_features: int,
@@ -307,7 +327,9 @@ class QKVBlockedF8Linear(MergedBlockedF8Linear, QKVMixin):
                  device: torch.device | None = None,
                  is_tp: bool = True,
                  dp_gather: bool = False,
-                 num_replicate_kv_heads: int = 1):
+                 num_replicate_kv_heads: int = 1,
+                 checkpoint_output_shard_sizes: tuple[int, int, int] | None = None,
+                 continuous_qkv_scale_layout: bool = False):
         self.block_size = 128
         self.init_tp_args(is_tp, all_reduce=False, colwise=True, layer_type='attn')
         QKVMixin.__init__(self,
@@ -320,7 +342,12 @@ class QKVBlockedF8Linear(MergedBlockedF8Linear, QKVMixin):
                           tp=self.tp,
                           tp_rank=self.tp_rank)
 
-        all_out_features = self.get_qkv_out_feautures()
+        logical_out_features = self.get_qkv_out_feautures()
+        self.logical_out_features = logical_out_features
+        self.checkpoint_output_shard_sizes = checkpoint_output_shard_sizes
+        self.continuous_qkv_scale_layout = continuous_qkv_scale_layout
+        self._output_shard_plans = self._build_output_shard_plans(logical_out_features)
+        all_out_features = tuple(plan.physical_rows for plan in self._output_shard_plans)
         out_names = ('q', 'k', 'v')
         super().__init__(in_features,
                          all_out_features,
@@ -333,48 +360,134 @@ class QKVBlockedF8Linear(MergedBlockedF8Linear, QKVMixin):
                          out_names=out_names,
                          dp_gather=dp_gather,
                          layer_type='attn')
+        self.scale_split_section = [plan.scale_rows for plan in self._output_shard_plans]
 
     def _update_all_out_features(self, all_out_features: list[int], replicate: list[bool] | None):
         """Update all out features."""
         return all_out_features
 
+    def _build_output_shard_plans(self, logical_sections: tuple[int, int, int]):
+        """Align TP-local Q/K/V inside their checkpoint quant shards."""
+        _, rank = self.get_tp_world_rank()
+        quant_shards = getattr(self, 'checkpoint_output_shard_sizes', None) or self.qkv_split_section
+        continuous_qkv_scales = getattr(self, 'continuous_qkv_scale_layout', False)
+        if len(logical_sections) != 3 or len(quant_shards) != 3:
+            raise ValueError('Blocked-FP8 QKV sharding requires exactly three Q/K/V sections.')
+        trailing_padding = 0
+        if continuous_qkv_scales:
+            trailing_padding = div_up(sum(logical_sections), self.block_size) * self.block_size \
+                - sum(logical_sections)
+        plans = []
+        for shard_idx, (shard_id, logical_rows, source_rows, quant_shard_rows) in enumerate(
+                zip(('q', 'k', 'v'), logical_sections, self.qkv_split_section, quant_shards)):
+            rank_idx = rank if shard_id == 'q' else rank // self.num_replicate_kv_heads
+            logical_start = rank_idx * logical_rows
+            logical_end = logical_start + logical_rows
+            if logical_end > source_rows:
+                raise ValueError(
+                    f'QKV {shard_id} TP shard [{logical_start}:{logical_end}] exceeds {source_rows} source rows.')
+            if quant_shard_rows <= 0 or source_rows % quant_shard_rows:
+                raise ValueError(
+                    f'QKV {shard_id} source rows {source_rows} must be divisible by checkpoint '
+                    f'quantization shard size {quant_shard_rows}.')
+            quant_shard_idx = logical_start // quant_shard_rows
+            quant_shard_start = quant_shard_idx * quant_shard_rows
+            quant_shard_end = quant_shard_start + quant_shard_rows
+            if logical_end > quant_shard_end:
+                raise ValueError(
+                    f'QKV {shard_id} TP shard [{logical_start}:{logical_end}] crosses checkpoint '
+                    f'quantization shard [{quant_shard_start}:{quant_shard_end}].')
+            relative_start = logical_start - quant_shard_start
+            relative_end = logical_end - quant_shard_start
+            if continuous_qkv_scales:
+                if relative_start % self.block_size:
+                    raise ValueError(
+                        f'Fused QKV {shard_id} TP shard starts at unaligned checkpoint row '
+                        f'{relative_start}; its scale blocks cannot be repacked without requantization.')
+                physical_rows = logical_rows + (trailing_padding if shard_idx == 2 else 0)
+                scales_per_quant_shard = div_up(quant_shard_rows, self.block_size)
+                scale_start = quant_shard_idx * scales_per_quant_shard + relative_start // self.block_size
+                scale_rows = div_up(logical_rows, self.block_size)
+                plans.append(
+                    _QKVShardPlan(shard_idx, logical_start, logical_rows, physical_rows, 0,
+                                  logical_rows, scale_start, scale_rows))
+                continue
+            physical_relative_start = relative_start // self.block_size * self.block_size
+            physical_relative_end = div_up(relative_end, self.block_size) * self.block_size
+            physical_rows = physical_relative_end - physical_relative_start
+            weight_start = quant_shard_start + physical_relative_start
+            weight_end = min(quant_shard_start + physical_relative_end, quant_shard_end)
+            weight_load_rows = weight_end - weight_start
+            valid_start = relative_start - physical_relative_start
+            scales_per_quant_shard = div_up(quant_shard_rows, self.block_size)
+            scale_start = quant_shard_idx * scales_per_quant_shard + physical_relative_start // self.block_size
+            scale_rows = physical_rows // self.block_size
+            plans.append(
+                _QKVShardPlan(shard_idx, weight_start, weight_load_rows, physical_rows, valid_start,
+                              logical_rows, scale_start, scale_rows))
+        if continuous_qkv_scales:
+            physical_scale_rows = div_up(sum(plan.physical_rows for plan in plans), self.block_size)
+            source_scale_rows = sum(plan.scale_rows for plan in plans)
+            if physical_scale_rows != source_scale_rows:
+                raise ValueError(
+                    'Fused QKV checkpoint scale rows do not match the packed runtime output: '
+                    f'{source_scale_rows} != {physical_scale_rows}.')
+        return tuple(plans)
+
+    def _get_output_shard(self, shard_id: Any) -> _QKVShardPlan:
+        """Return checkpoint weight/scale rows for a TP-local shard."""
+        return self._output_shard_plans[self.out_names_map[shard_id]]
+
     def weight_loader(self, param: torch.nn.Parameter, loaded_weight: torch.Tensor, shard_id: Any):
         """Weight loader."""
-        _, rank = self.get_tp_world_rank()
-        shard_idx = self.out_names_map[shard_id]
-
-        num_head = self.num_q_heads if shard_id == 'q' \
-            else self.num_kv_heads
-        head_dim = self.head_size if shard_id in ['q', 'k'] \
-            else self.head_size_v
-        # update to duplicate k/v for tp_size > num_kv_heads
-        rank_idx = rank if shard_id == 'q' \
-            else rank // self.num_replicate_kv_heads
-        sec_len = num_head * head_dim
+        plan = self._get_output_shard(shard_id)
         all_out_features = self.all_out_features
         if param._weight_type == 'scales':
             loaded_weight = loaded_weight.to(torch.float32)
-            all_out_features = [sec // self.block_size for sec in all_out_features]
-            sec_len = sec_len // self.block_size
-
-        sec_start = rank_idx * sec_len
+            all_out_features = self.scale_split_section
+            sec_start, sec_len = plan.scale_start, plan.scale_rows
+        else:
+            sec_start, sec_len = plan.weight_start, plan.weight_load_rows
 
         loaded_weight = loaded_weight.narrow(dim=0, start=sec_start, length=sec_len)
-        param_w = param.data.split(all_out_features, 0)[shard_idx]
-        param_w.copy_(loaded_weight)
+        param_w = param.data.split(all_out_features, 0)[plan.shard_idx]
+        if param._weight_type == 'scales':
+            param_w.copy_(loaded_weight)
+        else:
+            param_w.zero_()
+            param_w.narrow(0, 0, sec_len).copy_(loaded_weight)
 
     def weight_loader_with_quant(self, param: torch.nn.Parameter, loaded_weight: torch.Tensor, shard_id: Any):
         """Weight loader with weight quant."""
         if loaded_weight.dtype != param.dtype:
-            # quant loaded weight
-            quanted_weight, scaling = quant_blocked_fp8(loaded_weight.to(param.device),
+            if self.continuous_qkv_scale_layout:
+                raise ValueError('Fused QKV output quantization requires native blocked-FP8 checkpoint weights.')
+            plan = self._get_output_shard(shard_id)
+            physical_weight = torch.zeros((plan.physical_rows, loaded_weight.shape[1]),
+                                          dtype=loaded_weight.dtype,
+                                          device=param.device)
+            physical_weight[:plan.weight_load_rows].copy_(
+                loaded_weight.narrow(0, plan.weight_start, plan.weight_load_rows))
+            quanted_weight, scaling = quant_blocked_fp8(physical_weight,
                                                         param.dtype,
                                                         self.block_size,
                                                         scale_fmt=self.scale_fmt)
-            self.weight_loader(self.weight, quanted_weight, shard_id)
-            self.weight_loader(self.weight_scale_inv, scaling, shard_id)
+            self.weight.data.split(self.all_out_features, 0)[plan.shard_idx].copy_(quanted_weight)
+            self.weight_scale_inv.data.split(self.scale_split_section, 0)[plan.shard_idx].copy_(scaling)
         else:
             return self.weight_loader(param, loaded_weight, shard_id)
+
+    def split_qkv(self, x: torch.Tensor):
+        """Crop physical alignment rows and restore logical Q/K/V heads."""
+        physical = x.split(self.all_out_features, dim=-1)
+        q, k, v = (
+            value.narrow(-1, plan.valid_start, plan.logical_rows)
+            for value, plan in zip(physical, self._output_shard_plans)
+        )
+        q = q.unflatten(-1, (self.num_q_heads, self.head_size))
+        k = k.unflatten(-1, (self.num_kv_heads, self.head_size))
+        v = v.unflatten(-1, (self.num_kv_heads, self.head_size_v))
+        return q, k, v
 
     def weight_spliter(self, loaded_weight: torch.Tensor, layout: str = 'default'):
         """Weight spliter."""
@@ -382,5 +495,5 @@ class QKVBlockedF8Linear(MergedBlockedF8Linear, QKVMixin):
         assert layout == 'default'
         qkv_split_section = self.qkv_split_section
         if loaded_weight.dim() == 2 and loaded_weight.dtype != self.fp8_dtype:
-            qkv_split_section = [sec // self.block_size for sec in qkv_split_section]
+            qkv_split_section = [div_up(sec, self.block_size) for sec in qkv_split_section]
         return loaded_weight.split(qkv_split_section, dim=0)

--- a/lmdeploy/pytorch/spec_decode/proposers/__init__.py
+++ b/lmdeploy/pytorch/spec_decode/proposers/__init__.py
@@ -1,8 +1,8 @@
 # Copyright (c) OpenMMLab. All rights reserved.
-# Copyright (c) OpenMMLab. All rights reserved.
 
 from .deepseek_mtp import DeepseekMTP  # noqa F401
 from .eagle import Eagle  # noqa F401
 from .eagle3 import Eagle3  # noqa F401
 from .hy3_mtp import Hy3MTP  # noqa F401
+from .mimo_mtp import MiMoMTP  # noqa F401
 from .qwen3_5_mtp import Qwen3_5MTP  # noqa F401

--- a/lmdeploy/pytorch/spec_decode/proposers/base.py
+++ b/lmdeploy/pytorch/spec_decode/proposers/base.py
@@ -135,7 +135,47 @@ class BaseSpecProposer:
             mrope_pos_ids=mrope_pos_ids,
             target_hidden_states=target_hidden_states,
             model_metas=model_metas,
+            spec_step_idx=model_inputs.spec_step_idx + 1,
         )
+
+    def advance_draft_depth(self,
+                            model_inputs: ModelInputs,
+                            extra_inputs: ExtraInputs | None,
+                            next_input_ids: torch.Tensor,
+                            target_hidden_states: torch.Tensor,
+                            model_metas: list[Any],
+                            *,
+                            first_depth: bool) -> tuple[ModelInputs, ExtraInputs | None]:
+        """Advance recurrent draft state to the next speculative depth.
+
+        The first transition converts target-model inputs into compact draft decoding inputs. Later transitions advance
+        those decoding inputs by one token. Subclasses may override this transition for architectures whose draft depths
+        do not follow autoregressive time.
+        """
+        if first_depth:
+            if extra_inputs is None:
+                raise ValueError('The first draft-depth transition requires extra inputs.')
+            model_inputs = self.update_inputs_decoding(model_inputs, extra_inputs, next_input_ids.transpose(0, 1),
+                                                       target_hidden_states, model_metas)
+            # Compact recurrent inputs contain one row per request, so later
+            # draft outputs no longer require last-token selection.
+            extra_inputs.last_token_indices = None
+        else:
+            step_seqlens = model_inputs.seq_length.new_ones(model_inputs.seq_length.size(0))
+            model_inputs = model_inputs.step(next_input_ids.transpose(0, 1), step_seqlens)
+            model_inputs.model_metas = model_metas
+            model_inputs.target_hidden_states = target_hidden_states
+            if model_inputs.target_position_ids is not None:
+                model_inputs.target_position_ids += 1
+        return model_inputs, None
+
+    def get_draft_depth_token_counts(self, dp_meta) -> list[int]:
+        """Return per-rank token counts after advancing a draft depth.
+
+        Recurrent draft models compact the next depth to one token per active request, so the DP batch counts are also
+        the token counts. Draft architectures that retain a varlen sequence across depths may override this contract.
+        """
+        return dp_meta.dp_batches
 
     def embed_input_ids(self, input_ids: torch.Tensor):
         """embed_input_ids."""

--- a/lmdeploy/pytorch/spec_decode/proposers/base.py
+++ b/lmdeploy/pytorch/spec_decode/proposers/base.py
@@ -62,7 +62,6 @@ def draft_model_forward(
 class BaseSpecProposer:
     supports_draft_depth_protocol = False
 
-
     def __init__(self, specdecode_config: SpecDecodeConfig, device: torch.device = None):
         self.specdecode_config = specdecode_config
         self.model = None
@@ -137,7 +136,6 @@ class BaseSpecProposer:
             mrope_pos_ids=mrope_pos_ids,
             target_hidden_states=target_hidden_states,
             model_metas=model_metas,
-            spec_step_idx=model_inputs.spec_step_idx + 1,
         )
 
     def embed_input_ids(self, input_ids: torch.Tensor):

--- a/lmdeploy/pytorch/spec_decode/proposers/base.py
+++ b/lmdeploy/pytorch/spec_decode/proposers/base.py
@@ -60,6 +60,8 @@ def draft_model_forward(
 
 
 class BaseSpecProposer:
+    supports_draft_depth_protocol = False
+
 
     def __init__(self, specdecode_config: SpecDecodeConfig, device: torch.device = None):
         self.specdecode_config = specdecode_config
@@ -137,45 +139,6 @@ class BaseSpecProposer:
             model_metas=model_metas,
             spec_step_idx=model_inputs.spec_step_idx + 1,
         )
-
-    def advance_draft_depth(self,
-                            model_inputs: ModelInputs,
-                            extra_inputs: ExtraInputs | None,
-                            next_input_ids: torch.Tensor,
-                            target_hidden_states: torch.Tensor,
-                            model_metas: list[Any],
-                            *,
-                            first_depth: bool) -> tuple[ModelInputs, ExtraInputs | None]:
-        """Advance recurrent draft state to the next speculative depth.
-
-        The first transition converts target-model inputs into compact draft decoding inputs. Later transitions advance
-        those decoding inputs by one token. Subclasses may override this transition for architectures whose draft depths
-        do not follow autoregressive time.
-        """
-        if first_depth:
-            if extra_inputs is None:
-                raise ValueError('The first draft-depth transition requires extra inputs.')
-            model_inputs = self.update_inputs_decoding(model_inputs, extra_inputs, next_input_ids.transpose(0, 1),
-                                                       target_hidden_states, model_metas)
-            # Compact recurrent inputs contain one row per request, so later
-            # draft outputs no longer require last-token selection.
-            extra_inputs.last_token_indices = None
-        else:
-            step_seqlens = model_inputs.seq_length.new_ones(model_inputs.seq_length.size(0))
-            model_inputs = model_inputs.step(next_input_ids.transpose(0, 1), step_seqlens)
-            model_inputs.model_metas = model_metas
-            model_inputs.target_hidden_states = target_hidden_states
-            if model_inputs.target_position_ids is not None:
-                model_inputs.target_position_ids += 1
-        return model_inputs, None
-
-    def get_draft_depth_token_counts(self, dp_meta) -> list[int]:
-        """Return per-rank token counts after advancing a draft depth.
-
-        Recurrent draft models compact the next depth to one token per active request, so the DP batch counts are also
-        the token counts. Draft architectures that retain a varlen sequence across depths may override this contract.
-        """
-        return dp_meta.dp_batches
 
     def embed_input_ids(self, input_ids: torch.Tensor):
         """embed_input_ids."""

--- a/lmdeploy/pytorch/spec_decode/proposers/mimo_mtp.py
+++ b/lmdeploy/pytorch/spec_decode/proposers/mimo_mtp.py
@@ -11,6 +11,8 @@ from .base import SPEC_PROPOSERS, BaseSpecProposer
 class MiMoMTP(BaseSpecProposer):
     """MiMo same-position, multi-depth MTP proposer."""
 
+    supports_draft_depth_protocol = True
+
     def build_model(self, empty_init: bool, target_model: torch.nn.Module = None, build_model_ctx=None):
         """Build the MiMo draft and bind its target-owned TP embedding."""
         if target_model is None:

--- a/lmdeploy/pytorch/spec_decode/proposers/mimo_mtp.py
+++ b/lmdeploy/pytorch/spec_decode/proposers/mimo_mtp.py
@@ -1,0 +1,89 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+
+import torch
+
+from ...model_inputs import ModelInputs
+from ...strategies.ar_spec.model_agent import ARSpecExtraInputs
+from .base import SPEC_PROPOSERS, BaseSpecProposer
+
+
+@SPEC_PROPOSERS.register_module(name='mimo_mtp')
+class MiMoMTP(BaseSpecProposer):
+    """MiMo same-position, multi-depth MTP proposer."""
+
+    def build_model(self, empty_init: bool, target_model: torch.nn.Module = None, build_model_ctx=None):
+        """Build the MiMo draft and bind its target-owned TP embedding."""
+        if target_model is None:
+            raise ValueError('MiMo MTP requires the target model for its shared token embedding.')
+        # MiMo always shares the target vocab-parallel embedding; unlike the
+        # DeepSeek DSA optimization this is part of the model architecture.
+        super().build_model(empty_init, target_model=target_model, build_model_ctx=build_model_ctx)
+        draft_model = self.model
+        if not hasattr(draft_model, 'set_input_embeddings'):
+            raise TypeError(f'{type(draft_model).__name__} cannot bind MiMo shared token embeddings.')
+        draft_model.set_input_embeddings(target_model.get_input_embeddings())
+
+    def advance_draft_depth(self,
+                            model_inputs: ModelInputs,
+                            extra_inputs: ARSpecExtraInputs | None,
+                            next_input_ids: torch.Tensor,
+                            target_hidden_states: torch.Tensor,
+                            model_metas: list,
+                            *,
+                            first_depth: bool) -> tuple[ModelInputs, ARSpecExtraInputs]:
+        """Advance one same-position MiMo depth without advancing time."""
+        # Every depth conditions on the same target-model state; only the
+        # candidate token/embedding stream and prediction depth change.
+        del target_hidden_states, first_depth
+        if extra_inputs is None:
+            raise ValueError('MiMo MTP depth transitions require AR speculative inputs.')
+        last_token_indices = extra_inputs.last_token_indices
+        input_ids = model_inputs.input_ids.clone()
+        input_ids[:, :-1] = model_inputs.input_ids[:, 1:]
+        input_ids[:, last_token_indices] = next_input_ids.flatten()
+
+        target_inputs_embeds = model_inputs.target_inputs_embeds
+        if target_inputs_embeds is not None:
+            target_inputs_embeds = target_inputs_embeds.clone()
+            target_inputs_embeds[:, :-1] = model_inputs.target_inputs_embeds[:, 1:]
+            target_inputs_embeds[:, last_token_indices] = self.embed_input_ids(next_input_ids.flatten())
+
+        model_inputs = model_inputs.clone(
+            input_ids=input_ids,
+            target_inputs_embeds=target_inputs_embeds,
+            target_hidden_states=model_inputs.target_hidden_states,
+            model_metas=model_metas,
+            spec_step_idx=model_inputs.spec_step_idx + 1,
+        )
+        return model_inputs, extra_inputs
+
+    def get_draft_depth_token_counts(self, dp_meta) -> list[int]:
+        """Preserve varlen prompt sizes across same-position MTP depths."""
+        num_tokens = dp_meta.dp_draft_num_tokens
+        if num_tokens is None:
+            raise RuntimeError('MiMo MTP requires per-rank draft token counts for DP depth transitions.')
+        return num_tokens
+
+    async def get_outputs(self,
+                          model_outputs: dict[str, torch.Tensor],
+                          model_inputs: ModelInputs,
+                          extra_inputs: ARSpecExtraInputs = None,
+                          guided_processors: dict | None = None):
+        """Select the active MiMo depth's norm/head and produce its draft."""
+        raw_hidden_states = model_outputs['hidden_states']
+        model_metas = model_outputs['model_metas']
+        if extra_inputs is not None:
+            raw_hidden_states = raw_hidden_states[:, extra_inputs.last_token_indices]
+
+        draft_model = self.model.get_model() if hasattr(self.model, 'get_model') else self.model
+        logits_hidden_states = draft_model.prepare_hidden_states_for_logits(
+            raw_hidden_states, spec_step_idx=model_inputs.spec_step_idx)
+        logits = self.target_model.get_logits(logits_hidden_states)[0]
+
+        guided_bitmask = await self.guided_helper.prepare_bitmask(logits, guided_processors)
+        if guided_bitmask is not None:
+            self.guided_helper.apply_bitmask(logits, guided_bitmask)
+        draft_token_ids = logits.argmax(dim=-1, keepdim=True)
+
+        await self.guided_helper.accept_draft_tokens(draft_token_ids, guided_processors)
+        return draft_token_ids, model_metas, raw_hidden_states

--- a/lmdeploy/pytorch/spec_decode/spec_agent.py
+++ b/lmdeploy/pytorch/spec_decode/spec_agent.py
@@ -571,6 +571,18 @@ class SpecModelAgent(BaseSpecModelAgent):
             output = self.proposer._forward(inputs, cache_engine=self.cache_engine)
         return output
 
+    def _uses_draft_depth_protocol(self) -> bool:
+        """Validate and return the proposer's depth-transition capability."""
+        if not getattr(self.proposer, 'supports_draft_depth_protocol', False):
+            return False
+        required_hooks = ('advance_draft_depth', 'get_draft_depth_token_counts')
+        missing_hooks = [name for name in required_hooks if not callable(getattr(self.proposer, name, None))]
+        if missing_hooks:
+            raise TypeError(
+                f'{type(self.proposer).__name__} declares draft-depth protocol '
+                f'but is missing: {", ".join(missing_hooks)}')
+        return True
+
     async def async_sampling_logits(self, model_inputs: ModelInputs, extra_inputs: ARSpecExtraInputs,
                                     sampling_inputs: SamplingInputs):
         """Sample target logits and run rejection sampling."""
@@ -596,9 +608,10 @@ class SpecModelAgent(BaseSpecModelAgent):
             inputs = self.proposer.model.update_inputs(inputs)
             return inputs
 
+        uses_draft_depth_protocol = self._uses_draft_depth_protocol()
         outputs = self._forward_impl(inputs)
         if (inputs.dp_meta is None and inputs.is_chunk and not inputs.is_last_chunk
-                and not getattr(self.proposer, 'supports_draft_depth_protocol', False)):
+                and not uses_draft_depth_protocol):
             # Legacy proposers do not own a persistent per-depth cache, so
             # DP=1 non-last chunks can skip speculative outputs entirely.
             output_draft_ids = inputs.input_ids.new_zeros(inputs.seq_length.size(0), self.num_spec_tokens)
@@ -619,7 +632,7 @@ class SpecModelAgent(BaseSpecModelAgent):
                 guided_processors=draft_guided_processors)
             draft_tokens_li = [draft_token_ids]
             if loop_count > 0:
-                if not getattr(self.proposer, 'supports_draft_depth_protocol', False):
+                if not uses_draft_depth_protocol:
                     advance_draft_depth = None
                 else:
                     advance_draft_depth = self.proposer.advance_draft_depth
@@ -687,7 +700,7 @@ class SpecModelAgent(BaseSpecModelAgent):
             return None, None
 
         padding_batch_size = max(dp_meta.dp_batches)
-        if getattr(self.proposer, 'supports_draft_depth_protocol', False):
+        if self._uses_draft_depth_protocol():
             num_tokens = self.proposer.get_draft_depth_token_counts(dp_meta)
         else:
             # Legacy depth transitions compact every request to one token;

--- a/lmdeploy/pytorch/spec_decode/spec_agent.py
+++ b/lmdeploy/pytorch/spec_decode/spec_agent.py
@@ -769,7 +769,11 @@ class SpecModelAgent(BaseSpecModelAgent):
             for batch_size in capture_batch_sizes:
                 max_query_len = self.num_spec_tokens + 1
                 protocol_model = self.proposer.model.get_model()
-                specs = protocol_model.get_cudagraph_warmup_specs(max_query_len)
+                get_warmup_specs = getattr(protocol_model, 'get_cudagraph_warmup_specs', None)
+                if not callable(get_warmup_specs):
+                    specs = ((max_query_len, 0), (1, 0))
+                else:
+                    specs = get_warmup_specs(max_query_len)
                 for query_len, spec_step_idx in specs:
                     inputs = self.inputs_strategy.make_dummy(
                         batch_size,

--- a/lmdeploy/pytorch/spec_decode/spec_agent.py
+++ b/lmdeploy/pytorch/spec_decode/spec_agent.py
@@ -584,22 +584,6 @@ class SpecModelAgent(BaseSpecModelAgent):
         Args:
             inputs (dict): The input data comes from _make_inputs.
         """
-        def __build_dp_meta(inputs: ModelInputs):
-            """Prepare for dp."""
-            # update inputs for draft model
-            dp_meta = inputs.dp_meta
-            padding_batch_size = None
-            if dp_meta is None:
-                return dp_meta, None
-
-            padding_batch_size = max(dp_meta.dp_batches)
-            num_tokens = self.proposer.get_draft_depth_token_counts(dp_meta)
-            new_dpmeta = DPMeta.build(inputs.input_ids.numel(), num_tokens)
-            new_dpmeta.dp_batches = dp_meta.dp_batches
-            new_dpmeta.dp_is_decoding = dp_meta.dp_is_decoding
-            new_dpmeta.dp_draft_num_tokens = dp_meta.dp_draft_num_tokens
-            return new_dpmeta, padding_batch_size
-
         def _update_dp_model_inputs(inputs: ModelInputs, dp_meta: DPMeta, padding_batch_size: int | None):
             if dp_meta is None:
                 return inputs
@@ -634,15 +618,29 @@ class SpecModelAgent(BaseSpecModelAgent):
                 guided_processors=draft_guided_processors)
             draft_tokens_li = [draft_token_ids]
             if loop_count > 0:
-                inputs, draft_extra_inputs = self.proposer.advance_draft_depth(
-                    inputs,
-                    extra_inputs,
-                    draft_token_ids,
-                    target_hidden_states,
-                    model_metas,
-                    first_depth=True)
+                if not getattr(self.proposer, 'supports_draft_depth_protocol', False):
+                    advance_draft_depth = None
+                else:
+                    advance_draft_depth = self.proposer.advance_draft_depth
+                if advance_draft_depth is not None:
+                    inputs, draft_extra_inputs = advance_draft_depth(
+                        inputs,
+                        extra_inputs,
+                        draft_token_ids,
+                        target_hidden_states,
+                        model_metas,
+                        first_depth=True)
+                else:
+                    inputs = self.proposer.update_inputs_decoding(
+                        inputs,
+                        extra_inputs,
+                        draft_token_ids.transpose(0, 1),
+                        target_hidden_states,
+                        model_metas,
+                    )
+                    draft_extra_inputs = None
                 # for dp > 1, need to update dp_meta and model inputs for next loop
-                dp_meta, padding_batch_size = __build_dp_meta(inputs)
+                dp_meta, padding_batch_size = self._build_draft_depth_dp_meta(inputs)
                 # pad block_offsets for non-last chunks dummy run when dp>1
                 if dp_meta is not None and inputs.is_chunk and not inputs.is_last_chunk:
                     inputs.block_offsets = torch.nn.functional.pad(inputs.block_offsets, (0, 1), value=0)
@@ -654,13 +652,21 @@ class SpecModelAgent(BaseSpecModelAgent):
                         guided_processors=draft_guided_processors)
                     draft_tokens_li.append(draft_token_ids)
                     if loop_idx < loop_count - 1:
-                        inputs, draft_extra_inputs = self.proposer.advance_draft_depth(
-                            inputs,
-                            draft_extra_inputs,
-                            draft_token_ids,
-                            target_hidden_states,
-                            model_metas,
-                            first_depth=False)
+                        if advance_draft_depth is not None:
+                            inputs, draft_extra_inputs = advance_draft_depth(
+                                inputs,
+                                draft_extra_inputs,
+                                draft_token_ids,
+                                target_hidden_states,
+                                model_metas,
+                                first_depth=False)
+                        else:
+                            step_seqlens = inputs.seq_length.new_ones(inputs.seq_length.size(0))
+                            inputs = inputs.step(draft_token_ids.transpose(0, 1), step_seqlens)
+                            inputs.model_metas = model_metas
+                            inputs.target_hidden_states = target_hidden_states
+                            if inputs.target_position_ids is not None:
+                                inputs.target_position_ids += 1
 
             output_draft_ids = torch.cat(draft_tokens_li, dim=-1)
 
@@ -673,6 +679,22 @@ class SpecModelAgent(BaseSpecModelAgent):
             logprobs=extra_inputs.logprobs,
         )
         return extra_inputs
+
+    def _build_draft_depth_dp_meta(self, inputs: ModelInputs):
+        dp_meta = inputs.dp_meta
+        if dp_meta is None:
+            return None, None
+
+        padding_batch_size = max(dp_meta.dp_batches)
+        if getattr(self.proposer, 'supports_draft_depth_protocol', False):
+            num_tokens = self.proposer.get_draft_depth_token_counts(dp_meta)
+        else:
+            num_tokens = [inputs.input_ids.numel()] * len(dp_meta.dp_batches)
+        new_dpmeta = DPMeta.build(inputs.input_ids.numel(), num_tokens)
+        new_dpmeta.dp_batches = dp_meta.dp_batches
+        new_dpmeta.dp_is_decoding = dp_meta.dp_is_decoding
+        new_dpmeta.dp_draft_num_tokens = dp_meta.dp_draft_num_tokens
+        return new_dpmeta, padding_batch_size
 
     async def async_model_forward(
         self,

--- a/lmdeploy/pytorch/spec_decode/spec_agent.py
+++ b/lmdeploy/pytorch/spec_decode/spec_agent.py
@@ -597,9 +597,10 @@ class SpecModelAgent(BaseSpecModelAgent):
             return inputs
 
         outputs = self._forward_impl(inputs)
-        if inputs.dp_meta is None and inputs.is_chunk and not inputs.is_last_chunk:
-            # DP=1 non-last chunks do not consume draft tokens, so skip the
-            # remaining speculative forwards.
+        if (inputs.dp_meta is None and inputs.is_chunk and not inputs.is_last_chunk
+                and not getattr(self.proposer, 'supports_draft_depth_protocol', False)):
+            # Legacy proposers do not own a persistent per-depth cache, so
+            # DP=1 non-last chunks can skip speculative outputs entirely.
             output_draft_ids = inputs.input_ids.new_zeros(inputs.seq_length.size(0), self.num_spec_tokens)
         else:
             # Fork guided processors for draft model.
@@ -689,7 +690,11 @@ class SpecModelAgent(BaseSpecModelAgent):
         if getattr(self.proposer, 'supports_draft_depth_protocol', False):
             num_tokens = self.proposer.get_draft_depth_token_counts(dp_meta)
         else:
-            num_tokens = [inputs.input_ids.numel()] * len(dp_meta.dp_batches)
+            # Legacy depth transitions compact every request to one token;
+            # therefore the rank-global batch layout is also the token layout.
+            # Reusing the local flattened count for every rank would make TP
+            # collectives disagree when DP ranks have different batch sizes.
+            num_tokens = list(dp_meta.dp_batches)
         new_dpmeta = DPMeta.build(inputs.input_ids.numel(), num_tokens)
         new_dpmeta.dp_batches = dp_meta.dp_batches
         new_dpmeta.dp_is_decoding = dp_meta.dp_is_decoding

--- a/lmdeploy/pytorch/spec_decode/spec_agent.py
+++ b/lmdeploy/pytorch/spec_decode/spec_agent.py
@@ -238,6 +238,7 @@ class SpecModelAgent(BaseSpecModelAgent):
             draft_dp_meta = DPMeta.build(input_ids.numel(), all_num_tokens)
         draft_dp_meta.dp_batches = dp_meta.dp_batches
         draft_dp_meta.dp_is_decoding = dp_meta.dp_is_decoding
+        draft_dp_meta.dp_draft_num_tokens = all_num_tokens
         return draft_dp_meta
 
     def _prepare_inputs_from_main(self, model_inputs: ModelInputs, extra_inputs: ExtraInputs):
@@ -592,8 +593,11 @@ class SpecModelAgent(BaseSpecModelAgent):
                 return dp_meta, None
 
             padding_batch_size = max(dp_meta.dp_batches)
-            new_dpmeta = DPMeta.build(inputs.input_ids.numel(), dp_meta.dp_batches)
+            num_tokens = self.proposer.get_draft_depth_token_counts(dp_meta)
+            new_dpmeta = DPMeta.build(inputs.input_ids.numel(), num_tokens)
+            new_dpmeta.dp_batches = dp_meta.dp_batches
             new_dpmeta.dp_is_decoding = dp_meta.dp_is_decoding
+            new_dpmeta.dp_draft_num_tokens = dp_meta.dp_draft_num_tokens
             return new_dpmeta, padding_batch_size
 
         def _update_dp_model_inputs(inputs: ModelInputs, dp_meta: DPMeta, padding_batch_size: int | None):
@@ -630,10 +634,13 @@ class SpecModelAgent(BaseSpecModelAgent):
                 guided_processors=draft_guided_processors)
             draft_tokens_li = [draft_token_ids]
             if loop_count > 0:
-                inputs = self.proposer.update_inputs_decoding(inputs, extra_inputs, draft_token_ids.transpose(0, 1),
-                                                              target_hidden_states, model_metas)
-                # set last_token_indices to None for decoding
-                extra_inputs.last_token_indices = None
+                inputs, draft_extra_inputs = self.proposer.advance_draft_depth(
+                    inputs,
+                    extra_inputs,
+                    draft_token_ids,
+                    target_hidden_states,
+                    model_metas,
+                    first_depth=True)
                 # for dp > 1, need to update dp_meta and model inputs for next loop
                 dp_meta, padding_batch_size = __build_dp_meta(inputs)
                 # pad block_offsets for non-last chunks dummy run when dp>1
@@ -643,16 +650,17 @@ class SpecModelAgent(BaseSpecModelAgent):
                     inputs = _update_dp_model_inputs(inputs, dp_meta, padding_batch_size)
                     outputs = self._forward_impl(inputs)
                     draft_token_ids, model_metas, target_hidden_states = await self.proposer.get_outputs(
-                        outputs, inputs,
+                        outputs, inputs, draft_extra_inputs,
                         guided_processors=draft_guided_processors)
                     draft_tokens_li.append(draft_token_ids)
                     if loop_idx < loop_count - 1:
-                        step_seqlens = inputs.seq_length.new_ones(inputs.seq_length.size(0))
-                        inputs = inputs.step(draft_token_ids.transpose(0, 1), step_seqlens)
-                        inputs.model_metas = model_metas
-                        inputs.target_hidden_states = target_hidden_states
-                        if inputs.target_position_ids is not None:
-                            inputs.target_position_ids += 1
+                        inputs, draft_extra_inputs = self.proposer.advance_draft_depth(
+                            inputs,
+                            draft_extra_inputs,
+                            draft_token_ids,
+                            target_hidden_states,
+                            model_metas,
+                            first_depth=False)
 
             output_draft_ids = torch.cat(draft_tokens_li, dim=-1)
 
@@ -717,33 +725,26 @@ class SpecModelAgent(BaseSpecModelAgent):
 
             capture_batch_sizes = self.proposer.model.get_capture_batch_sizes()
             capture_batch_sizes = sorted(capture_batch_sizes, reverse=True)
-
             # warmup decode
             for batch_size in capture_batch_sizes:
-                # decode with num_spec_tokens + 1 per seq
-                inputs = self.inputs_strategy.make_dummy(batch_size,
-                                                         is_decoding=True,
-                                                         device='cuda',
-                                                         vocab_size=self.model_config.vocab_size,
-                                                         max_q_seqlen=self.num_spec_tokens + 1,
-                                                         target_hidden_size=target_hidden_size,
-                                                         target_dtype=self.model_config.dtype,
-                                                         meta=self.make_dummy_meta)
-                self._build_warmup_dp_meta(inputs)
-                self._forward_impl(inputs)
-                torch.cuda.synchronize()
-                # decode 1 tokens per sequence
-                inputs = self.inputs_strategy.make_dummy(batch_size,
-                                                         is_decoding=True,
-                                                         device='cuda',
-                                                         vocab_size=self.model_config.vocab_size,
-                                                         max_q_seqlen=1,
-                                                         target_hidden_size=self.model_config.hidden_size,
-                                                         target_dtype=self.model_config.dtype,
-                                                         meta=self.make_dummy_meta)
-                self._build_warmup_dp_meta(inputs)
-                self._forward_impl(inputs)
-                torch.cuda.synchronize()
+                max_query_len = self.num_spec_tokens + 1
+                protocol_model = self.proposer.model.get_model()
+                specs = protocol_model.get_cudagraph_warmup_specs(max_query_len)
+                for query_len, spec_step_idx in specs:
+                    inputs = self.inputs_strategy.make_dummy(
+                        batch_size,
+                        is_decoding=True,
+                        device='cuda',
+                        vocab_size=self.model_config.vocab_size,
+                        max_q_seqlen=query_len,
+                        target_hidden_size=(target_hidden_size
+                                            if query_len > 1 else self.model_config.hidden_size),
+                        target_dtype=self.model_config.dtype,
+                        meta=self.make_dummy_meta)
+                    inputs.spec_step_idx = spec_step_idx
+                    self._build_warmup_dp_meta(inputs)
+                    self._forward_impl(inputs)
+                    torch.cuda.synchronize()
 
     def reset_graph_runner(self):
         """Reset graph runner."""

--- a/lmdeploy/pytorch/strategies/ar_spec/__init__.py
+++ b/lmdeploy/pytorch/strategies/ar_spec/__init__.py
@@ -27,7 +27,12 @@ class ARSpecStrategyFactory(StrategyFactoryBase):
     def build_cudagraph_strategy(self) -> 'CudagraphStrategy':
         """Build cudagraph strategy."""
         from .cudagraph import ARSpecCudagraphStrategy
-        return ARSpecCudagraphStrategy(self.specdecode_config.num_speculative_tokens, self.specdecode_config.method)
+        draft_model_config = self.specdecode_config.model_config
+        architectures = getattr(draft_model_config.hf_config, 'architectures', None) or []
+        return ARSpecCudagraphStrategy(
+            self.specdecode_config.num_speculative_tokens,
+            architectures[0] if architectures else None,
+        )
 
     def build_sampling_strategy(self) -> 'SamplingStrategy':
         """Build sampling strategy."""

--- a/lmdeploy/pytorch/strategies/ar_spec/__init__.py
+++ b/lmdeploy/pytorch/strategies/ar_spec/__init__.py
@@ -27,11 +27,9 @@ class ARSpecStrategyFactory(StrategyFactoryBase):
     def build_cudagraph_strategy(self) -> 'CudagraphStrategy':
         """Build cudagraph strategy."""
         from .cudagraph import ARSpecCudagraphStrategy
-        draft_model_config = self.specdecode_config.model_config
-        architectures = getattr(draft_model_config.hf_config, 'architectures', None) or []
         return ARSpecCudagraphStrategy(
             self.specdecode_config.num_speculative_tokens,
-            architectures[0] if architectures else None,
+            self.specdecode_config.method,
         )
 
     def build_sampling_strategy(self) -> 'SamplingStrategy':

--- a/lmdeploy/pytorch/strategies/ar_spec/cudagraph.py
+++ b/lmdeploy/pytorch/strategies/ar_spec/cudagraph.py
@@ -4,17 +4,17 @@ from ..base.cudagraph import CudagraphStrategy
 
 class ARSpecCudagraphStrategy(CudagraphStrategy):
 
-    def __init__(self, num_spec_tokens: int, draft_arch: str | None = None):
+    def __init__(self, num_spec_tokens: int, method: str):
         super().__init__()
         self.num_spec_tokens = num_spec_tokens
-        self.uniform_query_len = draft_arch == 'MiMoV2FlashMTPModel'
+        self.method = method
 
     def get_max_tokens(self, batch_size: int, origin_batch_size: int, num_tokens: int) -> int:
         """Get max tokens."""
         if num_tokens == origin_batch_size:
             return batch_size
 
-        if self.uniform_query_len:
+        if self.method == 'mimo_mtp':
             if num_tokens % origin_batch_size != 0:
                 raise ValueError('Speculative CUDA Graph requires a uniform query length per batch.')
             query_len = num_tokens // origin_batch_size

--- a/lmdeploy/pytorch/strategies/ar_spec/cudagraph.py
+++ b/lmdeploy/pytorch/strategies/ar_spec/cudagraph.py
@@ -4,19 +4,19 @@ from ..base.cudagraph import CudagraphStrategy
 
 class ARSpecCudagraphStrategy(CudagraphStrategy):
 
-    def __init__(self, num_spec_tokens: int, method: str):
+    def __init__(self, num_spec_tokens: int, draft_arch: str | None = None):
         super().__init__()
         self.num_spec_tokens = num_spec_tokens
-        self.method = method
+        self.uniform_query_len = draft_arch == 'MiMoV2FlashMTPModel'
 
     def get_max_tokens(self, batch_size: int, origin_batch_size: int, num_tokens: int) -> int:
         """Get max tokens."""
         if num_tokens == origin_batch_size:
             return batch_size
 
-        if self.method == 'mimo_mtp':
+        if self.uniform_query_len:
             if num_tokens % origin_batch_size != 0:
-                raise ValueError('MiMo MTP CUDA Graph requires a uniform query length per batch.')
+                raise ValueError('Speculative CUDA Graph requires a uniform query length per batch.')
             query_len = num_tokens // origin_batch_size
             return batch_size * query_len
 

--- a/lmdeploy/pytorch/strategies/ar_spec/cudagraph.py
+++ b/lmdeploy/pytorch/strategies/ar_spec/cudagraph.py
@@ -14,4 +14,10 @@ class ARSpecCudagraphStrategy(CudagraphStrategy):
         if num_tokens == origin_batch_size:
             return batch_size
 
+        if self.method == 'mimo_mtp':
+            if num_tokens % origin_batch_size != 0:
+                raise ValueError('MiMo MTP CUDA Graph requires a uniform query length per batch.')
+            query_len = num_tokens // origin_batch_size
+            return batch_size * query_len
+
         return batch_size * (self.num_spec_tokens + 1)

--- a/lmdeploy/pytorch/weight_loader/model_weight_loader.py
+++ b/lmdeploy/pytorch/weight_loader/model_weight_loader.py
@@ -167,6 +167,13 @@ class ModelWeightLoader:
         """Load model weights implementation."""
         assert hasattr(model, 'load_weights')
         paths = self._shard_paths
+        select_paths = getattr(model, 'select_weight_paths', None)
+        if select_paths is not None:
+            if not callable(select_paths):
+                raise TypeError(f'{type(model).__name__}.select_weight_paths must be callable.')
+            paths = tuple(select_paths(self.model_path, paths))
+            if not paths:
+                raise RuntimeError(f'{type(model).__name__}.select_weight_paths returned no checkpoint files.')
         _, rank = get_world_rank()
         disable_tqdm = rank != 0
 

--- a/lmdeploy/serve/parsers/tool_parser/__init__.py
+++ b/lmdeploy/serve/parsers/tool_parser/__init__.py
@@ -7,6 +7,7 @@ from .interns2preview_tool_parser import InternS2PreviewToolParser
 from .json_tool_parser import JsonToolParser
 from .kimi_k2_tool_parser import KimiK2ToolParser
 from .llama3_tool_parser import Llama3JsonToolParser
+from .mimo_tool_parser import MiMoToolParser
 from .qwen3_tool_parser import Qwen3ToolParser
 from .qwen3coder_tool_parser import Qwen3CoderToolParser
 from .tool_parser import ToolParser, ToolParserManager
@@ -22,6 +23,7 @@ __all__ = [
     'Glm47ToolParser',
     'Internlm2ToolParser',
     'Llama3JsonToolParser',
+    'MiMoToolParser',
     'Qwen3ToolParser',
     'Qwen3CoderToolParser',
     'InternS2PreviewToolParser',

--- a/lmdeploy/serve/parsers/tool_parser/mimo_tool_parser.py
+++ b/lmdeploy/serve/parsers/tool_parser/mimo_tool_parser.py
@@ -19,7 +19,9 @@ class MiMoToolParser(Qwen3CoderToolParser):
     """
 
     strip_value_newlines = False
-    _incomplete_entity = re.compile(r'&(?:#[xX][0-9A-Fa-f]*|#\d*|[A-Za-z][A-Za-z0-9]*)?$')
+    # Keep at most one bounded, potentially incomplete entity between chunks.
+    _incomplete_entity = re.compile(
+        r'&(?:#[xX][0-9A-Fa-f]{0,8}|#\d{0,10}|[A-Za-z][A-Za-z0-9]{0,31})?$')
 
     def __init__(self):
         super().__init__()
@@ -31,7 +33,7 @@ class MiMoToolParser(Qwen3CoderToolParser):
         self._html_entity_suffix = ''
 
     def _stream_string_delta(self, text: str, json_fragments: list[str]) -> None:
-        """Decode complete HTML entities while retaining a split suffix."""
+        """Decode complete entities while retaining a split entity suffix."""
         text = self._html_entity_suffix + text
         self._html_entity_suffix = ''
         match = self._incomplete_entity.search(text)
@@ -42,8 +44,8 @@ class MiMoToolParser(Qwen3CoderToolParser):
             super()._stream_string_delta(html.unescape(text), json_fragments)
 
     def _finish_arg(self, json_fragments: list[str]) -> None:
-        """Flush a trailing entity and finish the active argument."""
-        if self._arg_state.mode == 'streaming' and self._html_entity_suffix:
+        """Flush a trailing entity candidate before closing the value."""
+        if self._html_entity_suffix:
             XmlToolParser._stream_string_delta(
                 self,
                 html.unescape(self._html_entity_suffix),

--- a/lmdeploy/serve/parsers/tool_parser/mimo_tool_parser.py
+++ b/lmdeploy/serve/parsers/tool_parser/mimo_tool_parser.py
@@ -1,0 +1,64 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+from __future__ import annotations
+
+import html
+import re
+from typing import Any
+
+from .qwen3coder_tool_parser import Qwen3CoderToolParser
+from .tool_parser import ToolParserManager
+from .xml_tool_parser import XmlToolParser
+
+
+@ToolParserManager.register_module('mimo')
+class MiMoToolParser(Qwen3CoderToolParser):
+    """Parse MiMo XML tool calls.
+
+    MiMo uses the same function/parameter tags as Qwen3-Coder, but its prompt contract preserves parameter whitespace.
+    HTML entities are decoded before values are converted according to the request's JSON schema.
+    """
+
+    strip_value_newlines = False
+    _incomplete_entity = re.compile(r'&(?:#[xX][0-9A-Fa-f]*|#\d*|[A-Za-z][A-Za-z0-9]*)?$')
+
+    def __init__(self):
+        super().__init__()
+        self._html_entity_suffix = ''
+
+    def _reset_stream_state(self) -> None:
+        """Reset MiMo's cross-chunk HTML entity buffer."""
+        super()._reset_stream_state()
+        self._html_entity_suffix = ''
+
+    def _stream_string_delta(self, text: str, json_fragments: list[str]) -> None:
+        """Decode complete HTML entities while retaining a split suffix."""
+        text = self._html_entity_suffix + text
+        self._html_entity_suffix = ''
+        match = self._incomplete_entity.search(text)
+        if match is not None:
+            self._html_entity_suffix = match.group()
+            text = text[:match.start()]
+        if text:
+            super()._stream_string_delta(html.unescape(text), json_fragments)
+
+    def _finish_arg(self, json_fragments: list[str]) -> None:
+        """Flush a trailing entity and finish the active argument."""
+        if self._arg_state.mode == 'streaming' and self._html_entity_suffix:
+            XmlToolParser._stream_string_delta(
+                self,
+                html.unescape(self._html_entity_suffix),
+                json_fragments,
+            )
+        self._html_entity_suffix = ''
+        super()._finish_arg(json_fragments)
+
+    def _normalize_complete_value(self, raw_value: str) -> str:
+        """Decode entities without stripping MiMo value whitespace."""
+        return html.unescape(super()._normalize_complete_value(raw_value))
+
+    @staticmethod
+    def _coerce_value(raw_value: str, schema_type: str | None) -> Any:
+        """Keep string whitespace and coerce non-string schema values."""
+        if schema_type is None or schema_type == 'string':
+            return raw_value
+        return XmlToolParser._coerce_value(raw_value, schema_type)

--- a/tests/pytorch/kernel/test_fa3_attention.py
+++ b/tests/pytorch/kernel/test_fa3_attention.py
@@ -5,10 +5,12 @@ from types import SimpleNamespace
 import torch
 
 from lmdeploy.messages import QuantPolicy
-from lmdeploy.pytorch.backends.attention import PagedAttentionBuildSpec
+from lmdeploy.pytorch.backends.attention import PagedAttentionBuildSpec, SWAStateRingAttentionBuildSpec
 from lmdeploy.pytorch.backends.cuda.attention import _build_paged_attention
 from lmdeploy.pytorch.backends.cuda.attention.default import TritonAttentionImpl, TritonAttentionMetadata
 from lmdeploy.pytorch.backends.cuda.attention.fa3 import FA3Impl
+from lmdeploy.pytorch.backends.cuda.attention.swa_state_ring import SWAStateRingAttentionImpl
+from lmdeploy.pytorch.backends.cuda.op_backend import CudaOpsBackend
 
 _BLOCK_SIZE = 16
 _PREFILL_SEQLENS = (29, 18)
@@ -41,12 +43,31 @@ def test_attention_builder_falls_back_when_fa3_lacks_asymmetric_head_shape(monke
                 mla_index_topk=None,
                 learnable_sink=False,
                 block_sparse_size=1,
-                allow_fa3=True,
             ))
     finally:
         attention_mod._enable_fa3.cache_clear()
 
     assert type(impl) is TritonAttentionImpl
+
+
+def test_swa_state_ring_uses_dedicated_backend_implementation():
+    spec = SWAStateRingAttentionBuildSpec(
+        num_heads=8,
+        head_dim=192,
+        scale=None,
+        num_kv_heads=2,
+        v_head_dim=128,
+        sliding_window=(127, 0),
+        learnable_sink=True,
+    )
+
+    impl = CudaOpsBackend.build_op(spec)
+
+    assert type(impl) is SWAStateRingAttentionImpl
+    assert impl.supports_multi_token_decode is True
+    assert impl.scale == 1.0 / (192**0.5)
+    assert impl.flash_attention_fwd is None
+    assert impl.paged_attention_fwd is None
 
 
 def _make_prefill_metadata(q_seqlens, block_offsets):

--- a/tests/pytorch/kernel/test_fa3_attention.py
+++ b/tests/pytorch/kernel/test_fa3_attention.py
@@ -1,6 +1,7 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import sys
 from types import SimpleNamespace
+from unittest.mock import Mock
 
 import torch
 
@@ -9,6 +10,7 @@ from lmdeploy.pytorch.backends.attention import PagedAttentionBuildSpec, SWAStat
 from lmdeploy.pytorch.backends.cuda.attention import _build_paged_attention
 from lmdeploy.pytorch.backends.cuda.attention.default import TritonAttentionImpl, TritonAttentionMetadata
 from lmdeploy.pytorch.backends.cuda.attention.fa3 import FA3Impl
+from lmdeploy.pytorch.backends.cuda.attention.fa3_capabilities import fa3_build_supports_operation
 from lmdeploy.pytorch.backends.cuda.attention.swa_state_ring import SWAStateRingAttentionImpl
 from lmdeploy.pytorch.backends.cuda.op_backend import CudaOpsBackend
 
@@ -26,28 +28,95 @@ def test_attention_builder_falls_back_when_fa3_lacks_asymmetric_head_shape(monke
     }
     monkeypatch.setitem(sys.modules, 'flash_attn_config', SimpleNamespace(CONFIG={'build_flags': flags}))
     monkeypatch.setattr(attention_mod, 'use_fa3_warning', lambda: True)
-    attention_mod._enable_fa3.cache_clear()
-    try:
-        impl = _build_paged_attention(
-            PagedAttentionBuildSpec(
-                num_heads=8,
-                head_dim=192,
-                scale=None,
-                num_kv_heads=2,
-                v_head_dim=128,
-                alibi=False,
-                sliding_window=None,
-                logit_softcapping=0.0,
-                causal=True,
-                use_flash_mla=False,
-                mla_index_topk=None,
-                learnable_sink=False,
-                block_sparse_size=1,
-            ))
-    finally:
-        attention_mod._enable_fa3.cache_clear()
+    monkeypatch.setattr(torch.cuda, 'get_device_capability', lambda: (9, 0))
+    impl = _build_paged_attention(
+        PagedAttentionBuildSpec(
+            num_heads=8,
+            head_dim=192,
+            scale=None,
+            num_kv_heads=2,
+            v_head_dim=128,
+            alibi=False,
+            sliding_window=None,
+            logit_softcapping=0.0,
+            causal=True,
+            use_flash_mla=False,
+            mla_index_topk=None,
+            learnable_sink=False,
+            block_sparse_size=1,
+        ))
 
     assert type(impl) is TritonAttentionImpl
+
+
+def test_fa3_operation_capability_checks_arch_and_build_features(monkeypatch):
+    flags = {
+        'FLASHATTENTION_DISABLE_HDIM128': False,
+        'FLASHATTENTION_DISABLE_HDIM192': False,
+        'FLASH_ATTENTION_DISABLE_HDIMDIFF192': False,
+    }
+    monkeypatch.setitem(sys.modules, 'flash_attn_config', SimpleNamespace(CONFIG={'build_flags': flags}))
+
+    assert not fa3_build_supports_operation(
+        192,
+        128,
+        device_capability=(8, 0),
+        dtype=torch.bfloat16,
+        paged_kv=True,
+        varlen=True,
+    )
+    assert fa3_build_supports_operation(
+        192,
+        128,
+        device_capability=(9, 0),
+        dtype=torch.bfloat16,
+        paged_kv=True,
+        varlen=True,
+    )
+
+    requirements = {
+        'FLASHATTENTION_DISABLE_PAGEDKV': dict(paged_kv=True),
+        'FLASHATTENTION_DISABLE_VARLEN': dict(varlen=True),
+        'FLASHATTENTION_DISABLE_LOCAL': dict(local=True),
+        'FLASHATTENTION_DISABLE_SOFTCAP': dict(softcap=True),
+        'FLASHATTENTION_DISABLE_FP16': dict(dtype=torch.float16),
+    }
+    for flag, requirement in requirements.items():
+        flags[flag] = True
+        assert not fa3_build_supports_operation(
+            128,
+            128,
+            device_capability=(9, 0),
+            **requirement,
+        )
+        flags[flag] = False
+
+
+def test_legacy_spec_metadata_skips_fa3_when_fallback_is_selected(monkeypatch):
+    """Triton fallback must not retain a hidden FA3 metadata dependency."""
+    import lmdeploy.pytorch.backends.cuda.attention as attention_mod
+
+    update_meta = Mock()
+    monkeypatch.setattr(attention_mod, '_enable_fa3', lambda *args, **kwargs: False)
+    monkeypatch.setattr(CudaOpsBackend, 'update_meta_flashattn', update_meta)
+    step_context = SimpleNamespace(
+        is_decoding=True,
+        q_seqlens=torch.tensor([2]),
+        input_ids=torch.zeros((1, 2), dtype=torch.long),
+        model_config=SimpleNamespace(
+            use_flash_mla=False,
+            model_paradigm='ar_spec',
+            head_dim=192,
+            v_head_dim=128,
+            sliding_window=None,
+            dtype=torch.bfloat16,
+            is_gated_delta=False,
+        ),
+    )
+
+    metadata = object()
+    assert CudaOpsBackend._legacy_update_step_context(step_context, metadata) is metadata
+    update_meta.assert_not_called()
 
 
 def test_swa_state_ring_uses_dedicated_backend_implementation():
@@ -198,7 +267,7 @@ def test_fa3_prefill_uses_guarded_flatten_buffer_and_max_kv_seqlen():
     assert captured['flash_softcap'] == 0.0
 
 
-def test_fa3_speculative_decode_uses_normalized_disabled_softcap():
+def test_fa3_multi_token_decode_uses_mode_and_normalized_softcap():
     impl = FA3Impl.__new__(FA3Impl)
     impl.scale = 1.0
     impl.causal = True
@@ -211,6 +280,7 @@ def test_fa3_speculative_decode_uses_normalized_disabled_softcap():
 
     def fake_flash_attn_with_kvcache(query, k_cache, v_cache, **kwargs):
         captured['softcap'] = kwargs['softcap']
+        captured['causal'] = kwargs['causal']
         return torch.empty_like(query)
 
     impl.flash_attn_with_kvcache_v3 = fake_flash_attn_with_kvcache
@@ -225,7 +295,50 @@ def test_fa3_speculative_decode_uses_normalized_disabled_softcap():
     k_cache = torch.empty((2, _BLOCK_SIZE, 2, 8), dtype=torch.float16)
     v_cache = torch.empty_like(k_cache)
 
-    output = impl._decoding_speculative(query, k_cache, v_cache, metadata, max_q_seqlen=2)
+    for decode_mode, expected_causal in (('block', False), ('speculative', True)):
+        output = impl._decoding_speculative(
+            query,
+            k_cache,
+            v_cache,
+            metadata,
+            max_q_seqlen=2,
+            decode_mode=decode_mode,
+        )
 
-    assert output.shape == (2, 2, 2, 8)
-    assert captured['softcap'] == 0.0
+        assert output.shape == (2, 2, 2, 8)
+        assert captured['softcap'] == 0.0
+        assert captured['causal'] is expected_causal
+
+
+def test_fa3_scheduler_metadata_uses_decode_mode(monkeypatch):
+    from lmdeploy.pytorch.backends.cuda.attention import fa3 as fa3_module
+
+    causal_values = []
+
+    def fake_get_meta_flashattn(**kwargs):
+        causal_values.append(kwargs['causal'])
+        return torch.empty(1)
+
+    monkeypatch.setattr(fa3_module, '_get_meta_flashattn', fake_get_meta_flashattn)
+    step_context = SimpleNamespace(
+        decode_mode='block',
+        input_ids=torch.zeros((1, 2), dtype=torch.long),
+        model_config=SimpleNamespace(block_size=16, dtype=torch.bfloat16),
+    )
+    kwargs = dict(
+        batch_size=1,
+        kv_seqlens=torch.tensor([2]),
+        block_offsets=torch.tensor([[0]], dtype=torch.int32),
+        step_context=step_context,
+        num_heads_q=2,
+        num_heads_kv=1,
+        head_size=128,
+        v_head_size=128,
+        sliding_window=None,
+    )
+
+    fa3_module._build_fa3_metadata(**kwargs)
+    step_context.decode_mode = 'speculative'
+    fa3_module._build_fa3_metadata(**kwargs)
+
+    assert causal_values == [False, True]

--- a/tests/pytorch/kernel/test_fa3_attention.py
+++ b/tests/pytorch/kernel/test_fa3_attention.py
@@ -5,11 +5,31 @@ from types import SimpleNamespace
 import torch
 
 from lmdeploy.messages import QuantPolicy
-from lmdeploy.pytorch.backends.cuda.attention.default import TritonAttentionMetadata
+from lmdeploy.pytorch.backends.cuda.attention import TritonAttentionBuilder
+from lmdeploy.pytorch.backends.cuda.attention.default import TritonAttentionImpl, TritonAttentionMetadata
 from lmdeploy.pytorch.backends.cuda.attention.fa3 import FA3Impl
 
 _BLOCK_SIZE = 16
 _PREFILL_SEQLENS = (29, 18)
+
+
+def test_attention_builder_falls_back_when_fa3_lacks_asymmetric_head_shape(monkeypatch):
+    """Avoid dispatching a head shape omitted from the installed FA3 wheel."""
+    import lmdeploy.pytorch.backends.cuda.attention as attention_mod
+
+    flags = {
+        'FLASHATTENTION_DISABLE_HDIM192': False,
+        'FLASH_ATTENTION_DISABLE_HDIMDIFF192': True,
+    }
+    monkeypatch.setitem(sys.modules, 'flash_attn_config', SimpleNamespace(CONFIG={'build_flags': flags}))
+    monkeypatch.setattr(attention_mod, 'use_fa3_warning', lambda: True)
+    attention_mod._enable_fa3.cache_clear()
+    try:
+        impl = TritonAttentionBuilder.build(num_heads=8, head_size=192, num_kv_heads=2, v_head_size=128)
+    finally:
+        attention_mod._enable_fa3.cache_clear()
+
+    assert type(impl) is TritonAttentionImpl
 
 
 def _make_prefill_metadata(q_seqlens, block_offsets):

--- a/tests/pytorch/kernel/test_fa3_attention.py
+++ b/tests/pytorch/kernel/test_fa3_attention.py
@@ -70,6 +70,42 @@ def test_swa_state_ring_uses_dedicated_backend_implementation():
     assert impl.paged_attention_fwd is None
 
 
+def test_paged_attention_spec_requires_native_multi_token_decode(monkeypatch):
+    from lmdeploy.pytorch.backends.attention import PagedAttentionBuildSpec
+    from lmdeploy.pytorch.backends.cuda.op_backend import CudaOpsBackend
+    from lmdeploy.pytorch.model_inputs import StepContextManager, set_step_ctx_manager
+
+    ctx = StepContextManager(SimpleNamespace(
+        model_paradigm='ar_spec',
+        use_flash_mla=False,
+        num_spec_tokens=2,
+        enable_return_routed_experts=False,
+        max_batch_size=1,
+    ))
+    monkeypatch.setattr('lmdeploy.pytorch.backends.cuda.attention.require_fa3_for_speculative_decoding',
+                        lambda: None)
+    monkeypatch.setattr('lmdeploy.pytorch.model_inputs.get_step_ctx_manager', lambda: ctx)
+
+    spec = PagedAttentionBuildSpec(
+        num_heads=8,
+        head_dim=192,
+        scale=None,
+        num_kv_heads=2,
+        v_head_dim=128,
+        alibi=False,
+        sliding_window=(127, 0),
+        logit_softcapping=0.0,
+        causal=True,
+        use_flash_mla=False,
+        mla_index_topk=None,
+        learnable_sink=True,
+        block_sparse_size=1,
+    )
+
+    assert spec.requires_multi_token_decode is True
+    assert CudaOpsBackend.build_op(spec) is not None
+
+
 def _make_prefill_metadata(q_seqlens, block_offsets):
     cu_seqlens = torch.nn.functional.pad(torch.cumsum(q_seqlens, dim=0, dtype=torch.int32), (1, 0))
     return TritonAttentionMetadata(

--- a/tests/pytorch/kernel/test_fa3_attention.py
+++ b/tests/pytorch/kernel/test_fa3_attention.py
@@ -5,7 +5,8 @@ from types import SimpleNamespace
 import torch
 
 from lmdeploy.messages import QuantPolicy
-from lmdeploy.pytorch.backends.cuda.attention import TritonAttentionBuilder
+from lmdeploy.pytorch.backends.attention import PagedAttentionBuildSpec
+from lmdeploy.pytorch.backends.cuda.attention import _build_paged_attention
 from lmdeploy.pytorch.backends.cuda.attention.default import TritonAttentionImpl, TritonAttentionMetadata
 from lmdeploy.pytorch.backends.cuda.attention.fa3 import FA3Impl
 
@@ -25,7 +26,23 @@ def test_attention_builder_falls_back_when_fa3_lacks_asymmetric_head_shape(monke
     monkeypatch.setattr(attention_mod, 'use_fa3_warning', lambda: True)
     attention_mod._enable_fa3.cache_clear()
     try:
-        impl = TritonAttentionBuilder.build(num_heads=8, head_size=192, num_kv_heads=2, v_head_size=128)
+        impl = _build_paged_attention(
+            PagedAttentionBuildSpec(
+                num_heads=8,
+                head_dim=192,
+                scale=None,
+                num_kv_heads=2,
+                v_head_dim=128,
+                alibi=False,
+                sliding_window=None,
+                logit_softcapping=0.0,
+                causal=True,
+                use_flash_mla=False,
+                mla_index_topk=None,
+                learnable_sink=False,
+                block_sparse_size=1,
+                allow_fa3=True,
+            ))
     finally:
         attention_mod._enable_fa3.cache_clear()
 

--- a/tests/pytorch/kernel/test_fa3_attention.py
+++ b/tests/pytorch/kernel/test_fa3_attention.py
@@ -70,22 +70,9 @@ def test_swa_state_ring_uses_dedicated_backend_implementation():
     assert impl.paged_attention_fwd is None
 
 
-def test_paged_attention_spec_requires_native_multi_token_decode(monkeypatch):
+def test_paged_attention_build_spec_is_pure_configuration():
     from lmdeploy.pytorch.backends.attention import PagedAttentionBuildSpec
     from lmdeploy.pytorch.backends.cuda.op_backend import CudaOpsBackend
-    from lmdeploy.pytorch.model_inputs import StepContextManager, set_step_ctx_manager
-
-    ctx = StepContextManager(SimpleNamespace(
-        model_paradigm='ar_spec',
-        use_flash_mla=False,
-        num_spec_tokens=2,
-        enable_return_routed_experts=False,
-        max_batch_size=1,
-    ))
-    monkeypatch.setattr('lmdeploy.pytorch.backends.cuda.attention.require_fa3_for_speculative_decoding',
-                        lambda: None)
-    monkeypatch.setattr('lmdeploy.pytorch.model_inputs.get_step_ctx_manager', lambda: ctx)
-
     spec = PagedAttentionBuildSpec(
         num_heads=8,
         head_dim=192,
@@ -102,7 +89,7 @@ def test_paged_attention_spec_requires_native_multi_token_decode(monkeypatch):
         block_sparse_size=1,
     )
 
-    assert spec.requires_multi_token_decode is True
+    assert not hasattr(spec, 'requires_multi_token_decode')
     assert CudaOpsBackend.build_op(spec) is not None
 
 

--- a/tests/pytorch/kernel/test_flash_attention.py
+++ b/tests/pytorch/kernel/test_flash_attention.py
@@ -115,35 +115,37 @@ def _naive_attention(batched_q, batched_kv, bias, sinks=None):
 
 
 def _naive_window_attention(q, k, v, seqlens_q, seqlens_k, window_size):
-    try:
-        from lmdeploy.pytorch.third_party.flash_attn_interface import flash_attn_varlen_func
-    except Exception:
-        try:
-            from flash_attn import flash_attn_varlen_func
-        except Exception:
-            pytest.skip('Skip window attention test since flash attention is not available.')
+    window_left, window_right = window_size
+    group = q.shape[1] // k.shape[1]
+    if group != 1:
+        k = k.repeat_interleave(group, dim=1)
+        v = v.repeat_interleave(group, dim=1)
 
-    def _make_cu_seqlens(seqlens):
-        cu_seqlens = seqlens.cumsum(0)
-        cu_zero = cu_seqlens.new_zeros(1)
-        cu_seqlens = torch.cat([cu_zero, cu_seqlens])
-        return cu_seqlens
+    scale = q.shape[-1]**-0.5
+    outputs = []
+    q_offset = 0
+    k_offset = 0
+    for q_len, kv_len in zip(seqlens_q.tolist(), seqlens_k.tolist()):
+        query = q[q_offset:q_offset + q_len]
+        key = k[k_offset:k_offset + kv_len]
+        value = v[k_offset:k_offset + kv_len]
+        q_offset += q_len
+        k_offset += kv_len
 
-    max_seqlen_q = seqlens_q.max().item()
-    max_seqlen_k = seqlens_k.max().item()
-    cu_seqlens_q = _make_cu_seqlens(seqlens_q).int()
-    cu_seqlens_k = _make_cu_seqlens(seqlens_k).int()
+        logits = query.transpose(0, 1).float() @ key.permute(1, 2, 0).float() * scale
+        query_pos = torch.arange(q_len, device=q.device) + kv_len - q_len
+        key_pos = torch.arange(kv_len, device=q.device)
+        window_mask = key_pos <= query_pos[:, None]
+        if window_left >= 0:
+            window_mask &= key_pos >= query_pos[:, None] - window_left
+        if window_right >= 0:
+            window_mask &= key_pos <= query_pos[:, None] + window_right
+        logits = logits.masked_fill(~window_mask[None], float('-inf'))
+        attn_weight = torch.softmax(logits, dim=-1, dtype=torch.float32)
+        output = attn_weight @ value.transpose(0, 1).float()
+        outputs.append(output.transpose(0, 1).to(v.dtype))
 
-    output = flash_attn_varlen_func(q,
-                                    k,
-                                    v,
-                                    cu_seqlens_q,
-                                    cu_seqlens_k,
-                                    max_seqlen_q=max_seqlen_q,
-                                    max_seqlen_k=max_seqlen_k,
-                                    causal=True,
-                                    window_size=window_size)
-    return output
+    return torch.cat(outputs, dim=0)
 
 
 def test_flash_attention_asymmetric_head_matches_reference():

--- a/tests/pytorch/kernel/test_flash_attention.py
+++ b/tests/pytorch/kernel/test_flash_attention.py
@@ -146,6 +146,46 @@ def _naive_window_attention(q, k, v, seqlens_q, seqlens_k, window_size):
     return output
 
 
+def test_flash_attention_asymmetric_head_matches_reference():
+    """Run the split-D head shape that previously exceeded SM90 resources."""
+    from lmdeploy.pytorch.kernels.cuda.flashattention import flash_attn_varlen_func
+
+    head_dim_k, head_dim_v = 192, 128
+    torch.manual_seed(123)
+    dtype = torch.float16
+    device = 'cuda'
+    num_heads_q = 4
+    num_heads_kv = 2
+    q_seqlens = torch.tensor([7, 11], dtype=torch.int32, device=device)
+    history_lens = torch.tensor([5, 3], dtype=torch.int32, device=device)
+    kv_seqlens = q_seqlens + history_lens
+
+    q = torch.rand(2, 11, num_heads_q, head_dim_k, dtype=dtype, device=device)
+    k = torch.rand(2, 14, num_heads_kv, head_dim_k, dtype=dtype, device=device)
+    v = torch.rand(2, 14, num_heads_kv, head_dim_v, dtype=dtype, device=device)
+    bias = _make_bias(q_seqlens, history_lens, -1e30, causal=True)
+    expected = _conti_input(_naive_attention(q, (k, v), bias), q_seqlens)
+
+    packed_q = _conti_input(q, q_seqlens)
+    packed_k = _conti_input(k, kv_seqlens).transpose(0, 1).contiguous()
+    packed_v = _conti_input(v, kv_seqlens).transpose(0, 1).contiguous()
+    cu_seqlens_q = torch.nn.functional.pad(q_seqlens.cumsum(0), (1, 0))
+    cu_seqlens_k = torch.nn.functional.pad(kv_seqlens.cumsum(0), (1, 0))
+
+    actual = flash_attn_varlen_func(
+        packed_q,
+        packed_k,
+        packed_v,
+        cu_seqlens_q=cu_seqlens_q,
+        cu_seqlens_k=cu_seqlens_k,
+        max_seqlen_q=int(q_seqlens.max().item()),
+        max_seqlen_k=int(kv_seqlens.max().item()),
+        causal=True,
+    )
+
+    torch.testing.assert_close(actual, expected, atol=2e-3, rtol=2e-3)
+
+
 class TestFlashAttention:
 
     @pytest.fixture

--- a/tests/pytorch/kernel/test_mla_attention.py
+++ b/tests/pytorch/kernel/test_mla_attention.py
@@ -245,6 +245,18 @@ def test_bf16_sparse_decode_skips_fp8_flashmla_metadata():
     assert not hasattr(metadata, 'tile_scheduler_metadata')
 
 
+def test_attention_preserves_flashmla_metadata_adapter(monkeypatch):
+    from lmdeploy.pytorch.nn import attention as attention_module
+
+    backend = Mock()
+    metadata = object()
+    monkeypatch.setattr(attention_module, 'get_backend', lambda: backend)
+
+    attention_module.Attention.update_meta_flashmla(metadata, 16)
+
+    backend.update_meta_flashmla.assert_called_once_with(metadata, 16)
+
+
 def test_bf16_mla_flatten_uses_shared_k_latent_as_value():
     impl = object.__new__(mla_module.FlashMLAImpl)
     impl.v_head_size = 512

--- a/tests/pytorch/kernel/test_mla_attention.py
+++ b/tests/pytorch/kernel/test_mla_attention.py
@@ -51,6 +51,10 @@ def test_flash_mla_build_spec_selects_sparse_impl(monkeypatch):
         PagedAttentionBuildSpec(mla_index_topk=2048, **spec_kwargs)) is sparse_output
     assert sparse_impl.call_args.kwargs['use_fa3'] is True
 
+    assert CudaOpsBackend.build_op(
+        PagedAttentionBuildSpec(mla_index_topk=2048, allow_fa3=False, **spec_kwargs)) is sparse_output
+    assert sparse_impl.call_args.kwargs['use_fa3'] is False
+
 
 def test_builder_selects_tilelang_sparse_impl_from_env(monkeypatch):
     output = object()

--- a/tests/pytorch/kernel/test_mla_attention.py
+++ b/tests/pytorch/kernel/test_mla_attention.py
@@ -52,8 +52,8 @@ def test_flash_mla_build_spec_selects_sparse_impl(monkeypatch):
     assert sparse_impl.call_args.kwargs['use_fa3'] is True
 
     assert CudaOpsBackend.build_op(
-        PagedAttentionBuildSpec(mla_index_topk=2048, allow_fa3=False, **spec_kwargs)) is sparse_output
-    assert sparse_impl.call_args.kwargs['use_fa3'] is False
+        PagedAttentionBuildSpec(mla_index_topk=2048, **spec_kwargs)) is sparse_output
+    assert sparse_impl.call_args.kwargs['use_fa3'] is True
 
 
 def test_builder_selects_tilelang_sparse_impl_from_env(monkeypatch):

--- a/tests/pytorch/kernel/test_paged_attention.py
+++ b/tests/pytorch/kernel/test_paged_attention.py
@@ -424,7 +424,8 @@ class TestPagedAttention(TestPagedAttentionBase):
         impl.bind_step_meta_group(1)
         output = impl.forward(
             queries.flatten(0, 1), None, None, k_cache, v_cache, metadata,
-            learnable_sink=sinks).unflatten(0, (batch_size, query_len))
+            learnable_sink=sinks,
+            decode_mode='speculative').unflatten(0, (batch_size, query_len))
 
         reference = torch.empty_like(output)
         scale = head_size**-0.5
@@ -449,7 +450,7 @@ class TestPagedAttention(TestPagedAttentionBase):
             with torch.cuda.graph(graph):
                 graph_output = impl.forward(
                     queries.flatten(0, 1), None, None, k_cache, v_cache,
-                    metadata, learnable_sink=sinks)
+                    metadata, learnable_sink=sinks, decode_mode='speculative')
             queries.add_(0.125)
             kv_seqlens.sub_(3)
             graph.replay()
@@ -470,6 +471,7 @@ class TestPagedAttention(TestPagedAttentionBase):
                                                   blocked_kv, block_offsets,
                                                   kv_seqlens, layout, conti_gt):
         """Empty split-K partitions must not contribute stale values."""
+
         from lmdeploy.pytorch.kernels.cuda import pagedattention
 
         monkeypatch.setattr(pagedattention, '_get_split_k', lambda *args: 128)
@@ -483,6 +485,22 @@ class TestPagedAttention(TestPagedAttentionBase):
             kv_layout=layout,
         )
         torch.testing.assert_close(out, conti_gt, atol=1e-3, rtol=1e-5)
+
+    def test_decode_mode_selects_causal_speculative_mask(self):
+        """Triton decode keeps SDAR block masks unless spec opts in."""
+        from lmdeploy.pytorch.backends.cuda.attention.default import TritonAttentionImpl
+
+        impl = TritonAttentionImpl(num_heads=1, head_size=8)
+        captured_kwargs = {}
+
+        def fake_paged_attention(*args, **kwargs):
+            captured_kwargs.update(kwargs)
+            return args[0]
+
+        impl.paged_attention_fwd = fake_paged_attention
+
+        assert impl.decode_mode_uses_causal_mask('block') is False
+        assert impl.decode_mode_uses_causal_mask('speculative') is True
 
     @pytest.mark.parametrize('feat_dim', [16], indirect=True)
     @pytest.mark.parametrize('feat_dim_v', [16], indirect=True)

--- a/tests/pytorch/kernel/test_paged_attention.py
+++ b/tests/pytorch/kernel/test_paged_attention.py
@@ -294,6 +294,20 @@ class TestPagedAttentionBase:
     def conti_gt(self, gt, seq_lens):
         yield _conti_input(gt, seq_lens)
 
+    @pytest.fixture
+    def win_size(self, request):
+        yield request.param
+
+    @pytest.fixture
+    def window_gt(self, conti_q, conti_kv, seq_lens, history_lens, win_size):
+        kv_lens = seq_lens + history_lens
+        yield _naive_window_attention(conti_q,
+                                      conti_kv[0],
+                                      conti_kv[1],
+                                      seq_lens,
+                                      kv_lens,
+                                      window_size=(win_size, win_size))
+
 
 class TestPagedAttention(TestPagedAttentionBase):
 
@@ -315,19 +329,161 @@ class TestPagedAttention(TestPagedAttentionBase):
                                       kv_layout=layout)
         torch.testing.assert_close(out, conti_gt, atol=1e-3, rtol=1e-5)
 
-    @pytest.fixture
-    def win_size(self, request):
-        yield request.param
+    @pytest.mark.parametrize(
+        ('window_size', 'use_sinks'),
+        [(None, False), ((127, 0), True)],
+    )
+    def test_causal_multi_token_with_shared_prefix(self, window_size, use_sinks):
+        """Multi-token attention reads causal full/windowed KV from shared
+        pages."""
+        from lmdeploy.pytorch.backends.cuda.attention.default import (
+            TritonAttentionImpl,
+            TritonAttentionMetadata,
+        )
+        from lmdeploy.pytorch.kernels.cuda import flash_attn_with_kvcache
 
-    @pytest.fixture
-    def window_gt(self, conti_q, conti_kv, seq_lens, history_lens, win_size):
-        kv_lens = seq_lens + history_lens
-        yield _naive_window_attention(conti_q,
-                                      conti_kv[0],
-                                      conti_kv[1],
-                                      seq_lens,
-                                      kv_lens,
-                                      window_size=(win_size, win_size))
+        torch.manual_seed(123)
+        device = 'cuda'
+        dtype = torch.bfloat16
+        batch_size, query_len = 2, 4
+        num_q_heads, num_kv_heads = 8, 1
+        head_size, value_head_size, block_size = 192, 128, 16
+        history_lens = torch.tensor([141, 155], device=device)
+        kv_seqlens = history_lens + query_len
+        max_blocks = int((kv_seqlens.max().item() + block_size - 1) // block_size)
+
+        queries = torch.randn(
+            batch_size, query_len, num_q_heads, head_size, device=device, dtype=dtype
+        )
+        keys = [
+            torch.randn(int(length), num_kv_heads, head_size, device=device, dtype=dtype)
+            for length in kv_seqlens
+        ]
+        values = [
+            torch.randn(int(length), num_kv_heads, value_head_size, device=device, dtype=dtype)
+            for length in kv_seqlens
+        ]
+        # Model a real prefix-cache hit: both requests reference the same first
+        # physical page and therefore have identical KV for that prefix.
+        keys[1][:block_size].copy_(keys[0][:block_size])
+        values[1][:block_size].copy_(values[0][:block_size])
+
+        page_table = torch.zeros(batch_size, max_blocks, dtype=torch.long, device=device)
+        page_table[:, 0] = 0
+        next_page = 1
+        for batch_id, length in enumerate(kv_seqlens.tolist()):
+            num_blocks = (length + block_size - 1) // block_size
+            page_table[batch_id, 1:num_blocks] = torch.arange(
+                next_page, next_page + num_blocks - 1, device=device
+            )
+            next_page += num_blocks - 1
+
+        k_cache = torch.zeros(next_page, block_size, num_kv_heads, head_size, device=device, dtype=dtype)
+        v_cache = torch.zeros(
+            next_page, block_size, num_kv_heads, value_head_size, device=device, dtype=dtype
+        )
+        for batch_id, length in enumerate(kv_seqlens.tolist()):
+            for logical_block in range((length + block_size - 1) // block_size):
+                physical_block = int(page_table[batch_id, logical_block])
+                start = logical_block * block_size
+                end = min(start + block_size, length)
+                k_cache[physical_block, :end - start].copy_(keys[batch_id][start:end])
+                v_cache[physical_block, :end - start].copy_(values[batch_id][start:end])
+
+        sinks = (
+            torch.randn(num_q_heads, device=device, dtype=dtype)
+            if use_sinks
+            else None
+        )
+        cu_seqlens_q = torch.arange(
+            0, (batch_size + 1) * query_len, query_len,
+            dtype=torch.int32, device=device)
+        kernel_metadata = TritonAttentionMetadata(
+            is_decoding=True,
+            block_offsets=page_table,
+            q_start_loc=cu_seqlens_q[:-1],
+            q_seqlens=torch.full(
+                (batch_size, ), query_len, dtype=torch.int32, device=device),
+            kv_seqlens=kv_seqlens,
+            cu_seqlens_q=cu_seqlens_q,
+        )
+        # The outer metadata intentionally describes a different route. The
+        # bound group metadata must be authoritative for this implementation.
+        metadata = TritonAttentionMetadata(
+            is_decoding=False,
+            block_offsets=torch.zeros_like(page_table),
+            kernel_metadata=(None, kernel_metadata),
+        )
+        impl = TritonAttentionImpl(
+            num_heads=num_q_heads,
+            head_size=head_size,
+            num_kv_heads=num_kv_heads,
+            v_head_size=value_head_size,
+            sliding_window=window_size,
+            enable_paged_multi_token_decode=True,
+        )
+        impl.bind_step_meta_group(1)
+        output = impl.forward(
+            queries.flatten(0, 1), None, None, k_cache, v_cache, metadata,
+            learnable_sink=sinks).unflatten(0, (batch_size, query_len))
+
+        reference = torch.empty_like(output)
+        scale = head_size**-0.5
+        for batch_id in range(batch_size):
+            for query_id in range(query_len):
+                query_pos = int(history_lens[batch_id]) + query_id
+                start = 0 if window_size is None else max(query_pos - window_size[0], 0)
+                key = keys[batch_id][start:query_pos + 1, 0].float()
+                value = values[batch_id][start:query_pos + 1, 0].float()
+                logits = queries[batch_id, query_id].float() @ key.T * scale
+                if sinks is not None:
+                    logits = torch.cat((logits, sinks[:, None].float()), dim=-1)
+                probs = logits.softmax(dim=-1)
+                if sinks is not None:
+                    probs = probs[:, :-1]
+                reference[batch_id, query_id] = (probs @ value).to(dtype)
+
+        torch.testing.assert_close(output, reference, atol=2e-2, rtol=2e-2)
+
+        if use_sinks:
+            graph = torch.cuda.CUDAGraph()
+            with torch.cuda.graph(graph):
+                graph_output = impl.forward(
+                    queries.flatten(0, 1), None, None, k_cache, v_cache,
+                    metadata, learnable_sink=sinks)
+            queries.add_(0.125)
+            kv_seqlens.sub_(3)
+            graph.replay()
+            replay_reference = flash_attn_with_kvcache(
+                queries.flatten(0, 1), k_cache, v_cache,
+                cache_seqlens=kv_seqlens, page_table=page_table,
+                max_seqlen_q=query_len, window_size=window_size,
+                sinks=sinks, causal_multi_token=True)
+            torch.testing.assert_close(graph_output, replay_reference, atol=2e-2, rtol=2e-2)
+
+    @pytest.mark.parametrize('feat_dim', [192], indirect=True)
+    @pytest.mark.parametrize('feat_dim_v', [128], indirect=True)
+    @pytest.mark.parametrize(['num_heads_q', 'num_heads_k'], [(16, 1)], indirect=True)
+    @pytest.mark.parametrize('history_lens', [(1370, )], indirect=True)
+    @pytest.mark.parametrize('block_size', [64], indirect=True)
+    @pytest.mark.parametrize('layout', ['bshd'], indirect=True)
+    def test_empty_split_k_partitions_are_neutral(self, monkeypatch, conti_q,
+                                                  blocked_kv, block_offsets,
+                                                  kv_seqlens, layout, conti_gt):
+        """Empty split-K partitions must not contribute stale values."""
+        from lmdeploy.pytorch.kernels.cuda import pagedattention
+
+        monkeypatch.setattr(pagedattention, '_get_split_k', lambda *args: 128)
+        blocked_k, blocked_v = blocked_kv
+        out = pagedattention.flash_attn_with_kvcache(
+            conti_q,
+            blocked_k,
+            blocked_v,
+            page_table=block_offsets,
+            cache_seqlens=kv_seqlens,
+            kv_layout=layout,
+        )
+        torch.testing.assert_close(out, conti_gt, atol=1e-3, rtol=1e-5)
 
     @pytest.mark.parametrize('feat_dim', [16], indirect=True)
     @pytest.mark.parametrize('feat_dim_v', [16], indirect=True)
@@ -519,7 +675,7 @@ def _make_blocked_cache_fp8_scalar(batched_k, batched_v, seq_lens, history_lens,
     return blocked_k, blocked_v, k_scale, v_scale, dequant_k, dequant_v
 
 
-class TestPagedAttentionInt8(TestPagedAttention):
+class TestPagedAttentionInt8(TestPagedAttentionBase):
 
     @pytest.fixture
     def nbits(self):

--- a/tests/pytorch/kernel/test_paged_attention.py
+++ b/tests/pytorch/kernel/test_paged_attention.py
@@ -154,35 +154,37 @@ def _naive_attention(batched_q, batched_kv, bias, sinks=None):
 
 
 def _naive_window_attention(q, k, v, seqlens_q, seqlens_k, window_size):
-    try:
-        from lmdeploy.pytorch.third_party.flash_attn_interface import flash_attn_varlen_func
-    except Exception:
-        try:
-            from flash_attn import flash_attn_varlen_func
-        except Exception:
-            pytest.skip('Skip window attention test since flash attention is not available.')
+    window_left, window_right = window_size
+    group = q.shape[1] // k.shape[1]
+    if group != 1:
+        k = k.repeat_interleave(group, dim=1)
+        v = v.repeat_interleave(group, dim=1)
 
-    def _make_cu_seqlens(seqlens):
-        cu_seqlens = seqlens.cumsum(0)
-        cu_zero = cu_seqlens.new_zeros(1)
-        cu_seqlens = torch.cat([cu_zero, cu_seqlens])
-        return cu_seqlens
+    scale = q.shape[-1]**-0.5
+    outputs = []
+    q_offset = 0
+    k_offset = 0
+    for q_len, kv_len in zip(seqlens_q.tolist(), seqlens_k.tolist()):
+        query = q[q_offset:q_offset + q_len]
+        key = k[k_offset:k_offset + kv_len]
+        value = v[k_offset:k_offset + kv_len]
+        q_offset += q_len
+        k_offset += kv_len
 
-    max_seqlen_q = seqlens_q.max().item()
-    max_seqlen_k = seqlens_k.max().item()
-    cu_seqlens_q = _make_cu_seqlens(seqlens_q).int()
-    cu_seqlens_k = _make_cu_seqlens(seqlens_k).int()
+        logits = query.transpose(0, 1).float() @ key.permute(1, 2, 0).float() * scale
+        query_pos = torch.arange(q_len, device=q.device) + kv_len - q_len
+        key_pos = torch.arange(kv_len, device=q.device)
+        window_mask = key_pos <= query_pos[:, None]
+        if window_left >= 0:
+            window_mask &= key_pos >= query_pos[:, None] - window_left
+        if window_right >= 0:
+            window_mask &= key_pos <= query_pos[:, None] + window_right
+        logits = logits.masked_fill(~window_mask[None], float('-inf'))
+        attn_weight = torch.softmax(logits, dim=-1, dtype=torch.float32)
+        output = attn_weight @ value.transpose(0, 1).float()
+        outputs.append(output.transpose(0, 1).to(v.dtype))
 
-    output = flash_attn_varlen_func(q,
-                                    k,
-                                    v,
-                                    cu_seqlens_q,
-                                    cu_seqlens_k,
-                                    max_seqlen_q=max_seqlen_q,
-                                    max_seqlen_k=max_seqlen_k,
-                                    causal=True,
-                                    window_size=window_size)
-    return output
+    return torch.cat(outputs, dim=0)
 
 
 class TestPagedAttentionBase:

--- a/tests/pytorch/kernel/test_paged_attention.py
+++ b/tests/pytorch/kernel/test_paged_attention.py
@@ -420,7 +420,6 @@ class TestPagedAttention(TestPagedAttentionBase):
             num_kv_heads=num_kv_heads,
             v_head_size=value_head_size,
             sliding_window=window_size,
-            enable_paged_multi_token_decode=True,
         )
         impl.bind_step_meta_group(1)
         output = impl.forward(

--- a/tests/pytorch/kernel/test_swa_state_ring.py
+++ b/tests/pytorch/kernel/test_swa_state_ring.py
@@ -1,0 +1,144 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+from types import SimpleNamespace
+
+import torch
+
+from lmdeploy.pytorch.backends.cuda.attention.swa_state_ring import (
+    SWAStateRingMetadata,
+    swa_state_ring_attention,
+)
+from lmdeploy.pytorch.kernels.cuda.swa_state_ring import flatten_swa_state_ring, scatter_swa_state_ring
+
+
+def test_swa_state_ring_flattens_history_then_updates_current_tokens():
+    ring = torch.zeros((1, 4, 1, 8), dtype=torch.bfloat16, device='cuda')
+    ring[0, 0].fill_(10)
+    ring[0, 1].fill_(20)
+    current = torch.stack((torch.full((1, 8), 30), torch.full((1, 8), 40))).to(
+        device='cuda', dtype=torch.bfloat16)
+    state_slots = torch.tensor([0], dtype=torch.int64, device='cuda')
+    start_positions = torch.tensor([2], dtype=torch.int64, device='cuda')
+    q_seqlens = torch.tensor([2], dtype=torch.int32, device='cuda')
+    cu_q_seqlens = torch.tensor([0, 2], dtype=torch.int32, device='cuda')
+    history_lens = torch.tensor([2], dtype=torch.int32, device='cuda')
+    cu_kv_seqlens = torch.tensor([0, 4], dtype=torch.int32, device='cuda')
+
+    flattened = flatten_swa_state_ring(
+        ring,
+        current,
+        state_slots,
+        start_positions,
+        q_seqlens,
+        cu_q_seqlens,
+        history_lens,
+        cu_kv_seqlens,
+        max_q_seqlen=2,
+    )
+    expected = torch.tensor([10, 20, 30, 40], dtype=torch.bfloat16, device='cuda')
+    torch.testing.assert_close(flattened[:4, 0, 0], expected)
+
+    scatter_swa_state_ring(
+        current,
+        ring,
+        state_slots,
+        start_positions,
+        q_seqlens,
+        cu_q_seqlens,
+        max_q_seqlen=2,
+    )
+    torch.testing.assert_close(ring[0, :, 0, 0], expected)
+
+
+def test_swa_state_ring_q1_paged_decode_matches_flatten():
+    """The q=1 ring-page fast path preserves pre-wrap and wrapped results."""
+
+    from lmdeploy.pytorch.kernels.cuda import flash_attn_varlen_func, flash_attn_with_kvcache
+
+    torch.manual_seed(7)
+    batch_size = 2
+    window_size = 128
+    num_q_heads = 8
+    num_kv_heads = 1
+    head_dim = 192
+    value_dim = 128
+    dtype = torch.bfloat16
+    device = 'cuda'
+
+    query = torch.randn(batch_size, num_q_heads, head_dim, dtype=dtype, device=device)
+    current_k = torch.randn(batch_size, num_kv_heads, head_dim, dtype=dtype, device=device)
+    current_v = torch.randn(batch_size, num_kv_heads, value_dim, dtype=dtype, device=device)
+    k_ring = torch.randn(batch_size, window_size, num_kv_heads, head_dim, dtype=dtype, device=device)
+    v_ring = torch.randn(batch_size, window_size, num_kv_heads, value_dim, dtype=dtype, device=device)
+    attn_metadata = SimpleNamespace(
+        q_seqlens=torch.ones(batch_size, dtype=torch.int64, device=device),
+        # The first sequence has not wrapped; the second has wrapped.
+        kv_seqlens=torch.tensor([6, 194], dtype=torch.int64, device=device),
+    )
+    metadata = SWAStateRingMetadata.from_step_context(
+        attn_metadata,
+        SimpleNamespace(max_q_seqlen=1),
+        state_slots=torch.arange(batch_size, dtype=torch.int64, device=device),
+        num_state_slots=batch_size,
+        window_size=window_size,
+    )
+    flat_k = flatten_swa_state_ring(
+        k_ring,
+        current_k,
+        metadata.state_slots,
+        metadata.start_positions,
+        metadata.q_seqlens,
+        metadata.cu_q_seqlens,
+        metadata.history_lens,
+        metadata.cu_kv_seqlens,
+        metadata.max_q_seqlen,
+    )
+    flat_v = flatten_swa_state_ring(
+        v_ring,
+        current_v,
+        metadata.state_slots,
+        metadata.start_positions,
+        metadata.q_seqlens,
+        metadata.cu_q_seqlens,
+        metadata.history_lens,
+        metadata.cu_kv_seqlens,
+        metadata.max_q_seqlen,
+    )
+    scale = head_dim**-0.5
+    sinks = torch.randn(num_q_heads, dtype=dtype, device=device)
+    expected = flash_attn_varlen_func(
+        query,
+        flat_k,
+        flat_v,
+        metadata.cu_q_seqlens,
+        metadata.cu_kv_seqlens,
+        max_seqlen_q=1,
+        max_seqlen_k=window_size,
+        window_size=window_size - 1,
+        softmax_scale=scale,
+        causal=True,
+        sinks=sinks,
+        kv_layout='shd',
+    )
+
+    impl = SimpleNamespace(
+        flash_attention_fwd=flash_attn_varlen_func,
+        paged_attention_fwd=flash_attn_with_kvcache,
+        alibi=False,
+        scale=scale,
+        logit_softcapping=None,
+    )
+    attention = SimpleNamespace(impl=impl, _lazy_init=lambda device: None)
+    actual = swa_state_ring_attention(
+        attention,
+        query,
+        current_k,
+        current_v,
+        k_ring,
+        v_ring,
+        metadata,
+        sink=sinks,
+    )
+
+    torch.testing.assert_close(actual, expected, atol=3e-3, rtol=3e-3)
+    torch.testing.assert_close(k_ring[0, 5], current_k[0])
+    torch.testing.assert_close(k_ring[1, 65], current_k[1])

--- a/tests/pytorch/kernel/test_swa_state_ring.py
+++ b/tests/pytorch/kernel/test_swa_state_ring.py
@@ -5,8 +5,9 @@ import torch
 
 from lmdeploy.pytorch.backends.cuda.attention.swa_state_ring import (
     SWAStateRingMetadata,
-    swa_state_ring_attention,
+    SWAStateRingAttentionImpl,
 )
+from lmdeploy.pytorch.backends.attention import SWAStateRingAttentionBuildSpec
 from lmdeploy.pytorch.kernels.cuda.swa_state_ring import flatten_swa_state_ring, scatter_swa_state_ring
 
 
@@ -120,23 +121,24 @@ def test_swa_state_ring_q1_paged_decode_matches_flatten():
         kv_layout='shd',
     )
 
-    impl = SimpleNamespace(
-        flash_attention_fwd=flash_attn_varlen_func,
-        paged_attention_fwd=flash_attn_with_kvcache,
-        alibi=False,
-        scale=scale,
-        logit_softcapping=None,
-    )
-    attention = SimpleNamespace(impl=impl, _lazy_init=lambda device: None)
-    actual = swa_state_ring_attention(
-        attention,
+    impl = SWAStateRingAttentionImpl(
+        SWAStateRingAttentionBuildSpec(
+            num_heads=num_q_heads,
+            head_dim=head_dim,
+            num_kv_heads=num_kv_heads,
+            v_head_dim=value_dim,
+            scale=scale,
+            sliding_window=(window_size - 1, 0),
+            learnable_sink=True,
+        ))
+    actual = impl.forward(
         query,
         current_k,
         current_v,
         k_ring,
         v_ring,
         metadata,
-        sink=sinks,
+        learnable_sink=sinks,
     )
 
     torch.testing.assert_close(actual, expected, atol=3e-3, rtol=3e-3)

--- a/tests/pytorch/kernel/test_swa_state_ring.py
+++ b/tests/pytorch/kernel/test_swa_state_ring.py
@@ -3,11 +3,11 @@ from types import SimpleNamespace
 
 import torch
 
-from lmdeploy.pytorch.backends.cuda.attention.swa_state_ring import (
-    SWAStateRingMetadata,
-    SWAStateRingAttentionImpl,
-)
 from lmdeploy.pytorch.backends.attention import SWAStateRingAttentionBuildSpec
+from lmdeploy.pytorch.backends.cuda.attention.swa_state_ring import (
+    SWAStateRingAttentionImpl,
+    SWAStateRingMetadata,
+)
 from lmdeploy.pytorch.kernels.cuda.swa_state_ring import flatten_swa_state_ring, scatter_swa_state_ring
 
 
@@ -53,7 +53,7 @@ def test_swa_state_ring_flattens_history_then_updates_current_tokens():
 def test_swa_state_ring_q1_paged_decode_matches_flatten():
     """The q=1 ring-page fast path preserves pre-wrap and wrapped results."""
 
-    from lmdeploy.pytorch.kernels.cuda import flash_attn_varlen_func, flash_attn_with_kvcache
+    from lmdeploy.pytorch.kernels.cuda import flash_attn_varlen_func
 
     torch.manual_seed(7)
     batch_size = 2

--- a/tests/pytorch/nn/test_linear_blocked_fp8.py
+++ b/tests/pytorch/nn/test_linear_blocked_fp8.py
@@ -1,0 +1,163 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+import lmdeploy.pytorch.nn.linear.blocked_fp8 as blocked_fp8
+from lmdeploy.pytorch.config import TPMode
+from lmdeploy.pytorch.nn.linear.blocked_fp8 import QKVBlockedF8Linear
+
+
+class _ReferenceBlockedF8Impl:
+
+    def set_scale_fmt(self, scale_fmt):
+        del scale_fmt
+
+    def forward(self, x, weight, weight_scale_inv, *args, **kwargs):
+        del args, kwargs
+        row_scales = weight_scale_inv.repeat_interleave(128, dim=0)
+        col_scales = row_scales.repeat_interleave(128, dim=1)
+        dequantized = weight.float() * col_scales[:weight.size(0), :weight.size(1)]
+        return (x.float() @ dequantized.T).to(x.dtype)
+
+
+def _build_qkv(monkeypatch, *, tp, rank, num_kv_heads, num_replicas,
+               checkpoint_sections, continuous):
+
+    def _init_tp_args(self, *args, **kwargs):
+        del args, kwargs
+        self.is_tp = True
+        self.all_reduce = False
+        self.tp = tp
+        self.tp_rank = rank
+        self.tp_mode = TPMode.DEFAULT
+        self.tp_group = None
+        self.gather_group = None
+        self._tp_args_initialized = True
+
+    backend = SimpleNamespace(
+        get_layer_impl_builder=lambda op: SimpleNamespace(
+            build=lambda *args, **kwargs: _ReferenceBlockedF8Impl()))
+    monkeypatch.setattr(QKVBlockedF8Linear, 'init_tp_args', _init_tp_args)
+    monkeypatch.setattr(blocked_fp8, 'get_backend', lambda: backend)
+    return QKVBlockedF8Linear(
+        in_features=128,
+        num_q_heads=64,
+        num_kv_heads=num_kv_heads,
+        head_size=192,
+        head_size_v=128,
+        dtype=torch.bfloat16,
+        device=torch.device('cpu'),
+        num_replicate_kv_heads=num_replicas,
+        checkpoint_output_shard_sizes=checkpoint_sections,
+        continuous_qkv_scale_layout=continuous,
+    )
+
+
+def _source_weight(rows, offset):
+    values = (torch.arange(rows, dtype=torch.float32) + offset).remainder(13) - 6
+    return values[:, None].expand(rows, 128).to(torch.float8_e4m3fn)
+
+
+def _load_qkv(linear, weights, scales):
+    for shard_id in ('q', 'k', 'v'):
+        linear.weight.weight_loader(linear.weight, weights[shard_id], shard_id)
+        linear.weight_scale_inv.weight_loader(
+            linear.weight_scale_inv, scales[shard_id], shard_id)
+
+
+def _project(x, weight, row_scales):
+    dequantized = weight.float() * row_scales[:, None]
+    return (x.float() @ dequantized.T).to(x.dtype)
+
+
+@pytest.mark.parametrize(
+    ('tp', 'rank', 'num_kv_heads', 'num_replicas'),
+    [(4, 3, 4, 1), (8, 7, 8, 2)],
+)
+def test_full_qkv_loader_matches_checkpoint_quantization(monkeypatch, tp, rank,
+                                                         num_kv_heads,
+                                                         num_replicas):
+    """Full QKV preserves its TP4 K/V boundary under TP4 and TP8."""
+    linear = _build_qkv(
+        monkeypatch,
+        tp=tp,
+        rank=rank,
+        num_kv_heads=num_kv_heads,
+        num_replicas=num_replicas,
+        checkpoint_sections=(3072, 192, 128),
+        continuous=True,
+    )
+    weights = {
+        'q': _source_weight(12288, 0),
+        'k': _source_weight(768, 3),
+        'v': _source_weight(512, 7),
+    }
+    scales = {
+        'q': (1 + torch.arange(96, dtype=torch.float32) / 32)[:, None],
+        'k': (5 + torch.arange(8, dtype=torch.float32) / 16)[:, None],
+        'v': (9 + torch.arange(4, dtype=torch.float32) / 8)[:, None],
+    }
+    _load_qkv(linear, weights, scales)
+
+    x = torch.linspace(-1, 1, 128, dtype=torch.bfloat16).view(1, 128)
+    query, key, value = linear.split_qkv(linear(x))
+
+    q_rows = 12288 // tp
+    q_start = rank * q_rows
+    kv_rank = rank // num_replicas
+    k_start = kv_rank * 192
+    v_start = kv_rank * 128
+    q_scale = scales['q'].flatten().repeat_interleave(128)[q_start:q_start + q_rows]
+    k_scale = scales['k'][kv_rank * 2:kv_rank * 2 + 2].flatten().repeat_interleave(128)[:192]
+    # The checkpoint block crossing K/V uses K's final scale for V[0:64].
+    v_scale = torch.cat((
+        scales['k'][kv_rank * 2 + 1].expand(64),
+        scales['v'][kv_rank].expand(64),
+    ))
+
+    expected_q = _project(x, weights['q'][q_start:q_start + q_rows], q_scale)
+    expected_k = _project(x, weights['k'][k_start:k_start + 192], k_scale)
+    expected_v = _project(x, weights['v'][v_start:v_start + 128], v_scale)
+    torch.testing.assert_close(query.flatten(1), expected_q)
+    torch.testing.assert_close(key.flatten(1), expected_k)
+    torch.testing.assert_close(value.flatten(1), expected_v)
+
+
+def test_swa_qkv_loader_matches_unaligned_tp8_shard(monkeypatch):
+    """SWA TP8 crops an unaligned K shard without changing its scale grid."""
+    linear = _build_qkv(
+        monkeypatch,
+        tp=8,
+        rank=7,
+        num_kv_heads=8,
+        num_replicas=1,
+        checkpoint_sections=(3072, 384, 256),
+        continuous=False,
+    )
+    weights = {
+        'q': _source_weight(12288, 0),
+        'k': _source_weight(1536, 3),
+        'v': _source_weight(1024, 7),
+    }
+    scales = {
+        'q': (1 + torch.arange(96, dtype=torch.float32) / 32)[:, None],
+        'k': (5 + torch.arange(12, dtype=torch.float32) / 16)[:, None],
+        'v': (9 + torch.arange(8, dtype=torch.float32) / 8)[:, None],
+    }
+    _load_qkv(linear, weights, scales)
+
+    x = torch.linspace(-1, 1, 128, dtype=torch.bfloat16).view(1, 128)
+    query, key, value = linear.split_qkv(linear(x))
+    q_start, k_start, v_start = 7 * 1536, 7 * 192, 7 * 128
+    q_scale = scales['q'].flatten().repeat_interleave(128)[q_start:q_start + 1536]
+    k_scale = scales['k'].flatten().repeat_interleave(128)[k_start:k_start + 192]
+    v_scale = scales['v'].flatten().repeat_interleave(128)[v_start:v_start + 128]
+
+    expected_q = _project(x, weights['q'][q_start:q_start + 1536], q_scale)
+    expected_k = _project(x, weights['k'][k_start:k_start + 192], k_scale)
+    expected_v = _project(x, weights['v'][v_start:v_start + 128], v_scale)
+    torch.testing.assert_close(query.flatten(1), expected_q)
+    torch.testing.assert_close(key.flatten(1), expected_k)
+    torch.testing.assert_close(value.flatten(1), expected_v)

--- a/tests/pytorch/nn/test_linear_blocked_fp8.py
+++ b/tests/pytorch/nn/test_linear_blocked_fp8.py
@@ -37,6 +37,7 @@ def _build_qkv(monkeypatch, *, tp, rank, num_kv_heads, num_replicas,
         self._tp_args_initialized = True
 
     backend = SimpleNamespace(
+        build_op=lambda *args, **kwargs: _ReferenceBlockedF8Impl(),
         get_layer_impl_builder=lambda op: SimpleNamespace(
             build=lambda *args, **kwargs: _ReferenceBlockedF8Impl()))
     monkeypatch.setattr(QKVBlockedF8Linear, 'init_tp_args', _init_tp_args)

--- a/tests/pytorch/spec_decode/test_cudagraph_strategy.py
+++ b/tests/pytorch/spec_decode/test_cudagraph_strategy.py
@@ -4,7 +4,7 @@ from lmdeploy.pytorch.strategies.ar_spec.cudagraph import ARSpecCudagraphStrateg
 
 
 def test_arspec_cudagraph_uses_single_token_graph_for_all_methods():
-    strategy = ARSpecCudagraphStrategy(num_spec_tokens=4, draft_arch='Qwen3_5MTPModel')
+    strategy = ARSpecCudagraphStrategy(num_spec_tokens=4, method='qwen3_5_mtp')
 
     assert strategy.get_max_tokens(batch_size=8, origin_batch_size=8, num_tokens=8) == 8
 
@@ -49,49 +49,26 @@ def test_triton_metadata_builder_uses_explicit_decode_mode():
 
 
 def test_arspec_cudagraph_uses_same_allocation_for_full_spec_capture():
-    strategy = ARSpecCudagraphStrategy(num_spec_tokens=4, draft_arch='Qwen3_5MTPModel')
+    strategy = ARSpecCudagraphStrategy(num_spec_tokens=4, method='qwen3_5_mtp')
 
     assert strategy.get_max_tokens(batch_size=8, origin_batch_size=8, num_tokens=40) == 40
 
 
-def test_arspec_cudagraph_uses_uniform_query_len_for_mimo_arch():
-    strategy = ARSpecCudagraphStrategy(num_spec_tokens=3, draft_arch='MiMoV2FlashMTPModel')
+def test_arspec_cudagraph_uses_uniform_query_len_for_mimo_method():
+    strategy = ARSpecCudagraphStrategy(num_spec_tokens=3, method='mimo_mtp')
 
     assert strategy.get_max_tokens(batch_size=8, origin_batch_size=8, num_tokens=24) == 24
 
 
-def test_ar_spec_factory_derives_uniform_query_len_capability_mimo():
+def test_ar_spec_factory_derives_uniform_query_len_from_mimo_method():
     from types import SimpleNamespace
 
-    from lmdeploy.pytorch.config import ModelConfig, SpecDecodeConfig
     from lmdeploy.pytorch.strategies.ar_spec import ARSpecStrategyFactory
 
-    model_config = ModelConfig(
-        hidden_size=5120,
-        num_layers=48,
-        num_attention_heads=64,
-        num_key_value_heads=8,
-        bos_token_id=0,
-        eos_token_id=[0],
-        head_dim=192,
-        hf_config=SimpleNamespace(architectures=['MiMoV2FlashMTPModel']),
-        model_paradigm='ar_spec',
-    )
-    spec_config = SpecDecodeConfig(
-        model='mimo-draft',
-        method='arbitrary_method',
+    model_config = SimpleNamespace(bos_token_id=0)
+    spec_config = SimpleNamespace(
+        method='mimo_mtp',
         num_speculative_tokens=3,
-        model_config=ModelConfig(
-            hidden_size=5120,
-            num_layers=3,
-            num_attention_heads=64,
-            num_key_value_heads=8,
-            bos_token_id=0,
-            eos_token_id=[0],
-            head_dim=192,
-            hf_config=SimpleNamespace(architectures=['MiMoV2FlashMTPModel']),
-            model_paradigm='ar_spec',
-        ),
     )
     strategy = ARSpecStrategyFactory(model_config, spec_config).build_cudagraph_strategy()
 
@@ -99,7 +76,7 @@ def test_ar_spec_factory_derives_uniform_query_len_capability_mimo():
 
 
 def test_arspec_cudagraph_keeps_full_spec_capture_for_eagle3():
-    strategy = ARSpecCudagraphStrategy(num_spec_tokens=4, draft_arch='Eagle3DeepseekV2ForCausalLM')
+    strategy = ARSpecCudagraphStrategy(num_spec_tokens=4, method='eagle3')
 
     assert strategy.get_max_tokens(batch_size=8, origin_batch_size=8, num_tokens=8) == 8
     assert strategy.get_max_tokens(batch_size=8, origin_batch_size=8, num_tokens=40) == 40
@@ -159,40 +136,6 @@ def test_cudagraph_fa3_metadata_uses_single_query_len_for_single_token_capture()
     )
 
     assert model.max_seqlen_q_calls == [1, 1]
-
-
-def test_mimo_target_multi_token_capability_reads_transformer_layers():
-    from lmdeploy.pytorch.models.mimo_v2_flash import MiMoV2FlashForCausalLM
-
-    model = MiMoV2FlashForCausalLM.__new__(MiMoV2FlashForCausalLM)
-    model.model = SimpleNamespace(
-        layers=[
-            SimpleNamespace(self_attn=SimpleNamespace(attn_fwd=SimpleNamespace(
-                supports_multi_token_decode=True))),
-        ])
-
-    assert model.supports_multi_token_decode() is True
-
-
-def test_mimo_mtp_capture_state_accepts_runner_protocol():
-    import torch
-
-    from lmdeploy.pytorch.models.mimo_v2_flash_mtp import MiMoV2FlashMTPModel
-    from lmdeploy.pytorch.models.utils.cudagraph import GraphCaptureContext
-
-    model = MiMoV2FlashMTPModel.__new__(MiMoV2FlashMTPModel)
-    model.model = SimpleNamespace(num_mtp_layers=2)
-    caches = [[torch.zeros(1), torch.zeros(1)], [torch.ones(1), torch.ones(1)]]
-
-    state = model.get_cudagraph_capture_state(
-        GraphCaptureContext(
-            past_key_values=caches,
-            attn_metadata=SimpleNamespace(q_seqlens=torch.tensor([1])),
-            num_blocks=8,
-            spec_step_idx=3,
-        ))
-
-    assert state.tensors == tuple(caches[1])
 
 
 def test_full_graph_disables_legacy_fa3_metadata_without_support(monkeypatch):
@@ -427,6 +370,7 @@ def test_cuda_graph_key_separates_query_len_without_target_hidden_size(monkeypat
     context = SimpleNamespace(
         global_is_decoding=lambda: True,
         target_hidden_states=torch.zeros((1, 8, 16)),
+        decode_mode='block',
     )
     runner = cuda_graph_runner.CUDAGraphRunner.__new__(cuda_graph_runner.CUDAGraphRunner)
     runner.ctx_mgr = SimpleNamespace(current_context=lambda: context)
@@ -465,6 +409,17 @@ def test_cuda_graph_key_separates_query_len_without_target_hidden_size(monkeypat
     )
     assert key_qlen4 != key_qlen1
 
+    context.decode_mode = 'speculative'
+    key_speculative = runner.get_graph_key(
+        input_ids=input_ids_qlen4,
+        position_ids=torch.zeros_like(input_ids_qlen4),
+        past_key_values=[],
+        attn_metadata=attn_metadata_qlen4,
+        inputs_embeds=None,
+    )
+    assert key_speculative != key_qlen4
+
+    context.decode_mode = 'block'
     context.target_hidden_states = torch.zeros((1, 8, 32))
     key_hidden32 = runner.get_graph_key(
         input_ids=input_ids_qlen4,

--- a/tests/pytorch/spec_decode/test_cudagraph_strategy.py
+++ b/tests/pytorch/spec_decode/test_cudagraph_strategy.py
@@ -223,7 +223,6 @@ def test_cudagraph_capture_rolls_back_state_before_semantic_forward(monkeypatch)
     runner.get_graph_key = lambda **kwargs: (2, True, False, 2)
     runner._get_max_tokens = lambda *args: 4
     runner._get_decode_model_forward = lambda: model
-    runner._supports_multi_token_decode = False
     runner._full_graph_runners = {}
     runner.num_blocks = 8
     runner._full_graph_pool_handle = None

--- a/tests/pytorch/spec_decode/test_cudagraph_strategy.py
+++ b/tests/pytorch/spec_decode/test_cudagraph_strategy.py
@@ -2,19 +2,63 @@ from lmdeploy.pytorch.strategies.ar_spec.cudagraph import ARSpecCudagraphStrateg
 
 
 def test_arspec_cudagraph_uses_single_token_graph_for_all_methods():
-    strategy = ARSpecCudagraphStrategy(num_spec_tokens=4, method='qwen3_5_mtp')
+    strategy = ARSpecCudagraphStrategy(num_spec_tokens=4, draft_arch='Qwen3_5MTPModel')
 
     assert strategy.get_max_tokens(batch_size=8, origin_batch_size=8, num_tokens=8) == 8
 
 
 def test_arspec_cudagraph_uses_same_allocation_for_full_spec_capture():
-    strategy = ARSpecCudagraphStrategy(num_spec_tokens=4, method='qwen3_5_mtp')
+    strategy = ARSpecCudagraphStrategy(num_spec_tokens=4, draft_arch='Qwen3_5MTPModel')
 
     assert strategy.get_max_tokens(batch_size=8, origin_batch_size=8, num_tokens=40) == 40
 
 
+def test_arspec_cudagraph_uses_uniform_query_len_for_mimo_arch():
+    strategy = ARSpecCudagraphStrategy(num_spec_tokens=3, draft_arch='MiMoV2FlashMTPModel')
+
+    assert strategy.get_max_tokens(batch_size=8, origin_batch_size=8, num_tokens=24) == 24
+
+
+def test_ar_spec_factory_derives_uniform_query_len_capability_mimo():
+    from types import SimpleNamespace
+
+    from lmdeploy.pytorch.config import ModelConfig, SpecDecodeConfig
+    from lmdeploy.pytorch.strategies.ar_spec import ARSpecStrategyFactory
+
+    model_config = ModelConfig(
+        hidden_size=5120,
+        num_layers=48,
+        num_attention_heads=64,
+        num_key_value_heads=8,
+        bos_token_id=0,
+        eos_token_id=[0],
+        head_dim=192,
+        hf_config=SimpleNamespace(architectures=['MiMoV2FlashMTPModel']),
+        model_paradigm='ar_spec',
+    )
+    spec_config = SpecDecodeConfig(
+        model='mimo-draft',
+        method='arbitrary_method',
+        num_speculative_tokens=3,
+        model_config=ModelConfig(
+            hidden_size=5120,
+            num_layers=3,
+            num_attention_heads=64,
+            num_key_value_heads=8,
+            bos_token_id=0,
+            eos_token_id=[0],
+            head_dim=192,
+            hf_config=SimpleNamespace(architectures=['MiMoV2FlashMTPModel']),
+            model_paradigm='ar_spec',
+        ),
+    )
+    strategy = ARSpecStrategyFactory(model_config, spec_config).build_cudagraph_strategy()
+
+    assert strategy.get_max_tokens(batch_size=8, origin_batch_size=8, num_tokens=24) == 24
+
+
 def test_arspec_cudagraph_keeps_full_spec_capture_for_eagle3():
-    strategy = ARSpecCudagraphStrategy(num_spec_tokens=4, method='eagle3')
+    strategy = ARSpecCudagraphStrategy(num_spec_tokens=4, draft_arch='Eagle3DeepseekV2ForCausalLM')
 
     assert strategy.get_max_tokens(batch_size=8, origin_batch_size=8, num_tokens=8) == 8
     assert strategy.get_max_tokens(batch_size=8, origin_batch_size=8, num_tokens=40) == 40

--- a/tests/pytorch/spec_decode/test_cudagraph_strategy.py
+++ b/tests/pytorch/spec_decode/test_cudagraph_strategy.py
@@ -179,7 +179,7 @@ def test_cudagraph_capture_rolls_back_state_before_semantic_forward(monkeypatch)
     runner.get_graph_key = lambda **kwargs: (2, True, False, 2)
     runner._get_max_tokens = lambda *args: 4
     runner._get_decode_model_forward = lambda: model
-    runner._supports_non_fa3_speculative_graph = False
+    runner._supports_multi_token_decode = False
     runner._full_graph_runners = {}
     runner.num_blocks = 8
     runner._full_graph_pool_handle = None

--- a/tests/pytorch/spec_decode/test_cudagraph_strategy.py
+++ b/tests/pytorch/spec_decode/test_cudagraph_strategy.py
@@ -9,6 +9,45 @@ def test_arspec_cudagraph_uses_single_token_graph_for_all_methods():
     assert strategy.get_max_tokens(batch_size=8, origin_batch_size=8, num_tokens=8) == 8
 
 
+def test_triton_metadata_builder_uses_explicit_decode_mode():
+    import torch
+
+    from lmdeploy.pytorch.backends.cuda.attention.default import (
+        TritonAttentionMetadata,
+        build_triton_attention_metadata,
+    )
+    from lmdeploy.pytorch.backends.cuda.step_metadata import CudaSequenceMetadata
+
+    class ModelConfig:
+
+        @property
+        def model_paradigm(self):
+            raise AssertionError('metadata builder must not inspect model paradigm')
+
+    step_context = SimpleNamespace(
+        is_decoding=True,
+        kv_quant_policy=None,
+        max_q_seqlen=2,
+        decode_mode='block',
+        model_config=ModelConfig(),
+    )
+    sequence_metadata = CudaSequenceMetadata(
+        block_offsets=torch.zeros((1, 1), dtype=torch.int32),
+        q_start_loc=torch.tensor([0, 2], dtype=torch.int32),
+        q_seqlens=torch.tensor([2], dtype=torch.int32),
+        kv_start_loc=None,
+        kv_seqlens=torch.tensor([2], dtype=torch.int32),
+        kv_flatten_size=None,
+        cu_seqlens_q=torch.tensor([0, 2], dtype=torch.int32),
+        cu_seqlens_k=torch.tensor([0, 2], dtype=torch.int32),
+        max_kv_seqlen=2,
+    )
+
+    metadata = build_triton_attention_metadata(TritonAttentionMetadata, step_context, sequence_metadata)
+
+    assert metadata.decode_mode == 'block'
+
+
 def test_arspec_cudagraph_uses_same_allocation_for_full_spec_capture():
     strategy = ARSpecCudagraphStrategy(num_spec_tokens=4, draft_arch='Qwen3_5MTPModel')
 

--- a/tests/pytorch/spec_decode/test_cudagraph_strategy.py
+++ b/tests/pytorch/spec_decode/test_cudagraph_strategy.py
@@ -139,7 +139,7 @@ def test_cudagraph_capture_rolls_back_state_before_semantic_forward(monkeypatch)
 
     cache = [torch.arange(24).view(6, 4), torch.arange(24, 48).view(6, 4)]
     original = [tensor.clone() for tensor in cache]
-    block_offsets = torch.tensor([[1, 3], [3, 4]])
+    block_offsets = torch.tensor([[-1, 1, 3], [3, 4, 8]])
     block_ids = torch.tensor([1, 3, 4])
 
     class FakeSingleGraphRunner:

--- a/tests/pytorch/spec_decode/test_cudagraph_strategy.py
+++ b/tests/pytorch/spec_decode/test_cudagraph_strategy.py
@@ -135,7 +135,7 @@ def test_cudagraph_capture_rolls_back_state_before_semantic_forward(monkeypatch)
 
     import torch
 
-    from lmdeploy.pytorch.backends.cuda import graph_runner as graph_runner_mod
+    from lmdeploy.pytorch.backends.cuda.graph_runner import runner as graph_runner_mod
 
     cache = [torch.arange(24).view(6, 4), torch.arange(24, 48).view(6, 4)]
     original = [tensor.clone() for tensor in cache]
@@ -179,9 +179,10 @@ def test_cudagraph_capture_rolls_back_state_before_semantic_forward(monkeypatch)
     runner.get_graph_key = lambda **kwargs: (2, True, False, 2)
     runner._get_max_tokens = lambda *args: 4
     runner._get_decode_model_forward = lambda: model
-    runner._runner_map = {}
+    runner._supports_non_fa3_speculative_graph = False
+    runner._full_graph_runners = {}
     runner.num_blocks = 8
-    runner.graph_pool_handle = None
+    runner._full_graph_pool_handle = None
     runner.model_config = SimpleNamespace()
     runner.device = torch.device('cpu')
 
@@ -198,7 +199,7 @@ def test_cudagraph_capture_rolls_back_state_before_semantic_forward(monkeypatch)
     )
 
     assert output == 'semantic-output'
-    assert (2, True, False, 2) in runner._runner_map
+    assert (2, True, False, 2) in runner._full_graph_runners
     for actual, expected in zip(cache, original):
         expected[block_ids] += 1
         torch.testing.assert_close(actual, expected)

--- a/tests/pytorch/spec_decode/test_cudagraph_strategy.py
+++ b/tests/pytorch/spec_decode/test_cudagraph_strategy.py
@@ -76,6 +76,134 @@ def test_cudagraph_fa3_metadata_uses_single_query_len_for_single_token_capture()
     assert model.max_seqlen_q_calls == [1, 1]
 
 
+def test_cudagraph_fill_preserves_runtime_attention_metadata():
+    from types import SimpleNamespace
+
+    import torch
+
+    from lmdeploy.pytorch.models.utils.cudagraph import CudaGraphMeta, CudaGraphMixin
+
+    model = CudaGraphMixin()
+    graph_meta = CudaGraphMeta(
+        max_batchs=2,
+        max_tokens=4,
+        num_blocks=2,
+        is_decoding=True,
+        device=torch.device('cpu'),
+        input_buffers={},
+        output_buffers={},
+        decode_query_len=2,
+    )
+    input_ids = torch.arange(4).view(1, 4)
+    position_ids = input_ids.clone()
+    attn_metadata = SimpleNamespace(
+        q_seqlens=torch.tensor([2, 2]),
+        block_offsets=torch.tensor([[3, 4], [5, 6]]),
+        q_start_loc=torch.tensor([0, 2]),
+        kv_seqlens=torch.tensor([7, 11]),
+    )
+    original_fields = {
+        name: getattr(attn_metadata, name).clone()
+        for name in ('q_seqlens', 'block_offsets', 'q_start_loc', 'kv_seqlens')
+    }
+    graph_meta.input_buffers = model.make_buffers_cudagraph(
+        graph_meta,
+        input_ids=input_ids,
+        position_ids=position_ids,
+        past_key_values=[],
+        attn_metadata=attn_metadata,
+    )
+
+    for _ in range(2):
+        graph_inputs = model.fill_buffers_cudagraph(
+            graph_meta,
+            input_ids=input_ids,
+            position_ids=position_ids,
+            past_key_values=[],
+            attn_metadata=attn_metadata,
+            inputs_embeds=None,
+        )
+        for name, expected in original_fields.items():
+            assert torch.equal(getattr(attn_metadata, name), expected)
+        assert torch.equal(graph_inputs['attn_metadata'].q_seqlens[:2], original_fields['q_seqlens'])
+        assert torch.equal(graph_inputs['attn_metadata'].kv_seqlens[:2], original_fields['kv_seqlens'])
+        assert torch.equal(graph_inputs['attn_metadata'].block_offsets[:2], original_fields['block_offsets'])
+
+
+def test_cudagraph_capture_rolls_back_state_before_semantic_forward(monkeypatch):
+    from types import SimpleNamespace
+
+    import torch
+
+    from lmdeploy.pytorch.backends.cuda import graph_runner as graph_runner_mod
+
+    cache = [torch.arange(24).view(6, 4), torch.arange(24, 48).view(6, 4)]
+    original = [tensor.clone() for tensor in cache]
+    block_offsets = torch.tensor([[1, 3], [3, 4]])
+    block_ids = torch.tensor([1, 3, 4])
+
+    class FakeSingleGraphRunner:
+
+        def __init__(self, *args, **kwargs):
+            del args, kwargs
+
+        def capture(self, **kwargs):
+            del kwargs
+            for tensor in cache:
+                tensor[block_ids] += 10
+            return 'capture-output'
+
+        def forward(self, **kwargs):
+            del kwargs
+            for tensor, expected in zip(cache, original):
+                torch.testing.assert_close(tensor, expected)
+                tensor[block_ids] += 1
+            return 'semantic-output'
+
+    monkeypatch.setattr(graph_runner_mod, 'CUDASingleGraphRunner', FakeSingleGraphRunner)
+    monkeypatch.setattr(
+        graph_runner_mod,
+        'get_deepep_state',
+        lambda: SimpleNamespace(enabled=lambda: False),
+    )
+
+    model = SimpleNamespace(
+        get_cudagraph_capture_cache=lambda past_key_values, spec_step_idx: cache,
+        get_cudagraph_extra_key=lambda **kwargs: (),
+    )
+    runner = graph_runner_mod.CUDAGraphRunner.__new__(graph_runner_mod.CUDAGraphRunner)
+    runner.model = model
+    runner.ctx_mgr = SimpleNamespace(
+        current_context=lambda: SimpleNamespace(global_is_decoding=lambda: True))
+    runner.enable_graph = lambda **kwargs: True
+    runner.get_graph_key = lambda **kwargs: (2, True, False, 2)
+    runner._get_max_tokens = lambda *args: 4
+    runner._get_decode_model_forward = lambda: model
+    runner._runner_map = {}
+    runner.num_blocks = 8
+    runner.graph_pool_handle = None
+    runner.model_config = SimpleNamespace()
+    runner.device = torch.device('cpu')
+
+    output = runner(
+        input_ids=torch.zeros((1, 4), dtype=torch.long),
+        position_ids=torch.zeros((1, 4), dtype=torch.long),
+        past_key_values=[],
+        attn_metadata=SimpleNamespace(
+            q_seqlens=torch.tensor([2, 2]),
+            block_offsets=block_offsets.to(torch.int32),
+        ),
+        inputs_embeds=None,
+        spec_step_idx=0,
+    )
+
+    assert output == 'semantic-output'
+    assert (2, True, False, 2) in runner._runner_map
+    for actual, expected in zip(cache, original):
+        expected[block_ids] += 1
+        torch.testing.assert_close(actual, expected)
+
+
 def test_cuda_graph_key_separates_query_len_without_target_hidden_size(monkeypatch):
     from types import SimpleNamespace
 

--- a/tests/pytorch/spec_decode/test_cudagraph_strategy.py
+++ b/tests/pytorch/spec_decode/test_cudagraph_strategy.py
@@ -139,17 +139,19 @@ def test_mimo_mtp_capture_state_accepts_runner_protocol():
     import torch
 
     from lmdeploy.pytorch.models.mimo_v2_flash_mtp import MiMoV2FlashMTPModel
+    from lmdeploy.pytorch.models.utils.cudagraph import GraphCaptureContext
 
     model = MiMoV2FlashMTPModel.__new__(MiMoV2FlashMTPModel)
     model.model = SimpleNamespace(num_mtp_layers=2)
     caches = [[torch.zeros(1), torch.zeros(1)], [torch.ones(1), torch.ones(1)]]
 
     state = model.get_cudagraph_capture_state(
-        caches,
-        attn_metadata=SimpleNamespace(q_seqlens=torch.tensor([1])),
-        num_blocks=8,
-        spec_step_idx=3,
-    )
+        GraphCaptureContext(
+            past_key_values=caches,
+            attn_metadata=SimpleNamespace(q_seqlens=torch.tensor([1])),
+            num_blocks=8,
+            spec_step_idx=3,
+        ))
 
     assert state.tensors == tuple(caches[1])
 
@@ -323,11 +325,17 @@ def test_cudagraph_capture_rolls_back_state_before_semantic_forward(monkeypatch)
         lambda: SimpleNamespace(enabled=lambda: False),
     )
 
-    model = SimpleNamespace(
-        get_cudagraph_capture_state=lambda *args, **kwargs: GraphCaptureState(
+    capture_contexts = []
+
+    def get_cudagraph_capture_state(capture_context):
+        capture_contexts.append(capture_context)
+        return GraphCaptureState(
             tensors=tuple(cache),
             block_ids=block_ids,
-        ),
+        )
+
+    model = SimpleNamespace(
+        get_cudagraph_capture_state=get_cudagraph_capture_state,
         get_cudagraph_extra_key=lambda **kwargs: (),
     )
     runner = graph_runner_mod.CUDAGraphRunner.__new__(graph_runner_mod.CUDAGraphRunner)
@@ -358,6 +366,11 @@ def test_cudagraph_capture_rolls_back_state_before_semantic_forward(monkeypatch)
     )
 
     assert output == 'semantic-output'
+    assert len(capture_contexts) == 1
+    assert capture_contexts[0].past_key_values == []
+    assert capture_contexts[0].num_blocks == 8
+    assert capture_contexts[0].spec_step_idx == 0
+    assert capture_contexts[0].attn_metadata.q_seqlens.tolist() == [2, 2]
     assert (2, True, False, 2) in runner._full_graph_runners
     for actual, expected in zip(cache, original):
         expected[block_ids] += 1

--- a/tests/pytorch/spec_decode/test_cudagraph_strategy.py
+++ b/tests/pytorch/spec_decode/test_cudagraph_strategy.py
@@ -76,6 +76,46 @@ def test_cudagraph_fa3_metadata_uses_single_query_len_for_single_token_capture()
     assert model.max_seqlen_q_calls == [1, 1]
 
 
+def test_graph_capture_state_snapshots_request_visible_paged_rows():
+    import torch
+
+    from lmdeploy.pytorch.models.utils.cudagraph import GraphCaptureState
+
+    cache = torch.arange(40, dtype=torch.float32).reshape(8, 5)
+    state = GraphCaptureState.from_paged_tensors(
+        (cache, ),
+        block_offsets=torch.tensor([[-1, 1, 3], [3, 11, 5]]),
+        num_blocks=8,
+        num_requests=1,
+    )
+
+    state.snapshot()
+    captured = cache.clone()
+    cache[torch.tensor([1, 3, 5])] += 10
+
+    state.restore()
+    assert torch.equal(cache[[1, 3]], captured[[1, 3]])
+    assert torch.equal(cache[5], cache[5])
+
+
+def test_graph_capture_state_snapshots_full_tensors_without_block_ids():
+    import torch
+
+    from lmdeploy.pytorch.models.utils.cudagraph import GraphCaptureState
+
+    cache = [torch.arange(12).view(3, 4), torch.arange(12, 24).view(3, 4)]
+    original = [tensor.clone() for tensor in cache]
+    state = GraphCaptureState(tensors=tuple(cache))
+
+    state.snapshot()
+    for tensor in cache:
+        tensor.add_(1)
+
+    state.restore()
+    for actual, expected in zip(cache, original):
+        torch.testing.assert_close(actual, expected)
+
+
 def test_cudagraph_fill_preserves_runtime_attention_metadata():
     from types import SimpleNamespace
 
@@ -136,6 +176,7 @@ def test_cudagraph_capture_rolls_back_state_before_semantic_forward(monkeypatch)
     import torch
 
     from lmdeploy.pytorch.backends.cuda.graph_runner import runner as graph_runner_mod
+    from lmdeploy.pytorch.models.utils.cudagraph import GraphCaptureState
 
     cache = [torch.arange(24).view(6, 4), torch.arange(24, 48).view(6, 4)]
     original = [tensor.clone() for tensor in cache]
@@ -168,7 +209,10 @@ def test_cudagraph_capture_rolls_back_state_before_semantic_forward(monkeypatch)
     )
 
     model = SimpleNamespace(
-        get_cudagraph_capture_cache=lambda past_key_values, spec_step_idx: cache,
+        get_cudagraph_capture_state=lambda *args, **kwargs: GraphCaptureState(
+            tensors=tuple(cache),
+            block_ids=block_ids,
+        ),
         get_cudagraph_extra_key=lambda **kwargs: (),
     )
     runner = graph_runner_mod.CUDAGraphRunner.__new__(graph_runner_mod.CUDAGraphRunner)

--- a/tests/pytorch/spec_decode/test_cudagraph_strategy.py
+++ b/tests/pytorch/spec_decode/test_cudagraph_strategy.py
@@ -120,6 +120,43 @@ def test_cudagraph_fa3_metadata_uses_single_query_len_for_single_token_capture()
     assert model.max_seqlen_q_calls == [1, 1]
 
 
+def test_full_graph_disables_legacy_fa3_metadata_without_support(monkeypatch):
+    from types import SimpleNamespace
+
+    from lmdeploy.pytorch.backends.cuda.graph_runner.full_graph import _make_graph_meta
+
+    ctx_mgr = SimpleNamespace(backend_step_meta_plan=None)
+    model_config = SimpleNamespace(
+        vocab_size=100,
+        use_mla_fp8_cache=False,
+        use_flash_mla=False,
+        mla_index_topk=None,
+        model_paradigm='ar',
+        states_shapes=None,
+        use_mrope=False,
+        block_size=64,
+    )
+    common_kwargs = dict(
+        max_batches=1,
+        max_tokens=1,
+        num_blocks=1,
+        is_decoding=True,
+        decode_query_len=1,
+        device='cpu',
+    )
+
+    meta = _make_graph_meta(model_config, ctx_mgr, **common_kwargs)
+    assert meta.use_fa3_decoding is False
+
+    model_config.model_paradigm = 'ar_spec'
+    meta = _make_graph_meta(model_config, ctx_mgr, **common_kwargs)
+    assert meta.use_fa3_decoding is True
+
+    meta = _make_graph_meta(
+        model_config, ctx_mgr, supports_multi_token_decode=True, **common_kwargs)
+    assert meta.use_fa3_decoding is False
+
+
 def test_graph_capture_state_snapshots_request_visible_paged_rows():
     import torch
 
@@ -267,6 +304,7 @@ def test_cudagraph_capture_rolls_back_state_before_semantic_forward(monkeypatch)
     runner.get_graph_key = lambda **kwargs: (2, True, False, 2)
     runner._get_max_tokens = lambda *args: 4
     runner._get_decode_model_forward = lambda: model
+    runner._supports_multi_token_decode = False
     runner._full_graph_runners = {}
     runner.num_blocks = 8
     runner._full_graph_pool_handle = None

--- a/tests/pytorch/spec_decode/test_cudagraph_strategy.py
+++ b/tests/pytorch/spec_decode/test_cudagraph_strategy.py
@@ -1,3 +1,5 @@
+from types import SimpleNamespace
+
 from lmdeploy.pytorch.strategies.ar_spec.cudagraph import ARSpecCudagraphStrategy
 
 
@@ -118,6 +120,38 @@ def test_cudagraph_fa3_metadata_uses_single_query_len_for_single_token_capture()
     )
 
     assert model.max_seqlen_q_calls == [1, 1]
+
+
+def test_mimo_target_multi_token_capability_reads_transformer_layers():
+    from lmdeploy.pytorch.models.mimo_v2_flash import MiMoV2FlashForCausalLM
+
+    model = MiMoV2FlashForCausalLM.__new__(MiMoV2FlashForCausalLM)
+    model.model = SimpleNamespace(
+        layers=[
+            SimpleNamespace(self_attn=SimpleNamespace(attn_fwd=SimpleNamespace(
+                supports_multi_token_decode=True))),
+        ])
+
+    assert model.supports_multi_token_decode() is True
+
+
+def test_mimo_mtp_capture_state_accepts_runner_protocol():
+    import torch
+
+    from lmdeploy.pytorch.models.mimo_v2_flash_mtp import MiMoV2FlashMTPModel
+
+    model = MiMoV2FlashMTPModel.__new__(MiMoV2FlashMTPModel)
+    model.model = SimpleNamespace(num_mtp_layers=2)
+    caches = [[torch.zeros(1), torch.zeros(1)], [torch.ones(1), torch.ones(1)]]
+
+    state = model.get_cudagraph_capture_state(
+        caches,
+        attn_metadata=SimpleNamespace(q_seqlens=torch.tensor([1])),
+        num_blocks=8,
+        spec_step_idx=3,
+    )
+
+    assert state.tensors == tuple(caches[1])
 
 
 def test_full_graph_disables_legacy_fa3_metadata_without_support(monkeypatch):

--- a/tests/pytorch/spec_decode/test_spec_agent.py
+++ b/tests/pytorch/spec_decode/test_spec_agent.py
@@ -165,6 +165,10 @@ class _DummyProposer:
     def __init__(self):
         self.get_outputs_calls = 0
         self.update_inputs_decoding_calls = 0
+        self.advance_draft_depth_calls = 0
+        self.advance_extra_inputs = []
+        self.next_extra_inputs = object()
+        self.next_depth_dp_num_tokens = None
         self.model = _DummyDraftModel()
 
     async def get_outputs(self, outputs, inputs, extra_inputs=None, guided_processors=None):
@@ -187,6 +191,34 @@ class _DummyProposer:
             target_hidden_states=target_hidden_states,
             model_metas=model_metas,
         )
+
+    def advance_draft_depth(self,
+                            inputs,
+                            extra_inputs,
+                            draft_token_ids,
+                            target_hidden_states,
+                            model_metas,
+                            *,
+                            first_depth):
+        """Mirror the default recurrent draft transition for agent tests."""
+        self.advance_draft_depth_calls += 1
+        self.advance_extra_inputs.append(extra_inputs)
+        if first_depth:
+            inputs = self.update_inputs_decoding(inputs, extra_inputs, draft_token_ids.transpose(0, 1),
+                                                 target_hidden_states, model_metas)
+            extra_inputs.last_token_indices = None
+        else:
+            step_seqlens = inputs.seq_length.new_ones(inputs.seq_length.size(0))
+            inputs = inputs.step(draft_token_ids.transpose(0, 1), step_seqlens)
+            inputs.model_metas = model_metas
+            inputs.target_hidden_states = target_hidden_states
+        return inputs, self.next_extra_inputs
+
+    def get_draft_depth_token_counts(self, dp_meta):
+        """Return the configured depth layout or the recurrent default."""
+        if self.next_depth_dp_num_tokens is not None:
+            return self.next_depth_dp_num_tokens
+        return dp_meta.dp_batches
 
 
 def test_guided_serial_bitmask_updates_inference_tensor():
@@ -536,6 +568,7 @@ def test_async_model_forward_dp1_non_last_chunk_skips_remaining_spec_forwards():
     assert forward_calls == 1
     assert agent.proposer.get_outputs_calls == 0
     assert agent.proposer.update_inputs_decoding_calls == 0
+    assert agent.proposer.advance_draft_depth_calls == 0
 
 
 def test_async_model_forward_dp_non_last_chunk_pads_block_offsets(monkeypatch):
@@ -571,6 +604,8 @@ def test_async_model_forward_dp_non_last_chunk_pads_block_offsets(monkeypatch):
     assert forward_calls == agent.num_spec_tokens
     assert agent.proposer.get_outputs_calls == agent.num_spec_tokens
     assert agent.proposer.update_inputs_decoding_calls == 1
+    assert agent.proposer.advance_draft_depth_calls == agent.num_spec_tokens - 1
+    assert agent.proposer.advance_extra_inputs == [extra_inputs, agent.proposer.next_extra_inputs]
     assert agent.proposer.model.update_inputs_calls == agent.num_spec_tokens - 1
     assert forwarded_inputs[0] is inputs
     assert [inp.block_offsets.size(1) for inp in forwarded_inputs] == [1, 2, 2]
@@ -607,6 +642,40 @@ def test_async_model_forward_preserves_dp_global_decoding_in_draft_loop(monkeypa
     asyncio.run(agent._async_model_forward(inputs, extra_inputs, sampling_inputs=None))
 
     assert agent.proposer.model.update_inputs_dp_is_decoding == [True, True]
+
+
+def test_async_model_forward_uses_proposer_dp_token_layout(monkeypatch):
+    """Draft architectures may preserve varlen tokens across MTP depths."""
+    import lmdeploy.pytorch.spec_decode.spec_agent as spec_agent_mod
+    from lmdeploy.pytorch.model_inputs import DPMeta
+    from lmdeploy.pytorch.spec_decode.spec_agent import SpecModelAgent
+
+    build_num_tokens = []
+
+    def _build(seqlen, num_tokens):
+        build_num_tokens.append(list(num_tokens))
+        return DPMeta()
+
+    monkeypatch.setattr(spec_agent_mod.DPMeta, 'build', staticmethod(_build))
+    dp_meta = DPMeta(
+        dp_batches=[1, 1],
+        dp_is_decoding=False,
+        dp_draft_num_tokens=[5, 9],
+    )
+    inputs, extra_inputs = _make_non_last_chunk_inputs(dp_meta=dp_meta)
+    inputs.is_chunk = False
+
+    agent = object.__new__(SpecModelAgent)
+    agent.num_spec_tokens = 3
+    agent.rank = 0
+    agent.proposer = _DummyProposer()
+    agent.proposer.next_depth_dp_num_tokens = [5, 9]
+    agent.guided_helper = GuidedSpecHelper()
+    agent._forward_impl = lambda _inputs: {}
+
+    asyncio.run(agent._async_model_forward(inputs, extra_inputs, sampling_inputs=None))
+
+    assert build_num_tokens == [[5, 9]]
 
 
 def test_spec_model_agent_warmup_adds_dp_meta_for_draft_capture(monkeypatch):
@@ -648,6 +717,12 @@ def test_spec_model_agent_warmup_adds_dp_meta_for_draft_capture(monkeypatch):
 
         def get_capture_batch_sizes(self):
             return [2]
+
+        def get_model(self):
+            return self
+
+        def get_cudagraph_warmup_specs(self, max_query_len):
+            return ((max_query_len, 0), (1, 0))
 
     class DummyProposer:
 

--- a/tests/pytorch/spec_decode/test_spec_agent.py
+++ b/tests/pytorch/spec_decode/test_spec_agent.py
@@ -558,7 +558,7 @@ def test_async_model_forward_dp1_non_last_chunk_skips_remaining_spec_forwards():
     agent = object.__new__(SpecModelAgent)
     agent.num_spec_tokens = 3
     agent.rank = 0
-    agent.proposer = _DummyProposer()
+    agent.proposer = _LegacyDummyProposer()
     agent.guided_helper = GuidedSpecHelper()
     forward_calls = 0
 
@@ -577,6 +577,33 @@ def test_async_model_forward_dp1_non_last_chunk_skips_remaining_spec_forwards():
     assert agent.proposer.get_outputs_calls == 0
     assert agent.proposer.update_inputs_decoding_calls == 0
     assert agent.proposer.advance_draft_depth_calls == 0
+
+
+def test_async_model_forward_dp1_non_last_chunk_runs_draft_depth_protocol():
+    """Protocol proposers must retain draft outputs for non-last chunks."""
+    from lmdeploy.pytorch.spec_decode.spec_agent import SpecModelAgent
+
+    inputs, extra_inputs = _make_non_last_chunk_inputs()
+    agent = object.__new__(SpecModelAgent)
+    agent.num_spec_tokens = 3
+    agent.rank = 0
+    agent.proposer = _DummyProposer()
+    agent.guided_helper = GuidedSpecHelper()
+    forward_calls = 0
+
+    def _forward_impl(_inputs):
+        nonlocal forward_calls
+        forward_calls += 1
+        return {'call': forward_calls}
+
+    agent._forward_impl = _forward_impl
+
+    output = asyncio.run(agent._async_model_forward(inputs, extra_inputs, sampling_inputs=None))
+
+    expected = torch.tensor([[0, 1, 2], [0, 1, 2]], dtype=torch.long)
+    torch.testing.assert_close(output.output_draft_token_ids, expected)
+    assert forward_calls == agent.num_spec_tokens
+    assert agent.proposer.advance_draft_depth_calls == agent.num_spec_tokens - 1
 
 
 def test_async_model_forward_dp1_uses_legacy_draft_depth_transition():
@@ -606,6 +633,28 @@ def test_async_model_forward_dp1_uses_legacy_draft_depth_transition():
     assert forward_calls == agent.num_spec_tokens
     assert agent.proposer.update_inputs_decoding_calls == 1
     assert agent.proposer.advance_draft_depth_calls == 0
+
+
+def test_build_draft_depth_dp_meta_legacy_uses_rank_batch_token_counts(monkeypatch):
+    """Legacy recurrent depth uses one token per rank-local request."""
+    import lmdeploy.pytorch.spec_decode.spec_agent as spec_agent_mod
+    from lmdeploy.pytorch.model_inputs import DPMeta
+    from lmdeploy.pytorch.spec_decode.spec_agent import SpecModelAgent
+
+    build_num_tokens = []
+
+    def _build(seqlen, num_tokens):
+        build_num_tokens.append(list(num_tokens))
+        return DPMeta()
+
+    monkeypatch.setattr(spec_agent_mod.DPMeta, 'build', staticmethod(_build))
+    inputs, _ = _make_non_last_chunk_inputs(dp_meta=DPMeta(dp_batches=[2, 5]))
+    agent = object.__new__(SpecModelAgent)
+    agent.proposer = _LegacyDummyProposer()
+
+    agent._build_draft_depth_dp_meta(inputs)
+
+    assert build_num_tokens == [[2, 5]]
 
 
 def test_async_model_forward_dp_non_last_chunk_pads_block_offsets(monkeypatch):

--- a/tests/pytorch/spec_decode/test_spec_agent.py
+++ b/tests/pytorch/spec_decode/test_spec_agent.py
@@ -229,6 +229,20 @@ class _LegacyDummyProposer(_DummyProposer):
         raise AssertionError('legacy proposing must not require draft-depth DP metadata.')
 
 
+def test_draft_depth_protocol_requires_both_transition_hooks():
+    from lmdeploy.pytorch.spec_decode.spec_agent import SpecModelAgent
+
+    class _MalformedProposer:
+        supports_draft_depth_protocol = True
+        advance_draft_depth = None
+
+    agent = object.__new__(SpecModelAgent)
+    agent.proposer = _MalformedProposer()
+
+    with pytest.raises(TypeError, match='get_draft_depth_token_counts'):
+        agent._uses_draft_depth_protocol()
+
+
 def test_guided_serial_bitmask_updates_inference_tensor():
     """Serial guided masking can update logits produced under inference
     mode."""

--- a/tests/pytorch/spec_decode/test_spec_agent.py
+++ b/tests/pytorch/spec_decode/test_spec_agent.py
@@ -161,6 +161,7 @@ class _DummyDraftModel:
 
 
 class _DummyProposer:
+    supports_draft_depth_protocol = True
 
     def __init__(self):
         self.get_outputs_calls = 0
@@ -219,6 +220,13 @@ class _DummyProposer:
         if self.next_depth_dp_num_tokens is not None:
             return self.next_depth_dp_num_tokens
         return dp_meta.dp_batches
+
+
+class _LegacyDummyProposer(_DummyProposer):
+    supports_draft_depth_protocol = False
+
+    def get_draft_depth_token_counts(self, dp_meta):
+        raise AssertionError('legacy proposing must not require draft-depth DP metadata.')
 
 
 def test_guided_serial_bitmask_updates_inference_tensor():
@@ -568,6 +576,35 @@ def test_async_model_forward_dp1_non_last_chunk_skips_remaining_spec_forwards():
     assert forward_calls == 1
     assert agent.proposer.get_outputs_calls == 0
     assert agent.proposer.update_inputs_decoding_calls == 0
+    assert agent.proposer.advance_draft_depth_calls == 0
+
+
+def test_async_model_forward_dp1_uses_legacy_draft_depth_transition():
+    from lmdeploy.pytorch.spec_decode.spec_agent import SpecModelAgent
+
+    inputs, extra_inputs = _make_non_last_chunk_inputs()
+    inputs.is_chunk = False
+    inputs.is_last_chunk = True
+    agent = object.__new__(SpecModelAgent)
+    agent.num_spec_tokens = 3
+    agent.rank = 0
+    agent.proposer = _LegacyDummyProposer()
+    agent.guided_helper = GuidedSpecHelper()
+    forward_calls = 0
+
+    def _forward_impl(_inputs):
+        nonlocal forward_calls
+        forward_calls += 1
+        return {'call': forward_calls}
+
+    agent._forward_impl = _forward_impl
+
+    output = asyncio.run(agent._async_model_forward(inputs, extra_inputs, sampling_inputs=None))
+
+    expected = torch.tensor([[0, 1, 2], [0, 1, 2]], dtype=torch.long)
+    assert torch.equal(output.output_draft_token_ids, expected)
+    assert forward_calls == agent.num_spec_tokens
+    assert agent.proposer.update_inputs_decoding_calls == 1
     assert agent.proposer.advance_draft_depth_calls == 0
 
 

--- a/tests/pytorch/spec_decode/test_spec_agent.py
+++ b/tests/pytorch/spec_decode/test_spec_agent.py
@@ -649,6 +649,24 @@ def test_async_model_forward_dp1_uses_legacy_draft_depth_transition():
     assert agent.proposer.advance_draft_depth_calls == 0
 
 
+def test_legacy_base_transition_does_not_advance_draft_depth():
+    """The opt-in depth protocol must not alter legacy proposer state."""
+    from lmdeploy.pytorch.spec_decode.proposers.base import BaseSpecProposer
+
+    inputs, extra_inputs = _make_non_last_chunk_inputs()
+    inputs.spec_step_idx = 7
+    output = BaseSpecProposer.update_inputs_decoding(
+        object.__new__(BaseSpecProposer),
+        inputs,
+        extra_inputs,
+        torch.tensor([[3, 4]], dtype=torch.long),
+        torch.zeros(1, 2, 4),
+        [{}, {}],
+    )
+
+    assert output.spec_step_idx == inputs.spec_step_idx
+
+
 def test_build_draft_depth_dp_meta_legacy_uses_rank_batch_token_counts(monkeypatch):
     """Legacy recurrent depth uses one token per rank-local request."""
     import lmdeploy.pytorch.spec_decode.spec_agent as spec_agent_mod

--- a/tests/pytorch/test_distributed.py
+++ b/tests/pytorch/test_distributed.py
@@ -1,0 +1,31 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+from types import SimpleNamespace
+
+import torch
+
+import lmdeploy.pytorch.distributed as distributed
+
+
+def test_reduce_scatter_by_tp_sizes_uses_disjoint_output(monkeypatch):
+    """The collective output must not alias any reduce-scatter input view."""
+    manager = SimpleNamespace(current_config=lambda: SimpleNamespace(attn_tp=2))
+    monkeypatch.setattr(distributed, 'get_dist_manager', lambda: manager)
+
+    seen = {}
+
+    def _reduce_scatter(output, inputs, group):
+        seen['group'] = group
+        seen['inputs'] = inputs
+        output_storage = output.untyped_storage().data_ptr()
+        assert all(output_storage != item.untyped_storage().data_ptr() for item in inputs)
+        output.copy_(inputs[0])
+
+    monkeypatch.setattr(distributed.dist, 'reduce_scatter', _reduce_scatter)
+
+    source = torch.arange(12, dtype=torch.float32).reshape(3, 4)
+    result = distributed.reduce_scatter_by_tp_sizes(source, rank=0, tp_sizes=[2, 1], group='test-group')
+
+    assert seen['group'] == 'test-group'
+    assert len(seen['inputs']) == 4
+    torch.testing.assert_close(result, source[:2])
+    assert result.untyped_storage().data_ptr() != source.untyped_storage().data_ptr()

--- a/tests/test_lmdeploy/serve/parsers/test_mimo_parser.py
+++ b/tests/test_lmdeploy/serve/parsers/test_mimo_parser.py
@@ -1,0 +1,144 @@
+import json
+
+from lmdeploy.serve.openai.protocol import ChatCompletionRequest
+from lmdeploy.serve.parsers import ResponseParserManager
+from lmdeploy.serve.parsers.reasoning_parser import ReasoningParserManager
+from lmdeploy.serve.parsers.tool_parser import MiMoToolParser, ToolParserManager
+
+from .helpers import final_tool_call, final_tool_calls, first_stream_delta
+
+MODEL_ID = 'XiaomiMiMo/MiMo-V2-Flash'
+
+
+def _make_request(*, stream: bool = False):
+    return ChatCompletionRequest(
+        model=MODEL_ID,
+        messages=[],
+        stream=stream,
+        tools=[{
+            'type': 'function',
+            'function': {
+                'name': 'run_command',
+                'description': 'Run a command.',
+                'parameters': {
+                    'type': 'object',
+                    'properties': {
+                        'command': {
+                            'type': 'string'
+                        },
+                        'timeout': {
+                            'type': 'integer'
+                        },
+                        'options': {
+                            'type': 'object'
+                        },
+                    },
+                },
+            },
+        }],
+        tool_choice='auto',
+        chat_template_kwargs={'enable_thinking': True},
+    )
+
+
+def _make_response_parser(*, stream: bool = False):
+    cls = ResponseParserManager.get('default')
+    cls.reasoning_parser_cls = ReasoningParserManager.get('default')
+    cls.tool_parser_cls = ToolParserManager.get('mimo')
+    return cls(request=_make_request(stream=stream))
+
+
+def test_mimo_complete_preserves_string_and_coerces_typed_values():
+    parser = MiMoToolParser()
+    parser.adjust_request(_make_request())
+    payload = (
+        '<function=run_command>'
+        '<parameter=command>  printf &quot;a&amp;b&quot;\nnext  </parameter>'
+        '<parameter=timeout>30</parameter>'
+        '<parameter=options>{"check":true}</parameter>'
+        '</function>'
+    )
+
+    call = final_tool_call(parser, payload)
+
+    assert call is not None
+    assert call.function.name == 'run_command'
+    assert json.loads(call.function.arguments) == {
+        'command': '  printf "a&b"\nnext  ',
+        'timeout': 30,
+        'options': {
+            'check': True
+        },
+    }
+
+def test_mimo_streaming_handles_split_tags_and_multiline_value():
+    parser = _make_response_parser(stream=True)
+    chunks = [
+        '<think>Need a tool.</think>',
+        '<tool_',
+        'call><function=run_',
+        'command><parameter=command>line 1\n',
+        '  line 2</parameter><parameter=timeout>',
+        '10</parameter></function></tool_call>',
+    ]
+    reasoning_parts = []
+    name = None
+    arguments = ''
+
+    for chunk in chunks:
+        for delta, emitted in parser.stream_chunk(delta_text=chunk, delta_token_ids=[]):
+            if delta.reasoning_content:
+                reasoning_parts.append(delta.reasoning_content)
+            if not emitted or not delta.tool_calls:
+                continue
+            for call in delta.tool_calls:
+                if call.function and call.function.name:
+                    name = call.function.name
+                if call.function and call.function.arguments:
+                    arguments += call.function.arguments
+
+    for _ in range(3):
+        delta, emitted = first_stream_delta(parser.stream_chunk(delta_text='', delta_token_ids=[]))
+        if emitted and delta and delta.tool_calls:
+            for call in delta.tool_calls:
+                if call.function and call.function.name:
+                    name = call.function.name
+                if call.function and call.function.arguments:
+                    arguments += call.function.arguments
+
+    assert ''.join(reasoning_parts) == 'Need a tool.'
+    assert name == 'run_command'
+    assert json.loads(arguments) == {
+        'command': 'line 1\n  line 2',
+        'timeout': 10,
+    }
+    assert parser.tool_parser is not None
+    assert parser.tool_parser.block_closed is True
+
+
+def test_mimo_streaming_decodes_split_html_entity():
+    parser = MiMoToolParser()
+    parser.adjust_request(_make_request(stream=True))
+    parser.begin_tool_block()
+    pending = ''
+    deltas = []
+
+    for chunk in (
+        '<function=run_command><parameter=command>A &quo',
+        't;b&amp;c</parameter></function></tool_call>',
+    ):
+        text = pending + chunk
+        consumed = parser.feed_tool_block(text, deltas, final=False)
+        pending = text[consumed:]
+
+    assert pending == ''
+    calls = parser.build_tool_calls(deltas)
+    assert json.loads(calls[0].function.arguments) == {'command': 'A "b&c'}
+
+
+def test_mimo_filters_unknown_tool_names():
+    parser = MiMoToolParser()
+    parser.adjust_request(_make_request())
+
+    calls = final_tool_calls(parser, '<function=unknown></function>')
+    assert calls == []


### PR DESCRIPTION
## Motivation

This PR adds support for Xiaomi MiMo-V2-Flash in LMDeploy's PyTorch backend. MiMo-V2-Flash uses hybrid full-attention and sliding-window-attention (SWA) layers and provides a three-layer MTP module for speculative decoding. This PR adds the required model implementation, attention and KV-cache support, MTP integration, and tool-call parsing.

## Modification

- Add the MiMo-V2-Flash model configuration and target model implementation.
- Add the three-layer MiMo MTP draft model.
- Add support for the model's hybrid full-attention/SWA layer pattern.
- Add SWA state-ring cache and related CUDA attention kernels.
- Add tensor-parallel KV-head replication for full-attention and SWA layers.
- Add paged SWA KV-cache handling for speculative decoding.
- Integrate MiMo MTP with LMDeploy speculative decoding and CUDA-graph paths.
- Add the MiMo tool-call parser and register it with the parser manager.
- Add the FP8 linear and attention paths required by the model.
- Update model registration, supported-model lists, and English/Chinese documentation.

LMDeploy and Hugging Face were evaluated with aligned settings. The LMDeploy values are averages over repeated runs.

| Benchmark        | LMDeploy              | Hugging Face | Difference |
| ---------------- | --------------------- | ------------ | ---------- |
| GPQA-Diamond     | 84.47% (8-run average) | 83.70%      | +0.77 pp   |
| AIME 2025        | 95.10% (32-run average) | 94.10%     | +1.00 pp   |

## Acceptance of MTP

The following results use TP8 + DP2 + EP8, attention TP4 per DP group, fixed 128-request ShareGPT workload, 2048 generated tokens, temperature 0, `ignore_eos=true`, three MTP draft positions, and three repeated runs.

### Aggregate results

| Engine   | Mean accept length | Acceptance rate                          |
| -------- | ------------------ | ---------------------------------------- |
| LMDeploy | 3.115              | 70.49% (native draft-token definition)   |
| SGLang   | 3.076              | 76.91% (including bonus-token normalization) |

### Per-position results

| Engine   | Position 1 | Position 2 | Position 3 | Strict 3/3 acceptance |
| -------- | ---------- | ---------- | ---------- | --------------------- |
| LMDeploy | 85.89%     | 69.38%     | 56.20%     | 56.20%                |
| SGLang   | 84.86%     | 67.99%     | 54.78%     | 54.78%                |

LMDeploy's native acceptance rate is `accepted_draft_tokens / drafted_tokens` and excludes the bonus token. Mean accept length includes the bonus token. Position values are prefix acceptance probabilities; they must not be multiplied together. The strict 3/3 rate is the probability that all three draft positions are accepted.

## Performance

The fixed-output benchmark uses the same ShareGPT inputs, TP8 + DP2 + EP8 topology, attention TP4 per DP group, concurrency 128, and three repetitions per point.

### MTP throughput and TTFT

| Engine         | Output | Duration (s) | Request throughput (req/s) | Output throughput (tok/s) | TTFT Mean (ms) | TTFT P50 (ms) | TTFT P99 (ms) |
| -------------- | ------ | ------------ | -------------------------- | ------------------------- | -------------- | ------------- | ------------- |
| LMDeploy MTP   | 2048   | 36.46        | 3.51                       | 7195.01                   | 934.35         | 909.23        | 1029.04       |
| SGLang MTP     | 2048   | 35.18        | 3.64                       | 7457.21                   | 469.01         | 463.74        | 535.28        |
| LMDeploy MTP   | 4096   | 66.54        | 1.93                       | 7896.77                   | 689.53         | 676.68        | 797.08        |
| SGLang MTP     | 4096   | 63.66        | 2.01                       | 8239.97                   | 366.37         | 367.62        | 389.05        |
| LMDeploy MTP   | 8192   | 121.75       | 1.06                       | 8677.01                   | 733.45         | 731.26        | 798.63        |
| SGLang MTP     | 8192   | 119.26       | 1.08                       | 8806.60                   | 692.20         | 701.28        | 739.12        |

### MTP TPOT and ITL

| Engine         | Output | TPOT Mean (ms) | TPOT P50 (ms) | TPOT P99 (ms) | ITL Mean (ms) | ITL P50 (ms) | ITL P99 (ms) |
| -------------- | ------ | -------------- | ------------- | ------------- | ------------- | ------------ | ------------ |
| LMDeploy MTP   | 2048   | 13.21          | 12.93         | 16.96         | 41.75         | 38.39        | 180.02       |
| SGLang MTP     | 2048   | 13.44          | 13.42         | 16.83         | 41.20         | 38.49        | 126.80       |
| LMDeploy MTP   | 4096   | 12.08          | 11.84         | 15.74         | 41.19         | 38.62        | 118.37       |
| SGLang MTP     | 4096   | 12.27          | 12.15         | 15.26         | 40.28         | 38.60        | 58.35        |
| LMDeploy MTP   | 8192   | 11.32          | 11.20         | 13.57         | 41.12         | 38.96        | 75.59        |
| SGLang MTP     | 8192   | 11.61          | 11.44         | 13.95         | 40.72         | 39.08        | 49.32        |

LMDeploy MTP output throughput is 96.5%, 95.8%, and 98.5% of SGLang MTP for 2048, 4096, and 8192 output tokens, respectively. MTP TPOT remains within 3% of SGLang in these tests.

## Runtime validation

- TP4 and TP8 target inference and CUDA Graph serving.
- TP8 + DP2 + EP8 + DeepEP + DeepGEMM + MTP3 production topology.
- Prefix caching with MTP and high-concurrency replay.
- SWA boundary and speculative accept/reject/rollback cases.
- MiMo tool-call API round trips.

## Compatibility

No intentional backward-incompatible changes are introduced. MiMo-V2-Flash support targets the PyTorch backend. MTP requires the three-layer draft weights included in the checkpoint. FA3 is optional; unsupported asymmetric head-dimension builds automatically use Triton.

## Validation

- Ruff and `git diff --check` pass.
- Focused model, attention, cache, MTP, FP8, distributed, CUDA Graph, and parser tests pass.
- Real-checkpoint TP4/TP8 and production-topology runtime validation pass.

## Assistance 

Assisted with Codex, reviewed manually.

## Checklist

1. Pre-commit or other linting tools are used to fix the potential lint issues.
2. The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
3. If the modification has a dependency on downstream projects of a newer version, this PR should be tested with all supported versions of downstream projects.
4. The documentation has been modified accordingly, like docstring or example tutorials.