### PR TITLE
[Fix] Release GEMM cache-flushing buffer on thread exit

### DIFF
--- a/src/turbomind/kernels/gemm/CMakeLists.txt
+++ b/src/turbomind/kernels/gemm/CMakeLists.txt
@@ -160,3 +160,10 @@ target_compile_options(gemm2 PRIVATE
 )
 set_property(TARGET gemm2 PROPERTY POSITION_INDEPENDENT_CODE ON)
 set_property(TARGET gemm2 PROPERTY CUDA_RESOLVE_DEVICE_SYMBOLS ON)
+
+if (BUILD_TEST)
+    find_package(Threads REQUIRED)
+    # Link only the helper to keep leak checking independent of kernel registries.
+    add_executable(test_cache_flushing test/test_cache_flushing.cc tuner/cache_utils.cu)
+    target_link_libraries(test_cache_flushing PRIVATE CUDA::cudart Threads::Threads)
+endif ()

--- a/src/turbomind/kernels/gemm/test/test_cache_flushing.cc
+++ b/src/turbomind/kernels/gemm/test/test_cache_flushing.cc
@@ -1,0 +1,78 @@
+// Copyright (c) OpenMMLab. All rights reserved.
+
+// Run with compute-sanitizer --tool memcheck --leak-check full --error-exitcode 99.
+// Leak checking must include thread-local destruction after main returns.
+#include <cuda_runtime.h>
+
+#include <exception>
+#include <iostream>
+#include <stdexcept>
+#include <thread>
+
+#include "src/turbomind/kernels/gemm/tuner/cache_utils.h"
+
+namespace {
+
+void Check(cudaError_t status)
+{
+    if (status != cudaSuccess) {
+        throw std::runtime_error(cudaGetErrorString(status));
+    }
+}
+
+void Flush()
+{
+    // Exercise reuse on one thread, then destruction after its stream retires.
+    cudaStream_t stream{};
+    Check(cudaStreamCreate(&stream));
+
+    try {
+        turbomind::gemm::CacheFlushing::flush(stream);
+        turbomind::gemm::CacheFlushing::flush(stream);
+        Check(cudaGetLastError());
+        Check(cudaStreamSynchronize(stream));
+    }
+    catch (...) {
+        cudaStreamDestroy(stream);
+        throw;
+    }
+
+    Check(cudaStreamDestroy(stream));
+}
+
+}  // namespace
+
+int main()
+{
+    try {
+        Check(cudaSetDevice(0));
+
+        for (int i = 0; i < 2; ++i) {
+            std::exception_ptr error;
+            std::thread        worker([&] {
+                try {
+                    Check(cudaSetDevice(0));
+                    Flush();
+                }
+                catch (...) {
+                    error = std::current_exception();
+                }
+            });
+
+            worker.join();
+
+            if (error) {
+                std::rethrow_exception(error);
+            }
+        }
+
+        // Also check main-thread TLS cleanup. Do not mask leaks with device reset.
+        Flush();
+    }
+    catch (const std::exception& error) {
+        std::cerr << error.what() << '\n';
+        return 1;
+    }
+
+    return 0;
+}

--- a/src/turbomind/kernels/gemm/test/test_cache_flushing.cc
+++ b/src/turbomind/kernels/gemm/test/test_cache_flushing.cc
@@ -2,14 +2,14 @@
 
 // Run with compute-sanitizer --tool memcheck --leak-check full --error-exitcode 99.
 // Leak checking must include thread-local destruction after main returns.
+#include "src/turbomind/kernels/gemm/tuner/cache_utils.h"
+
 #include <cuda_runtime.h>
 
 #include <exception>
 #include <iostream>
 #include <stdexcept>
 #include <thread>
-
-#include "src/turbomind/kernels/gemm/tuner/cache_utils.h"
 
 namespace {
 

--- a/src/turbomind/kernels/gemm/tuner/cache_utils.cu
+++ b/src/turbomind/kernels/gemm/tuner/cache_utils.cu
@@ -14,6 +14,11 @@ CacheFlushing::CacheFlushing()
     cudaMalloc(&buffer_, size_);
 }
 
+CacheFlushing::~CacheFlushing() noexcept
+{
+    cudaFree(buffer_);
+}
+
 void CacheFlushing::flush(cudaStream_t stream)
 {
     thread_local CacheFlushing inst{};

--- a/src/turbomind/kernels/gemm/tuner/cache_utils.h
+++ b/src/turbomind/kernels/gemm/tuner/cache_utils.h
@@ -12,10 +12,17 @@ public:
 
 private:
     CacheFlushing();
+    ~CacheFlushing() noexcept;
+
+    CacheFlushing(const CacheFlushing&)            = delete;
+    CacheFlushing& operator=(const CacheFlushing&) = delete;
+    CacheFlushing(CacheFlushing&&)                 = delete;
+    CacheFlushing& operator=(CacheFlushing&&)      = delete;
+
     void operator()(cudaStream_t stream) const;
 
-    uint32_t* buffer_;
-    size_t    size_;
+    uint32_t* buffer_{};
+    size_t    size_{};
 };
 
 }  // namespace turbomind::gemm

--- a/src/turbomind/kernels/gemm/tuner/cache_utils.h
+++ b/src/turbomind/kernels/gemm/tuner/cache_utils.h
@@ -2,7 +2,9 @@
 
 #pragma once
 
+#include <cstddef>
 #include <cstdint>
+#include <cuda_runtime_api.h>
 
 namespace turbomind::gemm {
 
@@ -21,8 +23,8 @@ private:
 
     void operator()(cudaStream_t stream) const;
 
-    uint32_t* buffer_{};
-    size_t    size_{};
+    uint32_t*   buffer_{};
+    std::size_t size_{};
 };
 
 }  // namespace turbomind::gemm


### PR DESCRIPTION
## Motivation

`CacheFlushing` allocates an L2-sized CUDA buffer for each thread that performs GEMM tuning, but the buffer is never freed. When an executor thread exits, its thread-local `CacheFlushing` object loses ownership of the allocation, resulting in a memory leak.

On an RTX 4080 SUPER, this leaks 64 MiB per thread that initializes the helper.

This PR fixes the lifetime management of the CUDA buffer and adds a regression test to verify that the allocation is released when the thread-local object is destroyed.

## Modification

* Add a non-throwing destructor to `CacheFlushing` that releases the CUDA buffer.
* Initialize the buffer-related members explicitly.
* Disable copy and move operations to preserve unique ownership of the CUDA allocation.
* Keep the existing static `flush` interface and same-thread buffer reuse behavior unchanged.
* Add a standalone `test_cache_flushing` target under `BUILD_TEST`.

The regression test:

* exercises two successive worker threads and main-thread cleanup;
* calls the helper twice per thread to cover same-thread buffer reuse;
* retires non-default CUDA streams before thread-local destruction; and
* links only the cache-flushing helper and CUDA Runtime so unrelated kernel-registration errors do not obscure the leak check.

Validation was performed with CUDA 13.0.88, an RTX 4080 SUPER, and GCC 13.3.

Before the fix:

* 201,326,592 bytes leaked across three allocations;
* Compute Sanitizer exited with code 99.

After the fix:

* zero leaked bytes;
* zero sanitizer errors;
* Compute Sanitizer exited with code 0.

The regression test can be built and checked with:

```sh
cmake --build build --target test_cache_flushing
compute-sanitizer --tool memcheck --leak-check full --error-exitcode 99 build/bin/test_cache_flushing
```

The build must be configured with `BUILD_TEST=ON`.

Running `test_cache_flushing` without Compute Sanitizer exercises the relevant lifetime paths, but does not by itself assert leak freedom.

## BC-breaking (Optional)

No. This change does not modify the public `CacheFlushing::flush` interface or its existing same-thread buffer reuse behavior.

## Use cases (Optional)

N/A. This PR fixes a memory leak in the GEMM tuning helper and adds regression coverage; it does not introduce a new user-facing feature.

## Checklist

* [x] Pre-commit or other linting tools are used to fix potential lint issues.
* [x] The modification is covered by a dedicated regression test.
* [x] No new dependency on downstream projects or newer downstream versions is introduced.
* [x] Relevant code documentation/comments have been updated where applicable.