### PR TITLE
[Docs] Fix syntax in the Chinese output logits example

### DIFF
--- a/docs/zh_cn/llm/pipeline.md
+++ b/docs/zh_cn/llm/pipeline.md
@@ -123,7 +123,7 @@ from lmdeploy import pipeline, GenerationConfig
 
 pipe = pipeline('internlm/internlm2_5-7b-chat')
 
-gen_config=GenerationConfig(output_logits='generation'
+gen_config=GenerationConfig(output_logits='generation',
                             max_new_tokens=10)
 response = pipe(['Hi, pls intro yourself', 'Shanghai is'],
                 gen_config=gen_config)


### PR DESCRIPTION
## Motivation

The Chinese pipeline guide's generated-token logits example is missing a comma between output_logits and max_new_tokens, so copying it raises SyntaxError.

## Modification

Add the missing comma, matching the existing English example. No runtime behavior changes.

## Validation

- Reproduced SyntaxError from the original Python fence; ast.parse passes after the fix.
- Confirmed the corrected Python fence is identical to its English counterpart.
- git diff --check and Markdown parsing passed.
- Rendered the changed page with MyST/docutils and compared diagnostics with the original page: no new diagnostics. Both versions report the same unresolved cross-page documentation target in standalone rendering. The full Sphinx build cannot start in this environment because FastAPI is not installed.

No model inference was run for this syntax-only documentation fix.

The configured pre-commit hooks passed for the changed file, including mdformat.
