### PR TITLE
Perf/pytorch block fp8 moe decode

### DIFF
--- a/lmdeploy/pytorch/envs.py
+++ b/lmdeploy/pytorch/envs.py
@@ -208,6 +208,12 @@ with set_envs():
         'LMDEPLOY_MOE_STATIC_FP8_USE_COMPILED_QUANT',
         False,
     )
+    # Use measured active-expert block schedules for supported Block-FP8 MoE
+    # decode shapes. Unknown shapes retain the established dense schedule.
+    moe_active_block_decode = env_to_bool(
+        'LMDEPLOY_MOE_ACTIVE_BLOCK_DECODE',
+        False,
+    )
 
     # Hy3
     hy3_shared_expert_overlap = env_to_bool(

--- a/lmdeploy/pytorch/kernels/cuda/activation.py
+++ b/lmdeploy/pytorch/kernels/cuda/activation.py
@@ -3,6 +3,7 @@ import torch
 import triton
 import triton.language as tl
 
+from .blocked_gemm_fp8 import fast_round_scale
 from .utils import get_device_props
 
 fast_expf = tl.math.exp
@@ -89,6 +90,142 @@ def silu_and_mul(gate_up: torch.Tensor, out: torch.Tensor = None):
                                num_stages=num_stages)
 
     return out
+
+
+@triton.jit(do_not_specialize=['M'])
+def _silu_and_mul_post_quant_kernel(
+    gateup_ptr,
+    out_ptr,
+    scale_ptr,
+    M,
+    N: tl.constexpr,
+    fp8_min: tl.constexpr,
+    fp8_max: tl.constexpr,
+    stride_gum,
+    stride_gun: tl.constexpr,
+    stride_om,
+    stride_on: tl.constexpr,
+    stride_sm,
+    stride_sg,
+    ROUND_SCALE: tl.constexpr,
+    GROUP_SIZE: tl.constexpr,
+    NUM_GROUPS_PER_CTA: tl.constexpr,
+    NUM_STAGES: tl.constexpr,
+):
+    """Apply SiLU-and-mul and directly emit block-quantized FP8 values."""
+    group_id = tl.program_id(0) * NUM_GROUPS_PER_CTA
+    m_id_start = tl.program_id(1)
+    m_id_stride = tl.num_programs(1)
+
+    group_size_cta: tl.constexpr = GROUP_SIZE * NUM_GROUPS_PER_CTA
+    offs_n = group_id * GROUP_SIZE + tl.arange(0, group_size_cta)
+    offs_n = tl.max_contiguous(tl.multiple_of(offs_n, GROUP_SIZE), GROUP_SIZE)
+    offs_s = group_id + tl.arange(0, NUM_GROUPS_PER_CTA)
+    reciprocal_fp8_max = 1.0 / fp8_max
+
+    if N % group_size_cta == 0:
+        mask_n = True
+        mask_s = True
+    else:
+        mask_n = offs_n < N
+        mask_s = offs_s < tl.cdiv(N, GROUP_SIZE)
+
+    gate_ptrs = gateup_ptr + m_id_start * stride_gum + offs_n * stride_gun
+    up_ptrs = gateup_ptr + m_id_start * stride_gum + (N + offs_n) * stride_gun
+    out_ptrs = out_ptr + m_id_start * stride_om + offs_n * stride_on
+    scale_ptrs = scale_ptr + m_id_start * stride_sm + offs_s * stride_sg
+
+    for _ in tl.range(m_id_start, M, m_id_stride, num_stages=NUM_STAGES):
+        gate = tl.load(gate_ptrs, mask=mask_n, other=0.0).to(tl.float32)
+        up = tl.load(up_ptrs, mask=mask_n, other=0.0)
+
+        # Preserve the established two-kernel numerical boundary: the SiLU
+        # result is rounded to the gate/up dtype before multiplication, and
+        # the product is rounded again before its per-group amax is computed.
+        gate = gate / (1 + fast_expf(-gate))
+        gate = gate.to(gateup_ptr.dtype.element_ty)
+        activated = (gate * up).to(gateup_ptr.dtype.element_ty).to(tl.float32)
+        activated = activated.reshape(NUM_GROUPS_PER_CTA, GROUP_SIZE)
+
+        amax = tl.max(tl.abs(activated), axis=1)
+        amax = tl.maximum(amax, 1e-6).to(tl.float32)
+        if ROUND_SCALE:
+            scale = fast_round_scale(amax, reciprocal_fp8_max)
+            reciprocal_scale = 1.0 / scale
+        else:
+            scale = amax * reciprocal_fp8_max
+            reciprocal_scale = fp8_max / amax
+
+        out = activated * reciprocal_scale[:, None]
+        out = tl.clamp(out, fp8_min, fp8_max).to(out_ptr.dtype.element_ty)
+        tl.store(out_ptrs, out.reshape(group_size_cta), mask=mask_n)
+        tl.store(scale_ptrs, scale, mask=mask_s)
+
+        gate_ptrs += m_id_stride * stride_gum
+        up_ptrs += m_id_stride * stride_gum
+        out_ptrs += m_id_stride * stride_om
+        scale_ptrs += m_id_stride * stride_sm
+
+
+def silu_and_mul_post_quant(gate_up: torch.Tensor,
+                            group_size: int,
+                            dtype: torch.dtype = torch.float8_e4m3fn,
+                            scale_fmt: str | None = None) -> tuple[torch.Tensor, torch.Tensor]:
+    """Fuse SiLU-and-mul with per-token-group FP8 quantization.
+
+    The result matches ``quant_fp8(silu_and_mul(gate_up))`` while avoiding the
+    materialized BF16/FP16 activation and its second HBM read.
+    """
+    assert scale_fmt in (None, 'ue8m0')
+    assert gate_up.dim() >= 2
+    assert gate_up.stride(-1) == 1, 'last dimension must be contiguous'
+    hidden = gate_up.size(-1) // 2
+    assert gate_up.size(-1) == hidden * 2
+    assert hidden % group_size == 0
+
+    out = gate_up.new_empty(*gate_up.shape[:-1], hidden, dtype=dtype)
+    scales = gate_up.new_empty(*gate_up.shape[:-1], hidden // group_size, dtype=torch.float32)
+    if gate_up.numel() == 0:
+        return out, scales
+
+    gate_up_2d = gate_up.reshape(-1, hidden * 2)
+    out_2d = out.reshape(-1, hidden)
+    scales_2d = scales.reshape(-1, hidden // group_size)
+    m = gate_up_2d.size(0)
+
+    finfo = torch.finfo(dtype)
+    num_warps = 4
+    num_groups_per_cta = 4
+    grid_size0 = triton.cdiv(hidden, group_size * num_groups_per_cta)
+    props = get_device_props(gate_up.device.index)
+    max_ctas = props['multi_processor_count'] * min(props['blocks_per_sm'],
+                                                    props['warps_per_sm'] // num_warps)
+    grid_size1 = min(m, max(1, max_ctas // grid_size0))
+    assert grid_size0 < 65536 and grid_size1 < 65536
+    num_stages = min(4, max(1, triton.cdiv(m, grid_size1)))
+
+    _silu_and_mul_post_quant_kernel[(grid_size0, grid_size1)](
+        gate_up_2d,
+        out_2d,
+        scales_2d,
+        m,
+        N=hidden,
+        fp8_min=finfo.min,
+        fp8_max=finfo.max,
+        stride_gum=gate_up_2d.stride(0),
+        stride_gun=gate_up_2d.stride(1),
+        stride_om=out_2d.stride(0),
+        stride_on=out_2d.stride(1),
+        stride_sm=scales_2d.stride(0),
+        stride_sg=scales_2d.stride(1),
+        ROUND_SCALE=scale_fmt == 'ue8m0',
+        GROUP_SIZE=group_size,
+        NUM_GROUPS_PER_CTA=num_groups_per_cta,
+        NUM_STAGES=num_stages,
+        num_warps=num_warps,
+        num_stages=num_stages,
+    )
+    return out, scales
 
 
 @triton.jit

--- a/lmdeploy/pytorch/kernels/cuda/moe/blocked_fp8.py
+++ b/lmdeploy/pytorch/kernels/cuda/moe/blocked_fp8.py
@@ -6,6 +6,8 @@ import torch
 import triton
 import triton.language as tl
 
+from lmdeploy.pytorch import envs as _envs
+
 from ..activation import silu_and_mul
 from ..blocked_gemm_fp8 import quant_fp8
 from .fused_moe import _get_sorted_idx, _get_sorted_idx_blocks, _make_intermediate, _renormalize, moe_reduce
@@ -517,6 +519,84 @@ def _origin_blocked_fp8_moe_configs(num_tokens: int, num_routes: int, num_expert
     return gate_config, down_config
 
 
+def _supports_blocked_fp8_decode_fast_path(input: torch.Tensor,
+                                           w1: torch.Tensor,
+                                           w2: torch.Tensor,
+                                           topk_ids: torch.Tensor,
+                                           num_experts: int):
+    """Check the correctness contract of active-block decode scheduling."""
+    if not input.is_cuda or torch.cuda.get_device_capability(input.device) != (9, 0):
+        return False
+    if input.dim() != 2 or w1.dim() != 3 or w2.dim() != 3 or topk_ids.dim() != 2:
+        return False
+
+    num_tokens, hidden = input.shape
+    local_experts, gate_up_features, gate_k = w1.shape
+    down_experts, down_features, down_k = w2.shape
+    topk = topk_ids.size(1)
+    return (
+        num_tokens >= 1
+        and topk_ids.size(0) == num_tokens
+        and 1 <= topk <= 16
+        and local_experts == down_experts == num_experts
+        and num_experts >= 64
+        and gate_k == hidden == down_features
+        and gate_up_features == 2 * down_k
+        and hidden % 128 == 0
+        and down_k % 128 == 0
+    )
+
+
+_ACTIVE_BLOCK_DECODE_CONFIG = dict(block_m=16, block_n=128, num_warps=4, num_stages=3)
+
+# Measured backend geometries. Keys intentionally contain no model identity:
+# (SM, input dtype, output dtype, group size, M, E, top-k,
+#  hidden/down N, gate-up N).
+_ACTIVE_BLOCK_DECODE_SHAPE_CONFIGS = {
+    ((9, 0), torch.float8_e4m3fn, torch.bfloat16, 128, 1, 256, 8, 6144, 512):
+    _ACTIVE_BLOCK_DECODE_CONFIG,
+    ((9, 0), torch.float8_e4m3fn, torch.bfloat16, 128, 4, 256, 8, 6144, 512):
+    _ACTIVE_BLOCK_DECODE_CONFIG,
+    ((9, 0), torch.float8_e4m3fn, torch.bfloat16, 128, 16, 256, 8, 6144, 512):
+    _ACTIVE_BLOCK_DECODE_CONFIG,
+    ((9, 0), torch.float8_e4m3fn, torch.bfloat16, 128, 17, 256, 8, 6144, 512):
+    _ACTIVE_BLOCK_DECODE_CONFIG,
+    ((9, 0), torch.float8_e4m3fn, torch.bfloat16, 128, 32, 256, 8, 6144, 512):
+    _ACTIVE_BLOCK_DECODE_CONFIG,
+    ((9, 0), torch.float8_e4m3fn, torch.bfloat16, 128, 8, 256, 8, 6144, 1024):
+    _ACTIVE_BLOCK_DECODE_CONFIG,
+    ((9, 0), torch.float8_e4m3fn, torch.bfloat16, 128, 16, 256, 8, 6144, 1024):
+    _ACTIVE_BLOCK_DECODE_CONFIG,
+    ((9, 0), torch.float8_e4m3fn, torch.bfloat16, 128, 32, 256, 8, 6144, 1024):
+    _ACTIVE_BLOCK_DECODE_CONFIG,
+}
+
+
+def _select_active_block_decode_config(num_tokens: int,
+                                       num_routes: int,
+                                       num_experts: int,
+                                       local_experts: int,
+                                       gate_out_features: int,
+                                       down_out_features: int,
+                                       device_capability: tuple[int, int],
+                                       input_dtype: torch.dtype,
+                                       out_dtype: torch.dtype,
+                                       group_size: int):
+    """Select an exact measured active-block schedule, or safely fall back."""
+    if local_experts != num_experts or local_experts < 256:
+        return None
+    if num_tokens < 1 or num_routes > 2048 or num_experts > 2048:
+        return None
+
+    topk, remainder = divmod(num_routes, num_tokens)
+    if remainder != 0:
+        return None
+    shape_key = (device_capability, input_dtype, out_dtype, group_size, num_tokens,
+                 num_experts, topk, down_out_features, gate_out_features)
+    config = _ACTIVE_BLOCK_DECODE_SHAPE_CONFIGS.get(shape_key)
+    return None if config is None else dict(config)
+
+
 def _compact_blocked_fp8_moe_config(num_routes: int, num_experts: int):
     """Choose compact routed-blocked-FP8 MoE launch config."""
     avg_routes = triton.cdiv(num_routes, num_experts)
@@ -704,8 +784,21 @@ def fused_moe_blocked_fp8(input: torch.Tensor,
     gate_moe_cfg, down_moe_cfg = _origin_blocked_fp8_moe_configs(M, topk_ids.numel(), num_experts, E)
     supports_compact = _supports_compact_blocked_fp8_moe(input, input_scale, w1, w1_scale, w2, w2_scale, topk_ids,
                                                          num_experts, expert_offset)
-    compact_moe_cfg = None
-    if supports_compact:
+    active_decode_config = None
+    if (_envs.moe_active_block_decode and supports_compact
+            and _supports_blocked_fp8_decode_fast_path(input, w1, w2, topk_ids, num_experts)):
+        active_decode_config = _select_active_block_decode_config(M,
+                                                                  topk_ids.numel(),
+                                                                  num_experts,
+                                                                  E,
+                                                                  w1.size(1),
+                                                                  w2.size(1),
+                                                                  torch.cuda.get_device_capability(input.device),
+                                                                  input.dtype,
+                                                                  out_dtype,
+                                                                  group_size)
+    compact_moe_cfg = active_decode_config
+    if compact_moe_cfg is None and supports_compact:
         compact_moe_cfg = _select_compact_blocked_fp8_moe_both_config(M, topk_ids.numel(), num_experts, E,
                                                                       w1.size(1), w1.size(2))
     use_compact_both = compact_moe_cfg is not None

--- a/lmdeploy/pytorch/kernels/cuda/moe/blocked_fp8.py
+++ b/lmdeploy/pytorch/kernels/cuda/moe/blocked_fp8.py
@@ -8,7 +8,7 @@ import triton.language as tl
 
 from lmdeploy.pytorch import envs as _envs
 
-from ..activation import silu_and_mul
+from ..activation import silu_and_mul_post_quant
 from ..blocked_gemm_fp8 import quant_fp8
 from .fused_moe import _get_sorted_idx, _get_sorted_idx_blocks, _make_intermediate, _renormalize, moe_reduce
 
@@ -860,14 +860,16 @@ def fused_moe_blocked_fp8(input: torch.Tensor,
             **gate_moe_cfg,
         )
 
-    # activate
+    # Activate and directly emit the block-quantized down-projection input.
     intermediate_cache1 = intermediate_cache1.flatten(0, -2)
     if act_func is None:
-        gate_cache = silu_and_mul(intermediate_cache1)
+        gate_cache, gate_scale = silu_and_mul_post_quant(intermediate_cache1,
+                                                         group_size,
+                                                         dtype=input.dtype)
     else:
         gate_cache = act_func(intermediate_cache1)
+        gate_cache, gate_scale = quant_fp8(gate_cache, group_size, dtype=input.dtype)
     del intermediate_cache1
-    gate_cache, gate_scale = quant_fp8(gate_cache, group_size, dtype=input.dtype)
 
     intermediate_cache2 = _make_intermediate((M, topk, w2.shape[1]), dtype=out_dtype, device=device, zeros=not full_exp)
     # down


### PR DESCRIPTION


## Motivation

The existing PyTorch Block-FP8 MoE path may launch GEMM CTAs for every local
expert during small-batch decode, even though only a small subset of experts
receives tokens. For example, with `M=1`, `top-k=8`, and `E=256`, at most eight
experts are active while the original dense expert grid still covers all 256
experts.

The activation path also materializes the BF16 SwiGLU result before launching
a separate FP8 quantization kernel:

```text
gate/up GEMM
  -> silu_and_mul
  -> BF16 intermediate
  -> quant_fp8
  -> FP8 down-projection input
```

This PR reduces both the inactive-expert launch overhead and the intermediate
activation traffic in Block-FP8 MoE decode.

## Modification

### Active-expert block scheduling

Add an opt-in active-block dispatch:

```bash
LMDEPLOY_MOE_ACTIVE_BLOCK_DECODE=1
```

The path reuses the existing compact MoE kernel and routed-block metadata, but
launches GEMM programs only for expert blocks that receive tokens.

Dispatch is selected using backend properties only:

- GPU compute capability
- input and output dtype
- FP8 group size
- token count
- expert count and top-k
- hidden and local projection dimensions

There are no model-name checks. Unknown or unsupported shapes retain the
existing schedule. The optimization also falls back for unsupported expert
layouts, dtypes, GPUs, and tensor shapes.

### Fused SwiGLU and FP8 quantization

Fuse `silu_and_mul` with group-wise FP8 quantization for the default Block-FP8
MoE activation:

```text
gate/up GEMM
  -> silu_and_mul_post_quant
  -> FP8 activation + scale
  -> down-projection GEMM
```

This removes one kernel launch and avoids materializing and rereading the BF16
activation. Custom activation functions continue using the existing fallback.

## Performance

### End-to-end active-block scheduling

Environment:

- 8 x NVIDIA H200
- PyTorch engine
- TP=8, EP=1
- CUDA Graph enabled
- Block-FP8 MoE model
- input length 128, output length 256
- symmetric-memory AllReduce baseline
- one warm-up and five measured repeats; median reported

| Concurrency | Baseline TPOT | Active TPOT | TPOT reduction | Baseline tok/s | Active tok/s | Throughput gain |
| ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 1 | 20.023 ms | 17.527 ms | 12.47% | 48.371 | 55.053 | 13.82% |
| 4 | 21.147 ms | 18.769 ms | 11.24% | 183.429 | 205.707 | 12.14% |

The baseline and candidate both used the fused SwiGLU/quant path, so this table
isolates the contribution of active-block scheduling.

### SwiGLU and FP8 quantization microbenchmark

The benchmark used the TP8 local routed-MoE shape with `top-k=8` and local
intermediate size 256.

| Decode M | Separate kernels | Fused kernel | Latency reduction |
| ---: | ---: | ---: | ---: |
| 1 | 7.403 us | 5.466 us | 26.17% |
| 4 | 7.565 us | 5.424 us | 28.30% |
| 16 | 7.690 us | 5.777 us | 24.87% |
| 32 | 7.892 us | 5.861 us | 25.74% |

This is an operator-level result and is not added directly to the end-to-end
active-block gain.

## BC-breaking

No backward-incompatible API changes are introduced.

The active-block schedule is opt-in, and unsupported shapes fall back to the
existing implementation. The fused activation preserves the established
custom-activation fallback.

## Correctness and validation

- The fused FP8 activation is bitwise equal to
  `quant_fp8(silu_and_mul(x))` for the measured shapes.
- The generated FP8 scales are bitwise equal.
- Greedy end-to-end output digests matched across all measured repeats.
- Existing kernel tests pass: `97 passed`.
- `py_compile` and `git diff --check` pass.

Commands:

```bash
python -m pytest -q \
  tests/pytorch/kernel/test_activation.py \
  tests/pytorch/kernel/test_fused_moe.py

python -m py_compile \
  lmdeploy/pytorch/kernels/cuda/activation.py \
  lmdeploy/pytorch/kernels/cuda/moe/blocked_fp8.py

git diff --check
```

## Checklist

- [x] Existing lint/static checks pass.
- [x] Existing kernel tests pass.
- [x] Unsupported configurations retain the established fallback.
- [x] No new dependency or backward-incompatible API change is introduced.
